### PR TITLE
fix: left join with scenarios fails to scan if no left rows found

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -3,7 +3,6 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 
@@ -38,7 +37,6 @@ func (api *API) handleListDecisions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Println(decisions)
 	PresentModel(w, utils.Map(decisions, dto.NewAPIDecision))
 }
 

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -61,7 +60,6 @@ func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 		assert.Equal(t, args[1], "Infinity")
 	}
 	assert.Equal(t, strings.ReplaceAll(sql, "\"", ""), expectedQueryDbFieldExpectedWithoutJoin)
-	fmt.Println(sql)
 }
 
 func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {

--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -56,7 +56,7 @@ func selectJoinScheduledExecutionAndScenario() squirrel.SelectBuilder {
 	return NewQueryBuilder().
 		Select(columns...).
 		From(fmt.Sprintf("%s AS se", dbmodels.TABLE_SCHEDULED_EXECUTIONS)).
-		LeftJoin(fmt.Sprintf("%s AS scenario ON scenario.id = se.scenario_id", dbmodels.TABLE_SCENARIOS))
+		Join(fmt.Sprintf("%s AS scenario ON scenario.id = se.scenario_id", dbmodels.TABLE_SCENARIOS))
 }
 
 func (repo *ScheduledExecutionRepositoryPostgresql) GetScheduledExecution(tx Transaction, id string) (models.ScheduledExecution, error) {


### PR DESCRIPTION
This bug results from the fact that we deleted scenarios (because of data model cleanup ? not sure). Not great, but either way the left join here was broken because the following scan would break if no left rows found.

(+ remove some unwanted debug logs)