### PR TITLE
feat: better errors on ingestion fail

### DIFF
--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -129,7 +129,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 
 		_, err = parseStringValuesToMap(headers, row, table)
 		if err != nil {
-			return models.UploadLog{}, fmt.Errorf("Error found at line %d in CSV (%w)", processedLinesCount+1, models.BadParameterError)
+			return models.UploadLog{}, fmt.Errorf("Error found at line %d in CSV: %w (%w)", processedLinesCount+1, err, models.BadParameterError)
 		}
 
 		if err := csvWriter.WriteAll([][]string{row}); err != nil {


### PR DESCRIPTION
## Context

While parsing & validating the csv file for data ingestion, we were losing the details of parsing errors. Therefore the user had very few context about what went wrong.
Now we also provide it in the error message.

[See front-end PR for details](https://github.com/checkmarble/marble-frontend/pull/183)