### PR TITLE
reduce db pool max connections

### DIFF
--- a/infra/postgres_connections_pool.go
+++ b/infra/postgres_connections_pool.go
@@ -3,12 +3,16 @@ package infra
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/exaring/otelpgx"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const MAX_CONNECTIONS = 100
+const (
+	MAX_CONNECTIONS          = 40
+	MAX_CONNECTION_IDLE_TIME = 5 * time.Minute
+)
 
 func NewPostgresConnectionPool(connectionString string) (*pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(connectionString)
@@ -17,6 +21,7 @@ func NewPostgresConnectionPool(connectionString string) (*pgxpool.Pool, error) {
 	}
 	cfg.ConnConfig.Tracer = otelpgx.NewTracer()
 	cfg.MaxConns = MAX_CONNECTIONS
+	cfg.MaxConnIdleTime = MAX_CONNECTION_IDLE_TIME
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), cfg)
 	if err != nil {

--- a/router.go
+++ b/router.go
@@ -63,10 +63,10 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 			if ctx.Span.Name == "GET /token" {
 				return 0.1
 			}
-			return 1.0
+			return 0.5
 		}),
 		// Experimental - value to be adjusted in prod once volumes go up - relative to the trace sampling rate
-		ProfilesSampleRate: 1.0,
+		ProfilesSampleRate: 0.5,
 	}); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
To be considered in the context of https://github.com/checkmarble/terraform/pull/14.
Max_instances*max_connections_per_pool should remain broadly lesser than the db instance's max connections (this is an approximation, because we also have to account for cron jobs)

For context:
- the staging DB with 1 vcpu and 4Gb RAM has max 100 connections
- the prod DB with 4 vcpu and 1Gb RAM has max 500 connections
- max connections are broadly proportional to RAM IIUC