### PR TITLE
rename all .dto() methods to .toDomain()

### DIFF
--- a/pg_repository/data_models.go
+++ b/pg_repository/data_models.go
@@ -22,7 +22,7 @@ type dbDataModel struct {
 	DeletedAt pgtype.Time `db:"deleted_at"`
 }
 
-func (dm *dbDataModel) dto() (app.DataModel, error) {
+func (dm *dbDataModel) toDomain() (app.DataModel, error) {
 	var tables map[string]app.Table
 	if err := json.Unmarshal(dm.Tables, &tables); err != nil {
 		return app.DataModel{}, fmt.Errorf("unable to unmarshal data model tables: %w", err)
@@ -52,7 +52,7 @@ func (r *PGRepository) GetDataModel(ctx context.Context, orgID string) (app.Data
 		return app.DataModel{}, fmt.Errorf("unable to get data model for org(id: %s): %w", orgID, err)
 	}
 
-	return dataModel.dto()
+	return dataModel.toDomain()
 }
 
 func (r *PGRepository) CreateDataModel(ctx context.Context, orgID string, dataModel app.DataModel) (app.DataModel, error) {
@@ -85,5 +85,5 @@ func (r *PGRepository) CreateDataModel(ctx context.Context, orgID string, dataMo
 		return app.DataModel{}, fmt.Errorf("unable to create token: %w", err)
 	}
 
-	return createdDataModel.dto()
+	return createdDataModel.toDomain()
 }

--- a/pg_repository/decision_rules.go
+++ b/pg_repository/decision_rules.go
@@ -21,7 +21,7 @@ type dbDecisionRule struct {
 	DeletedAt     pgtype.Time `db:"deleted_at"`
 }
 
-func (dr *dbDecisionRule) dto() app.RuleExecution {
+func (dr *dbDecisionRule) toDomain() app.RuleExecution {
 	return app.RuleExecution{
 		Rule: app.Rule{
 			Name:        dr.Name,
@@ -72,7 +72,7 @@ func (r *PGRepository) createDecisionRules(ctx context.Context, tx pgx.Tx, orgID
 
 	decisionRulesDTOs := make([]app.RuleExecution, len(createdDecisionRules))
 	for i, decisionRule := range createdDecisionRules {
-		decisionRulesDTOs[i] = decisionRule.dto()
+		decisionRulesDTOs[i] = decisionRule.toDomain()
 	}
 	return decisionRulesDTOs, err
 }

--- a/pg_repository/decisions.go
+++ b/pg_repository/decisions.go
@@ -26,7 +26,7 @@ type dbDecision struct {
 	DeletedAt           pgtype.Time `db:"deleted_at"`
 }
 
-func (d *dbDecision) dto() app.Decision {
+func (d *dbDecision) toDomain() app.Decision {
 	return app.Decision{
 		ID:                  d.ID,
 		CreatedAt:           d.CreatedAt,
@@ -69,9 +69,9 @@ func (r *PGRepository) GetDecision(ctx context.Context, orgID string, decisionID
 		return app.Decision{}, fmt.Errorf("unable to get decision: %w", err)
 	}
 
-	decisionDTO := decision.dto()
+	decisionDTO := decision.toDomain()
 	for _, rule := range decision.Rules {
-		decisionDTO.RuleExecutions = append(decisionDTO.RuleExecutions, rule.dto())
+		decisionDTO.RuleExecutions = append(decisionDTO.RuleExecutions, rule.toDomain())
 	}
 	return decisionDTO, nil
 }
@@ -121,7 +121,7 @@ func (r *PGRepository) StoreDecision(ctx context.Context, orgID string, decision
 		return app.Decision{}, fmt.Errorf("unable to create decision rules: %w", err)
 	}
 
-	createdDecisionDTO := createdDecision.dto()
+	createdDecisionDTO := createdDecision.toDomain()
 	createdDecisionDTO.RuleExecutions = createdDecisionRules
 
 	err = tx.Commit(ctx)

--- a/pg_repository/organisations.go
+++ b/pg_repository/organisations.go
@@ -19,7 +19,7 @@ type dbOrganization struct {
 	DeletedAt    pgtype.Time `db:"deleted_at"`
 }
 
-func (org *dbOrganization) dto() app.Organization {
+func (org *dbOrganization) toDomain() app.Organization {
 	return app.Organization{
 		ID:   org.ID,
 		Name: org.Name,
@@ -49,7 +49,7 @@ func (r *PGRepository) GetOrganization(ctx context.Context, orgID string) (app.O
 		return app.Organization{}, fmt.Errorf("unable to get organization(id: %s): %w", orgID, err)
 	}
 
-	organizationDTO := organization.dto()
+	organizationDTO := organization.toDomain()
 	return organizationDTO, nil
 }
 
@@ -70,7 +70,7 @@ func (r *PGRepository) GetOrganizations(ctx context.Context) ([]app.Organization
 
 	organizationDTOs := make([]app.Organization, len(organizations))
 	for i, org := range organizations {
-		organizationDTOs[i] = org.dto()
+		organizationDTOs[i] = org.toDomain()
 	}
 	return organizationDTOs, nil
 }
@@ -97,7 +97,7 @@ func (r *PGRepository) CreateOrganization(ctx context.Context, organization app.
 		return app.Organization{}, fmt.Errorf("unable to create organization: %w", err)
 	}
 
-	return createdOrg.dto(), nil
+	return createdOrg.toDomain(), nil
 }
 
 type dbUpdateOrganizationInput struct {
@@ -126,7 +126,7 @@ func (r *PGRepository) UpdateOrganization(ctx context.Context, organization app.
 		return app.Organization{}, fmt.Errorf("unable to update org(id: %s): %w", organization.ID, err)
 	}
 
-	return updatedOrg.dto(), nil
+	return updatedOrg.toDomain(), nil
 }
 
 // TODO(soft-delete): handle cascade soft deletion

--- a/pg_repository/rules.go
+++ b/pg_repository/rules.go
@@ -27,7 +27,7 @@ type dbScenarioIterationRule struct {
 	DeletedAt           pgtype.Time `db:"deleted_at"`
 }
 
-func (sir *dbScenarioIterationRule) dto() (app.Rule, error) {
+func (sir *dbScenarioIterationRule) toDomain() (app.Rule, error) {
 	formula, err := operators.UnmarshalOperatorBool(sir.Formula)
 	if err != nil {
 		return app.Rule{}, fmt.Errorf("unable to unmarshal rule: %w", err)
@@ -64,7 +64,7 @@ func (r *PGRepository) GetScenarioIterationRule(ctx context.Context, orgID strin
 		return app.Rule{}, fmt.Errorf("unable to get rule: %w", err)
 	}
 
-	ruleDTO, err := rule.dto()
+	ruleDTO, err := rule.toDomain()
 	if err != nil {
 		return app.Rule{}, fmt.Errorf("dto issue: %w", err)
 	}
@@ -97,7 +97,7 @@ func (r *PGRepository) ListScenarioIterationRules(ctx context.Context, orgID str
 
 	var ruleDTOs []app.Rule
 	for _, rule := range rules {
-		ruleDTO, err := rule.dto()
+		ruleDTO, err := rule.toDomain()
 		if err != nil {
 			return nil, fmt.Errorf("dto issue: %w", err)
 		}
@@ -171,7 +171,7 @@ func (r *PGRepository) CreateScenarioIterationRule(ctx context.Context, orgID st
 		return app.Rule{}, fmt.Errorf("unable to create rule: %w", err)
 	}
 
-	ruleDTO, err := createdRule.dto()
+	ruleDTO, err := createdRule.toDomain()
 	if err != nil {
 		return app.Rule{}, fmt.Errorf("dto issue: %w", err)
 	}
@@ -251,7 +251,7 @@ func (r *PGRepository) createScenarioIterationRules(ctx context.Context, tx pgx.
 
 	rulesDTOs := make([]app.Rule, len(createdRules))
 	for i, createdRule := range createdRules {
-		rulesDTOs[i], err = createdRule.dto()
+		rulesDTOs[i], err = createdRule.toDomain()
 		if err != nil {
 			return nil, fmt.Errorf("dto issue: %w", err)
 		}
@@ -330,7 +330,7 @@ func (r *PGRepository) UpdateScenarioIterationRule(ctx context.Context, orgID st
 		return app.Rule{}, fmt.Errorf("unable to update rule(id: %s): %w", rule.ID, err)
 	}
 
-	ruleDTO, err := updatedRule.dto()
+	ruleDTO, err := updatedRule.toDomain()
 	if err != nil {
 		return app.Rule{}, fmt.Errorf("dto issue: %w", err)
 	}

--- a/pg_repository/scenario_iterations.go
+++ b/pg_repository/scenario_iterations.go
@@ -30,7 +30,7 @@ type dbScenarioIteration struct {
 	DeletedAt            pgtype.Time     `db:"deleted_at"`
 }
 
-func (si *dbScenarioIteration) dto() (app.ScenarioIteration, error) {
+func (si *dbScenarioIteration) toDomain() (app.ScenarioIteration, error) {
 	siDTO := app.ScenarioIteration{
 		ID:         si.ID,
 		ScenarioID: si.ScenarioID,
@@ -86,7 +86,7 @@ func (r *PGRepository) ListScenarioIterations(ctx context.Context, orgID string,
 
 	var scenarioIterationDTOs []app.ScenarioIteration
 	for _, si := range scenarioIterations {
-		siDTO, err := si.dto()
+		siDTO, err := si.toDomain()
 		if err != nil {
 			return nil, fmt.Errorf("dto issue: %w", err)
 		}
@@ -130,12 +130,12 @@ func (r *PGRepository) getScenarioIterationRaw(ctx context.Context, pool PgxPool
 		return app.ScenarioIteration{}, fmt.Errorf("unable to collect scenario iteration: %w", err)
 	}
 
-	scenarioIterationDTO, err := scenarioIteration.dto()
+	scenarioIterationDTO, err := scenarioIteration.toDomain()
 	if err != nil {
 		return app.ScenarioIteration{}, fmt.Errorf("dto issue: %w", err)
 	}
 	for _, rule := range scenarioIteration.Rules {
-		ruleDto, err := rule.dto()
+		ruleDto, err := rule.toDomain()
 		if err != nil {
 			return app.ScenarioIteration{}, fmt.Errorf("dto issue: %w", err)
 		}
@@ -192,7 +192,7 @@ func (r *PGRepository) CreateScenarioIteration(ctx context.Context, orgID string
 		return app.ScenarioIteration{}, fmt.Errorf("unable to create scenario iteration: %w", err)
 	}
 
-	scenarioIterationDTO, err := createdScenarioIteration.dto()
+	scenarioIterationDTO, err := createdScenarioIteration.toDomain()
 	if err != nil {
 		return app.ScenarioIteration{}, fmt.Errorf("dto issue: %w", err)
 	}
@@ -279,7 +279,7 @@ func (r *PGRepository) UpdateScenarioIteration(ctx context.Context, orgID string
 		return app.ScenarioIteration{}, fmt.Errorf("unable to update scenario iteration: %w", err)
 	}
 
-	scenarioIterationDTO, err := updatedScenarioIteration.dto()
+	scenarioIterationDTO, err := updatedScenarioIteration.toDomain()
 	if err != nil {
 		return app.ScenarioIteration{}, fmt.Errorf("dto issue: %w", err)
 	}

--- a/pg_repository/scenario_publications.go
+++ b/pg_repository/scenario_publications.go
@@ -22,7 +22,7 @@ type dbScenarioPublication struct {
 	CreatedAt           time.Time `db:"created_at"`
 }
 
-func (sp *dbScenarioPublication) dto() app.ScenarioPublication {
+func (sp *dbScenarioPublication) toDomain() app.ScenarioPublication {
 	return app.ScenarioPublication{
 		ID:    sp.ID,
 		Rank:  sp.Rank,
@@ -63,7 +63,7 @@ func (r *PGRepository) ListScenarioPublications(ctx context.Context, orgID strin
 
 	scenarioPubblicationDTOs := make([]app.ScenarioPublication, len(scenarioPublications))
 	for i, scenario := range scenarioPublications {
-		scenarioPubblicationDTOs[i] = scenario.dto()
+		scenarioPubblicationDTOs[i] = scenario.toDomain()
 	}
 	return scenarioPubblicationDTOs, err
 }
@@ -137,7 +137,7 @@ func (r *PGRepository) CreateScenarioPublication(ctx context.Context, orgID stri
 			if err != nil {
 				return nil, fmt.Errorf("unable to unpublish old scenario iteration: %w", err)
 			}
-			scenarioPublications = append(scenarioPublications, unpublishOldIteration.dto())
+			scenarioPublications = append(scenarioPublications, unpublishOldIteration.toDomain())
 		}
 
 		err = r.publishScenarioIteration(ctx, tx, orgID, sp.ScenarioIterationID)
@@ -155,7 +155,7 @@ func (r *PGRepository) CreateScenarioPublication(ctx context.Context, orgID stri
 		if err != nil {
 			return nil, fmt.Errorf("unable to publish new scenario iteration: %w", err)
 		}
-		scenarioPublications = append(scenarioPublications, publishNewIteration.dto())
+		scenarioPublications = append(scenarioPublications, publishNewIteration.toDomain())
 
 		err = r.setLiveScenarioIteration(ctx, tx, orgID, sp.ScenarioIterationID)
 		if err != nil {
@@ -176,7 +176,7 @@ func (r *PGRepository) CreateScenarioPublication(ctx context.Context, orgID stri
 		if err != nil {
 			return nil, fmt.Errorf("unable to unpublish provided scenario iteration: %w", err)
 		}
-		scenarioPublications = append(scenarioPublications, unpublishOldIteration.dto())
+		scenarioPublications = append(scenarioPublications, unpublishOldIteration.toDomain())
 
 		err = r.unsetLiveScenarioIteration(ctx, tx, orgID, scenarioID)
 		if err != nil {
@@ -214,5 +214,5 @@ func (r *PGRepository) GetScenarioPublication(ctx context.Context, orgID string,
 		return app.ScenarioPublication{}, fmt.Errorf("unable to get scenario publication: %w", err)
 	}
 
-	return scenarioPublication.dto(), err
+	return scenarioPublication.toDomain(), err
 }

--- a/pg_repository/scenarios.go
+++ b/pg_repository/scenarios.go
@@ -23,7 +23,7 @@ type dbScenario struct {
 	DeletedAt         pgtype.Time `db:"deleted_at"`
 }
 
-func (s *dbScenario) dto() app.Scenario {
+func (s *dbScenario) toDomain() app.Scenario {
 	scenario := app.Scenario{
 		ID:                s.ID,
 		Name:              s.Name,
@@ -56,7 +56,7 @@ func (r *PGRepository) ListScenarios(ctx context.Context, orgID string) ([]app.S
 
 	scenarioDTOs := []app.Scenario{}
 	for _, s := range scenarios {
-		scenarioDTOs = append(scenarioDTOs, s.dto())
+		scenarioDTOs = append(scenarioDTOs, s.toDomain())
 	}
 	return scenarioDTOs, nil
 }
@@ -82,7 +82,7 @@ func (r *PGRepository) GetScenario(ctx context.Context, orgID string, scenarioID
 		return app.Scenario{}, fmt.Errorf("unable to get scenario: %w", err)
 	}
 
-	return scenario.dto(), nil
+	return scenario.toDomain(), nil
 }
 
 type dbCreateScenario struct {
@@ -112,7 +112,7 @@ func (r *PGRepository) CreateScenario(ctx context.Context, orgID string, scenari
 		return app.Scenario{}, fmt.Errorf("unable to create scenario: %w", err)
 	}
 
-	return createdScenario.dto(), nil
+	return createdScenario.toDomain(), nil
 }
 
 type dbUpdateScenarioInput struct {
@@ -143,7 +143,7 @@ func (r *PGRepository) UpdateScenario(ctx context.Context, orgID string, scenari
 		return app.Scenario{}, fmt.Errorf("unable to update scenario(id: %s): %w", scenario.ID, err)
 	}
 
-	return updatedScenario.dto(), nil
+	return updatedScenario.toDomain(), nil
 }
 
 func (r *PGRepository) setLiveScenarioIteration(ctx context.Context, tx pgx.Tx, orgID string, scenarioIterationID string) error {

--- a/pg_repository/tokens.go
+++ b/pg_repository/tokens.go
@@ -18,7 +18,7 @@ type dbToken struct {
 	DeletedAt pgtype.Time `db:"deleted_at"`
 }
 
-func (t *dbToken) dto() app.Token {
+func (t *dbToken) toDomain() app.Token {
 	return app.Token{
 		ID:    t.ID,
 		OrgID: t.OrgID,
@@ -100,5 +100,5 @@ func (r *PGRepository) CreateToken(ctx context.Context, token CreateToken) (app.
 		return app.Token{}, fmt.Errorf("unable to create token: %w", err)
 	}
 
-	return createdToken.dto(), nil
+	return createdToken.toDomain(), nil
 }


### PR DESCRIPTION
Justification: what those methods (on repo level objects) really do is convert a dto to a business domain object, not the opposite.