### PR TITLE
refactor(api): remove get validation endpoint

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -55,7 +55,6 @@ func (api *API) routes(auth *Authentication, tokenHandler *TokenHandler, logger 
 	router.POST("/scenario-iterations/:iteration_id", api.CreateDraftFromIteration)
 	router.PATCH("/scenario-iterations/:iteration_id", api.UpdateScenarioIteration)
 	router.POST("/scenario-iterations/:iteration_id/validate", api.ValidateScenarioIteration)
-	router.GET("/scenario-iterations/:iteration_id/validate", api.ValidateScenarioIteration)
 	router.POST("/scenario-iterations/:iteration_id/commit", api.CommitScenarioIterationVersion)
 	router.POST("/scenario-iterations/:iteration_id/schedule-execution", api.handleCreateScheduledExecution)
 


### PR DESCRIPTION
Clean up PR

Blocked by [this PR](https://github.com/checkmarble/marble-frontend/pull/376).

I recommand to merge this when the above PR is merged (and released, so we ensure no breaking change during deployment)