### PR TITLE
refactor(dto): rename error to code in validation dto

### DIFF
--- a/dto/scenario_validation_dto.go
+++ b/dto/scenario_validation_dto.go
@@ -7,7 +7,7 @@ import (
 
 type ScenarioValidationErrorDto struct {
 	Message string `json:"message"`
-	Code    string `json:"error"`
+	Code    string `json:"code"`
 }
 
 func AdaptScenarioValidationErrorDto(err models.ScenarioValidationError) ScenarioValidationErrorDto {


### PR DESCRIPTION
Small refac that make more sense IMO (need to be merge with the frontend corresponding changes, since this is breaking)