### PR TITLE
fix: order rules by name

### DIFF
--- a/repositories/rules.go
+++ b/repositories/rules.go
@@ -33,6 +33,7 @@ func (repo *MarbleDbRepository) ListRulesByIterationId(tx Transaction, iteration
 		pgTx,
 		selectRules().
 			Where(squirrel.Eq{"scenario_iteration_id": iterationId}).
+			OrderBy("name ASC").
 			OrderBy("created_at DESC"),
 		dbmodels.AdaptRule,
 	)


### PR DESCRIPTION
[Story](https://linear.app/checkmarble/issue/MAR-434/rules-displayed-in-alphabetical-order)