### PR TITLE
feat: permit read own organization

### DIFF
--- a/usecases/organization_usecase.go
+++ b/usecases/organization_usecase.go
@@ -42,7 +42,7 @@ func (usecase *OrganizationUseCase) CreateOrganization(ctx context.Context, crea
 }
 
 func (usecase *OrganizationUseCase) GetOrganization(ctx context.Context, organizationId string) (models.Organization, error) {
-	if err := usecase.enforceSecurity.ListOrganization(); err != nil {
+	if err := usecase.enforceSecurity.ReadOrganization(organizationId); err != nil {
 		return models.Organization{}, err
 	}
 	return usecase.organizationRepository.GetOrganizationById(nil, organizationId)


### PR DESCRIPTION
[Relate to "Display warning if no s3 bucket"](https://github.com/checkmarble/marble-frontend/pull/138)

I use the existing `ReadOrganization` function but didn't add a permission. 
Because we have very few info at the organization level, it seems overkill to add it, and it would most likely have been set on Viewer level. That 100% open to discussion