### PR TITLE
feat: create schema in client's database transaction

### DIFF
--- a/repositories/client_tables_repository.go
+++ b/repositories/client_tables_repository.go
@@ -22,7 +22,7 @@ type ClientTablesRepositoryPostgresql struct {
 func (repo *ClientTablesRepositoryPostgresql) CreateSchema(tx Transaction, schema string) error {
 	pgTx := repo.toPostgresTransaction(tx)
 
-	sql := fmt.Sprintf("CREATE SCHEMA %s", pgx.Identifier.Sanitize([]string{schema}))
+	sql := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pgx.Identifier.Sanitize([]string{schema}))
 
 	_, err := pgTx.Exec(sql)
 	return err

--- a/usecases/organization/organization_creator.go
+++ b/usecases/organization/organization_creator.go
@@ -23,7 +23,16 @@ func (creator *OrganizationCreator) CreateOrganizationWithId(newOrganizationId s
 		if err != nil {
 			return models.Organization{}, err
 		}
-		return creator.OrganizationRepository.GetOrganizationById(tx, newOrganizationId)
+		organization, err := creator.OrganizationRepository.GetOrganizationById(tx, newOrganizationId)
+		if err != nil {
+			return models.Organization{}, err
+		}
+
+		err = creator.PopulateClientTables.CreateClientTables(tx, organization, models.DATABASE_MARBLE)
+		if err != nil {
+			return models.Organization{}, err
+		}
+		return organization, err
 	})
 
 	if err != nil {
@@ -31,11 +40,6 @@ func (creator *OrganizationCreator) CreateOrganizationWithId(newOrganizationId s
 	}
 
 	err = creator.OrganizationSeeder.Seed(organization.ID)
-	if err != nil {
-		return models.Organization{}, err
-	}
-
-	err = creator.PopulateClientTables.CreateClientTables(organization, models.DATABASE_MARBLE)
 	if err != nil {
 		return models.Organization{}, err
 	}


### PR DESCRIPTION
Rework the transactions when an organization is created:

### One transaction for marble DB:

- creation of the organization
- création of client_tables

### Another transaction to create data in client's DB

- creation of the schema
- TODO: creation of the tables transaction, account...

