### PR TITLE
feat(list): return data on list creation endpoint

### DIFF
--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -42,7 +42,7 @@ func (api *API) handlePostCustomList() http.HandlerFunc {
 		inputDto := ctx.Value(httpin.Input).(*dto.CreateCustomListInputDto).Body
 
 		usecase := api.usecases.NewCustomListUseCase()
-		err = usecase.CreateCustomList(ctx, models.CreateCustomListInput{
+		customList, err := usecase.CreateCustomList(ctx, models.CreateCustomListInput{
 			OrgId:       orgID,
 			Name:        inputDto.Name,
 			Description: inputDto.Description,
@@ -51,7 +51,7 @@ func (api *API) handlePostCustomList() http.HandlerFunc {
 			logger.ErrorCtx(ctx, "error creating a list: \n"+err.Error())
 			return
 		}
-		PresentNothing(w)
+		PresentModelWithNameStatusCode(w, "custom_list", dto.AdaptCustomListDto(customList), http.StatusCreated)
 	}
 }
 
@@ -153,7 +153,7 @@ func (api *API) handlePostCustomListValue() http.HandlerFunc {
 		requestData := inputDto.Body
 
 		usecase := api.usecases.NewCustomListUseCase()
-		err = usecase.AddCustomListValue(ctx, models.AddCustomListValueInput{
+		customListValue, err := usecase.AddCustomListValue(ctx, models.AddCustomListValueInput{
 			CustomListId: listId,
 			OrgId:        orgID,
 			Value:        requestData.Value,
@@ -163,7 +163,7 @@ func (api *API) handlePostCustomListValue() http.HandlerFunc {
 			return
 		}
 
-		PresentNothing(w)
+		PresentModelWithNameStatusCode(w, "custom_list_value", dto.AdaptCustomListValueDto(customListValue), http.StatusCreated)
 	}
 }
 

--- a/api/present_model.go
+++ b/api/present_model.go
@@ -23,6 +23,13 @@ func PresentModelWithName(w http.ResponseWriter, keyName string, models any) {
 	})
 }
 
+func PresentModelWithNameStatusCode(w http.ResponseWriter, keyName string, models any, statusCode int) {
+	w.WriteHeader(statusCode)
+	PresentModel(w, map[string]any{
+		keyName: models,
+	})
+}
+
 func PresentNothing(w http.ResponseWriter) {
 	PresentNothingStatusCode(w, http.StatusNoContent)
 }

--- a/dto/custom_list_dto.go
+++ b/dto/custom_list_dto.go
@@ -7,17 +7,11 @@ import (
 )
 
 type CustomList struct {
-	Id          string            `json:"id"`
-	Name        string            `json:"name"`
-	Description string            `json:"description"`
-	CreatedAt   time.Time         `json:"createdAt"`
-	UpdatedAt   time.Time         `json:"updatedAt"`
-	Values      []CustomListValue `json:"values,omitempty"`
-}
-
-type CustomListValue struct {
-	Id    string `json:"id"`
-	Value string `json:"value"`
+	Id          string    `json:"id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
 }
 
 func AdaptCustomListDto(list models.CustomList) CustomList {
@@ -30,10 +24,29 @@ func AdaptCustomListDto(list models.CustomList) CustomList {
 	}
 }
 
-func AdaptCustomListWithValuesDto(list models.CustomList, values []models.CustomListValue) CustomList {
-	customList := AdaptCustomListDto(list)
-	customList.Values = utils.Map(values, AdaptCustomListValueDto)
-	return customList
+type CustomListWithValues struct {
+	Id          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description"`
+	CreatedAt   time.Time         `json:"createdAt"`
+	UpdatedAt   time.Time         `json:"updatedAt"`
+	Values      []CustomListValue `json:"values"`
+}
+
+type CustomListValue struct {
+	Id    string `json:"id"`
+	Value string `json:"value"`
+}
+
+func AdaptCustomListWithValuesDto(list models.CustomList, values []models.CustomListValue) CustomListWithValues {
+	return CustomListWithValues{
+		Id:          string(list.Id),
+		Name:        list.Name,
+		Description: list.Description,
+		CreatedAt:   list.CreatedAt,
+		UpdatedAt:   list.UpdatedAt,
+		Values:      utils.Map(values, AdaptCustomListValueDto),
+	}
 }
 
 func AdaptCustomListValueDto(listValue models.CustomListValue) CustomListValue {

--- a/repositories/custom_list_repository.go
+++ b/repositories/custom_list_repository.go
@@ -11,6 +11,7 @@ type CustomListRepository interface {
 	AllCustomLists(tx Transaction, orgId string) ([]models.CustomList, error)
 	GetCustomListById(tx Transaction, id string) (models.CustomList, error)
 	GetCustomListValues(tx Transaction, getCustomList models.GetCustomListValuesInput) ([]models.CustomListValue, error)
+	GetCustomListValueById(tx Transaction, id string) (models.CustomListValue, error)
 	CreateCustomList(tx Transaction, createCustomList models.CreateCustomListInput, newCustomListId string) error
 	UpdateCustomList(tx Transaction, updateCustomList models.UpdateCustomListInput) error
 	SoftDeleteCustomList(tx Transaction, deleteCustomList models.DeleteCustomListInput) error
@@ -57,6 +58,18 @@ func (repo *CustomListRepositoryPostgresql) GetCustomListValues(tx Transaction, 
 			Select(dbmodels.ColumnsSelectCustomListValue...).
 			From(dbmodels.TABLE_CUSTOM_LIST_VALUE).
 			Where("custom_list_id = ? AND deleted_at IS NULL", getCustomList.Id),
+		dbmodels.AdaptCustomListValue,
+	)
+}
+func (repo *CustomListRepositoryPostgresql) GetCustomListValueById(tx Transaction, id string) (models.CustomListValue, error) {
+	pgTx := repo.transactionFactory.adaptMarbleDatabaseTransaction(tx)
+
+	return SqlToModel(
+		pgTx,
+		NewQueryBuilder().
+			Select(dbmodels.ColumnsSelectCustomListValue...).
+			From(dbmodels.TABLE_CUSTOM_LIST_VALUE).
+			Where("id = ? AND deleted_at IS NULL", id),
 		dbmodels.AdaptCustomListValue,
 	)
 }

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -9,17 +9,23 @@ import (
 )
 
 type CustomListUseCase struct {
-	transactionFactory repositories.TransactionFactory
-	CustomListRepository     repositories.CustomListRepository
+	transactionFactory   repositories.TransactionFactory
+	CustomListRepository repositories.CustomListRepository
 }
 
 func (usecase *CustomListUseCase) GetCustomLists(ctx context.Context, orgId string) ([]models.CustomList, error) {
 	return usecase.CustomListRepository.AllCustomLists(nil, orgId)
 }
 
-func (usecase *CustomListUseCase) CreateCustomList(ctx context.Context, createCustomList models.CreateCustomListInput) error {
-	newCustomListId := uuid.NewString()
-	return usecase.CustomListRepository.CreateCustomList(nil, createCustomList, newCustomListId)
+func (usecase *CustomListUseCase) CreateCustomList(ctx context.Context, createCustomList models.CreateCustomListInput) (models.CustomList, error) {
+	return repositories.TransactionReturnValue(usecase.transactionFactory, models.DATABASE_MARBLE_SCHEMA, func(tx repositories.Transaction) (models.CustomList, error) {
+		newCustomListId := uuid.NewString()
+		err := usecase.CustomListRepository.CreateCustomList(tx, createCustomList, newCustomListId)
+		if err != nil {
+			return models.CustomList{}, err
+		}
+		return usecase.CustomListRepository.GetCustomListById(tx, newCustomListId)
+	})
 }
 
 func (usecase *CustomListUseCase) UpdateCustomList(ctx context.Context, updateCustomList models.UpdateCustomListInput) (models.CustomList, error) {
@@ -29,7 +35,7 @@ func (usecase *CustomListUseCase) UpdateCustomList(ctx context.Context, updateCu
 			if err != nil {
 				return models.CustomList{}, err
 			}
-		} 
+		}
 		return usecase.CustomListRepository.GetCustomListById(tx, updateCustomList.Id)
 	})
 }
@@ -46,9 +52,15 @@ func (usecase *CustomListUseCase) GetCustomListValues(ctx context.Context, getCu
 	return usecase.CustomListRepository.GetCustomListValues(nil, getCustomListValues)
 }
 
-func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context, addCustomListValue models.AddCustomListValueInput) error {
-	newCustomListValueId := uuid.NewString()
-	return usecase.CustomListRepository.AddCustomListValue(nil, addCustomListValue, newCustomListValueId)
+func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context, addCustomListValue models.AddCustomListValueInput) (models.CustomListValue, error) {
+	return repositories.TransactionReturnValue(usecase.transactionFactory, models.DATABASE_MARBLE_SCHEMA, func(tx repositories.Transaction) (models.CustomListValue, error) {
+		newCustomListValueId := uuid.NewString()
+		err := usecase.CustomListRepository.AddCustomListValue(tx, addCustomListValue, newCustomListValueId)
+		if err != nil {
+			return models.CustomListValue{}, err
+		}
+		return usecase.CustomListRepository.GetCustomListValueById(tx, newCustomListValueId)
+	})
 }
 
 func (usecase *CustomListUseCase) DeleteCustomListValue(ctx context.Context, deleteCustomListValue models.DeleteCustomListValueInput) error {


### PR DESCRIPTION
The goal is to address [this demands](https://checkmarble.slack.com/archives/C04J8MPJJHY/p1688564793814359) :
- on get detail list, always return values (meaning, `values: []` when no values)
- on creation endpoints, return the created data + `201`