### PR TITLE
Thomas/fix wrong error code

### DIFF
--- a/usecases/ast_eval/evaluate/adaptArgument.go
+++ b/usecases/ast_eval/evaluate/adaptArgument.go
@@ -139,7 +139,7 @@ func adaptArgumentToListOfThings[T any](argument any) ([]T, error) {
 		"can't promote argument %v to []%T %w",
 		argument,
 		zero,
-		ast.ErrArgumentMustBeBool,
+		ast.ErrArgumentMustBeList,
 	)
 }
 


### PR DESCRIPTION
Self explanatory.

Other topic, some part of the validation pipeline are returning errors w\ sentinel errors (so returned as `UNEXPECTED_ERROR` in the frontend, impossible to associate to any correct label on the fronted).

I do not know how we can detect them on the current source code easilly, and fix them.

**Exemple:** 
in the file `usecases/ast_eval/evaluate/eval_comparaison.go`
```go
func (f Comparison) Evaluate(arguments ast.Arguments) (any, []error) {

	leftAny, rightAny, err := leftAndRight(arguments.Args)
	if err != nil {
		return MakeEvaluateError(err)
	}

	leftFloat, rightFloat, errs := adaptLeftAndRight(leftAny, rightAny, promoteArgumentToFloat64)
	if len(errs) == 0 {
		return MakeEvaluateResult(f.comparisonFloatFunction(leftFloat, rightFloat))
	}

	leftTime, rightTime, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToTime);
	if len(errs) == 0 {
		return MakeEvaluateResult(f.comparisonTimeFunction(leftTime, rightTime))
	}
       // above error is returned as UNEXPECTED_ERROR
	return MakeEvaluateError(fmt.Errorf("all arguments must be an integer, a float or a time")) 
}
```