### PR TITLE
feat: eval never use integer division

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_arithmetic.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic.go
@@ -41,11 +41,6 @@ func (f Arithmetic) Evaluate(arguments ast.Arguments) (any, error) {
 
 func arithmeticEval[T int64 | float64](function ast.Function, l, r T) (T, error) {
 
-	var zero T
-	if function == ast.FUNC_DIVIDE && r == zero {
-		return zero, models.DivisionByZeroError
-	}
-
 	switch function {
 	case ast.FUNC_ADD:
 		return l + r, nil
@@ -53,8 +48,6 @@ func arithmeticEval[T int64 | float64](function ast.Function, l, r T) (T, error)
 		return l - r, nil
 	case ast.FUNC_MULTIPLY:
 		return l * r, nil
-	case ast.FUNC_DIVIDE:
-		return l / r, nil
 	default:
 		return 0, fmt.Errorf("Arithmetic does not support %s function", function.DebugString())
 	}

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic_divide.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic_divide.go
@@ -1,0 +1,34 @@
+package evaluate
+
+import (
+	"fmt"
+	"marble/marble-backend/models"
+	"marble/marble-backend/models/ast"
+)
+
+type ArithmeticDivide struct {
+}
+
+func (f ArithmeticDivide) Evaluate(arguments ast.Arguments) (any, error) {
+
+	leftAny, rightAny, err := leftAndRight(ast.FUNC_DIVIDE, arguments.Args)
+	if err != nil {
+		return nil, err
+	}
+
+	// try to promote to float64
+	if left, right, err := adaptLeftAndRight(ast.FUNC_DIVIDE, leftAny, rightAny, promoteArgumentToFloat64); err == nil {
+
+		if right == 0.0 {
+			return 0.0, models.DivisionByZeroError
+		}
+
+		return left / right, nil
+
+	}
+
+	return nil, fmt.Errorf(
+		"all argments of function %s must be float64 %w",
+		ast.FUNC_DIVIDE.DebugString(), models.ErrRuntimeExpression,
+	)
+}

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic_divide_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic_divide_test.go
@@ -1,0 +1,31 @@
+package evaluate
+
+import (
+	"marble/marble-backend/models"
+	"marble/marble-backend/models/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const TEN_DIVIDE_BY_THREE = float64(3.3333333333333335)
+
+func TestNewArithmetic_divide_float64(t *testing.T) {
+
+	r, err := ArithmeticDivide{}.Evaluate(ast.Arguments{Args: []any{10.0, 3}})
+	assert.NoError(t, err)
+	assert.Equal(t, r, TEN_DIVIDE_BY_THREE)
+}
+
+func TestNewArithmetic_divide_int(t *testing.T) {
+
+	// check that no integer division is performed
+	r, err := ArithmeticDivide{}.Evaluate(ast.Arguments{Args: []any{10, 3}})
+	assert.NoError(t, err)
+	assert.Equal(t, r, TEN_DIVIDE_BY_THREE)
+}
+
+func TestNewArithmeticFunction_float_divide_by_zero(t *testing.T) {
+	_, err := ArithmeticDivide{}.Evaluate(ast.Arguments{Args: []any{1.0, 0.0}})
+	assert.ErrorIs(t, err, models.DivisionByZeroError)
+}

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic_test.go
@@ -1,7 +1,6 @@
 package evaluate
 
 import (
-	"marble/marble-backend/models"
 	"marble/marble-backend/models/ast"
 	"testing"
 
@@ -20,16 +19,4 @@ func TestNewArithmetic_basic(t *testing.T) {
 
 	helperTestArithmetic(t, ast.FUNC_SUBTRACT, []any{11, 2}, int64(9))
 	helperTestArithmetic(t, ast.FUNC_MULTIPLY, []any{4, 3}, int64(12))
-	helperTestArithmetic(t, ast.FUNC_DIVIDE, []any{10, 3}, int64(3))
-	helperTestArithmetic(t, ast.FUNC_DIVIDE, []any{10.0, 3}, float64(3.3333333333333335))
-}
-
-func TestNewArithmeticFunction_int_divide_by_zero(t *testing.T) {
-	_, err := NewArithmetic(ast.FUNC_DIVIDE).Evaluate(ast.Arguments{Args: []any{1, 0}})
-	assert.ErrorIs(t, err, models.DivisionByZeroError)
-}
-
-func TestNewArithmeticFunction_float_divide_by_zero(t *testing.T) {
-	_, err := NewArithmetic(ast.FUNC_DIVIDE).Evaluate(ast.Arguments{Args: []any{1.0, 0.0}})
-	assert.ErrorIs(t, err, models.DivisionByZeroError)
 }

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -34,7 +34,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_ADD, evaluate.NewArithmetic(ast.FUNC_ADD))
 	environment.AddEvaluator(ast.FUNC_SUBTRACT, evaluate.NewArithmetic(ast.FUNC_SUBTRACT))
 	environment.AddEvaluator(ast.FUNC_MULTIPLY, evaluate.NewArithmetic(ast.FUNC_MULTIPLY))
-	environment.AddEvaluator(ast.FUNC_DIVIDE, evaluate.NewArithmetic(ast.FUNC_DIVIDE))
+	environment.AddEvaluator(ast.FUNC_DIVIDE, evaluate.ArithmeticDivide{})
 	environment.AddEvaluator(ast.FUNC_GREATER, evaluate.NewComparison(ast.FUNC_GREATER))
 	environment.AddEvaluator(ast.FUNC_LESS, evaluate.NewComparison(ast.FUNC_LESS))
 	environment.AddEvaluator(ast.FUNC_EQUAL, evaluate.Equal{})


### PR DESCRIPTION
eval never use integer division .

`FUNC_DIVIDE` always promote it's operands to `float64`.