### PR TITLE
chore(launch): remove old confusing script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,15 +14,6 @@
       "args": ["--server", "--migrations"]
     },
     {
-      "name": "Launch Package (.env)",
-      "type": "go",
-      "request": "launch",
-      "mode": "auto",
-      "program": "${workspaceFolder}",
-      "envFile": ["${workspaceFolder}/.env.local", "${workspaceFolder}/.env"],
-      "args": ["--server"]
-    },
-    {
       "name": "Launch scheduled jobs (.env.local)",
       "type": "go",
       "request": "launch",


### PR DESCRIPTION
As far as I remember, I'm the only one using the deleted script (that I no longer use).