### PR TITLE
validate operators before evaluating them

### DIFF
--- a/app/operators/bool_operators.go
+++ b/app/operators/bool_operators.go
@@ -59,7 +59,7 @@ func init() {
 
 func (t True) Eval(d DataAccessor) (bool, error) { return true, nil }
 
-func (t True) isValid() bool { return true }
+func (t True) IsValid() bool { return true }
 
 func (t True) String() string { return "TRUE" }
 
@@ -88,7 +88,7 @@ func init() {
 
 func (f False) Eval(d DataAccessor) (bool, error) { return false, nil }
 
-func (f False) isValid() bool { return true }
+func (f False) IsValid() bool { return true }
 
 func (f False) String() string { return "FALSE" }
 
@@ -116,7 +116,7 @@ func init() {
 }
 
 func (eq EqBool) Eval(d DataAccessor) (bool, error) {
-	if !eq.isValid() {
+	if !eq.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 	valLeft, errLeft := eq.Left.Eval(d)
@@ -127,8 +127,8 @@ func (eq EqBool) Eval(d DataAccessor) (bool, error) {
 	return valLeft == valRight, nil
 }
 
-func (eq EqBool) isValid() bool {
-	return eq.Left != nil && eq.Right != nil && eq.Left.isValid() && eq.Right.isValid()
+func (eq EqBool) IsValid() bool {
+	return eq.Left != nil && eq.Right != nil && eq.Left.IsValid() && eq.Right.IsValid()
 }
 
 func (eq EqBool) String() string {
@@ -195,7 +195,7 @@ func init() {
 }
 
 func (field DbFieldBool) Eval(d DataAccessor) (bool, error) {
-	if !field.isValid() {
+	if !field.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 
@@ -220,7 +220,7 @@ func (field DbFieldBool) Eval(d DataAccessor) (bool, error) {
 	return valNullable.Bool, nil
 }
 
-func (field DbFieldBool) isValid() bool {
+func (field DbFieldBool) IsValid() bool {
 	return len(field.Path) > 0 && field.FieldName != ""
 }
 
@@ -279,7 +279,7 @@ func init() {
 }
 
 func (field PayloadFieldBool) Eval(d DataAccessor) (bool, error) {
-	if !field.isValid() {
+	if !field.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 
@@ -295,7 +295,7 @@ func (field PayloadFieldBool) Eval(d DataAccessor) (bool, error) {
 	return *valPointer, nil
 }
 
-func (field PayloadFieldBool) isValid() bool {
+func (field PayloadFieldBool) IsValid() bool {
 	return field.FieldName != ""
 }
 
@@ -349,7 +349,7 @@ func init() {
 }
 
 func (and And) Eval(d DataAccessor) (bool, error) {
-	if !and.isValid() {
+	if !and.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 
@@ -364,12 +364,12 @@ func (and And) Eval(d DataAccessor) (bool, error) {
 	return true, nil
 }
 
-func (and And) isValid() bool {
+func (and And) IsValid() bool {
 	if len(and.Operands) == 0 {
 		return false
 	}
 	for _, op := range and.Operands {
-		if op == nil || !op.isValid() {
+		if op == nil || !op.IsValid() {
 			return false
 		}
 	}
@@ -430,7 +430,7 @@ func init() {
 }
 
 func (or Or) Eval(d DataAccessor) (bool, error) {
-	if !or.isValid() {
+	if !or.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 
@@ -445,12 +445,12 @@ func (or Or) Eval(d DataAccessor) (bool, error) {
 	return false, nil
 }
 
-func (or Or) isValid() bool {
+func (or Or) IsValid() bool {
 	if len(or.Operands) == 0 {
 		return false
 	}
 	for _, op := range or.Operands {
-		if op == nil || !op.isValid() {
+		if op == nil || !op.IsValid() {
 			return false
 		}
 	}
@@ -511,7 +511,7 @@ func init() {
 }
 
 func (not Not) Eval(d DataAccessor) (bool, error) {
-	if !not.isValid() {
+	if !not.IsValid() {
 		return false, ErrEvaluatingInvalidOperator
 	}
 
@@ -522,8 +522,8 @@ func (not Not) Eval(d DataAccessor) (bool, error) {
 	return !res, nil
 }
 
-func (not Not) isValid() bool {
-	return not.Child != nil && not.Child.isValid()
+func (not Not) IsValid() bool {
+	return not.Child != nil && not.Child.IsValid()
 }
 
 func (not Not) String() string {

--- a/app/operators/operators.go
+++ b/app/operators/operators.go
@@ -46,7 +46,8 @@ type Operator interface {
 
 	// Self-print
 	String() string
-	isValid() bool
+
+	IsValid() bool
 }
 
 // Used to add and read the "type" kep anytime we marshal/unmarshal

--- a/app/operators/operators_test.go
+++ b/app/operators/operators_test.go
@@ -467,7 +467,7 @@ func TestInvalidOperators(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			if c.operator.isValid() {
+			if c.operator.IsValid() {
 				t.Errorf("operator should be invalid")
 			}
 		})

--- a/app/scenario.go
+++ b/app/scenario.go
@@ -88,7 +88,7 @@ func NewPublishedScenarioIteration(si ScenarioIteration) (PublishedScenarioItera
 	return result, nil
 }
 
-func (si ScenarioIteration) IsValideForPublication() bool {
+func (si ScenarioIteration) IsValidForPublication() bool {
 	if si.Body.ScoreReviewThreshold == nil {
 		return false
 	}
@@ -100,8 +100,15 @@ func (si ScenarioIteration) IsValideForPublication() bool {
 	if len(si.Body.Rules) < 1 {
 		return false
 	}
+	for _, rule := range si.Body.Rules {
+		if !rule.Formula.IsValid() {
+			return false
+		}
+	}
 
 	if si.Body.TriggerCondition == nil {
+		return false
+	} else if !si.Body.TriggerCondition.IsValid() {
 		return false
 	}
 

--- a/pg_repository/scenario_iterations.go
+++ b/pg_repository/scenario_iterations.go
@@ -298,7 +298,7 @@ func (r *PGRepository) publishScenarioIteration(ctx context.Context, tx pgx.Tx, 
 		return err
 	}
 
-	if !si.IsValideForPublication() {
+	if !si.IsValidForPublication() {
 		return app.ErrScenarioIterationNotValid
 	}
 


### PR DESCRIPTION
Follow-up on this thread: https://checkmarble.slack.com/archives/C04J8MPJJHY/p1683711861927999
Add a method on operators checking if they (and the whole subtree) are valid, in the sense that they have all the input they need to be evaluated.
Change of mind since the thread however: turned out it's not really easier to do it by setting a field while we deserialize (though "syntax" validation is still happening there: AKA for operators other than constant and variadic, the number of children is checked there.