### PR TITLE
bump go version: 1.22

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo is the Marble backend implementation:
 
-- 1 single Go app
+- 1 single go app
 - Postgres DB
 
 ## Getting Started

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmarble/marble-backend
 
-go 1.21
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.32.0

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -245,10 +245,6 @@ func evalAllScenarioRules(ctx context.Context, repositories ScenarioEvaluationRe
 
 	// Launch rules concurrently
 	for i, rule := range rules {
-
-		// i, rule := i, rule avoids scoping issues.
-		// should be solved with go 1.22
-		i, rule := i, rule
 		group.Go(func() error {
 			// return early if ctx is done
 			select {


### PR DESCRIPTION
Seems blocked as per https://github.com/github/roadmap/issues/918