### PR TITLE
fix: ignore port for db only if connecting through unix socket

### DIFF
--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -92,7 +92,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Need to declare this after the migrations, to have the correct search path
-	dbPool, err := infra.NewPostgresConnectionPool(pgConfig.GetConnectionString("development"))
+	dbPool, err := infra.NewPostgresConnectionPool(pgConfig.GetConnectionString())
 	if err != nil {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}

--- a/repositories/migrations.go
+++ b/repositories/migrations.go
@@ -27,7 +27,6 @@ var embedAnalyticsViews embed.FS
 type Migrater struct {
 	dbMigrationsFileSystem   embed.FS
 	analyticsViewsFileSystem embed.FS
-	env                      string
 	pgConfig                 utils.PGConfig
 	db                       *sql.DB
 }
@@ -36,7 +35,6 @@ func NewMigrater(pgConfig utils.PGConfig, env string) *Migrater {
 	return &Migrater{
 		dbMigrationsFileSystem:   embedMigrations,
 		analyticsViewsFileSystem: embedAnalyticsViews,
-		env:                      env,
 		pgConfig:                 pgConfig,
 	}
 }
@@ -59,7 +57,7 @@ func (m *Migrater) Run(ctx context.Context) error {
 }
 
 func (m *Migrater) openDb() error {
-	connectionString := m.pgConfig.GetConnectionString(m.env)
+	connectionString := m.pgConfig.GetConnectionString()
 	db, err := sql.Open("pgx", connectionString)
 	if err != nil {
 		return errors.Wrap(err, "unable to create connection pool for migrations")

--- a/repositories/postgres/postgres.go
+++ b/repositories/postgres/postgres.go
@@ -12,11 +12,12 @@ import (
 )
 
 type Configuration struct {
-	Host     string
-	Port     string
-	User     string
-	Password string
-	Database string
+	Database            string
+	DbConnectWithSocket bool
+	Host                string
+	Password            string
+	Port                string
+	User                string
 }
 
 type Database struct {
@@ -48,6 +49,9 @@ func New(conf Configuration) (*Database, error) {
 		conf.Password,
 		conf.Database,
 	)
+	if !conf.DbConnectWithSocket {
+		connectionString = fmt.Sprintf("%s port=%s", connectionString, conf.Port)
+	}
 	cfg, err := pgxpool.ParseConfig(connectionString)
 	if err != nil {
 		return nil, fmt.Errorf("create connection pool: %w", err)

--- a/utils/database.go
+++ b/utils/database.go
@@ -3,21 +3,22 @@ package utils
 import "fmt"
 
 type PGConfig struct {
-	Hostname         string
-	Port             string
-	User             string
-	Password         string
-	Database         string
-	ConnectionString string
+	ConnectionString    string
+	Database            string
+	DbConnectWithSocket bool
+	Hostname            string
+	Password            string
+	Port                string
+	User                string
 }
 
-func (config PGConfig) GetConnectionString(env string) string {
+func (config PGConfig) GetConnectionString() string {
 	if config.ConnectionString != "" {
 		return config.ConnectionString
 	}
 	connectionString := fmt.Sprintf("host=%s user=%s password=%s database=%s sslmode=disable",
 		config.Hostname, config.User, config.Password, config.Database)
-	if env == "development" {
+	if !config.DbConnectWithSocket {
 		// Cloud Run connects to the DB through a proxy and a unix socket, so we don't need need to specify the port
 		// but we do when running locally
 		connectionString = fmt.Sprintf("%s port=%s", connectionString, config.Port)


### PR DESCRIPTION
Related change in env vars for our cloud run: https://github.com/checkmarble/terraform/pull/11

Short explanation:
- as we're connecting through a socket from cloud Run to Cloud Sql because the former is serverless and the latter has a firewall (see [doc](https://cloud.google.com/sql/docs/postgres/connect-run)), we were ignoring the database port env variable if not running in development mode.
- that was fine for us but is not the general case and is presumably blocking for others running marble as open source