### PR TITLE
feat(ingestion): improve error messages

### DIFF
--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/google/uuid"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -102,8 +104,8 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 			break
 		}
 		if err != nil {
-			if parseError, ok := err.(*csv.ParseError); ok {
-				return models.UploadLog{}, fmt.Errorf("%w (%w)", parseError, models.BadParameterError)
+			if errors.As(err, &csv.ParseError{}) {
+				return models.UploadLog{}, fmt.Errorf("%w (%w)", err, models.BadParameterError)
 			}
 			return models.UploadLog{}, fmt.Errorf("error found at line %d in CSV (%w)", lineNumber, models.BadParameterError)
 		}


### PR DESCRIPTION
By doing ingestion locally, I found that :
- there is an error on the line number computation
- we can leverage some usefull CSV parser error (to help the user understand why there is a problem)

As we display raw error messages in the frontend, I assume we can live with that for now