### PR TITLE
Thomas/mar 412 api keys page

### DIFF
--- a/dto/apikey_dto.go
+++ b/dto/apikey_dto.go
@@ -3,17 +3,19 @@ package dto
 import "github.com/checkmarble/marble-backend/models"
 
 type ApiKey struct {
-	ApiKeyId       string `json:"api_key_id"`
+	Id             string `json:"id"`
 	OrganizationId string `json:"organization_id"`
 	Key            string `json:"key"`
+	Description    string `json:"description"`
 	Role           string `json:"role"`
 }
 
-func AdaptApiKeyDto(user models.ApiKey) ApiKey {
+func AdaptApiKeyDto(apiKey models.ApiKey) ApiKey {
 	return ApiKey{
-		ApiKeyId:       string(user.ApiKeyId),
-		OrganizationId: user.OrganizationId,
-		Key:            user.Key,
-		Role:           user.Role.String(),
+		Id:             apiKey.Id,
+		OrganizationId: apiKey.OrganizationId,
+		Key:            apiKey.Key,
+		Description:    apiKey.Description,
+		Role:           apiKey.Role.String(),
 	}
 }

--- a/models/api_key.go
+++ b/models/api_key.go
@@ -1,15 +1,15 @@
 package models
 
-type ApiKeyId string
-
 type ApiKey struct {
-	ApiKeyId       ApiKeyId
+	Id             string
 	OrganizationId string
 	Key            string
+	Description    string
 	Role           Role
 }
 
 type CreateApiKeyInput struct {
 	OrganizationId string
 	Key            string
+	Description    string
 }

--- a/repositories/api_key_repository.go
+++ b/repositories/api_key_repository.go
@@ -26,7 +26,8 @@ func (repo *ApiKeyRepositoryImpl) GetApiKeyByKey(ctx context.Context, tx Transac
 		NewQueryBuilder().
 			Select(dbmodels.ApiKeyFields...).
 			From(dbmodels.TABLE_APIKEYS).
-			Where("key = ?", key),
+			Where("key = ?", key).
+			Where("deleted_at IS NULL"),
 		dbmodels.AdaptApikey,
 	)
 }
@@ -40,7 +41,8 @@ func (repo *ApiKeyRepositoryImpl) GetApiKeysOfOrganization(ctx context.Context, 
 		NewQueryBuilder().
 			Select(dbmodels.ApiKeyFields...).
 			From(dbmodels.TABLE_APIKEYS).
-			Where("org_id = ?", organizationId),
+			Where("org_id = ?", organizationId).
+			Where("deleted_at IS NULL"),
 		dbmodels.AdaptApikey,
 	)
 
@@ -56,10 +58,12 @@ func (repo *ApiKeyRepositoryImpl) CreateApiKey(ctx context.Context, tx Transacti
 			Columns(
 				"org_id",
 				"key",
+				"description",
 			).
 			Values(
 				apiKey.OrganizationId,
 				apiKey.Key,
+				apiKey.Description,
 			),
 	)
 	return err

