### PR TITLE
feat: authorized errors return ScenarioTriggerConditionAndTriggerObjectMismatchError

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -47,6 +47,15 @@ var (
 
 var RuleExecutionAuthorizedErrors = []error{NullFieldReadError, NoRowsReadError, DivisionByZeroError}
 
+func IsAuthorizedError(err error) bool {
+	for _, authorizedError := range RuleExecutionAuthorizedErrors {
+		if errors.Is(err, authorizedError) {
+			return true
+		}
+	}
+	return false
+}
+
 type PayloadValidationErrors struct {
 	message string
 	errors  map[string]string


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-344/ast-evaluation-with-optional-fields)

## Context

We have a concept of "authorized errors", which do not interrupt a rule evaluation with an error but instead only stop the evaluation and set a 0 zero score.
Yet, in the trigger rule, there is not differentiation between these errors and classic errors, so evaluation fails when one occurs.

Instead we want to consider them as a "trigger not passed" situation