### PR TITLE
feat: add StringContains func

### DIFF
--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -19,6 +19,7 @@ var FuncOperators = []Function{
 	FUNC_NOT_EQUAL,
 	FUNC_IS_IN_LIST,
 	FUNC_IS_NOT_IN_LIST,
+	FUNC_STRING_CONTAINS,
 }
 
 const (
@@ -44,6 +45,7 @@ const (
 	FUNC_CUSTOM_LIST_ACCESS
 	FUNC_IS_IN_LIST
 	FUNC_IS_NOT_IN_LIST
+	FUNC_STRING_CONTAINS
 	FUNC_AGGREGATOR
 	FUNC_LIST
 	FUNC_FILTER
@@ -170,6 +172,11 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 	FUNC_IS_NOT_IN_LIST: {
 		DebugName:         "FUNC_IS_NOT_IN_LIST",
 		AstName:           "IsNotInList",
+		NumberOfArguments: 2,
+	},
+	FUNC_STRING_CONTAINS: {
+		DebugName:         "FUNC_STRING_CONTAINS",
+		AstName:           "StringContains",
 		NumberOfArguments: 2,
 	},
 	FUNC_AGGREGATOR: FuncAggregatorAttributes,

--- a/usecases/ast_eval/evaluate/eval_string_contains.go
+++ b/usecases/ast_eval/evaluate/eval_string_contains.go
@@ -1,0 +1,24 @@
+package evaluate
+
+import (
+	"strings"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+type StringContains struct{}
+
+func (f StringContains) Evaluate(arguments ast.Arguments) (any, []error) {
+	leftAny, rightAny, err := leftAndRight(arguments.Args)
+	if err != nil {
+		return MakeEvaluateError(err)
+	}
+
+	left, right, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToString)
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return strings.Contains(strings.ToLower(left), strings.ToLower(right)), nil
+}

--- a/usecases/ast_eval/evaluate/eval_string_contains_test.go
+++ b/usecases/ast_eval/evaluate/eval_string_contains_test.go
@@ -1,0 +1,38 @@
+package evaluate
+
+import (
+	"testing"
+	"github.com/checkmarble/marble-backend/models/ast"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestString_Contains_true(t *testing.T) {
+	result, errs := StringContains{}.Evaluate(ast.Arguments{Args: []any{"abc", "ab"}})
+	assert.Empty(t, errs)
+	assert.Equal(t, true, result)
+}
+
+func TestString_Contains_false(t *testing.T) {
+	result, errs := StringContains{}.Evaluate(ast.Arguments{Args: []any{"abc", "cd"}})
+	assert.Empty(t, errs)
+	assert.Equal(t, false, result)
+}
+
+func TestString_Contains_wrong_number_of_arguments(t *testing.T) {
+	_, errs := StringContains{}.Evaluate(ast.Arguments{Args: []any{"abc"}})
+	assert.NotEmpty(t, errs)
+	assert.ErrorIs(t, errs[0], ast.ErrWrongNumberOfArgument)
+}
+
+func TestString_Contains_wrong_type_of_arguments(t *testing.T) {
+	_, errs := StringContains{}.Evaluate(ast.Arguments{Args: []any{"abc", 1}})
+	assert.NotEmpty(t, errs)
+	assert.ErrorIs(t, errs[0], ast.ErrArgumentMustBeString)
+}
+
+func TestString_Contains_case_insensitive(t *testing.T) {
+	result, errs := StringContains{}.Evaluate(ast.Arguments{Args: []any{"abc", "AB"}})
+	assert.Empty(t, errs)
+	assert.Equal(t, true, result)
+}

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -47,6 +47,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_OR, evaluate.BooleanArithmetic{Function: ast.FUNC_OR})
 	environment.AddEvaluator(ast.FUNC_IS_IN_LIST, evaluate.NewStringInList(ast.FUNC_IS_IN_LIST))
 	environment.AddEvaluator(ast.FUNC_IS_NOT_IN_LIST, evaluate.NewStringInList(ast.FUNC_IS_NOT_IN_LIST))
+	environment.AddEvaluator(ast.FUNC_STRING_CONTAINS, evaluate.StringContains{})
 	environment.AddEvaluator(ast.FUNC_TIME_ADD, evaluate.NewTimeArithmetic(ast.FUNC_TIME_ADD))
 	environment.AddEvaluator(ast.FUNC_TIME_NOW, evaluate.NewTimeFunctions(ast.FUNC_TIME_NOW))
 	environment.AddEvaluator(ast.FUNC_PARSE_TIME, evaluate.NewTimeFunctions(ast.FUNC_PARSE_TIME))


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-339/additional-operators)

## Context
- add StringContains operator
- must have 2 arguments
- all arguments must be string
- comparison is case insensitive