### PR TITLE
ci: use marble-infra artifact registry

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -37,13 +37,9 @@ jobs:
 
       - name: Build
         run: |
-          docker build -t europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest .
+          docker build -t europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest .
 
       - name: Push
-        run: |
-          docker push europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest
-
-      - name: Push to marble-infra registry
         run: |
           docker push europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest
 
@@ -51,7 +47,7 @@ jobs:
         run: |
           gcloud beta run jobs deploy migrations \
             --quiet \
-            --image="europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest" \
+            --image="europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest" \
             --region="europe-west1" \
             --execute-now \
             --wait
@@ -60,26 +56,26 @@ jobs:
         run: |
           gcloud run deploy marble-backend \
             --quiet \
-            --image="europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest" \
+            --image="europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest" \
             --region="europe-west1"
 
       - name: Deploy scheduler job
         run: |
           gcloud beta run jobs deploy scheduler \
             --quiet \
-            --image="europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest" \
+            --image="europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest" \
             --region="europe-west1"
 
       - name: Deploy execute scheduled scenario job
         run: |
           gcloud beta run jobs deploy scheduled-executer \
             --quiet \
-            --image="europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest" \
+            --image="europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest" \
             --region="europe-west1"
 
       - name: Deploy data ingestion job
         run: |
           gcloud beta run jobs deploy data-ingestion \
             --quiet \
-            --image="europe-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/marble/marble-backend:latest" \
+            --image="europe-docker.pkg.dev/marble-infra/marble/marble-backend:latest" \
             --region="europe-west1" \


### PR DESCRIPTION
Goal: push and pull docker images from the google registry of [marble-infra](https://console.cloud.google.com/artifacts/docker/marble-infra/europe-west1/marble?hl=en&project=marble-infra
)