### PR TITLE
feat(auth): handle firebase session cookie

### DIFF
--- a/api/handle_post_firebase_id_token.go
+++ b/api/handle_post_firebase_id_token.go
@@ -14,7 +14,7 @@ func (api *API) handlePostFirebaseIdToken() http.HandlerFunc {
 		apiKey := ParseApiKeyHeader(request.Header)
 
 		// token from header
-		idToken, err := ParseAuthorizationBearerHeader(request.Header)
+		bearerToken, err := ParseAuthorizationBearerHeader(request.Header)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("Authorization header: %s", err.Error()), http.StatusBadRequest)
 			return
@@ -23,7 +23,7 @@ func (api *API) handlePostFirebaseIdToken() http.HandlerFunc {
 		context := request.Context()
 
 		usecase := api.usecases.NewMarbleTokenUseCase()
-		marbleToken, expirationTime, err := usecase.NewMarbleToken(context, apiKey, idToken)
+		marbleToken, expirationTime, err := usecase.NewMarbleToken(context, apiKey, bearerToken)
 		if err != nil {
 			err = wrapErrInUnAuthorizedError(err)
 		}

--- a/repositories/firebase_token_repository.go
+++ b/repositories/firebase_token_repository.go
@@ -13,24 +13,27 @@ type FireBaseTokenRepository struct {
 	firebaseClient auth.Client
 }
 
-func (repo *FireBaseTokenRepository) VerifyFirebaseIDToken(ctx context.Context, firebaseIdToken string) (FirebaseIdentity, error) {
-	token, err := repo.firebaseClient.VerifyIDToken(ctx, firebaseIdToken)
+func (repo *FireBaseTokenRepository) VerifyFirebaseToken(ctx context.Context, firebaseToken string) (FirebaseIdentity, error) {
+	token, err := repo.firebaseClient.VerifyIDToken(ctx, firebaseToken)
+	if err != nil {
+		token, err = repo.firebaseClient.VerifySessionCookie(ctx, firebaseToken)
+	}
 	if err != nil {
 		return FirebaseIdentity{}, err
 	}
 	identities := token.Firebase.Identities["email"]
 	if identities == nil {
-		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase IdToken content: Field email is missing.")
+		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase token content: Field email is missing.")
 	}
 
 	emails, ok := identities.([]interface{})
 	if !ok || len(emails) == 0 {
-		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase IdToken content: identities is not an array.")
+		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase token content: identities is not an array.")
 	}
 
 	email, ok := emails[0].(string)
 	if !ok {
-		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase IdToken content.")
+		return FirebaseIdentity{}, fmt.Errorf("Unexpected firebase token content.")
 	}
 
 	return FirebaseIdentity{

--- a/usecases/marble_token_usecase.go
+++ b/usecases/marble_token_usecase.go
@@ -52,7 +52,7 @@ func (usecase *MarbleTokenUseCase) makeTokenName(ctx context.Context, organizati
 	return fmt.Sprintf("ApiKey Of %s", organizationName), nil
 }
 
-func (usecase *MarbleTokenUseCase) NewMarbleToken(ctx context.Context, apiKey string, firebaseIdToken string) (string, time.Time, error) {
+func (usecase *MarbleTokenUseCase) NewMarbleToken(ctx context.Context, apiKey string, firebaseToken string) (string, time.Time, error) {
 	if apiKey != "" {
 		credentials, err := usecase.adaptCredentialFromApiKey(ctx, apiKey)
 		if err != nil {
@@ -62,8 +62,8 @@ func (usecase *MarbleTokenUseCase) NewMarbleToken(ctx context.Context, apiKey st
 		return usecase.encodeMarbleToken(credentials)
 	}
 
-	if firebaseIdToken != "" {
-		identity, err := usecase.firebaseTokenRepository.VerifyFirebaseIDToken(ctx, firebaseIdToken)
+	if firebaseToken != "" {
+		identity, err := usecase.firebaseTokenRepository.VerifyFirebaseToken(ctx, firebaseToken)
 
 		if err != nil {
 			return "", time.Time{}, fmt.Errorf("Firebase TokenID verification fail: %w", err)


### PR DESCRIPTION
The goal is to handle both firebase tokens :
- firebase session cookie: for the Remix app
- firebase id token : for the internal backoffice 

NB: the implemmention is open to critic, if you prefer to handle in two distinct functions the token handling.