### PR TITLE
Feat: adapt Equal & Comparision to Time

### DIFF
--- a/usecases/ast_eval/evaluate/eval_comparaison_test.go
+++ b/usecases/ast_eval/evaluate/eval_comparaison_test.go
@@ -1,41 +1,76 @@
 package evaluate
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models/ast"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func helperComparison(t *testing.T, f ast.Function, left, right int, expected bool) {
+func helperFloatComparison(t *testing.T, f ast.Function, left, right int, expected bool) {
+	r, errs := NewComparison(f).Evaluate(ast.Arguments{Args: []any{left, right}})
+	assert.Empty(t, errs)
+	assert.Equal(t, expected, r)
+}
+func helperTimeComparison(t *testing.T, f ast.Function, left, right time.Time, expected bool) {
 	r, errs := NewComparison(f).Evaluate(ast.Arguments{Args: []any{left, right}})
 	assert.Empty(t, errs)
 	assert.Equal(t, expected, r)
 }
 
 func TestComparison_comparisonFunction_greater_int(t *testing.T) {
-	helperComparison(t, ast.FUNC_GREATER, 2, 1, true)
-	helperComparison(t, ast.FUNC_GREATER, 1, 2, false)
-	helperComparison(t, ast.FUNC_GREATER, 1, 1, false)
+	helperFloatComparison(t, ast.FUNC_GREATER, 2, 1, true)
+	helperFloatComparison(t, ast.FUNC_GREATER, 1, 2, false)
+	helperFloatComparison(t, ast.FUNC_GREATER, 1, 1, false)
+
+	date1 := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	helperTimeComparison(t, ast.FUNC_GREATER, date2, date1, true)
+	helperTimeComparison(t, ast.FUNC_GREATER, date1, date2, false)
+	helperTimeComparison(t, ast.FUNC_GREATER, date1, date1, false)
 }
 
 func TestComparison_comparisonFunction_greater_or_equal_int(t *testing.T) {
-	helperComparison(t, ast.FUNC_GREATER_OR_EQUAL, 2, 1, true)
-	helperComparison(t, ast.FUNC_GREATER_OR_EQUAL, 1, 2, false)
-	helperComparison(t, ast.FUNC_GREATER_OR_EQUAL, 1, 1, true)
+	helperFloatComparison(t, ast.FUNC_GREATER_OR_EQUAL, 2, 1, true)
+	helperFloatComparison(t, ast.FUNC_GREATER_OR_EQUAL, 1, 2, false)
+	helperFloatComparison(t, ast.FUNC_GREATER_OR_EQUAL, 1, 1, true)
+
+	date1 := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	helperTimeComparison(t, ast.FUNC_GREATER_OR_EQUAL, date2, date1, true)
+	helperTimeComparison(t, ast.FUNC_GREATER_OR_EQUAL, date1, date2, false)
+	helperTimeComparison(t, ast.FUNC_GREATER_OR_EQUAL, date1, date1, true)
 }
 
 func TestComparison_comparisonFunction_less(t *testing.T) {
-	helperComparison(t, ast.FUNC_LESS, 2, 1, false)
-	helperComparison(t, ast.FUNC_LESS, 1, 2, true)
-	helperComparison(t, ast.FUNC_LESS, 1, 1, false)
+	helperFloatComparison(t, ast.FUNC_LESS, 2, 1, false)
+	helperFloatComparison(t, ast.FUNC_LESS, 1, 2, true)
+	helperFloatComparison(t, ast.FUNC_LESS, 1, 1, false)
+
+	date1 := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	helperTimeComparison(t, ast.FUNC_LESS, date1, date2, true)
+	helperTimeComparison(t, ast.FUNC_LESS, date2, date1, false)
+	helperTimeComparison(t, ast.FUNC_LESS, date1, date1, false)
 }
 
 func TestComparison_comparisonFunction_less_or_equal(t *testing.T) {
-	helperComparison(t, ast.FUNC_LESS_OR_EQUAL, 2, 1, false)
-	helperComparison(t, ast.FUNC_LESS_OR_EQUAL, 1, 2, true)
-	helperComparison(t, ast.FUNC_LESS_OR_EQUAL, 1, 1, true)
+	helperFloatComparison(t, ast.FUNC_LESS_OR_EQUAL, 2, 1, false)
+	helperFloatComparison(t, ast.FUNC_LESS_OR_EQUAL, 1, 2, true)
+	helperFloatComparison(t, ast.FUNC_LESS_OR_EQUAL, 1, 1, true)
+
+	date1 := time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+	date2 := time.Date(2023, time.February, 1, 0, 0, 0, 0, time.UTC)
+
+	helperTimeComparison(t, ast.FUNC_LESS_OR_EQUAL, date1, date2, true)
+	helperTimeComparison(t, ast.FUNC_LESS_OR_EQUAL, date2, date1, false)
+	helperTimeComparison(t, ast.FUNC_LESS_OR_EQUAL, date1, date1, true)
 }
 
 func TestComparison_comparisonFunction_mixed_int_float_false(t *testing.T) {
@@ -46,10 +81,7 @@ func TestComparison_comparisonFunction_mixed_int_float_false(t *testing.T) {
 
 func TestComparison_fail(t *testing.T) {
 	_, errs := NewComparison(ast.FUNC_ADD).Evaluate(ast.Arguments{Args: []any{"toto", false}})
-	if assert.Len(t, errs, 2) {
-		assert.ErrorIs(t, errs[0], ast.ErrArgumentMustBeIntOrFloat)
-		assert.ErrorIs(t, errs[1], ast.ErrArgumentMustBeIntOrFloat)
-	}
+	assert.Equal(t, errs, []error{fmt.Errorf("all arguments must be an integer, a float or a time")})
 }
 
 func TestComparison_wrongnumber_of_argument(t *testing.T) {
@@ -61,7 +93,5 @@ func TestComparison_wrongnumber_of_argument(t *testing.T) {
 
 func TestComparison_required(t *testing.T) {
 	_, errs := NewComparison(ast.FUNC_ADD).Evaluate(ast.Arguments{Args: []any{4, nil}})
-	if assert.Len(t, errs, 1) {
-		assert.ErrorIs(t, errs[0], ast.ErrArgumentRequired)
-	}
+	assert.Equal(t, errs, []error{fmt.Errorf("all arguments must be an integer, a float or a time")})
 }

--- a/usecases/ast_eval/evaluate/eval_equal.go
+++ b/usecases/ast_eval/evaluate/eval_equal.go
@@ -31,5 +31,9 @@ func (f Equal) Evaluate(arguments ast.Arguments) (any, []error) {
 		return MakeEvaluateResult(left == right)
 	}
 
-	return MakeEvaluateError(fmt.Errorf("all argments must be string, boolean, int or float"))
+	if left, right, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToTime); len(errs) == 0 {
+		return MakeEvaluateResult(left.Equal(right))
+	}
+
+	return MakeEvaluateError(fmt.Errorf("all arguments must be string, boolean, time, int or float"))
 }

--- a/usecases/ast_eval/evaluate/eval_equal_test.go
+++ b/usecases/ast_eval/evaluate/eval_equal_test.go
@@ -3,6 +3,7 @@ package evaluate
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models/ast"
 
@@ -44,7 +45,7 @@ func TestEqual_Evaluate_int(t *testing.T) {
 			name:   "different types",
 			args:   []any{1, "1"},
 			want:   nil,
-			errors: []error{fmt.Errorf("all argments must be string, boolean, int or float")},
+			errors: []error{fmt.Errorf("all arguments must be string, boolean, time, int or float")},
 		},
 	}
 
@@ -75,6 +76,13 @@ func TestEqual_Evaluate_string(t *testing.T) {
 func TestEqual_Evaluate_bool(t *testing.T) {
 
 	r, errs := Equal{}.Evaluate(ast.Arguments{Args: []any{false, false}})
+	assert.Empty(t, errs)
+	assert.Equal(t, true, r)
+}
+
+func TestEqual_Evaluate_time(t *testing.T) {
+
+	r, errs := Equal{}.Evaluate(ast.Arguments{Args: []any{time.Date(2016, time.April, 29, 0, 0, 0, 0, time.UTC), time.Date(2016, time.April, 29, 0, 0, 0, 0, time.UTC)}})
 	assert.Empty(t, errs)
 	assert.Equal(t, true, r)
 }

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic.go
@@ -33,7 +33,7 @@ func (f Arithmetic) Evaluate(arguments ast.Arguments) (any, []error) {
 		return MakeEvaluateResult(arithmeticEval(f.Function, left, right))
 	}
 
-	return MakeEvaluateError(fmt.Errorf("all argments must be int or float %w", ast.ErrArgumentMustBeIntOrFloat))
+	return MakeEvaluateError(fmt.Errorf("all arguments must be int or float %w", ast.ErrArgumentMustBeIntOrFloat))
 }
 
 func arithmeticEval[T int64 | float64](function ast.Function, l, r T) (T, error) {


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-294/handle-timestamps-in-the-rule-builder)

Allow to compare 2 dates and to check if they are equal