### PR TITLE
fix bug causing wrong database accessor identifiers to be sent to front

### DIFF
--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -54,19 +54,19 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 				return fmt.Errorf("table %s not found in data model", scenario.TriggerObjectType)
 			}
 
-			path = append(path, string(linkName))
+			pathForLink := append(path, string(linkName))
 
 			for fieldName := range table.Fields {
 				dataAccessors = append(dataAccessors,
 					ast.NewNodeDatabaseAccess(
 						scenario.TriggerObjectType,
 						string(fieldName),
-						path,
+						pathForLink,
 					),
 				)
 			}
 
-			if err := recursiveDatabaseAccessor(path, table.LinksToSingle); err != nil {
+			if err := recursiveDatabaseAccessor(pathForLink, table.LinksToSingle); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Turns out the bug that Arnaud encountered today had been around since forever, but we never caught it because we didn't run any tests with this setup:
- the trigger table has links to two distinct parent tables
It was caused by an erroneous mutation of a local variable within the for loop