### PR TITLE
Pascal/mar 459 internal metabase dashboard

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+      "recommendations": [
+            "golang.go",
+            "inferrinizzard.prettier-sql-vscode"
+      ]
+    }
+    

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -87,7 +87,11 @@ func TestMain(m *testing.M) {
 
 	pgConfig := utils.PGConfig{ConnectionString: databaseURL}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	repositories.RunMigrations("development", pgConfig, logger)
+	migrater := repositories.NewMigrater(pgConfig, "development")
+	err = migrater.Run(ctx)
+	if err != nil {
+		log.Fatalf("Could not run migrations: %s", err)
+	}
 
 	// Need to declare this after the migrations, to have the correct search path
 	dbPool, err := infra.NewPostgresConnectionPool(pgConfig.GetConnectionString("development"))

--- a/repositories/analytics_views/apikeys.sql
+++ b/repositories/analytics_views/apikeys.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS analytics.apikeys;
+
+CREATE VIEW
+      analytics.apikeys
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      deleted_at,
+      role
+FROM
+      marble.apikeys;

--- a/repositories/analytics_views/case_contributors.sql
+++ b/repositories/analytics_views/case_contributors.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS analytics.case_contributors;
+
+CREATE VIEW
+      analytics.case_contributors
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      case_id,
+      user_id,
+      created_at
+FROM
+      marble.case_contributors;

--- a/repositories/analytics_views/case_events.sql
+++ b/repositories/analytics_views/case_events.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS analytics.case_events;
+
+CREATE VIEW
+      analytics.case_events
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      case_id,
+      user_id,
+      event_type,
+      created_at,
+      resource_id,
+      resource_type,
+      new_value,
+      previous_value
+FROM
+      marble.case_events

--- a/repositories/analytics_views/case_files.sql
+++ b/repositories/analytics_views/case_files.sql
@@ -1,0 +1,14 @@
+DROP VIEW IF EXISTS analytics.case_files;
+
+CREATE VIEW
+      analytics.case_files
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      created_at,
+      case_id,
+      bucket_name,
+      file_reference
+FROM
+      marble.case_files

--- a/repositories/analytics_views/case_tags.sql
+++ b/repositories/analytics_views/case_tags.sql
@@ -1,0 +1,14 @@
+DROP VIEW IF EXISTS analytics.case_tags;
+
+CREATE VIEW
+      analytics.case_tags
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      case_id,
+      case_tags,
+      created_at,
+      deleted_at
+FROM
+      marble.case_tags

--- a/repositories/analytics_views/cases.sql
+++ b/repositories/analytics_views/cases.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS analytics.cases;
+
+CREATE VIEW
+      analytics.cases
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      'placeholder' AS name,
+      status,
+      created_at,
+      inbox_id
+FROM
+      marble.cases

--- a/repositories/analytics_views/custom_list_values.sql
+++ b/repositories/analytics_views/custom_list_values.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS analytics.custom_list_values;
+
+CREATE VIEW
+      analytics.custom_list_values
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      custom_list_id,
+      created_at,
+      deleted_at
+FROM
+      marble.custom_list_values

--- a/repositories/analytics_views/custom_lists.sql
+++ b/repositories/analytics_views/custom_lists.sql
@@ -1,0 +1,14 @@
+DROP VIEW IF EXISTS analytics.custom_lists;
+
+CREATE VIEW
+      analytics.custom_lists
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      organization_id,
+      created_at,
+      updated_at,
+      deleted_at
+FROM
+      marble.custom_lists

--- a/repositories/analytics_views/data_model_fields.sql
+++ b/repositories/analytics_views/data_model_fields.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS analytics.data_model_fields;
+
+CREATE VIEW
+      analytics.data_model_fields
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      table_id,
+      name,
+type,
+nullable,
+description,
+is_enum
+FROM
+      marble.data_model_fields

--- a/repositories/analytics_views/data_model_links.sql
+++ b/repositories/analytics_views/data_model_links.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS analytics.data_model_links;
+
+CREATE VIEW
+      analytics.data_model_links
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      organization_id,
+      name,
+      parent_table_id,
+      parent_field_id,
+      child_table_id,
+      child_field_id
+FROM
+      marble.data_model_links

--- a/repositories/analytics_views/data_model_tables.sql
+++ b/repositories/analytics_views/data_model_tables.sql
@@ -1,0 +1,13 @@
+DROP VIEW IF EXISTS analytics.data_model_tables;
+
+CREATE VIEW
+      analytics.data_model_tables
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      organization_id,
+      name,
+      description
+FROM
+      marble.data_model_tables

--- a/repositories/analytics_views/decision_rules.sql
+++ b/repositories/analytics_views/decision_rules.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS analytics.decision_rules;
+
+CREATE VIEW
+      analytics.decision_rules
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      decision_id,
+      name,
+      description,
+      score_modifier,
+      result,
+      error_code,
+      deleted_at
+FROM
+      marble.decision_rules

--- a/repositories/analytics_views/decisions.sql
+++ b/repositories/analytics_views/decisions.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE VIEW analytics.decisions
+WITH (security_invoker=false)
+AS 
+SELECT 
+      id,
+      org_id,
+      created_at,
+      outcome,
+      scenario_id,
+      scenario_name,
+      scenario_description,
+      scenario_version,
+      score,
+      error_code,
+      deleted_at,
+      trigger_object_type,
+      scheduled_execution_id,
+      case_id
+FROM marble.decisions

--- a/repositories/analytics_views/decisions.sql
+++ b/repositories/analytics_views/decisions.sql
@@ -1,9 +1,12 @@
-CREATE OR REPLACE VIEW analytics.decisions
-WITH (security_invoker=false)
-AS 
-SELECT 
+DROP VIEW IF EXISTS analytics.decisions;
+
+CREATE VIEW
+      analytics.decisions
+WITH
+      (security_invoker = false) AS
+SELECT
       id,
-      org_id,
+      org_id AS organization_id,
       created_at,
       outcome,
       scenario_id,
@@ -16,4 +19,5 @@ SELECT
       trigger_object_type,
       scheduled_execution_id,
       case_id
-FROM marble.decisions
+FROM
+      marble.decisions;

--- a/repositories/analytics_views/inbox_users.sql
+++ b/repositories/analytics_views/inbox_users.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS analytics.inbox_users;
+
+CREATE VIEW
+      analytics.inbox_users
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      created_at,
+      updated_at,
+      inbox_id,
+      user_id,
+      role
+FROM
+      marble.inbox_users

--- a/repositories/analytics_views/inboxes.sql
+++ b/repositories/analytics_views/inboxes.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS analytics.inboxes;
+
+CREATE VIEW
+      analytics.inboxes
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      name,
+      created_at,
+      updated_at,
+      organization_id,
+      status
+FROM
+      marble.inboxes

--- a/repositories/analytics_views/organizations.sql
+++ b/repositories/analytics_views/organizations.sql
@@ -1,0 +1,14 @@
+DROP VIEW IF EXISTS analytics.organizations;
+
+CREATE VIEW
+      analytics.organizations
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      name,
+      database_name,
+      deleted_at,
+      export_scheduled_execution_s3
+FROM
+      marble.organizations

--- a/repositories/analytics_views/organizations_schema.sql
+++ b/repositories/analytics_views/organizations_schema.sql
@@ -1,0 +1,12 @@
+DROP VIEW IF EXISTS analytics.organizations_schema;
+
+CREATE VIEW
+      analytics.organizations_schema
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      schema_name
+FROM
+      marble.organizations_schema

--- a/repositories/analytics_views/scenario_iteration_rules.sql
+++ b/repositories/analytics_views/scenario_iteration_rules.sql
@@ -1,0 +1,17 @@
+DROP VIEW IF EXISTS analytics.scenario_iteration_rules;
+
+CREATE VIEW
+      analytics.scenario_iteration_rules
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      scenario_iteration_id,
+      name,
+      description,
+      score_modifier,
+      created_at,
+      deleted_at
+FROM
+      marble.scenario_iteration_rules

--- a/repositories/analytics_views/scenario_iterations.sql
+++ b/repositories/analytics_views/scenario_iterations.sql
@@ -1,0 +1,19 @@
+DROP VIEW IF EXISTS analytics.scenario_iterations;
+
+CREATE VIEW
+      analytics.scenario_iterations
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      scenario_id,
+      version,
+      created_at,
+      updated_at,
+      score_review_threshold,
+      score_reject_threshold,
+      deleted_at,
+      schedule
+FROM
+      marble.scenario_iterations

--- a/repositories/analytics_views/scenario_publications.sql
+++ b/repositories/analytics_views/scenario_publications.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS analytics.scenario_publications;
+
+CREATE VIEW
+      analytics.scenario_publications
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      rank,
+      scenario_id,
+      scenario_iteration_id,
+      publication_action,
+      created_at
+FROM
+      marble.scenario_publications

--- a/repositories/analytics_views/scenarios.sql
+++ b/repositories/analytics_views/scenarios.sql
@@ -1,0 +1,17 @@
+DROP VIEW IF EXISTS analytics.scenarios;
+
+CREATE VIEW
+      analytics.scenarios
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      name,
+      description,
+      trigger_object_type,
+      created_at,
+      deleted_at,
+      live_scenario_iteration_id
+FROM
+      marble.scenarios

--- a/repositories/analytics_views/scheduled_executions.sql
+++ b/repositories/analytics_views/scheduled_executions.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS analytics.scheduled_executions;
+
+CREATE VIEW
+      analytics.scheduled_executions
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      organization_id,
+      scenario_id,
+      scenario_iteration_id,
+      status,
+      started_at,
+      finished_at,
+      number_of_created_decisions,
+      manual
+FROM
+      marble.scheduled_executions

--- a/repositories/analytics_views/tags.sql
+++ b/repositories/analytics_views/tags.sql
@@ -1,0 +1,16 @@
+DROP VIEW IF EXISTS analytics.tags;
+
+CREATE VIEW
+      analytics.tags
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      name,
+      color,
+      created_at,
+      updated_at,
+      deleted_at
+FROM
+      marble.tags

--- a/repositories/analytics_views/upload_logs.sql
+++ b/repositories/analytics_views/upload_logs.sql
@@ -1,0 +1,18 @@
+DROP VIEW IF EXISTS analytics.upload_logs;
+
+CREATE VIEW
+      analytics.upload_logs
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      org_id AS organization_id,
+      user_id,
+      file_name,
+      status,
+      started_at,
+      finished_at,
+      lines_processed,
+      table_name
+FROM
+      marble.upload_logs

--- a/repositories/analytics_views/users.sql
+++ b/repositories/analytics_views/users.sql
@@ -1,0 +1,15 @@
+DROP VIEW IF EXISTS analytics.users;
+
+CREATE VIEW
+      analytics.users
+WITH
+      (security_invoker = false) AS
+SELECT
+      id,
+      organization_id,
+      email,
+      firebase_uid,
+      role,
+      deleted_at
+FROM
+      marble.users

--- a/repositories/migrations/20240124111516_create_analytics_schema.sql
+++ b/repositories/migrations/20240124111516_create_analytics_schema.sql
@@ -5,20 +5,29 @@ CREATE SCHEMA IF NOT EXISTS analytics;
 
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO postgres;
 
-DO $$
-BEGIN
-CREATE USER analytics WITH PASSWORD 'default';
-EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
-END
-$$;
+DO $$ BEGIN
+      CREATE USER analytics WITH PASSWORD 'default';
 
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics;
+EXCEPTION
+      WHEN duplicate_object THEN RAISE NOTICE '%, skipping',
+      SQLERRM USING ERRCODE = SQLSTATE;
+
+END $$;
+
+GRANT
+SELECT
+      ON ALL TABLES IN SCHEMA analytics TO analytics;
+
 GRANT USAGE ON SCHEMA analytics TO analytics;
-ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT SELECT ON TABLES TO analytics;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics
+GRANT
+SELECT
+      ON TABLES TO analytics;
 
 ALTER ROLE analytics
-SET search_path TO analytics;
-
+SET
+      search_path TO analytics;
 
 -- +goose StatementEnd
 -- +goose Down

--- a/repositories/migrations/20240124111516_create_analytics_schema.sql
+++ b/repositories/migrations/20240124111516_create_analytics_schema.sql
@@ -12,8 +12,8 @@ EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING E
 END
 $$;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics
-GRANT USAGE ON SCHEMA analytics TO analytics
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics;
+GRANT USAGE ON SCHEMA analytics TO analytics;
 ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT SELECT ON TABLES TO analytics;
 
 ALTER ROLE analytics

--- a/repositories/migrations/20240124111516_create_analytics_schema.sql
+++ b/repositories/migrations/20240124111516_create_analytics_schema.sql
@@ -1,0 +1,28 @@
+-- +goose Up
+-- +goose StatementBegin
+-- create and make default the marble schema
+CREATE SCHEMA IF NOT EXISTS analytics;
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO postgres;
+
+DO $$
+BEGIN
+CREATE USER analytics WITH PASSWORD 'default';
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA analytics TO analytics
+GRANT USAGE ON SCHEMA analytics TO analytics
+ALTER DEFAULT PRIVILEGES IN SCHEMA analytics GRANT SELECT ON TABLES TO analytics;
+
+ALTER ROLE analytics
+SET search_path TO analytics;
+
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP SCHEMA IF EXISTS analytics CASCADE;
+
+-- +goose StatementEnd


### PR DESCRIPTION
The design is the following:
- a list of sql definitions of views for analytics (metabase) are stored in `repositories/analytics_views`. 
- every time we run the migrations, we recreate all the views based on the current definitions (this is a fast operation because overwriting views is a metadata only operation)
- we do this so that we can expose a read only user _without access to fields that we don't want to share_ for metabase (or similar tools). For instance, we don't expose the decision's trigger payload or the rules' AST definition. Feedback welcome if you think some fields that are exposed as of this PR should actually stay hidden
- I took the occasion to refactor the migration function a little bit


Next steps:
- deploy staging
- connect our metabase app to our staging db
- deploy prod, create a read only replica (we'll need this anyway for fail over in case of an incident)
- connect our metabase app to our prod replica db
- start building dashboards on metabase / expose customer data by building filtered views (by organization_id) in metabase