### PR TITLE
feat: allow scenario without rules

### DIFF
--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -114,6 +114,10 @@ func (repo *DecisionRepositoryImpl) StoreDecision(tx Transaction, decision model
 		return err
 	}
 
+	if len(decision.RuleExecutions) == 0 {
+		return nil
+	}
+
 	builderForRules := NewQueryBuilder().
 		Insert(dbmodels.TABLE_DECISION_RULES).
 		Columns(

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -46,10 +46,6 @@ func (validator *ValidateScenarioIterationImpl) Validate(si ScenarioAndIteration
 		addError(fmt.Errorf("scenario iteration has no ScoreRejectThreshold: \n%w", models.BadParameterError))
 	}
 
-	if len(iteration.Rules) < 1 {
-		addError(fmt.Errorf("scenario iteration has no rules: \n%w", models.BadParameterError))
-	}
-
 	dryRunEnvironment, err := validator.makeDryRunEnvironment(si)
 	if err != nil {
 		addError(err)


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-308/allow-scenarios-with-0-rules-to-be-saved-published-executed)

## Context

Scenario can be published without any rule.
Scenario can be executed without any rule.

## Test

- [x] Publish a draft without rules
- [x] Create a decision via postman on this scenario