### PR TITLE
fix: negative timestamp error

### DIFF
--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -59,8 +59,7 @@ func DryRunValue(prefix string, fieldName string, field models.Field) any {
 	case models.Float:
 		return 1.0
 	case models.Timestamp:
-		t, _ := time.Parse(time.RFC3339, time.RFC3339)
-		return t
+		return time.Now()
 	default:
 		return nil
 	}

--- a/usecases/ast_eval/evaluate/evaluate_database_access_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access_test.go
@@ -53,8 +53,8 @@ func TestDatabaseAccessValuesDryRun(t *testing.T) {
 	assert.Equal(t, 1.0, value)
 
 	testDatabaseAccessNamedArgs["fieldName"] = string(utils.DummyFieldNameForTimestamp)
-	timestamp, _ := time.Parse(time.RFC3339, time.RFC3339)
+	timestamp := time.Now()
 	value, errs = databaseAccessEval.Evaluate(ast.Arguments{NamedArgs: testDatabaseAccessNamedArgs})
 	assert.Len(t, errs, 0)
-	assert.Equal(t, timestamp, value)
+	assert.WithinDuration(t, timestamp, value.(time.Time), 1*time.Millisecond)
 }


### PR DESCRIPTION
Fix the infamous error:
```
Error #01: json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
```

## Reason
The dry run value for timestamp was `0001-01-01 00:00:00 +0000 UTC`, so when you were subtracting more than 365 days, you entered the realm of negative time 👽 
I'm not sure why we returned a string instead of a timestamp but it makes more sense to return `time.Now()` as the default value for dry runs