### PR TITLE
fix: viewer can't view scenarios because of validation

### DIFF
--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -188,7 +188,7 @@ func (usecase *ScenarioIterationUsecase) ValidateScenarioIteration(iterationId s
 		return validation, err
 	}
 
-	if err := usecase.enforceSecurity.CreateScenario(scenarioAndIteration.Scenario.OrganizationId); err != nil {
+	if err := usecase.enforceSecurity.ReadScenarioIteration(scenarioAndIteration.Iteration); err != nil {
 		return validation, err
 	}
 


### PR DESCRIPTION
Permission to validate a scenario iteration should be given to viewer users