### PR TITLE
revamp repos in app

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -7,43 +7,63 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+type Repositories struct {
+	organizationsRepo          RepositoryOrganizations
+	scenariosRepo              RepositoryScenarios
+	scenarioIterationsRepo     RepositoryScenarioItertions
+	scenarioIterationRulesRepo RepositoryScenarioItertionRules
+	scenarioPublicationsRepo   RepositoryScenarioPublications
+	decisionsRepo              RepositoryDecisions
+	dataIngestionRepo          RepositoryDataIngestion
+	commonRepo                 RepositoryCommon
+}
+
 type App struct {
-	repository RepositoryInterface
+	repository   Repository
+	repositories Repositories
 }
 
-type RepositoryInterface interface {
-	RepositoryScenarioInterface
-	RepositoryScenarioItertionInterface
-	RepositoryScenarioItertionRuleInterface
-	RepositoryScenarioPublicationInterface
-
-	// Data models & scenarios
-	GetDataModel(ctx context.Context, orgID string) (DataModel, error)
-
-	// token validation
-	GetOrganizationIDFromToken(ctx context.Context, token string) (orgID string, err error)
-
-	// Decisions
-	StoreDecision(ctx context.Context, orgID string, decision Decision) (Decision, error)
-	GetDecision(ctx context.Context, orgID string, decisionID string) (Decision, error)
-
-	// Ingestion
+type RepositoryDataIngestion interface {
 	IngestObject(ctx context.Context, dynamicStructWithReader DynamicStructWithReader, table Table, logger *slog.Logger) (err error)
-
-	// DB field access
 	GetDbField(ctx context.Context, readParams DbFieldReadParams) (interface{}, error)
-
-	// Organization
-	GetOrganizations(ctx context.Context) ([]Organization, error)
-	CreateOrganization(ctx context.Context, organization CreateOrganizationInput) (Organization, error)
-	GetOrganization(ctx context.Context, orgID string) (Organization, error)
-	UpdateOrganization(ctx context.Context, organization UpdateOrganizationInput) (Organization, error)
-	SoftDeleteOrganization(ctx context.Context, orgID string) error
 }
 
-func New(r RepositoryInterface) (*App, error) {
-	return &App{repository: r}, nil
+type RepositoryCommon interface {
+	GetOrganizationIDFromToken(ctx context.Context, token string) (orgID string, err error)
+	GetDataModel(ctx context.Context, orgID string) (DataModel, error)
 }
+
+type Repository interface {
+	RepositoryScenarios
+	RepositoryScenarioItertions
+	RepositoryScenarioItertionRules
+	RepositoryScenarioPublications
+	RepositoryOrganizations
+	RepositoryDecisions
+	RepositoryDataIngestion
+	RepositoryCommon
+} // bouger dans un folder "ports" ?
+
+func New(r Repository) (*App, error) {
+	return &App{
+		repository: r, // à drop
+		repositories: Repositories{
+			organizationsRepo:          r,
+			scenariosRepo:              r,
+			scenarioIterationsRepo:     r,
+			scenarioIterationRulesRepo: r,
+			scenarioPublicationsRepo:   r,
+			decisionsRepo:              r,
+			dataIngestionRepo:          r,
+			commonRepo:                 r,
+		},
+	}, nil
+}
+
+// Si je veux faire tourner des tests unitaires sur l'app, j'initialise seulement la partie des repositories dont j'ai besoin pour le test (et
+// j'implémente/mock leurs méthodes):
+// app := App{repositories: Repositories{dataIngestionRepo: mockDataIngestionRepo}}
+// concrètement, j'évite le problème "je me trimbale une énorme interface impossible à mocker car 30+ méthodes à implémenter"
 
 // Sentinel errors that the repository can use
 // We define those here because we can't import the repository package in the app itself

--- a/app/data_accessor.go
+++ b/app/data_accessor.go
@@ -8,7 +8,7 @@ import (
 type DataAccessorImpl struct {
 	DataModel  DataModel
 	Payload    DynamicStructWithReader
-	repository RepositoryInterface
+	repository Repository
 }
 
 type DbFieldReadParams struct {

--- a/app/handle_decision.go
+++ b/app/handle_decision.go
@@ -8,6 +8,11 @@ import (
 	"golang.org/x/exp/slog"
 )
 
+type RepositoryDecisions interface {
+	StoreDecision(ctx context.Context, orgID string, decision Decision) (Decision, error)
+	GetDecision(ctx context.Context, orgID string, decisionID string) (Decision, error)
+}
+
 var ErrScenarioNotFound = errors.New("scenario not found")
 var ErrDataModelNotFound = errors.New("data model not found")
 

--- a/app/handle_organization.go
+++ b/app/handle_organization.go
@@ -2,6 +2,14 @@ package app
 
 import "context"
 
+type RepositoryOrganizations interface {
+	GetOrganizations(ctx context.Context) ([]Organization, error)
+	CreateOrganization(ctx context.Context, organization CreateOrganizationInput) (Organization, error)
+	GetOrganization(ctx context.Context, orgID string) (Organization, error)
+	UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (Organization, error)
+	SoftDeleteOrganization(ctx context.Context, orgID string) error
+}
+
 func (app *App) GetOrganizations(ctx context.Context) ([]Organization, error) {
 	return app.repository.GetOrganizations(ctx)
 }
@@ -14,8 +22,8 @@ func (app *App) GetOrganization(ctx context.Context, organizationID string) (Org
 	return app.repository.GetOrganization(ctx, organizationID)
 }
 
-func (app *App) UpdateOrganization(ctx context.Context, organization UpdateOrganizationInput) (Organization, error) {
-	return app.repository.UpdateOrganization(ctx, organization)
+func (app *App) UpdateOrganization(ctx context.Context, input UpdateOrganizationInput) (Organization, error) {
+	return app.repository.UpdateOrganization(ctx, input)
 }
 
 func (app *App) SoftDeleteOrganization(ctx context.Context, organizationID string) error {

--- a/app/handle_scenario_iteration_rules.go
+++ b/app/handle_scenario_iteration_rules.go
@@ -2,7 +2,7 @@ package app
 
 import "context"
 
-type RepositoryScenarioItertionRuleInterface interface {
+type RepositoryScenarioItertionRules interface {
 	ListScenarioIterationRules(ctx context.Context, orgID string, filters GetScenarioIterationRulesFilters) ([]Rule, error)
 	CreateScenarioIterationRule(ctx context.Context, orgID string, rule CreateRuleInput) (Rule, error)
 	GetScenarioIterationRule(ctx context.Context, orgID string, ruleID string) (Rule, error)

--- a/app/handle_scenario_iterations.go
+++ b/app/handle_scenario_iterations.go
@@ -2,7 +2,7 @@ package app
 
 import "context"
 
-type RepositoryScenarioItertionInterface interface {
+type RepositoryScenarioItertions interface {
 	ListScenarioIterations(ctx context.Context, orgID string, filters GetScenarioIterationFilters) ([]ScenarioIteration, error)
 	CreateScenarioIteration(ctx context.Context, orgID string, scenarioIteration CreateScenarioIterationInput) (ScenarioIteration, error)
 	GetScenarioIteration(ctx context.Context, orgID string, scenarioIterationID string) (ScenarioIteration, error)

--- a/app/handle_scenario_publication.go
+++ b/app/handle_scenario_publication.go
@@ -4,7 +4,7 @@ import (
 	"context"
 )
 
-type RepositoryScenarioPublicationInterface interface {
+type RepositoryScenarioPublications interface {
 	ListScenarioPublications(ctx context.Context, orgID string, filters ListScenarioPublicationsFilters) ([]ScenarioPublication, error)
 	CreateScenarioPublication(ctx context.Context, orgID string, sp CreateScenarioPublicationInput) ([]ScenarioPublication, error)
 	GetScenarioPublication(ctx context.Context, orgID string, scenarioPublicationID string) (ScenarioPublication, error)

--- a/app/handle_scenarios.go
+++ b/app/handle_scenarios.go
@@ -2,7 +2,7 @@ package app
 
 import "context"
 
-type RepositoryScenarioInterface interface {
+type RepositoryScenarios interface {
 	ListScenarios(ctx context.Context, orgID string) ([]Scenario, error)
 	CreateScenario(ctx context.Context, orgID string, scenario CreateScenarioInput) (Scenario, error)
 	GetScenario(ctx context.Context, orgID string, scenarioID string) (Scenario, error)

--- a/app/scenario.go
+++ b/app/scenario.go
@@ -179,7 +179,7 @@ var (
 	ErrScenarioHasNoLiveVersion                         = errors.New("scenario has no live version")
 )
 
-func (s Scenario) Eval(ctx context.Context, repo RepositoryInterface, payloadStructWithReader DynamicStructWithReader, dataModel DataModel, logger *slog.Logger) (se ScenarioExecution, err error) {
+func (s Scenario) Eval(ctx context.Context, repo Repository, payloadStructWithReader DynamicStructWithReader, dataModel DataModel, logger *slog.Logger) (se ScenarioExecution, err error) {
 
 	///////////////////////////////
 	// Recover in case the evaluation panicked.


### PR DESCRIPTION
Need a quick opinion on this one. 
As a follow up to [this discussion](https://checkmarble.slack.com/archives/C04JB5ZADBN/p1683557234980699), I wanted to split the repository interface into smaller bits injected into the app/use cases.
Does this make sense to you ?

Concrètement, si je veux faire tourner des tests unitaires sur l'app, j'initialise seulement la partie des repositories dont j'ai besoin pour le test (et j'implémente/mock leurs méthodes):
`app := App{repositories: Repositories{dataIngestionRepo: mockDataIngestionRepo}}`
concrètement, j'évite le problème "je me trimbale une énorme interface impossible à mocker car 30+ méthodes à implémenter"