### PR TITLE
feat(docker-compose): use same postgres version as production

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   db:
     container_name: postgres
-    image: postgres
+    image: postgres:14.9
     restart: always
     environment:
       POSTGRES_USER: postgres


### PR DESCRIPTION
Since we are probably downgrading the version everywhere, the data won't be compatible.
So you will probably have to run :
`docker volume rm (docker volume ls -q)`