### PR TITLE
fix: scenario iteration version

### DIFF
--- a/usecases/scenarios/scenario_publisher.go
+++ b/usecases/scenarios/scenario_publisher.go
@@ -125,11 +125,14 @@ func (publisher *ScenarioPublisher) getNewVersion(tx repositories.Transaction, o
 	if err != nil {
 		return 0, err
 	}
-	newVersion := 1
+
+	var latestVersion int
 	for _, scenarioIteration := range scenarioIterations {
-		if scenarioIteration.Version != nil {
-			newVersion = *scenarioIteration.Version + 1
+		if scenarioIteration.Version != nil && *scenarioIteration.Version > latestVersion {
+			latestVersion = *scenarioIteration.Version
 		}
 	}
+	newVersion := latestVersion + 1
+
 	return newVersion, nil
 }


### PR DESCRIPTION
[Issue](https://linear.app/checkmarble/issue/MAR-217/version-handling-on-iterations-is-broken)

## Context

The code was always using the Version 1 to create the new version number