### PR TITLE
test: liveness probe log

### DIFF
--- a/api/handle_liveness_probe.go
+++ b/api/handle_liveness_probe.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 )
 
 func HandleLivenessProbe(c *gin.Context) {
+	fmt.Println("Liveness probe ok")
 	c.JSON(http.StatusOK, gin.H{
 		"mood": "Feu flammes !",
 	})

--- a/router.go
+++ b/router.go
@@ -39,7 +39,6 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	}
 
 	logger := utils.LoggerFromContext(ctx)
-	loggingMiddleware := middleware.NewLogging(logger, middleware.WithIgnorePath([]string{"/liveness"}))
 
 	r := gin.New()
 
@@ -73,7 +72,7 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	r.Use(cors.New(corsOption(conf.env)))
 	if conf.env == "development" {
 		// GCP already logs those elements
-		r.Use(loggingMiddleware)
+		r.Use(middleware.NewLogging(logger))
 	}
 	r.Use(otelgin.Middleware("marble-backend"))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))


### PR DESCRIPTION
Small thing I want to test - it seems like cloud run does not log liveness checks in the request logs logger