### PR TITLE
fix blank bug + add parse time node

### DIFF
--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -31,6 +31,7 @@ const (
 	FUNC_OR
 	FUNC_ADD_TIME
 	FUNC_TIME_NOW
+	FUNC_PARSE_TIME
 	FUNC_PAYLOAD
 	FUNC_DB_ACCESS
 	FUNC_CUSTOM_LIST_ACCESS
@@ -121,6 +122,11 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 		DebugName:         "FUNC_TIME_NOW",
 		AstName:           "TimeNow",
 		NumberOfArguments: 0,
+	},
+	FUNC_PARSE_TIME: {
+		DebugName:         "FUNC_PARSE_TIME",
+		AstName:           "ParseTime",
+		NumberOfArguments: 1,
 	},
 	FUNC_PAYLOAD: {
 		DebugName:         "FUNC_PAYLOAD",

--- a/usecases/ast_eval/evaluate/evaluate_blank_variables.go
+++ b/usecases/ast_eval/evaluate/evaluate_blank_variables.go
@@ -89,12 +89,19 @@ func (blank BlankDatabaseAccess) getFirstTransactionDate(arguments ast.Arguments
 		return time.Now(), nil
 	}
 
-	return org_transaction.InOrganizationSchema(
+	firstTransaction, err := org_transaction.InOrganizationSchema(
 		blank.OrgTransactionFactory,
 		blank.OrganizationIdOfContext,
-		func(tx repositories.Transaction) (time.Time, error) {
+		func(tx repositories.Transaction) (*time.Time, error) {
 			return blank.BlankDataReadRepository.GetFirstTransactionTimestamp(tx, ownerBusinessId)
 		})
+	if err != nil {
+		return time.Time{}, fmt.Errorf("BlankDatabaseAccess (FUNC_BLANK_FIRST_TRANSACTION_DATE): error reading first transaction from DB: %w", err)
+	}
+	if firstTransaction == nil {
+		return time.Time{}, fmt.Errorf("first transaction date is null for owner_business_id %s: %w", ownerBusinessId, models.NullFieldReadError)
+	}
+	return *firstTransaction, nil
 }
 
 func (blank BlankDatabaseAccess) sumTransactionsAmount(arguments ast.Arguments) (float64, error) {

--- a/usecases/ast_eval/evaluate/evaluate_time.go
+++ b/usecases/ast_eval/evaluate/evaluate_time.go
@@ -25,6 +25,20 @@ func (f TimeFunctions) Evaluate(arguments ast.Arguments) (any, error) {
 		}
 
 		return time.Now(), nil
+	case ast.FUNC_PARSE_TIME:
+		if err := verifyNumberOfArguments(f.Function, arguments.Args, 1); err != nil {
+			return nil, err
+		}
+
+		timeString, err := adaptArgumentToString(f.Function, arguments.Args[0])
+		if err != nil {
+			return nil, fmt.Errorf("TimeFunctions (FUNC_PARSE_TIME): error reading time from payload: %w", err)
+		}
+		t, err := time.Parse(time.RFC3339, timeString)
+		if err != nil {
+			return nil, fmt.Errorf("TimeFunctions (FUNC_PARSE_TIME): error parsing time: %w", err)
+		}
+		return t, nil
 	default:
 		return nil, fmt.Errorf(
 			"function %s not implemented: %w", f.Function.DebugString(), models.ErrRuntimeExpression,

--- a/usecases/ast_eval/evaluate/evaluate_time_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_time_test.go
@@ -13,3 +13,12 @@ func TestTimeNow(t *testing.T) {
 	assert.NoError(t, err)
 	assert.WithinDuration(t, time.Now(), result.(time.Time), 1*time.Millisecond)
 }
+
+func TestParseTime(t *testing.T) {
+	result, err := TimeFunctions{ast.FUNC_PARSE_TIME}.Evaluate(ast.Arguments{Args: []any{"2021-07-07T00:00:00Z"}})
+	assert.NoError(t, err)
+	assert.Equal(t, time.Date(2021, 7, 7, 0, 0, 0, 0, time.UTC), result.(time.Time))
+
+	_, err = TimeFunctions{ast.FUNC_PARSE_TIME}.Evaluate(ast.Arguments{Args: []any{"2021-07-07 00:00:00Z"}})
+	assert.Error(t, err)
+}

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -45,5 +45,6 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_IS_NOT_IN_LIST, evaluate.NewStringInList(ast.FUNC_IS_NOT_IN_LIST))
 	environment.AddEvaluator(ast.FUNC_ADD_TIME, evaluate.NewTimeArithmetic(ast.FUNC_ADD_TIME))
 	environment.AddEvaluator(ast.FUNC_TIME_NOW, evaluate.NewTimeFunctions(ast.FUNC_TIME_NOW))
+	environment.AddEvaluator(ast.FUNC_PARSE_TIME, evaluate.NewTimeFunctions(ast.FUNC_PARSE_TIME))
 	return environment
 }


### PR DESCRIPTION
- Fix a bug of which I don't understand why I didn't catch it by running locally earlier
- Introduce a "parse time" node so that I can run the blank scenario at a past date in prod