### PR TITLE
feat: operators can return nil, nil is a valid value

### DIFF
--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -314,7 +314,7 @@ func ingestAccounts(t *testing.T, table models.Table, ussecases usecases.Usecase
 	assert.NoError(t, err, "Could not ingest data")
 }
 
-func createTransactionPayload(transactionPayloadJson []byte, triggerObjectMap map[string]interface{}, t *testing.T, table models.Table) (models.PayloadReader) {
+func createTransactionPayload(transactionPayloadJson []byte, triggerObjectMap map[string]interface{}, t *testing.T, table models.Table) models.PayloadReader {
 	if err := json.Unmarshal(transactionPayloadJson, &triggerObjectMap); err != nil {
 		t.Fatalf("Could not unmarshal json: %s", err)
 	}
@@ -323,7 +323,7 @@ func createTransactionPayload(transactionPayloadJson []byte, triggerObjectMap ma
 	return transactionPayload
 }
 
-func createTransactionPayloadAndClientObject(transactionPayloadJson []byte,t *testing.T, table models.Table) (models.PayloadReader, models.ClientObject) {
+func createTransactionPayloadAndClientObject(transactionPayloadJson []byte, t *testing.T, table models.Table) (models.PayloadReader, models.ClientObject) {
 	triggerObjectMap := make(map[string]interface{})
 	ClientObject := models.ClientObject{TableName: table.Name, Data: triggerObjectMap}
 	transactionPayload := createTransactionPayload(transactionPayloadJson, triggerObjectMap, t, table)
@@ -394,8 +394,11 @@ func createDecisions(t *testing.T, table models.Table, usecasesWithCreds usecase
 	}, logger)
 	assert.NoError(t, err, "Could not create decision")
 	assert.Equal(t, models.Approve, approveNoNameDecision.Outcome, "Expected decision to be Approve, got %s", approveNoNameDecision.Outcome)
-	ruleExecution := approveNoNameDecision.RuleExecutions[0]
-	assert.ErrorIs(t, ruleExecution.Error, models.NullFieldReadError, "Expected error to be A field read in a rule is null, got %s", ruleExecution.Error)
+
+	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+		ruleExecution := approveNoNameDecision.RuleExecutions[0]
+		assert.ErrorIs(t, ruleExecution.Error, models.NullFieldReadError, "Expected error to be A field read in a rule is null, got %s", ruleExecution.Error)
+	}
 	fmt.Println("Created decision", approveNoNameDecision.DecisionId)
 
 	// Create a decision [APPROVE] without a record in db (no row read)
@@ -415,8 +418,10 @@ func createDecisions(t *testing.T, table models.Table, usecasesWithCreds usecase
 	}, logger)
 	assert.NoError(t, err, "Could not create decision")
 	assert.Equal(t, models.Approve, approveNoRecordDecision.Outcome, "Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-	ruleExecution = approveNoRecordDecision.RuleExecutions[0]
-	assert.ErrorIs(t, ruleExecution.Error, models.NoRowsReadError, "Expected error to be No rows were read from db in a rule, got %s", ruleExecution.Error)
+	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+		ruleExecution := approveNoRecordDecision.RuleExecutions[0]
+		assert.ErrorIs(t, ruleExecution.Error, models.NoRowsReadError, "Expected error to be No rows were read from db in a rule, got %s", ruleExecution.Error)
+	}
 	fmt.Println("Created decision", approveNoRecordDecision.DecisionId)
 
 	// // Create a decision [APPROVE] without a field in payload (null field read)
@@ -436,8 +441,10 @@ func createDecisions(t *testing.T, table models.Table, usecasesWithCreds usecase
 	}, logger)
 	assert.NoError(t, err, "Could not create decision")
 	assert.Equal(t, models.Approve, approveMissingFieldInPayloadDecision.Outcome, "Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-	ruleExecution = approveMissingFieldInPayloadDecision.RuleExecutions[0]
-	assert.ErrorIs(t, ruleExecution.Error, models.NullFieldReadError, "Expected error to be A field read in a rule is null, got %s", ruleExecution.Error)
+	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+		ruleExecution := approveMissingFieldInPayloadDecision.RuleExecutions[0]
+		assert.ErrorIs(t, ruleExecution.Error, models.NullFieldReadError, "Expected error to be A field read in a rule is null, got %s", ruleExecution.Error)
+	}
 	fmt.Println("Created decision", approveMissingFieldInPayloadDecision.DecisionId)
 
 	// Create a decision [APPROVE] with a division by zero
