### PR TITLE
fix: float/int filter comparison

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_filter_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter_test.go
@@ -135,3 +135,40 @@ func TestFilter_value_incompatible(t *testing.T) {
 	_, errs := filter.Evaluate(arguments)
 	assert.NotEmpty(t, errs)
 }
+
+var dataModelWithInt = models.DataModel{
+	Tables: map[models.TableName]models.Table{
+		"table1": {
+			Name: "table1",
+			Fields: map[models.FieldName]models.Field{
+				"field1": {
+					DataType: models.Int,
+					Nullable: false,
+				},
+			},
+		},
+	},
+}
+var filterWithInt = FilterEvaluator{DataModel: dataModelWithInt}
+
+func TestFilter_value_float(t *testing.T) {
+	arguments := ast.Arguments{
+		NamedArgs: map[string]any{
+			"tableName": "table1",
+			"fieldName": "field1",
+			"operator":  "=",
+			"value":     10.1,
+		},
+	}
+
+	expectedResult := ast.Filter{
+		TableName: "table1",
+		FieldName: "field1",
+		Operator:  ast.FILTER_EQUAL,
+		Value:     10.1,
+	}
+	result, errs := filterWithInt.Evaluate(arguments)
+	assert.Empty(t, errs)
+
+	assert.ObjectsAreEqualValues(expectedResult, result)
+}


### PR DESCRIPTION
## Context

We store our numerical constant as Float, so when we want to use them in the filters with a field which is Int in our database, the casting raises an error.
BUT since filters are only meant to sanitize data because creating an SQL query and SQL being smart enough to compare floats and ints (i'm looking at you Go 👀 ) we can make an exception in our sanitizing.

It's not the cleanest but it will have to do for now ¯\_(ツ)_/¯ 