### PR TITLE
refactor(api): list scenarios with liveVersionId

### DIFF
--- a/app/handle_scenarios.go
+++ b/app/handle_scenarios.go
@@ -5,7 +5,7 @@ import "context"
 type RepositoryScenarioInterface interface {
 	ListScenarios(ctx context.Context, orgID string) ([]Scenario, error)
 	CreateScenario(ctx context.Context, orgID string, scenario CreateScenarioInput) (Scenario, error)
-	GetScenario(ctx context.Context, orgID string, scenarioID string) (Scenario, error)
+	GetScenario(ctx context.Context, orgID string, scenarioID string) (ScenarioWithLiveVersion, error)
 	UpdateScenario(ctx context.Context, orgID string, scenario UpdateScenarioInput) (Scenario, error)
 }
 
@@ -17,7 +17,7 @@ func (app *App) CreateScenario(ctx context.Context, organizationID string, scena
 	return app.repository.CreateScenario(ctx, organizationID, scenario)
 }
 
-func (app *App) GetScenario(ctx context.Context, organizationID string, scenarioID string) (Scenario, error) {
+func (app *App) GetScenario(ctx context.Context, organizationID string, scenarioID string) (ScenarioWithLiveVersion, error) {
 	return app.repository.GetScenario(ctx, organizationID, scenarioID)
 }
 

--- a/app/scenario.go
+++ b/app/scenario.go
@@ -20,6 +20,15 @@ type Scenario struct {
 	Description       string
 	TriggerObjectType string
 	CreatedAt         time.Time
+	LiveVersionID     *string
+}
+
+type ScenarioWithLiveVersion struct {
+	ID                string
+	Name              string
+	Description       string
+	TriggerObjectType string
+	CreatedAt         time.Time
 	LiveVersion       *PublishedScenarioIteration
 }
 
@@ -171,7 +180,7 @@ var (
 	ErrScenarioHasNoLiveVersion                         = errors.New("scenario has no live version")
 )
 
-func (s Scenario) Eval(ctx context.Context, repo RepositoryInterface, payloadStructWithReader DynamicStructWithReader, dataModel DataModel, logger *slog.Logger) (se ScenarioExecution, err error) {
+func (s ScenarioWithLiveVersion) Eval(ctx context.Context, repo RepositoryInterface, payloadStructWithReader DynamicStructWithReader, dataModel DataModel, logger *slog.Logger) (se ScenarioExecution, err error) {
 
 	///////////////////////////////
 	// Recover in case the evaluation panicked.


### PR DESCRIPTION
## Goal
Expose the `liveVersionId` from which `isLive` can be inferred. The id is helpful to know which scenario iterations is Live.

## Caveats
I'm not totally satisfied with the current implementation :
- handling optional values from the repository using ptrs start to be really painfull
- naming is hard (I wonder if we can define a naming convention for "populated" models = when a FK relation is populated with the related entity in the repository)