### PR TITLE
fix: no db record should return empty slice, instead of nil

### DIFF
--- a/repositories/sql_to_row.go
+++ b/repositories/sql_to_row.go
@@ -40,7 +40,7 @@ func SqlToChannelOfModels[Model any](tx TransactionPostgres, query squirrel.Sqli
 
 func SqlToListOfRow[Model any](tx TransactionPostgres, query squirrel.Sqlizer, adapter func(row pgx.CollectableRow) (Model, error)) ([]Model, error) {
 
-	var models []Model
+	models := make([]Model, 0)
 	err := ForEachRow(tx, query, func(row pgx.CollectableRow) error {
 		model, err := adapter(row)
 		if err == nil {


### PR DESCRIPTION
## Context:

The default value of `var models []Model` is nil, whereas the default value of `models := make([]Model, 0)` is an empty slice.
Because of that (and because of the go adapter to json not being smart enough), the frontend was getting `nil` when it was expecting empty arrays.