### PR TITLE
fix: terraform gives permissions on GCS bucket to the backend SA

### DIFF
--- a/terraform-gcp/environment/gcs_data_ingestion.tf
+++ b/terraform-gcp/environment/gcs_data_ingestion.tf
@@ -7,3 +7,15 @@ resource "google_storage_bucket" "data_ingestion" {
 
   uniform_bucket_level_access = true
 }
+
+resource "google_storage_bucket_iam_member" "backend_service_account_object_admin" {
+  bucket = google_storage_bucket.data_ingestion.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.backend_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "backend_service_account_bucket_reader" {
+  bucket = google_storage_bucket.data_ingestion.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.backend_service_account.email}"
+}


### PR DESCRIPTION
I fixed those manually in the console last week while debugging 