### PR TITLE
Add "Unknown" ast function

### DIFF
--- a/api/handle_ast_expression.go
+++ b/api/handle_ast_expression.go
@@ -12,7 +12,7 @@ func (api *API) handleAvailableFunctions() http.HandlerFunc {
 		functions := make(map[string]dto.FuncAttributesDto)
 
 		for f, attributes := range ast.FuncAttributesMap {
-			if f == ast.FUNC_CONSTANT {
+			if f == ast.FUNC_CONSTANT || f == ast.FUNC_UNKNOWN {
 				continue
 			}
 			functions[attributes.AstName] = dto.AdaptFuncAttributesDto(attributes)

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -54,6 +54,10 @@ type FuncAttributes struct {
 
 // If number of arguments -1 the function can take any number of arguments
 var FuncAttributesMap = map[Function]FuncAttributes{
+	FUNC_UNKNOWN: {
+		DebugName: "UNKNOWN",
+		AstName:   "Unknown",
+	},
 	FUNC_CONSTANT: {
 		DebugName: "CONSTANT",
 		AstName:   "",

--- a/models/ast/ast_function_test.go
+++ b/models/ast/ast_function_test.go
@@ -1,0 +1,15 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFunction(t *testing.T) {
+	// The stability of int values of function are not critical, they are never serialized,
+	// but it is nice to have them in order
+	assert.Equal(t, int(FUNC_UNKNOWN), -1)
+	assert.Equal(t, int(FUNC_CONSTANT), 0)
+	assert.Equal(t, int(FUNC_ADD), 1)
+}

--- a/usecases/ast_eval/evaluate/evaluate_unknown.go
+++ b/usecases/ast_eval/evaluate/evaluate_unknown.go
@@ -1,0 +1,14 @@
+package evaluate
+
+import (
+	"fmt"
+	"marble/marble-backend/models"
+	"marble/marble-backend/models/ast"
+)
+
+type Unknown struct {
+}
+
+func (f Unknown) Evaluate(arguments ast.Arguments) (any, error) {
+	return nil, fmt.Errorf("function Unknown %w", models.ErrRuntimeExpression)
+}

--- a/usecases/ast_eval/evaluate/evaluate_unknown_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_unknown_test.go
@@ -1,0 +1,13 @@
+package evaluate
+
+import (
+	"marble/marble-backend/models/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnknown(t *testing.T) {
+	_, err := Unknown{}.Evaluate(ast.Arguments{})
+	assert.Error(t, err)
+}

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -30,6 +30,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	}
 
 	// add pure functions that to not rely on any context
+	environment.AddEvaluator(ast.FUNC_UNKNOWN, evaluate.Unknown{})
 	environment.AddEvaluator(ast.FUNC_ADD, evaluate.NewArithmetic(ast.FUNC_ADD))
 	environment.AddEvaluator(ast.FUNC_SUBTRACT, evaluate.NewArithmetic(ast.FUNC_SUBTRACT))
 	environment.AddEvaluator(ast.FUNC_MULTIPLY, evaluate.NewArithmetic(ast.FUNC_MULTIPLY))


### PR DESCRIPTION
Add `Unknown` ast function that stops the execution.

So:
- the builder can save AST with `Unknown` function
- the validation fail when an AST contain an `Unknown` function
- during dry run/validation, the children are evaluated
