### PR TITLE
fix: get preparation status works on an invalid iteration (no ast, in…

### DIFF
--- a/models/errors.go
+++ b/models/errors.go
@@ -52,6 +52,7 @@ var (
 	ErrScenarioHasNoLiveVersion                         = errors.Wrap(BadParameterError, "scenario has no live version")
 	ErrScenarioTriggerTypeAndTiggerObjectTypeMismatch   = errors.Wrap(BadParameterError, "scenario's trigger_type and provided trigger_object type are different")
 	ErrScenarioTriggerConditionAndTriggerObjectMismatch = errors.Wrap(BadParameterError, "trigger_object does not match the scenario's trigger conditions")
+	ErrInvalidAST                                       = errors.Wrap(BadParameterError, "invalid AST")
 	ErrPanicInScenarioEvalution                         = errors.New("panic during scenario evaluation")
 )
 

--- a/usecases/indexes/aggregate_query_test.go
+++ b/usecases/indexes/aggregate_query_test.go
@@ -1,6 +1,7 @@
 package indexes
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -248,7 +249,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 func TestAstNodeToQueryFamilies(t *testing.T) {
 	t.Run("empty node", func(t *testing.T) {
 		asserts := assert.New(t)
-		output, err := extractQueryFamiliesFromAst(ast.Node{})
+		output, err := extractQueryFamiliesFromAst(context.Background(), ast.Node{})
 		asserts.NoError(err)
 		asserts.Equal(0, output.Size())
 	})
@@ -294,7 +295,7 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 				},
 			},
 		}
-		output, err := extractQueryFamiliesFromAst(ast)
+		output, err := extractQueryFamiliesFromAst(context.Background(), ast)
 		asserts.NoError(err)
 		asserts.Equal(1, output.Size(), "There should be only 1 query family in the output set")
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)
@@ -380,7 +381,7 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 				},
 			},
 		}
-		output, err := extractQueryFamiliesFromAst(ast)
+		output, err := extractQueryFamiliesFromAst(context.Background(), ast)
 		asserts.NoError(err)
 		asserts.Equal(3, output.Size(), "There should be 2 query families in the output set")
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)

--- a/usecases/indexes/index_editor.go
+++ b/usecases/indexes/index_editor.go
@@ -80,6 +80,7 @@ func (editor ClientDbIndexEditor) GetIndexesToCreate(
 	}
 
 	toCreate, err = indexesToCreateFromScenarioIterations(
+		ctx,
 		[]models.ScenarioIteration{iterationToActivate.Iteration},
 		existingIndexes,
 	)


### PR DESCRIPTION
…valid ast...)

No fundamental reason why the data preparation endpoint should not be called on a not yet live, even on an as yet invalid scenario iteration. Even if there is no fundamental need for it either.