### PR TITLE
feat: handle CORS preflight request

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-chi/cors"
 	"golang.org/x/exp/slog"
 )
 
@@ -35,7 +36,7 @@ type AppInterface interface {
 	GetDataModel(ctx context.Context, organizationID string) (app.DataModel, error)
 }
 
-func New(port string, a AppInterface, logger *slog.Logger, signingSecrets SigningSecrets) (*http.Server, error) {
+func New(port string, a AppInterface, logger *slog.Logger, signingSecrets SigningSecrets, corsAllowLocalhost bool) (*http.Server, error) {
 
 	///////////////////////////////
 	// Setup a router
@@ -48,6 +49,7 @@ func New(port string, a AppInterface, logger *slog.Logger, signingSecrets Signin
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
+	r.Use(cors.Handler(corsOption(corsAllowLocalhost)))
 	r.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")

--- a/api/cors.go
+++ b/api/cors.go
@@ -1,0 +1,19 @@
+package api
+
+import (
+	"github.com/go-chi/cors"
+)
+
+func corsOption(corsAllowLocalhost bool) cors.Options {
+	allowedOrigins := []string{"https://*"}
+	if corsAllowLocalhost {
+		allowedOrigins = append(allowedOrigins, "http://localhost:3000")
+	}
+	return cors.Options{
+		AllowedOrigins:   allowedOrigins,
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedHeaders:   []string{"Authorization"},
+		AllowCredentials: false,
+		MaxAge:           7200, // Maximum value not ignored by any of major browsers
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/ggicci/httpin v0.10.1
+	github.com/go-chi/cors v1.2.1
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/ggicci/httpin v0.10.1/go.mod h1:RpidMNiWsPdLRwjuXAcvguOOWsEv0KS/ekjTp
 github.com/go-chi/chi/v5 v5.0.7/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/chi/v5 v5.0.8 h1:lD+NLqFcAi1ovnVZpsnObHGW4xb4J8lNmoYVfECH1Y0=
 github.com/go-chi/chi/v5 v5.0.8/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/go-chi/cors v1.2.1 h1:xEC8UT3Rlp2QuWNEr4Fs/c2EAGVKBwy/1vHx3bppil4=
+github.com/go-chi/cors v1.2.1/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=

--- a/main.go
+++ b/main.go
@@ -24,12 +24,15 @@ var embedMigrations embed.FS
 
 func run_server(pgRepository *pg_repository.PGRepository, port string, env string, logger *slog.Logger) {
 	ctx := context.Background()
+	corsAllowLocalhost := false
+
 	if env == "DEV" {
 		pgRepository.Seed()
+		corsAllowLocalhost = true
 	}
 
 	app, _ := app.New(pgRepository)
-	api, _ := api.New(port, app, logger, api.NewSigningSecrets())
+	api, _ := api.New(port, app, logger, api.NewSigningSecrets(), corsAllowLocalhost)
 
 	////////////////////////////////////////////////////////////
 	// Start serving the app


### PR DESCRIPTION
TLDR: backend handle CORS preflight request.

### Context
Frontend must be authorized to call the backend using Xhr request with "Authorization" header.

The rules implemented in this MR are liberal:
- any domain with https
- or http://localhost:3000 in dev
