### PR TITLE
style(naming): use consistent naming convention

### DIFF
--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -144,7 +144,7 @@ func (api *API) handlePostCustomListValue() http.HandlerFunc {
 			return
 		}
 		logger := api.logger.With(slog.String("orgID", orgID))
-		inputDto := ctx.Value(httpin.Input).(*dto.AddCustomListValueInputDto)
+		inputDto := ctx.Value(httpin.Input).(*dto.CreateCustomListValueInputDto)
 		listId := inputDto.CustomListID
 		requestData := inputDto.Body
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -153,15 +153,14 @@ func (api *API) routes() {
 			r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_READ)).Get("/", api.handleGetAllCustomLists())
 			r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.CreateCustomListInputDto{})).Post("/", api.handlePostCustomList())
 
-			r.Route("/{listId}", func(r chi.Router) {
+			r.Route("/{customListId}", func(r chi.Router) {
 				r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_READ), httpin.NewInput(dto.GetCustomListInputDto{})).Get("/", api.handleGetCustomListValues())
 				r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.UpdateCustomListInputDto{})).Patch("/", api.handlePatchCustomList())
 				r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.DeleteCustomListInputDto{})).Delete("/", api.handleDeleteCustomList())
 				r.Route("/values", func(r chi.Router) {
-					r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.AddCustomListValueInputDto{})).Post("/", api.handlePostCustomListValue())
+					r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.CreateCustomListValueInputDto{})).Post("/", api.handlePostCustomListValue())
 					r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_CREATE), httpin.NewInput(dto.DeleteCustomListValueInputDto{})).Delete("/", api.handleDeleteCustomListValue())
 				})
-		
 			})
 		})
 

--- a/dto/custom_list_dto.go
+++ b/dto/custom_list_dto.go
@@ -50,30 +50,30 @@ type UpdateCustomListBodyDto struct {
 }
 
 type UpdateCustomListInputDto struct {
-	CustomListID string             `in:"path=listId"`
-	Body   *UpdateCustomListBodyDto `in:"body=json"`
+	CustomListID string                   `in:"path=customListId"`
+	Body         *UpdateCustomListBodyDto `in:"body=json"`
 }
 
 type GetCustomListInputDto struct {
-	CustomListID string `in:"path=listId"`
+	CustomListID string `in:"path=customListId"`
 }
 
 type DeleteCustomListInputDto struct {
-	CustomListID string `in:"path=listId"`
+	CustomListID string `in:"path=customListId"`
 }
 
-type AddCustomListValueInputDto struct {
-	CustomListID string               `in:"path=listId"`
-	Body   *AddCustomListValueBodyDto `in:"body=json"`
+type CreateCustomListValueInputDto struct {
+	CustomListID string                        `in:"path=customListId"`
+	Body         *CreateCustomListValueBodyDto `in:"body=json"`
 }
 
-type AddCustomListValueBodyDto struct {
+type CreateCustomListValueBodyDto struct {
 	Value string `in:"path=value"`
 }
 
 type DeleteCustomListValueInputDto struct {
-	CustomListID string                  `in:"path=listId"`
-	Body   *DeleteCustomListValueBodyDto `in:"body=json"`
+	CustomListID string                        `in:"path=customListId"`
+	Body         *DeleteCustomListValueBodyDto `in:"body=json"`
 }
 
 type DeleteCustomListValueBodyDto struct {


### PR DESCRIPTION
Small PR I did while reviewing the implementation of `/custom-lists/*` endpoints to adapt the `openapi.yaml` spec.

No logic changes, only naming :
- `listId` -> `customListId`
- `Add*` -> `Create*`

I would rather prefer an independent rooting for custom list values, as we have with `/rules`, but this is out of scope for now.
Something like that :

```go
authedRouter.Route("/custom-list-values", func(r chi.Router) {
	r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_PUBLISH), httpin.NewInput(dto.CreateCustomListValueInputDto{})).Post("/", api.handlePostCustomListValue())

	r.Route("/{customListValueId}", func(r chi.Router) {
		r.With(api.enforcePermissionMiddleware(models.CUSTOM_LISTS_PUBLISH), httpin.NewInput(dto.DeleteCustomListValueInputDto{})).Delete("/", api.handleDeleteCustomListValue())
	})
})
```

The relationship is `1..N` between list and values, this is really close to the rules representation. For that kind of data, our current convention is to handle :
- Creation using a POST with the "parent" id pass inside the body -> ATM we pass parent id in parameter
- Deletion using a DELETE with the item id pass as a path parameter -> ATM we pass the parent id in parameter, and the item id in body