@@ -458,7 +465,9 @@ func createDecisions(t *testing.T, table models.Table, usecasesWithCreds usecase
 	}, logger)
 	assert.NoError(t, err, "Could not create decision")
 	assert.Equal(t, models.Approve, approveDivisionByZeroDecision.Outcome, "Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-	ruleExecution = approveDivisionByZeroDecision.RuleExecutions[0]
-	assert.ErrorIs(t, ruleExecution.Error, models.DivisionByZeroError, "Expected error to be A division by zero occurred in a rule, got %s", ruleExecution.Error)
+	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+		ruleExecution := approveDivisionByZeroDecision.RuleExecutions[0]
+		assert.ErrorIs(t, ruleExecution.Error, models.DivisionByZeroError, "Expected error to be A division by zero occurred in a rule, got %s", ruleExecution.Error)
+	}
 	fmt.Println("Created decision", approveNoNameDecision.DecisionId)
 }

--- a/usecases/ast_eval/evaluate_ast.go
+++ b/usecases/ast_eval/evaluate_ast.go
@@ -5,20 +5,20 @@ import (
 	"marble/marble-backend/utils"
 )
 
-func EvaluateAst(environment AstEvaluationEnvironment, node ast.Node) ast.NodeEvaluation {
+func EvaluateAst(environment AstEvaluationEnvironment, node ast.Node) (ast.NodeEvaluation, bool) {
 
 	// Early exit for constant, because it should have no children.
 	if node.Function == ast.FUNC_CONSTANT {
 		return ast.NodeEvaluation{
 			ReturnValue: node.Constant,
-		}
+		}, true
 	}
 
 	childEvaluationFail := false
 
 	evalChild := func(child ast.Node) ast.NodeEvaluation {
-		childEval := EvaluateAst(environment, child)
-		if childEval.EvaluationError != nil || childEval.ReturnValue == nil {
+		childEval, ok := EvaluateAst(environment, child)
+		if !ok {
 			childEvaluationFail = true
 		}
 
@@ -33,7 +33,7 @@ func EvaluateAst(environment AstEvaluationEnvironment, node ast.Node) ast.NodeEv
 
 	if childEvaluationFail {
 		// an error occured in at least one of the children. Stop the evaluation.
-		return evaluation
+		return evaluation, false
 	}
 
 	getReturnValue := func(e ast.NodeEvaluation) any { return e.ReturnValue }
@@ -45,9 +45,10 @@ func EvaluateAst(environment AstEvaluationEnvironment, node ast.Node) ast.NodeEv
 	evaluator, err := environment.GetEvaluator(node.Function)
 	if err != nil {
 		evaluation.EvaluationError = err
-		return evaluation
+		return evaluation, false
 	}
 
 	evaluation.ReturnValue, evaluation.EvaluationError = evaluator.Evaluate(arguments)
-	return evaluation
+	ok := evaluation.EvaluationError == nil
+	return evaluation, ok
 }

--- a/usecases/ast_eval/evaluate_ast_test.go
+++ b/usecases/ast_eval/evaluate_ast_test.go
@@ -10,7 +10,8 @@ import (
 func TestEval(t *testing.T) {
 	environment := NewAstEvaluationEnvironment()
 	root := ast.NewAstCompareBalance()
-	evaluation := EvaluateAst(environment, root)
+	evaluation, ok := EvaluateAst(environment, root)
+	assert.True(t, ok)
 	assert.NoError(t, evaluation.EvaluationError)
 	assert.Equal(t, true, evaluation.ReturnValue)
 }
@@ -18,19 +19,23 @@ func TestEval(t *testing.T) {
 func TestEvalAndOrFunction(t *testing.T) {
 	environment := NewAstEvaluationEnvironment()
 
-	evaluation := EvaluateAst(environment, NewAstAndTrue())
+	evaluation, ok := EvaluateAst(environment, NewAstAndTrue())
+	assert.True(t, ok)
 	assert.NoError(t, evaluation.EvaluationError)
 	assert.Equal(t, true, evaluation.ReturnValue)
 
-	evaluation = EvaluateAst(environment, NewAstAndFalse())
+	evaluation, ok = EvaluateAst(environment, NewAstAndFalse())
+	assert.True(t, ok)
 	assert.NoError(t, evaluation.EvaluationError)
 	assert.Equal(t, false, evaluation.ReturnValue)
 
-	evaluation = EvaluateAst(environment, NewAstOrTrue())
+	evaluation, ok = EvaluateAst(environment, NewAstOrTrue())
+	assert.True(t, ok)
 	assert.NoError(t, evaluation.EvaluationError)
 	assert.Equal(t, true, evaluation.ReturnValue)
 
-	evaluation = EvaluateAst(environment, NewAstOrFalse())
+	evaluation, ok = EvaluateAst(environment, NewAstOrFalse())
+	assert.True(t, ok)
 	assert.NoError(t, evaluation.EvaluationError)
 	assert.Equal(t, false, evaluation.ReturnValue)
 

--- a/usecases/ast_eval/evaluate_rule_ast_expression.go
+++ b/usecases/ast_eval/evaluate_rule_ast_expression.go
@@ -20,14 +20,12 @@ func (evaluator *EvaluateRuleAstExpression) EvaluateRuleAstExpression(ruleAstExp
 		DatabaseAccessReturnFakeValue: false,
 	})
 
-	evaluation := EvaluateAst(environment, ruleAstExpression)
+	evaluation, ok := EvaluateAst(environment, ruleAstExpression)
 
-	result := evaluation.ReturnValue
-
-	allErrors := errors.Join(evaluation.AllErrors()...)
-	if allErrors != nil {
-		return false, allErrors
+	if !ok {
+		return false, errors.Join(evaluation.AllErrors()...)
 	}
+	result := evaluation.ReturnValue
 
 	if value, ok := result.(bool); ok {
 		return value, nil

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -60,7 +60,7 @@ func (validator *ValidateScenarioIterationImpl) Validate(si ScenarioAndIteration
 	if trigger == nil {
 		addError(fmt.Errorf("scenario iteration has no trigger condition ast expression %w", models.BadParameterError))
 	} else {
-		result.TriggerEvaluation = ast_eval.EvaluateAst(dryRunEnvironment, *trigger)
+		result.TriggerEvaluation, _ = ast_eval.EvaluateAst(dryRunEnvironment, *trigger)
 	}
 
 	// validate each rule
@@ -71,7 +71,7 @@ func (validator *ValidateScenarioIterationImpl) Validate(si ScenarioAndIteration
 		if formula == nil {
 			addError(fmt.Errorf("scenario iteration rule has no formula ast expression %w", models.BadParameterError))
 		} else {
-			result.RulesEvaluations[ruleIndex] = ast_eval.EvaluateAst(dryRunEnvironment, *formula)
+			result.RulesEvaluations[ruleIndex], _ = ast_eval.EvaluateAst(dryRunEnvironment, *formula)
 		}
 	}
 


### PR DESCRIPTION
`EvaluateAst` return a boolean that indicate if an error occurred during the execution.

The error can be found in `ast.NodeEvaluation`, but returning this boolean allows `EvaluateAst` to stop using `nil` as a magic value to detect errors. 

So `nil` is now a supported value that can be returned by operators.

