### PR TITLE
fix(DecisionDto): fix date format

### DIFF
--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -13,8 +13,8 @@ type GetDecisionInput struct {
 
 type DecisionFilters struct {
 	ScenarioIds    []string  `form:"scenarioId[]"`
-	StartDate      time.Time `form:"startDate" time_format:"2006-01-02T15:04:05"`
-	EndDate        time.Time `form:"endDate" time_format:"2006-01-02T15:04:05"`
+	StartDate      time.Time `form:"startDate" time_format`
+	EndDate        time.Time `form:"endDate" time_format`
 	Outcomes       []string  `form:"outcome[]"`
 	TriggerObjects []string  `form:"triggerObject[]"`
 }


### PR DESCRIPTION
After looking at multiple sources (it tends to be really difficult to find in Gin the official doc that explain how Binding is working, and what each tag actually do) it seems we can relly on the "default" parsing (= RFC 3339).

The JS method `Date.toISOString()` always serialize to a simplified format based on [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) compatible with RFC 3339 (so it works).

**tl;dr: why people can't agree on a single norm for date time**