### PR TITLE
fix user_id foreign keys

### DIFF
--- a/repositories/case_contributor_repository.go
+++ b/repositories/case_contributor_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
-	"github.com/google/uuid"
 )
 
 func (repo *MarbleDbRepository) GetCaseContributor(tx Transaction, caseId, userId string) (*models.CaseContributor, error) {
@@ -27,12 +26,10 @@ func (repo *MarbleDbRepository) CreateCaseContributor(tx Transaction, caseId, us
 
 	query := NewQueryBuilder().Insert(dbmodels.TABLE_CASE_CONTRIBUTORS).
 		Columns(
-			"id",
 			"case_id",
 			"user_id",
 		).
 		Values(
-			uuid.NewString(),
 			caseId,
 			userId,
 		)

--- a/repositories/case_event_repository.go
+++ b/repositories/case_event_repository.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
-	"github.com/google/uuid"
 )
 
 func (repo *MarbleDbRepository) ListCaseEvents(tx Transaction, caseId string) ([]models.CaseEvent, error) {
@@ -32,7 +31,6 @@ func (repo *MarbleDbRepository) BatchCreateCaseEvents(tx Transaction, createCase
 
 	query := NewQueryBuilder().Insert(dbmodels.TABLE_CASE_EVENTS).
 		Columns(
-			"id",
 			"case_id",
 			"user_id",
 			"event_type",
@@ -45,7 +43,6 @@ func (repo *MarbleDbRepository) BatchCreateCaseEvents(tx Transaction, createCase
 
 	for _, createCaseEventAttribute := range createCaseEventAttributes {
 		query = query.Values(
-			uuid.NewString(),
 			createCaseEventAttribute.CaseId,
 			createCaseEventAttribute.UserId,
 			createCaseEventAttribute.EventType,

--- a/repositories/migrations/20231122111904_change_user_id_foreign_key.sql
+++ b/repositories/migrations/20231122111904_change_user_id_foreign_key.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE case_contributors ADD CONSTRAINT case_contributors_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE upload_logs DROP CONSTRAINT upload_logs_user_id_fkey;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE case_contributors DROP CONSTRAINT case_contributors_user_id_fkey;
+ALTER TABLE upload_logs ADD CONSTRAINT upload_logs_user_id_fkey FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+-- +goose StatementEnd


### PR DESCRIPTION
J'en ai profité pour enlever la foreign key sur les upload logs qui nous empêchait de supprimer des users