### PR TITLE
fix: execute migrations job when deploying it

### DIFF
--- a/.github/workflows/build_and_deploy.yaml
+++ b/.github/workflows/build_and_deploy.yaml
@@ -109,4 +109,6 @@ jobs:
             --service-account=marble-backend-cloud-run@${{ steps.get_env.outputs.GCP_PROJECT_ID }}.iam.gserviceaccount.com \
             --set-env-vars=PG_HOSTNAME=/cloudsql/${{ steps.get_env.outputs.GCP_PROJECT_ID }}:europe-west9:marble-sandbox,PG_USER=postgres,GOOGLE_CLOUD_PROJECT=${{ steps.get_env.outputs.GCP_PROJECT_ID }},ENV=${{ steps.get_env.outputs.ENV }} \
             --set-secrets=PG_PASSWORD=POSTGRES_SANDBOX:latest \
-            --set-cloudsql-instances=${{ steps.get_env.outputs.GCP_PROJECT_ID }}:europe-west9:marble-sandbox
+            --set-cloudsql-instances=${{ steps.get_env.outputs.GCP_PROJECT_ID }}:europe-west9:marble-sandbox \
+            --execute-now \
+            --wait


### PR DESCRIPTION
Currently, the job has to be executed manually from the GCP console. This is confusing and requires excessive permissions from developers.

See reference https://cloud.google.com/sdk/gcloud/reference/beta/run/jobs/create#--execute-now