### PR TITLE
POC PR: do not leak logic from dynamic struct

### DIFF
--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -145,7 +145,7 @@ func newDataModel() models.DataModel {
 					"company_id": {DataType: models.String, Nullable: true},
 					"name":       {DataType: models.String, Nullable: true},
 					"currency":   {DataType: models.String, Nullable: true},
-					"is_frozen":  {DataType: models.Bool},
+					"is_frozen":  {DataType: models.Bool, Nullable: true},
 				},
 				LinksToSingle: map[models.LinkName]models.LinkToSingle{
 					"company": {

--- a/models/decisions.go
+++ b/models/decisions.go
@@ -62,5 +62,5 @@ type CreateDecisionInput struct {
 	OrganizationId          string
 	ScenarioId              string
 	ClientObject            ClientObject
-	PayloadStructWithReader Payload
+	PayloadStructWithReader PayloadReader
 }

--- a/models/payload.go
+++ b/models/payload.go
@@ -2,9 +2,6 @@ package models
 
 import (
 	"fmt"
-	"marble/marble-backend/pure_utils"
-
-	dynamicstruct "github.com/ompluscator/dynamic-struct"
 )
 
 type PayloadReader interface {
@@ -20,22 +17,6 @@ type DbFieldReadParams struct {
 	Payload          PayloadReader
 }
 
-type Payload struct {
-	Reader    dynamicstruct.Reader
-	TableName TableName
-}
-
-func (payload Payload) ReadFieldFromPayload(fieldName FieldName) (any, error) {
-	// output type is string, bool, float64, int64, time.Time, bundled in an "any" interface
-	field := payload.Reader.GetField(pure_utils.Capitalize(string(fieldName)))
-
-	return field.Interface(), nil
-}
-
-func (payload Payload) ReadTableName() TableName {
-	return payload.TableName
-}
-
 type ClientObject struct {
 	TableName TableName
 	Data      map[string]any
@@ -45,7 +26,7 @@ func (obj ClientObject) ReadFieldFromPayload(fieldName FieldName) (any, error) {
 	// output type is string, bool, float64, int64, time.Time, bundled in an "any" interface
 	fieldValue, ok := obj.Data[string(fieldName)]
 	if !ok {
-		return nil, fmt.Errorf("No field with name %s", fieldName)
+		return nil, fmt.Errorf("no field with name %s", fieldName)
 	}
 	return fieldValue, nil
 }


### PR DESCRIPTION
As discussed:
- fix a bug where we add the zero value for nullable fields not present in the json/null in the json
- keep logic related to "dynamic reader" contained in its own file
possible next steps:
- drop `PayloadReader` interface entirely in favor of the concrete `ClientObject` struct
- move the remaining content from the "app" package (app/payload.go) to a better place - usecases ?

NB:
- Go unmarshals Time from json by parsing it from RFC 3339 / ISO 8601 format: https://romangaranin.net/posts/2021-02-19-json-time-and-golang/