### PR TITLE
test: ScenarioUsecase

### DIFF
--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -1,11 +1,12 @@
 package api
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
-	"net/http"
-	"time"
 
 	"github.com/ggicci/httpin"
 )
@@ -47,16 +48,10 @@ func (api *API) ListScenarios() http.HandlerFunc {
 
 func (api *API) CreateScenario() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		organizationId, err := utils.OrgIDFromCtx(ctx, r)
-		if presentError(w, r, err) {
-			return
-		}
-
-		input := ctx.Value(httpin.Input).(*dto.CreateScenarioInput)
+		input := r.Context().Value(httpin.Input).(*dto.CreateScenarioInput)
 
 		usecase := api.UsecasesWithCreds(r).NewScenarioUsecase()
-		scenario, err := usecase.CreateScenario(dto.AdaptCreateScenario(input, organizationId))
+		scenario, err := usecase.CreateScenario(dto.AdaptCreateScenario(input))
 		if presentError(w, r, err) {
 			return
 		}

--- a/dto/scenarios.go
+++ b/dto/scenarios.go
@@ -77,9 +77,8 @@ type ListScenarioPublicationsInput struct {
 	ScenarioIterationId *string `in:"query=scenarioIterationID"`
 }
 
-func AdaptCreateScenario(input *CreateScenarioInput, organizationId string) models.CreateScenarioInput {
+func AdaptCreateScenario(input *CreateScenarioInput) models.CreateScenarioInput {
 	return models.CreateScenarioInput{
-		OrganizationId:    organizationId,
 		Name:              input.Body.Name,
 		Description:       input.Body.Description,
 		TriggerObjectType: input.Body.TriggerObjectType,

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -205,7 +204,6 @@ func setupScenarioAndPublish(t *testing.T, usecasesWithCreds usecases.UsecasesWi
 	// Create a new empty scenario
 	scenarioUsecase := usecasesWithCreds.NewScenarioUsecase()
 	scenario, err := scenarioUsecase.CreateScenario(models.CreateScenarioInput{
-		OrganizationId:    organizationId,
 		Name:              "Test scenario",
 		Description:       "Test scenario description",
 		TriggerObjectType: "transactions",
@@ -214,14 +212,7 @@ func setupScenarioAndPublish(t *testing.T, usecasesWithCreds usecases.UsecasesWi
 	scenarioId := scenario.Id
 	fmt.Println("Created scenario", scenarioId)
 
-	// Security: check that creating a scenario on the wrong organization fails
-	_, err = scenarioUsecase.CreateScenario(models.CreateScenarioInput{
-		OrganizationId:    uuid.New().String(),
-		Name:              "Test scenario",
-		Description:       "Test scenario description",
-		TriggerObjectType: "transactions",
-	})
-	assert.Error(t, err, "Expected error creating scenario on wrong organization, got nil")
+	assert.Equal(t, scenario.OrganizationId, organizationId)
 
 	// Now, create a scenario iteration, with a rule
 	scenarioIterationUsecase := usecasesWithCreds.NewScenarioIterationUsecase()

--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -38,3 +38,43 @@ func (e *EnforceSecurity) CreateScheduledExecution(organizationId string) error 
 	args := e.Called(organizationId)
 	return args.Error(0)
 }
+
+func (e *EnforceSecurity) ReadScenario(scenario models.Scenario) error {
+	args := e.Called(scenario)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) ReadScenarioIteration(scenarioIteration models.ScenarioIteration) error {
+	args := e.Called(scenarioIteration)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) ReadScenarioPublication(scenarioPublication models.ScenarioPublication) error {
+	args := e.Called(scenarioPublication)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) PublishScenario(scenario models.Scenario) error {
+	args := e.Called(scenario)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) UpdateScenario(scenario models.Scenario) error {
+	args := e.Called(scenario)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) ListScenarios(organizationId string) error {
+	args := e.Called(organizationId)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) CreateScenario(organizationId string) error {
+	args := e.Called(organizationId)
+	return args.Error(0)
+}
+
+func (e *EnforceSecurity) CreateRule(scenarioIteration models.ScenarioIteration) error {
+	args := e.Called(scenarioIteration)
+	return args.Error(0)
+}

--- a/mocks/scenario_write_repository.go
+++ b/mocks/scenario_write_repository.go
@@ -11,8 +11,8 @@ type ScenarioWriteRepository struct {
 	mock.Mock
 }
 
-func (s *ScenarioWriteRepository) CreateScenario(tx repositories.Transaction, scenario models.CreateScenarioInput, newScenarioId string) error {
-	args := s.Called(tx, scenario, newScenarioId)
+func (s *ScenarioWriteRepository) CreateScenario(tx repositories.Transaction, organizationId string, scenario models.CreateScenarioInput, newScenarioId string) error {
+	args := s.Called(tx, organizationId, scenario, newScenarioId)
 	return args.Error(0)
 }
 

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -13,7 +13,6 @@ type Scenario struct {
 }
 
 type CreateScenarioInput struct {
-	OrganizationId    string
 	Name              string
 	Description       string
 	TriggerObjectType string

--- a/repositories/scenarios_write.go
+++ b/repositories/scenarios_write.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ScenarioWriteRepository interface {
-	CreateScenario(tx Transaction, scenario models.CreateScenarioInput, newScenarioId string) error
+	CreateScenario(tx Transaction, organizationId string, scenario models.CreateScenarioInput, newScenarioId string) error
 	UpdateScenario(tx Transaction, scenario models.UpdateScenarioInput) error
 	UpdateScenarioLiveIterationId(tx Transaction, scenarioId string, scenarioIterationId *string) error
 }
@@ -21,7 +21,7 @@ func NewScenarioWriteRepositoryPostgresql(transactionFactory TransactionFactoryP
 	}
 }
 
-func (repo *ScenarioWriteRepositoryPostgresql) CreateScenario(tx Transaction, scenario models.CreateScenarioInput, newScenarioId string) error {
+func (repo *ScenarioWriteRepositoryPostgresql) CreateScenario(tx Transaction, organizationId string, scenario models.CreateScenarioInput, newScenarioId string) error {
 	pgTx := repo.transactionFactory.adaptMarbleDatabaseTransaction(tx)
 
 	_, err := pgTx.ExecBuilder(
@@ -35,7 +35,7 @@ func (repo *ScenarioWriteRepositoryPostgresql) CreateScenario(tx Transaction, sc
 			).
 			Values(
 				newScenarioId,
-				scenario.OrganizationId,
+				organizationId,
 				scenario.Name,
 				scenario.Description,
 				scenario.TriggerObjectType,

--- a/usecases/scenario_usecase_test.go
+++ b/usecases/scenario_usecase_test.go
@@ -1,0 +1,193 @@
+package usecases
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/mocks"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ScenarioUsecaseTestSuite struct {
+	suite.Suite
+	transaction             *mocks.Transaction
+	transactionFactory      *mocks.TransactionFactory
+	enforceSecurity         *mocks.EnforceSecurity
+	scenarioReadRepository  *mocks.ScenarioReadRepository
+	scenarioWriteRepository *mocks.ScenarioWriteRepository
+
+	organizationId string
+	scenarioId     string
+	scenario       models.Scenario
+	securityError  error
+}
+
+func (suite *ScenarioUsecaseTestSuite) SetupTest() {
+	suite.transaction = new(mocks.Transaction)
+	suite.enforceSecurity = new(mocks.EnforceSecurity)
+	suite.transactionFactory = &mocks.TransactionFactory{TxMock: suite.transaction}
+	suite.scenarioReadRepository = new(mocks.ScenarioReadRepository)
+	suite.scenarioWriteRepository = new(mocks.ScenarioWriteRepository)
+	suite.securityError = errors.New("some security error")
+
+	suite.organizationId = "25ab6323-1657-4a52-923a-ef6983fe4532"
+	suite.scenarioId = "c5968ff7-6142-4623-a6b3-1539f345e5fa"
+	suite.scenario = models.Scenario{
+		Id:             suite.scenarioId,
+		OrganizationId: suite.organizationId,
+	}
+
+}
+
+func (suite *ScenarioUsecaseTestSuite) makeUsecase() *ScenarioUsecase {
+	return &ScenarioUsecase{
+		transactionFactory: suite.transactionFactory,
+		organizationIdOfContext: func() (string, error) {
+			return suite.organizationId, nil
+		},
+		enforceSecurity:         suite.enforceSecurity,
+		scenarioReadRepository:  suite.scenarioReadRepository,
+		scenarioWriteRepository: suite.scenarioWriteRepository,
+	}
+}
+
+func (suite *ScenarioUsecaseTestSuite) AssertExpectations() {
+	t := suite.T()
+	suite.transaction.AssertExpectations(t)
+	suite.enforceSecurity.AssertExpectations(t)
+	suite.transactionFactory.AssertExpectations(t)
+	suite.scenarioReadRepository.AssertExpectations(t)
+	suite.scenarioWriteRepository.AssertExpectations(t)
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestListScenarios() {
+
+	var expected = []models.Scenario{suite.scenario}
+	suite.scenarioReadRepository.On("ListScenariosOfOrganization", nil, suite.organizationId).Return(expected, nil)
+	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(nil)
+
+	result, err := suite.makeUsecase().ListScenarios()
+
+	t := suite.T()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestListScenarios_security() {
+
+	suite.scenarioReadRepository.On("ListScenariosOfOrganization", nil, suite.organizationId).Return([]models.Scenario{suite.scenario}, nil)
+	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(suite.securityError)
+
+	_, err := suite.makeUsecase().ListScenarios()
+
+	assert.ErrorIs(suite.T(), err, suite.securityError)
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestGetScenario() {
+
+	suite.scenarioReadRepository.On("GetScenarioById", nil, suite.scenarioId).Return(suite.scenario, nil)
+	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(nil)
+
+	result, err := suite.makeUsecase().GetScenario(suite.scenarioId)
+
+	t := suite.T()
+	assert.NoError(t, err)
+	assert.Equal(t, suite.scenario, result)
+
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestGetScenario_security() {
+
+	suite.scenarioReadRepository.On("GetScenarioById", nil, suite.scenarioId).Return(suite.scenario, nil)
+	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(suite.securityError)
+
+	_, err := suite.makeUsecase().GetScenario(suite.scenarioId)
+
+	assert.ErrorIs(suite.T(), err, suite.securityError)
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestUpdateScenario() {
+
+	scenarioInput := models.UpdateScenarioInput{
+		Id: suite.scenarioId,
+	}
+
+	updatedScenario := models.Scenario{
+		Id:   suite.scenarioId,
+		Name: "updated scenario",
+	}
+
+	suite.transactionFactory.On("Transaction", models.DATABASE_MARBLE_SCHEMA, mock.Anything).Return(nil)
+	suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(suite.scenario, nil).Once()
+	suite.enforceSecurity.On("UpdateScenario", suite.scenario).Return(nil)
+
+	suite.scenarioWriteRepository.On("UpdateScenario", suite.transaction, scenarioInput).Return(nil)
+	suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(updatedScenario, nil).Once()
+
+	result, err := suite.makeUsecase().UpdateScenario(scenarioInput)
+
+	t := suite.T()
+	assert.NoError(t, err)
+	assert.Equal(t, updatedScenario, result)
+
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestUpdateScenario_security() {
+
+	scenarioInput := models.UpdateScenarioInput{
+		Id: suite.scenarioId,
+	}
+
+	suite.transactionFactory.On("Transaction", models.DATABASE_MARBLE_SCHEMA, mock.Anything).Return(nil)
+	suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(suite.scenario, nil).Once()
+	suite.enforceSecurity.On("UpdateScenario", suite.scenario).Return(suite.securityError)
+
+	_, err := suite.makeUsecase().UpdateScenario(scenarioInput)
+
+	assert.ErrorIs(suite.T(), err, suite.securityError)
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestCreateScenario() {
+
+	createScenarioInput := models.CreateScenarioInput{
+		Name: "new scenario",
+	}
+
+	suite.enforceSecurity.On("CreateScenario", suite.organizationId).Return(nil)
+
+	suite.transactionFactory.On("Transaction", models.DATABASE_MARBLE_SCHEMA, mock.Anything).Return(nil)
+	suite.scenarioWriteRepository.On("CreateScenario", suite.transaction, suite.organizationId, createScenarioInput, mock.Anything).Return(nil)
+	suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, mock.Anything).Return(suite.scenario, nil).Once()
+
+	result, err := suite.makeUsecase().CreateScenario(createScenarioInput)
+
+	t := suite.T()
+	assert.NoError(t, err)
+	assert.Equal(t, suite.scenario, result)
+
+	suite.AssertExpectations()
+}
+
+func (suite *ScenarioUsecaseTestSuite) TestCreateScenario_security() {
+
+	suite.enforceSecurity.On("CreateScenario", suite.organizationId).Return(suite.securityError)
+
+	_, err := suite.makeUsecase().CreateScenario(models.CreateScenarioInput{})
+	assert.ErrorIs(suite.T(), err, suite.securityError)
+
+	suite.AssertExpectations()
+}
+
+func TestScenarioUsecase(t *testing.T) {
+	suite.Run(t, new(ScenarioUsecaseTestSuite))
+}


### PR DESCRIPTION
## Unit testing of `ScenarioUsecase`.

Two tests by function:
- one for the normal/nominal run
- one for security

## minor refactoring
- `CreateScenario` stop using `OrgIDFromCtx`, the scenario is created in the injected organization (`organizationIdOfContext`).
- `CreateScenario` returns early in case of security error 

## Note on the usage of the testify function `.Once()`

The tested function `ScenarioUsecase.UpdateScenario` calls `GetScenarioById` twice and expect different results (before and after the update).

That's why there is two `scenarioReadRepository.On`.

In this situation, the mock (`scenarioReadRepository`) must be configured with one `Once()`

```
suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(suite.scenario, nil).Once()
suite.scenarioReadRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(updatedScenario, nil).Once()
```


