### PR TITLE
add index on decision_id on decision_rules

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ggicci/httpin"
 )
 
+const defaultDecisionslimit = 10000
+
 func (api *API) handleGetDecision() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
@@ -42,7 +44,7 @@ func (api *API) handleListDecisions() http.HandlerFunc {
 		logger = logger.With(slog.String("organizationId", organizationId))
 
 		usecase := api.UsecasesWithCreds(r).NewDecisionUsecase()
-		decisions, err := usecase.ListDecisionsOfOrganization(organizationId)
+		decisions, err := usecase.ListDecisionsOfOrganization(organizationId, defaultDecisionslimit)
 		if presentError(w, r, err) {
 			return
 		}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,6 @@
 version: "3.8"
 
 services:
-  # marble-backend:
-  #   container_name: marble-backend
-  #   build: .
-  #   env_file: .env.docker-compose
-  #   ports:
-  #     - "8080:8080"
-  #   command:
-  #     - "-migrations"
-  #     - "-server"
-  #   depends_on:
-  #     db:
-  #       condition: service_healthy
-
   db:
     container_name: postgres
     image: postgres

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -21,6 +21,9 @@ type DecisionRepositoryImpl struct {
 	transactionFactory TransactionFactoryPosgresql
 }
 
+// the size of the batch is chosen without any benchmark
+const decisionRulesBatchSize = 1000
+
 func (repo *DecisionRepositoryImpl) DecisionById(transaction Transaction, decisionId string) (models.Decision, error) {
 	tx := repo.transactionFactory.adaptMarbleDatabaseTransaction(transaction)
 
@@ -214,8 +217,7 @@ func (repo *DecisionRepositoryImpl) channelOfDecisions(tx TransactionPostgres, q
 		// 	decisionsChannel <- dbmodels.AdaptDecision(dbDecision, rules)
 		// }
 
-		// the size of the batch is choose randomly.
-		for dbDecisions := range BatchChannel(dbDecisionsChannel, 1000) {
+		for dbDecisions := range BatchChannel(dbDecisionsChannel, decisionRulesBatchSize) {
 
 			// fetch rules of all decisions
 			rules, err := repo.rulesOfDecisionsBatch(

--- a/repositories/migrations/20230921150013_add_index_on_decision_rules.sql
+++ b/repositories/migrations/20230921150013_add_index_on_decision_rules.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX decision_rules_decisionId_idx ON decision_rules(decision_id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX decision_rules_decisionId_idx;
+-- +goose StatementEnd

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -39,12 +39,12 @@ func (usecase *DecisionUsecase) GetDecision(decisionId string) (models.Decision,
 	return decision, nil
 }
 
-func (usecase *DecisionUsecase) ListDecisionsOfOrganization(organizationId string) ([]models.Decision, error) {
+func (usecase *DecisionUsecase) ListDecisionsOfOrganization(organizationId string, limit int) ([]models.Decision, error) {
 	return transaction.TransactionReturnValue(
 		usecase.transactionFactory,
 		models.DATABASE_MARBLE_SCHEMA,
 		func(tx repositories.Transaction) ([]models.Decision, error) {
-			decisions, err := usecase.decisionRepository.DecisionsOfOrganization(tx, organizationId, 1000)
+			decisions, err := usecase.decisionRepository.DecisionsOfOrganization(tx, organizationId, limit)
 			if err != nil {
 				return []models.Decision{}, err
 			}


### PR DESCRIPTION
"Oopsies" between august 22 and sept 11, the demo scenario I created for Blank was running every 10 minutes in batch mode, which resulted in massive decisions created (15 millions & 5* as many rules, in prod environment).
Nb: turns out 75M decisions = 20Gb, it goes quickly with the amount of data we put inside the decision+rules json.

I cleaned up those decisions which where useless, but let's create this index for good measure (since it's a normal expected usecase to have large numbers of decisions).

This was discovered because the decisions page on the front for this organization became not responsive => we should add some monitoring on the DB

<img width="781" alt="Capture d’écran 2023-09-21 à 15 43 33" src="https://github.com/checkmarble/marble-backend/assets/128643171/571f5dfb-8e61-4b5a-8c23-91652373d99b">

<img width="1224" alt="Capture d’écran 2023-09-21 à 16 05 15" src="https://github.com/checkmarble/marble-backend/assets/128643171/e4be162c-4f8a-4a01-989e-02de04e6fd52">
