### PR TITLE
feat: fake GCS repo for local env

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -23,3 +23,4 @@ MARBLE_ADMIN_EMAIL=admin@checkmarble.com
 # AWS_SECRET_KEY=
 
 FAKE_AWS_S3=true
+FAKE_GCS=true

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ marble-backend
 .idea
 /.firebase
 __debug_bin*
+
+# Use by the Fake GcsRepository
+/tempFiles

--- a/main.go
+++ b/main.go
@@ -101,6 +101,7 @@ func main() {
 		config: models.GlobalConfiguration{
 			TokenLifetimeMinute: utils.GetIntEnv("TOKEN_LIFETIME_MINUTE", 60*2),
 			FakeAwsS3Repository: utils.GetBoolEnv("FAKE_AWS_S3", false),
+			FakeGcsRepository: utils.GetBoolEnv("FAKE_GCS", false),
 			GcsIngestionBucket:  utils.GetRequiredStringEnv("GCS_INGESTION_BUCKET"),
 		},
 	}

--- a/models/global_configuration.go
+++ b/models/global_configuration.go
@@ -3,5 +3,6 @@ package models
 type GlobalConfiguration struct {
 	TokenLifetimeMinute int
 	FakeAwsS3Repository bool
+	FakeGcsRepository bool
 	GcsIngestionBucket  string
 }

--- a/repositories/gcs_repository.go
+++ b/repositories/gcs_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"time"
 
@@ -16,7 +17,7 @@ type GcsRepository interface {
 	ListFiles(ctx context.Context, bucketName, prefix string) ([]models.GCSFile, error)
 	GetFile(ctx context.Context, bucketName, fileName string) (models.GCSFile, error)
 	MoveFile(ctx context.Context, bucketName, source, destination string) error
-	OpenStream(ctx context.Context, bucketName, fileName string) *storage.Writer
+	OpenStream(ctx context.Context, bucketName, fileName string) io.WriteCloser
 	UpdateFileMetadata(ctx context.Context, bucketName, fileName string, metadata map[string]string) error
 }
 
@@ -113,7 +114,7 @@ func (repository *GcsRepositoryImpl) MoveFile(ctx context.Context, bucketName, s
 	return nil
 }
 
-func (repository *GcsRepositoryImpl) OpenStream(ctx context.Context, bucketName, fileName string) *storage.Writer {
+func (repository *GcsRepositoryImpl) OpenStream(ctx context.Context, bucketName, fileName string) io.WriteCloser {
 	gcsClient := repository.getGCSClient(ctx)
 
 	writer := gcsClient.Bucket(bucketName).Object(fileName).NewWriter(ctx)

--- a/repositories/gcs_repository_fake.go
+++ b/repositories/gcs_repository_fake.go
@@ -1,0 +1,79 @@
+package repositories
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+type GcsRepositoryFake struct{}
+
+const tempFilesDirectory = "tempFiles"
+
+func (repo *GcsRepositoryFake) ListFiles(ctx context.Context, bucketName, prefix string) ([]models.GCSFile, error) {
+	cwd, _ := os.Getwd()
+	files, err := os.ReadDir(filepath.Join(cwd, tempFilesDirectory))
+	if err != nil {
+		return nil, err
+	}
+
+	var gcsFiles []models.GCSFile
+	for _, file := range files {
+		fileReader, err := os.Open(filepath.Join(cwd, tempFilesDirectory, file.Name()))
+		if err != nil {
+			return []models.GCSFile{}, err
+		}
+		gcsFiles = append(gcsFiles, models.GCSFile{
+			FileName:   file.Name(),
+			Reader:     fileReader,
+			BucketName: bucketName,
+		})
+	}
+
+	return gcsFiles, nil
+}
+
+func (repo *GcsRepositoryFake) GetFile(ctx context.Context, bucketName, fileName string) (models.GCSFile, error) {
+	cwd, _ := os.Getwd()
+	fileNameElements := strings.Split(fileName, "/")
+	path := filepath.Join(cwd, tempFilesDirectory, fileNameElements[len(fileNameElements)-1])
+	file, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+
+	return models.GCSFile{
+		FileName:   fileName,
+		Reader:     file,
+		BucketName: bucketName,
+	}, nil
+}
+
+func (repo *GcsRepositoryFake) MoveFile(ctx context.Context, bucketName, source, destination string) error {
+	return nil
+}
+
+func (repo *GcsRepositoryFake) OpenStream(ctx context.Context, bucketName, fileName string) io.WriteCloser {
+	cwd, _ := os.Getwd()
+	if _, err := os.Stat(tempFilesDirectory); os.IsNotExist(err) {
+		err := os.Mkdir(tempFilesDirectory, os.ModePerm)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	fileNameElements := strings.Split(fileName, "/")
+	file, err := os.Create(filepath.Join(cwd, tempFilesDirectory, fileNameElements[len(fileNameElements)-1]))
+	if err != nil {
+		panic(err)
+	}
+	return file
+}
+
+func (repo *GcsRepositoryFake) UpdateFileMetadata(ctx context.Context, bucketName, fileName string, metadata map[string]string) error {
+	return nil
+}

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -49,7 +49,7 @@ func (repo *UploadLogRepositoryImpl) CreateUploadLog(tx Transaction, log models.
 func (repo *UploadLogRepositoryImpl) UpdateUploadLog(tx Transaction, input models.UpdateUploadLogInput) error {
 	pgTx := repo.transactionFactory.adaptMarbleDatabaseTransaction(tx)
 
-	var updateRequest = NewQueryBuilder().Update(dbmodels.TABLE_CUSTOM_LIST)
+	var updateRequest = NewQueryBuilder().Update(dbmodels.TABLE_UPLOAD_LOGS)
 
 	if input.UploadStatus != "" {
 		updateRequest = updateRequest.Set("status", input.UploadStatus)

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -31,7 +31,6 @@ type IngestionUseCase struct {
 	transactionFactory    transaction.TransactionFactory
 	ingestionRepository   repositories.IngestionRepository
 	gcsRepository         repositories.GcsRepository
-	datamodelRepository   repositories.DataModelRepository
 	dataModelUseCase      DataModelUseCase
 	uploadLogRepository   repositories.UploadLogRepository
 	GcsIngestionBucket    string
@@ -227,7 +226,7 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context, file
 	if err := usecase.enforceSecurity.CanIngest(organizationId); err != nil {
 		return err
 	}
-	dataModel, err := usecase.datamodelRepository.GetDataModel(nil, organizationId)
+	dataModel, err := usecase.dataModelUseCase.GetDataModel(organizationId)
 	if err != nil {
 		return fmt.Errorf("error getting data model for organization %s: %w", organizationId, err)
 	}


### PR DESCRIPTION
It works on local \o/

Documentation to be written but basically: 
- the mock repo creates/read from a tempFiles directory with good old files

Additionally : 
- fix a copy pasta mistake on UploadLogRepository
- switch to the new `GetDataModel` function