--- a/repositories/dbmodels/db_api_keys.go
+++ b/repositories/dbmodels/db_api_keys.go
@@ -2,25 +2,27 @@ package dbmodels
 
 import (
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type DBApiKey struct {
-	Id             string      `db:"id"`
-	OrganizationId string      `db:"org_id"`
-	Key            string      `db:"key"`
-	DeletedAt      pgtype.Time `db:"deleted_at"`
-	Role           int         `db:"role"`
+	Id             string             `db:"id"`
+	OrganizationId string             `db:"org_id"`
+	Key            string             `db:"key"`
+	Description    string             `db:"description"`
+	DeletedAt      pgtype.Timestamptz `db:"deleted_at"`
+	Role           int                `db:"role"`
 }
-
-var ApiKeyFields = []string{"id", "org_id", "key", "deleted_at", "role"}
 
 const TABLE_APIKEYS = "apikeys"
 
+var ApiKeyFields = utils.ColumnList[DBApiKey]()
+
 func AdaptApikey(db DBApiKey) (models.ApiKey, error) {
 	return models.ApiKey{
-		ApiKeyId:       models.ApiKeyId(db.Id),
+		Id:             db.Id,
 		OrganizationId: db.OrganizationId,
 		Key:            db.Key,
 		Role:           models.Role(db.Role),

--- a/repositories/migrations/20240201155650_api_key_description.sql
+++ b/repositories/migrations/20240201155650_api_key_description.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE apikeys ADD COLUMN description VARCHAR(255) NOT NULL DEFAULT '';
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE apikeys DROP COLUMN description;
+-- +goose StatementEnd

--- a/usecases/marble_token_usecase.go
+++ b/usecases/marble_token_usecase.go
@@ -37,20 +37,20 @@ func (usecase *MarbleTokenUseCase) adaptCredentialFromApiKey(ctx context.Context
 
 	// Build a token name from the organization name because
 	// We don't want to log the apiKey itself.
-	apiKeyName, err := usecase.makeTokenName(ctx, apiKey.OrganizationId)
+	apiKeyName, err := usecase.makeTokenName(ctx, apiKey)
 	if err != nil {
 		return models.Credentials{}, err
 	}
 	return models.NewCredentialWithApiKey(apiKey.OrganizationId, apiKey.Role, apiKeyName), nil
 }
 
-func (usecase *MarbleTokenUseCase) makeTokenName(ctx context.Context, organizationId string) (string, error) {
-	organizationName, err := usecase.organizationRepository.GetOrganizationById(ctx, nil, organizationId)
+func (usecase *MarbleTokenUseCase) makeTokenName(ctx context.Context, apiKey models.ApiKey) (string, error) {
+	organizationName, err := usecase.organizationRepository.GetOrganizationById(ctx, nil, apiKey.OrganizationId)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("ApiKey Of %s", organizationName.Name), nil
+	return fmt.Sprintf("ApiKey Of %s: %s", organizationName.Name, apiKey.Description), nil
 }
 
 func (usecase *MarbleTokenUseCase) NewMarbleToken(ctx context.Context, apiKey string, firebaseToken string) (string, time.Time, error) {

--- a/usecases/organization/organization_seeder.go
+++ b/usecases/organization/organization_seeder.go
@@ -36,6 +36,7 @@ func (o *OrganizationSeeder) Seed(ctx context.Context, organizationId string) er
 	err := o.ApiKeyRepository.CreateApiKey(ctx, nil, models.CreateApiKeyInput{
 		OrganizationId: organizationId,
 		Key:            randomAPiKey(),
+		Description:    "Default API Key",
 	})
 	if err != nil {
 		log.Printf("error creating token: %v", err)

--- a/usecases/token/generator_test.go
+++ b/usecases/token/generator_test.go
@@ -16,7 +16,7 @@ import (
 func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 	apiKeyString := "api_key"
 	key := models.ApiKey{
-		ApiKeyId:       "api_key_id",
+		Id:             "api_key_id",
 		OrganizationId: "organization_id",
 		Key:            apiKeyString,
 		Role:           models.ADMIN,

--- a/usecases/token/validator_test.go
+++ b/usecases/token/validator_test.go
@@ -15,7 +15,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 	key := "api_key"
 
 	apiKey := models.ApiKey{
-		ApiKeyId:       "api_key_id",
+		Id:             "api_key_id",
 		OrganizationId: "organization_id",
 		Key:            key,
 		Role:           models.ADMIN,


### PR DESCRIPTION
First PR on the topic :
- take into account `deleted_at` (existing but ignored for now, not a real change since we cannot delete by API for now)
- add `description` column

NB: look at the second commit, I propose to add more context to api key name (IIUC, this is only used for logging purpose). I'm not totally sure of what is really collected by logs, but I think this would be cool to identify the used api key in the end (like the email help us identify the user). Still, using user ID or apikey ID fills better for this kind of thing... I'm not sure of what to do for that.