### PR TITLE
fix: need not create indexes if no field is indexable

### DIFF
--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -161,6 +161,7 @@ func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteInd
 	indexName := indexToIndexName(index)
 	indexedColumns := index.Indexed
 	includedColumns := index.Included
+
 	sql := fmt.Sprintf(
 		"CREATE INDEX CONCURRENTLY %s ON %s USING btree (%s)",
 		indexName,
@@ -176,6 +177,8 @@ func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteInd
 			),
 		)
 	}
+	sql += "WHERE valid_until='infinity'"
+
 	if _, err := exec.Exec(ctx, sql); err != nil {
 		errMessage := fmt.Sprintf(
 			"Error while creating index in schema %s with DDL \"%s\"",

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -32,7 +32,7 @@ func (repo *ClientDbRepository) ListAllValidIndexes(
 
 	var validOrPendingIndexes []models.ConcreteIndex
 	for _, pgIndex := range pgIndexes {
-		if pgIndex.IsValid || pgIndex.CreationInProgress {
+		if pgIndex.IsValid {
 			validOrPendingIndexes = append(validOrPendingIndexes, pgIndex.AdaptConcreteIndex())
 		}
 	}

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -155,16 +155,6 @@ func asynchronouslyCreateIndexes(
 	}
 }
 
-func indexAlreadyExists(index models.ConcreteIndex, existingIndexes []pg_indexes.PGIndex) bool {
-	for _, existingIndex := range existingIndexes {
-		existing := existingIndex.AdaptConcreteIndex()
-		if index.Equal(existing) {
-			return true
-		}
-	}
-	return false
-}
-
 func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteIndex) error {
 	logger := utils.LoggerFromContext(ctx)
 	qualifiedTableName := tableNameWithSchema(exec, index.TableName)
@@ -193,7 +183,7 @@ func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteInd
 			sql,
 		)
 		logger.ErrorContext(ctx, errMessage)
-		logger.ErrorContext(ctx, fmt.Sprintf("%+v", err))
+		utils.LogAndReportSentryError(ctx, err)
 		return errors.Wrap(err, errMessage)
 	}
 	logger.InfoContext(ctx, fmt.Sprintf(

--- a/usecases/indexes/aggregate_query.go
+++ b/usecases/indexes/aggregate_query.go
@@ -103,12 +103,7 @@ func aggregationNodeToQueryFamily(node ast.Node) (models.AggregateQueryFamily, e
 	}
 	aggregatedFieldName := models.FieldName(aggregatedFieldNameStr)
 
-	family := models.AggregateQueryFamily{
-		TableName:               models.TableName(queryTableName),
-		EqConditions:            set.New[models.FieldName](0),
-		IneqConditions:          set.New[models.FieldName](0),
-		SelectOrOtherConditions: set.New[models.FieldName](0),
-	}
+	family := models.NewAggregateQueryFamily(queryTableName)
 
 	filters, ok := node.NamedChildren["filters"]
 	if !ok {

--- a/usecases/indexes/aggregate_query_to_idx_test.go
+++ b/usecases/indexes/aggregate_query_to_idx_test.go
@@ -116,4 +116,14 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		})
 		asserts.True(expected.Equal(idxFamily), "The index families in the result are the expected ones")
 	})
+
+	t.Run("Case with no conditions", func(t *testing.T) {
+		asserts := assert.New(t)
+
+		qFamily := models.NewAggregateQueryFamily("")
+		qFamily.SelectOrOtherConditions = set.From([]models.FieldName{"a", "b", "c"})
+
+		idxFamily := qFamily.ToIndexFamilies()
+		asserts.Equal(0, idxFamily.Size(), "No indexable condition, so no family is rendered")
+	})
 }

--- a/utils/sentry.go
+++ b/utils/sentry.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getsentry/sentry-go"
+)
+
+func LogAndReportSentryError(ctx context.Context, err error) {
+	logger := LoggerFromContext(ctx)
+	logger.ErrorContext(ctx, fmt.Sprintf("%+v", err))
+	if hub := sentry.GetHubFromContext(ctx); hub != nil {
+		hub.CaptureException(err)
+	} else {
+		sentry.CaptureException(err)
+	}
+}


### PR DESCRIPTION
+ Add sentry log when an error happens while creating indexes (needed because the error doesn't bubble up back to the api request handler)