### PR TITLE
feat: automatically create case from decision

### DIFF
--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -103,7 +103,7 @@ func (api *API) handlePostCase(c *gin.Context) {
 		return
 	}
 
-	inboxCase, err := usecase.CreateCase(c.Request.Context(), userId, models.CreateCaseAttributes{
+	inboxCase, err := usecase.CreateCaseAsUser(c.Request.Context(), userId, models.CreateCaseAttributes{
 		DecisionIds:    data.DecisionIds,
 		InboxId:        data.InboxId,
 		Name:           data.Name,

--- a/api/handle_scenario_iterations.go
+++ b/api/handle_scenario_iterations.go
@@ -52,36 +52,9 @@ func (api *API) CreateScenarioIteration(c *gin.Context) {
 		return
 	}
 
-	createScenarioIterationInput := models.CreateScenarioIterationInput{
-		ScenarioId: input.ScenarioId,
-	}
-
-	if input.Body != nil {
-		createScenarioIterationInput.Body = &models.CreateScenarioIterationBody{
-			ScoreReviewThreshold: input.Body.ScoreReviewThreshold,
-			ScoreRejectThreshold: input.Body.ScoreRejectThreshold,
-			BatchTriggerSQL:      input.Body.BatchTriggerSQL,
-			Schedule:             input.Body.Schedule,
-			Rules:                make([]models.CreateRuleInput, len(input.Body.Rules)),
-		}
-
-		for i, rule := range input.Body.Rules {
-			createScenarioIterationInput.Body.Rules[i], err =
-				dto.AdaptCreateRuleInput(rule, organizationId)
-			if presentError(c, err) {
-				return
-			}
-		}
-
-		if input.Body.TriggerConditionAstExpression != nil {
-			trigger, err := dto.AdaptASTNode(*input.Body.TriggerConditionAstExpression)
-			if err != nil {
-				presentError(c, fmt.Errorf("invalid trigger: %w %w", err, models.BadParameterError))
-				return
-			}
-			createScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
-		}
-
+	createScenarioIterationInput, err := dto.AdaptCreateScenarioIterationInput(input, organizationId)
+	if presentError(c, err) {
+		return
 	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewScenarioIterationUsecase()
@@ -149,23 +122,9 @@ func (api *API) UpdateScenarioIteration(c *gin.Context) {
 		return
 	}
 
-	updateScenarioIterationInput := models.UpdateScenarioIterationInput{
-		Id: iterationID,
-		Body: &models.UpdateScenarioIterationBody{
-			ScoreReviewThreshold: data.Body.ScoreReviewThreshold,
-			ScoreRejectThreshold: data.Body.ScoreRejectThreshold,
-			Schedule:             data.Body.Schedule,
-			BatchTriggerSQL:      data.Body.BatchTriggerSQL,
-		},
-	}
-
-	if data.Body.TriggerConditionAstExpression != nil {
-		trigger, err := dto.AdaptASTNode(*data.Body.TriggerConditionAstExpression)
-		if err != nil {
-			presentError(c, fmt.Errorf("invalid trigger: %w %w", err, models.BadParameterError))
-			return
-		}
-		updateScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
+	updateScenarioIterationInput, err := dto.AdaptUpdateScenarioIterationInput(data, iterationID)
+	if presentError(c, err) {
+		return
 	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewScenarioIterationUsecase()

--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -12,24 +12,29 @@ import (
 )
 
 type APIScenario struct {
-	Id                string    `json:"id"`
-	OrganizationId    string    `json:"organization_id"`
-	Name              string    `json:"name"`
-	Description       string    `json:"description"`
-	TriggerObjectType string    `json:"triggerObjectType"`
-	CreatedAt         time.Time `json:"createdAt"`
-	LiveVersionID     *string   `json:"liveVersionId,omitempty"`
+	Id                     string    `json:"id"`
+	CreatedAt              time.Time `json:"createdAt"`
+	DecisionToCaseOutcomes []string  `json:"decision_to_case_outcomes"`
+	DecisionToCaseInboxId  *string   `json:"decision_to_case_inbox_id"`
+	Description            string    `json:"description"`
+	LiveVersionID          *string   `json:"liveVersionId,omitempty"`
+	Name                   string    `json:"name"`
+	OrganizationId         string    `json:"organization_id"`
+	TriggerObjectType      string    `json:"triggerObjectType"`
 }
 
 func NewAPIScenario(scenario models.Scenario) APIScenario {
 	return APIScenario{
-		Id:                scenario.Id,
-		OrganizationId:    scenario.OrganizationId,
-		Name:              scenario.Name,
-		Description:       scenario.Description,
-		TriggerObjectType: scenario.TriggerObjectType,
-		CreatedAt:         scenario.CreatedAt,
-		LiveVersionID:     scenario.LiveVersionID,
+		Id:        scenario.Id,
+		CreatedAt: scenario.CreatedAt,
+		DecisionToCaseOutcomes: pure_utils.Map(scenario.DecisionToCaseOutcomes,
+			func(o models.Outcome) string { return o.String() }),
+		DecisionToCaseInboxId: scenario.DecisionToCaseInboxId,
+		Description:           scenario.Description,
+		LiveVersionID:         scenario.LiveVersionID,
+		Name:                  scenario.Name,
+		OrganizationId:        scenario.OrganizationId,
+		TriggerObjectType:     scenario.TriggerObjectType,
 	}
 }
 

--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -2,44 +2,12 @@ package api
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/checkmarble/marble-backend/dto"
-	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 )
-
-type APIScenario struct {
-	Id                     string    `json:"id"`
-	CreatedAt              time.Time `json:"createdAt"`
-	DecisionToCaseOutcomes []string  `json:"decision_to_case_outcomes"`
-	DecisionToCaseInboxId  string    `json:"decision_to_case_inbox_id"`
-	Description            string    `json:"description"`
-	LiveVersionID          *string   `json:"liveVersionId,omitempty"`
-	Name                   string    `json:"name"`
-	OrganizationId         string    `json:"organization_id"`
-	TriggerObjectType      string    `json:"triggerObjectType"`
-}
-
-func NewAPIScenario(scenario models.Scenario) APIScenario {
-	out := APIScenario{
-		Id:        scenario.Id,
-		CreatedAt: scenario.CreatedAt,
-		DecisionToCaseOutcomes: pure_utils.Map(scenario.DecisionToCaseOutcomes,
-			func(o models.Outcome) string { return o.String() }),
-		Description:       scenario.Description,
-		LiveVersionID:     scenario.LiveVersionID,
-		Name:              scenario.Name,
-		OrganizationId:    scenario.OrganizationId,
-		TriggerObjectType: scenario.TriggerObjectType,
-	}
-	if scenario.DecisionToCaseInboxId != nil {
-		out.DecisionToCaseInboxId = *scenario.DecisionToCaseInboxId
-	}
-	return out
-}
 
 func (api *API) ListScenarios(c *gin.Context) {
 	usecase := api.UsecasesWithCreds(c.Request).NewScenarioUsecase()
@@ -47,7 +15,7 @@ func (api *API) ListScenarios(c *gin.Context) {
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, pure_utils.Map(scenarios, NewAPIScenario))
+	c.JSON(http.StatusOK, pure_utils.Map(scenarios, dto.AdaptScenarioDto))
 }
 
 func (api *API) CreateScenario(c *gin.Context) {
@@ -58,11 +26,11 @@ func (api *API) CreateScenario(c *gin.Context) {
 	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewScenarioUsecase()
-	scenario, err := usecase.CreateScenario(c.Request.Context(), dto.AdaptCreateScenario(input))
+	scenario, err := usecase.CreateScenario(c.Request.Context(), dto.AdaptCreateScenarioInput(input))
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, NewAPIScenario(scenario))
+	c.JSON(http.StatusOK, dto.AdaptScenarioDto(scenario))
 }
 
 func (api *API) GetScenario(c *gin.Context) {
@@ -74,7 +42,7 @@ func (api *API) GetScenario(c *gin.Context) {
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, NewAPIScenario(scenario))
+	c.JSON(http.StatusOK, dto.AdaptScenarioDto(scenario))
 }
 
 func (api *API) UpdateScenario(c *gin.Context) {
@@ -89,9 +57,9 @@ func (api *API) UpdateScenario(c *gin.Context) {
 
 	scenario, err := usecase.UpdateScenario(
 		c.Request.Context(),
-		dto.AdaptUpdateScenario(scenarioId, input))
+		dto.AdaptUpdateScenarioInput(scenarioId, input))
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, NewAPIScenario(scenario))
+	c.JSON(http.StatusOK, dto.AdaptScenarioDto(scenario))
 }

--- a/dto/case_event_dto.go
+++ b/dto/case_event_dto.go
@@ -4,16 +4,17 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/guregu/null/v5"
 )
 
 type APICaseEvent struct {
-	Id             string    `json:"id"`
-	CaseId         string    `json:"case_id"`
-	UserId         string    `json:"user_id"`
-	CreatedAt      time.Time `json:"created_at"`
-	EventType      string    `json:"event_type"`
-	AdditionalNote string    `json:"additional_note"`
-	NewValue       string    `json:"new_value"`
+	Id             string      `json:"id"`
+	CaseId         string      `json:"case_id"`
+	UserId         null.String `json:"user_id"`
+	CreatedAt      time.Time   `json:"created_at"`
+	EventType      string      `json:"event_type"`
+	AdditionalNote string      `json:"additional_note"`
+	NewValue       string      `json:"new_value"`
 }
 
 func NewAPICaseEvent(caseEvent models.CaseEvent) APICaseEvent {

--- a/dto/scenario_iterations.go
+++ b/dto/scenario_iterations.go
@@ -4,18 +4,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cockroachdb/errors"
+
 	"github.com/checkmarble/marble-backend/models"
 )
 
-type ScenarioIterationBodyDto struct {
-	TriggerConditionAstExpression *NodeDto  `json:"trigger_condition_ast_expression"`
-	Rules                         []RuleDto `json:"rules"`
-	ScoreReviewThreshold          *int      `json:"scoreReviewThreshold"`
-	ScoreRejectThreshold          *int      `json:"scoreRejectThreshold"`
-	BatchTriggerSQL               string    `json:"batchTriggerSql"`
-	Schedule                      string    `json:"schedule"`
-}
-
+// Read DTO
 type ScenarioIterationWithBodyDto struct {
 	ScenarioIterationDto
 	Body ScenarioIterationBodyDto `json:"body"`
@@ -27,6 +21,15 @@ type ScenarioIterationDto struct {
 	Version    *int      `json:"version"`
 	CreatedAt  time.Time `json:"createdAt"`
 	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+type ScenarioIterationBodyDto struct {
+	TriggerConditionAstExpression *NodeDto  `json:"trigger_condition_ast_expression"`
+	Rules                         []RuleDto `json:"rules"`
+	ScoreReviewThreshold          *int      `json:"scoreReviewThreshold"`
+	ScoreRejectThreshold          *int      `json:"scoreRejectThreshold"`
+	BatchTriggerSQL               string    `json:"batchTriggerSql"`
+	Schedule                      string    `json:"schedule"`
 }
 
 func AdaptScenarioIterationWithBodyDto(si models.ScenarioIteration) (ScenarioIterationWithBodyDto, error) {
@@ -65,4 +68,89 @@ func AdaptScenarioIterationWithBodyDto(si models.ScenarioIteration) (ScenarioIte
 		},
 		Body: body,
 	}, nil
+}
+
+// Update iteration DTO
+type UpdateScenarioIterationBody struct {
+	Body struct {
+		TriggerConditionAstExpression *NodeDto `json:"trigger_condition_ast_expression"`
+		ScoreReviewThreshold          *int     `json:"scoreReviewThreshold,omitempty"`
+		ScoreRejectThreshold          *int     `json:"scoreRejectThreshold,omitempty"`
+		Schedule                      *string  `json:"schedule"`
+		BatchTriggerSQL               *string  `json:"batchTriggerSQL"`
+	} `json:"body,omitempty"`
+}
+
+func AdaptUpdateScenarioIterationInput(input UpdateScenarioIterationBody, iterationId string) (models.UpdateScenarioIterationInput, error) {
+	updateScenarioIterationInput := models.UpdateScenarioIterationInput{
+		Id: iterationId,
+		Body: models.UpdateScenarioIterationBody{
+			ScoreReviewThreshold: input.Body.ScoreReviewThreshold,
+			ScoreRejectThreshold: input.Body.ScoreRejectThreshold,
+			Schedule:             input.Body.Schedule,
+			BatchTriggerSQL:      input.Body.BatchTriggerSQL,
+		},
+	}
+
+	if input.Body.TriggerConditionAstExpression != nil {
+		trigger, err := AdaptASTNode(*input.Body.TriggerConditionAstExpression)
+		if err != nil {
+			return models.UpdateScenarioIterationInput{}, errors.Wrap(
+				models.BadParameterError,
+				"invalid trigger",
+			)
+		}
+		updateScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
+	}
+
+	return updateScenarioIterationInput, nil
+}
+
+// Create iteration DTO
+type CreateScenarioIterationBody struct {
+	ScenarioId string `json:"scenarioId"`
+	Body       *struct {
+		TriggerConditionAstExpression *NodeDto              `json:"trigger_condition_ast_expression"`
+		Rules                         []CreateRuleInputBody `json:"rules"`
+		ScoreReviewThreshold          *int                  `json:"scoreReviewThreshold,omitempty"`
+		ScoreRejectThreshold          *int                  `json:"scoreRejectThreshold,omitempty"`
+		Schedule                      string                `json:"schedule"`
+		BatchTriggerSQL               string                `json:"batchTriggerSQL"`
+	} `json:"body,omitempty"`
+}
+
+func AdaptCreateScenarioIterationInput(input CreateScenarioIterationBody, organizationId string) (models.CreateScenarioIterationInput, error) {
+	createScenarioIterationInput := models.CreateScenarioIterationInput{
+		ScenarioId: input.ScenarioId,
+	}
+
+	if input.Body != nil {
+		createScenarioIterationInput.Body = &models.CreateScenarioIterationBody{
+			ScoreReviewThreshold: input.Body.ScoreReviewThreshold,
+			ScoreRejectThreshold: input.Body.ScoreRejectThreshold,
+			BatchTriggerSQL:      input.Body.BatchTriggerSQL,
+			Schedule:             input.Body.Schedule,
+			Rules:                make([]models.CreateRuleInput, len(input.Body.Rules)),
+		}
+
+		for i, rule := range input.Body.Rules {
+			var err error
+			createScenarioIterationInput.Body.Rules[i], err =
+				AdaptCreateRuleInput(rule, organizationId)
+			if err != nil {
+				return models.CreateScenarioIterationInput{}, err
+			}
+		}
+
+		if input.Body.TriggerConditionAstExpression != nil {
+			trigger, err := AdaptASTNode(*input.Body.TriggerConditionAstExpression)
+			if err != nil {
+				return models.CreateScenarioIterationInput{},
+					errors.Wrap(models.BadParameterError, "invalid trigger")
+			}
+			createScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
+		}
+
+	}
+	return createScenarioIterationInput, nil
 }

--- a/dto/scenarios.go
+++ b/dto/scenarios.go
@@ -2,6 +2,8 @@ package dto
 
 import (
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/guregu/null/v5"
 )
 
 type CreateScenarioBody struct {
@@ -15,13 +17,23 @@ type CreateScenarioInput struct {
 }
 
 type UpdateScenarioBody struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
+	DecisionToCaseOutcomes []string    `json:"decision_to_case_outcomes"`
+	DecisionToCaseInboxId  null.String `json:"decision_to_case_inbox_id"`
+	Description            *string     `json:"description"`
+	Name                   *string     `json:"name"`
 }
 
-type UpdateScenarioInput struct {
-	ScenarioId string              `in:"path=scenarioId"`
-	Body       *UpdateScenarioBody `in:"body=json"`
+func AdaptUpdateScenario(scenarioId string, input UpdateScenarioBody) models.UpdateScenarioInput {
+	parsedInput := models.UpdateScenarioInput{
+		Id:                    scenarioId,
+		DecisionToCaseInboxId: input.DecisionToCaseInboxId,
+		Description:           input.Description,
+		Name:                  input.Name,
+	}
+	if input.DecisionToCaseOutcomes != nil {
+		parsedInput.DecisionToCaseOutcomes = pure_utils.Map(input.DecisionToCaseOutcomes, models.OutcomeFrom)
+	}
+	return parsedInput
 }
 
 // Scenario iterations
@@ -35,11 +47,6 @@ type UpdateScenarioIterationData struct {
 
 type UpdateScenarioIterationBody struct {
 	Body *UpdateScenarioIterationData `json:"body,omitempty"`
-}
-
-type UpdateScenarioIterationInput struct {
-	ScenarioIterationId string                       `in:"path=scenarioIterationId"`
-	Payload             *UpdateScenarioIterationBody `in:"body=json"`
 }
 
 type CreateScenarioIterationBody struct {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/uuid v1.3.1
+	github.com/guregu/null/v5 v5.0.0
 	github.com/hashicorp/go-set/v2 v2.1.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.1

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.5/go.mod h1:RxW0N9901Cko
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/guregu/null/v5 v5.0.0 h1:PRxjqyOekS11W+w/7Vfz6jgJE/BCwELWtgvOJzddimw=
+github.com/guregu/null/v5 v5.0.0/go.mod h1:SjupzNy+sCPtwQTKWhUCqjhVCO69hpsl2QsZrWHjlwU=
 github.com/hashicorp/go-set/v2 v2.1.0 h1:iERPCQWks+I+4bTgy0CT2myZsCqNgBg79ZHqwniohXo=
 github.com/hashicorp/go-set/v2 v2.1.0/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -336,7 +336,7 @@ func setupScenarioAndPublish(t *testing.T, ctx context.Context,
 	updatedScenarioIteration, err := scenarioIterationUsecase.UpdateScenarioIteration(
 		usecasesWithCreds.Context, organizationId, models.UpdateScenarioIterationInput{
 			Id: scenarioIterationId,
-			Body: &models.UpdateScenarioIterationBody{
+			Body: models.UpdateScenarioIterationBody{
 				ScoreRejectThreshold: &threshold,
 			},
 		})

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -20,14 +20,15 @@ type CaseEvent struct {
 type CaseEventType string
 
 const (
-	CaseCreated       CaseEventType = "case_created"
-	CaseStatusUpdated CaseEventType = "status_updated"
-	DecisionAdded     CaseEventType = "decision_added"
-	CaseCommentAdded  CaseEventType = "comment_added"
-	CaseNameUpdated   CaseEventType = "name_updated"
-	CaseTagsUpdated   CaseEventType = "tags_updated"
-	CaseFileAdded     CaseEventType = "file_added"
-	CaseInboxChanged  CaseEventType = "inbox_changed"
+	CaseCreated              CaseEventType = "case_created"
+	CaseCreatedAutomatically CaseEventType = "case_created_automatically"
+	CaseStatusUpdated        CaseEventType = "status_updated"
+	DecisionAdded            CaseEventType = "decision_added"
+	CaseCommentAdded         CaseEventType = "comment_added"
+	CaseNameUpdated          CaseEventType = "name_updated"
+	CaseTagsUpdated          CaseEventType = "tags_updated"
+	CaseFileAdded            CaseEventType = "file_added"
+	CaseInboxChanged         CaseEventType = "inbox_changed"
 )
 
 type CaseEventResourceType string

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -22,15 +22,14 @@ type CaseEvent struct {
 type CaseEventType string
 
 const (
-	CaseCreated              CaseEventType = "case_created"
-	CaseCreatedAutomatically CaseEventType = "case_created_automatically"
-	CaseStatusUpdated        CaseEventType = "status_updated"
-	DecisionAdded            CaseEventType = "decision_added"
-	CaseCommentAdded         CaseEventType = "comment_added"
-	CaseNameUpdated          CaseEventType = "name_updated"
-	CaseTagsUpdated          CaseEventType = "tags_updated"
-	CaseFileAdded            CaseEventType = "file_added"
-	CaseInboxChanged         CaseEventType = "inbox_changed"
+	CaseCreated       CaseEventType = "case_created"
+	CaseStatusUpdated CaseEventType = "status_updated"
+	DecisionAdded     CaseEventType = "decision_added"
+	CaseCommentAdded  CaseEventType = "comment_added"
+	CaseNameUpdated   CaseEventType = "name_updated"
+	CaseTagsUpdated   CaseEventType = "tags_updated"
+	CaseFileAdded     CaseEventType = "file_added"
+	CaseInboxChanged  CaseEventType = "inbox_changed"
 )
 
 type CaseEventResourceType string

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -2,12 +2,14 @@ package models
 
 import (
 	"time"
+
+	"github.com/guregu/null/v5"
 )
 
 type CaseEvent struct {
 	Id             string
 	CaseId         string
-	UserId         string
+	UserId         null.String
 	CreatedAt      time.Time
 	EventType      CaseEventType
 	AdditionalNote string

--- a/models/decisions.go
+++ b/models/decisions.go
@@ -12,6 +12,8 @@ const (
 	UnknownOutcome
 )
 
+var ValidOutcomes = []Outcome{Approve, Review, Reject}
+
 // Provide a string value for each outcome
 func (o Outcome) String() string {
 	switch o {

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -41,7 +41,7 @@ type CreateScenarioIterationBody struct {
 
 type UpdateScenarioIterationInput struct {
 	Id   string
-	Body *UpdateScenarioIterationBody
+	Body UpdateScenarioIterationBody
 }
 
 type UpdateScenarioIterationBody struct {

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -3,25 +3,27 @@ package models
 import "time"
 
 type Scenario struct {
-	Id                string
-	OrganizationId    string
-	Name              string
-	Description       string
-	TriggerObjectType string
-	CreatedAt         time.Time
-	LiveVersionID     *string
+	Id                     string
+	CreatedAt              time.Time
+	DecisionToCaseOutcomes []Outcome
+	DecisionToCaseInboxId  string
+	Description            string
+	LiveVersionID          *string
+	Name                   string
+	OrganizationId         string
+	TriggerObjectType      string
 }
 
 type CreateScenarioInput struct {
-	Name              string
 	Description       string
+	Name              string
 	TriggerObjectType string
 }
 
 type UpdateScenarioInput struct {
 	Id          string
-	Name        *string
 	Description *string
+	Name        *string
 }
 
 type ListAllScenariosFilters struct {

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/guregu/null/v5"
+)
 
 type Scenario struct {
 	Id                     string
@@ -21,9 +25,11 @@ type CreateScenarioInput struct {
 }
 
 type UpdateScenarioInput struct {
-	Id          string
-	Description *string
-	Name        *string
+	Id                     string
+	DecisionToCaseOutcomes []Outcome
+	DecisionToCaseInboxId  null.String
+	Description            *string
+	Name                   *string
 }
 
 type ListAllScenariosFilters struct {

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -6,7 +6,7 @@ type Scenario struct {
 	Id                     string
 	CreatedAt              time.Time
 	DecisionToCaseOutcomes []Outcome
-	DecisionToCaseInboxId  string
+	DecisionToCaseInboxId  *string
 	Description            string
 	LiveVersionID          *string
 	Name                   string

--- a/repositories/case_event_repository.go
+++ b/repositories/case_event_repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 func (repo *MarbleDbRepository) ListCaseEvents(ctx context.Context, exec Executor, caseId string) ([]models.CaseEvent, error) {
@@ -53,9 +54,15 @@ func (repo *MarbleDbRepository) BatchCreateCaseEvents(ctx context.Context, exec 
 		)
 
 	for _, createCaseEventAttribute := range createCaseEventAttributes {
+		var userId pgtype.Text
+		if createCaseEventAttribute.UserId != "" {
+			userId = pgtype.Text{String: createCaseEventAttribute.UserId, Valid: true}
+		} else {
+			userId = pgtype.Text{Valid: false}
+		}
 		query = query.Values(
 			createCaseEventAttribute.CaseId,
-			createCaseEventAttribute.UserId,
+			userId,
 			createCaseEventAttribute.EventType,
 			createCaseEventAttribute.AdditionalNote,
 			createCaseEventAttribute.ResourceId,

--- a/repositories/dbmodels/db_case_event.go
+++ b/repositories/dbmodels/db_case_event.go
@@ -5,19 +5,20 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type DBCaseEvent struct {
-	Id             string    `db:"id"`
-	CaseId         string    `db:"case_id"`
-	UserId         string    `db:"user_id"`
-	CreatedAt      time.Time `db:"created_at"`
-	EventType      string    `db:"event_type"`
-	AdditionalNote *string   `db:"additional_note"`
-	ResourceId     *string   `db:"resource_id"`
-	ResourceType   *string   `db:"resource_type"`
-	NewValue       *string   `db:"new_value"`
-	PreviousValue  *string   `db:"previous_value"`
+	Id             string      `db:"id"`
+	CaseId         string      `db:"case_id"`
+	UserId         pgtype.Text `db:"user_id"`
+	CreatedAt      time.Time   `db:"created_at"`
+	EventType      string      `db:"event_type"`
+	AdditionalNote *string     `db:"additional_note"`
+	ResourceId     *string     `db:"resource_id"`
+	ResourceType   *string     `db:"resource_type"`
+	NewValue       *string     `db:"new_value"`
+	PreviousValue  *string     `db:"previous_value"`
 }
 
 const TABLE_CASE_EVENTS = "case_events"
@@ -44,7 +45,7 @@ func AdaptCaseEvent(caseEvent DBCaseEvent) (models.CaseEvent, error) {
 	return models.CaseEvent{
 		Id:             caseEvent.Id,
 		CaseId:         caseEvent.CaseId,
-		UserId:         caseEvent.UserId,
+		UserId:         caseEvent.UserId.String,
 		CreatedAt:      caseEvent.CreatedAt,
 		EventType:      models.CaseEventType(caseEvent.EventType),
 		AdditionalNote: additionalNote,

--- a/repositories/dbmodels/db_case_event.go
+++ b/repositories/dbmodels/db_case_event.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
-	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/guregu/null/v5"
 )
 
 type DBCaseEvent struct {
 	Id             string      `db:"id"`
 	CaseId         string      `db:"case_id"`
-	UserId         pgtype.Text `db:"user_id"`
+	UserId         null.String `db:"user_id"`
 	CreatedAt      time.Time   `db:"created_at"`
 	EventType      string      `db:"event_type"`
 	AdditionalNote *string     `db:"additional_note"`
@@ -45,7 +45,7 @@ func AdaptCaseEvent(caseEvent DBCaseEvent) (models.CaseEvent, error) {
 	return models.CaseEvent{
 		Id:             caseEvent.Id,
 		CaseId:         caseEvent.CaseId,
-		UserId:         caseEvent.UserId.String,
+		UserId:         caseEvent.UserId,
 		CreatedAt:      caseEvent.CreatedAt,
 		EventType:      models.CaseEventType(caseEvent.EventType),
 		AdditionalNote: additionalNote,

--- a/repositories/dbmodels/db_scenario.go
+++ b/repositories/dbmodels/db_scenario.go
@@ -4,20 +4,23 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/utils"
 
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type DBScenario struct {
-	Id                string      `db:"id"`
-	OrganizationId    string      `db:"org_id"`
-	Name              string      `db:"name"`
-	Description       string      `db:"description"`
-	TriggerObjectType string      `db:"trigger_object_type"`
-	CreatedAt         time.Time   `db:"created_at"`
-	LiveVersionID     pgtype.Text `db:"live_scenario_iteration_id"`
-	DeletedAt         pgtype.Time `db:"deleted_at"`
+	Id                     string      `db:"id"`
+	CreatedAt              time.Time   `db:"created_at"`
+	DecisionToCaseInboxId  pgtype.Text `db:"decision_to_case_inbox_id"`
+	DecisionToCaseOutcomes []string    `db:"decision_to_case_outcomes"`
+	DeletedAt              pgtype.Time `db:"deleted_at"`
+	Description            string      `db:"description"`
+	LiveVersionID          pgtype.Text `db:"live_scenario_iteration_id"`
+	Name                   string      `db:"name"`
+	OrganizationId         string      `db:"org_id"`
+	TriggerObjectType      string      `db:"trigger_object_type"`
 }
 
 const TABLE_SCENARIOS = "scenarios"
@@ -26,12 +29,17 @@ var SelectScenarioColumn = utils.ColumnList[DBScenario]()
 
 func AdaptScenario(dto DBScenario) (models.Scenario, error) {
 	scenario := models.Scenario{
-		Id:                dto.Id,
-		OrganizationId:    dto.OrganizationId,
-		Name:              dto.Name,
+		Id:        dto.Id,
+		CreatedAt: dto.CreatedAt,
+		DecisionToCaseOutcomes: pure_utils.Map(dto.DecisionToCaseOutcomes,
+			func(s string) models.Outcome { return models.OutcomeFrom(s) }),
 		Description:       dto.Description,
+		Name:              dto.Name,
+		OrganizationId:    dto.OrganizationId,
 		TriggerObjectType: dto.TriggerObjectType,
-		CreatedAt:         dto.CreatedAt,
+	}
+	if dto.DecisionToCaseInboxId.Valid {
+		scenario.DecisionToCaseInboxId = &dto.DecisionToCaseInboxId.String
 	}
 	if dto.LiveVersionID.Valid {
 		scenario.LiveVersionID = &dto.LiveVersionID.String

--- a/repositories/migrations/20240301225900_case_event_userid_nullable.sql
+++ b/repositories/migrations/20240301225900_case_event_userid_nullable.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE case_events
+ALTER COLUMN user_id
+DROP NOT NULL;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE case_events
+ALTER COLUMN user_id
+SET NOT NULL;
+
+-- +goose StatementEnd

--- a/repositories/migrations/20240304105230_scenario_decision_to_case_settings.sql
+++ b/repositories/migrations/20240304105230_scenario_decision_to_case_settings.sql
@@ -1,10 +1,10 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE scenarios
-ADD COLUMN decision_to_case_inbox_id UUID;
+ADD COLUMN decision_to_case_inbox_id UUID REFERENCES inboxes (id) ON DELETE SET NULL ON UPDATE CASCADE;
 
 ALTER TABLE scenarios
-ADD COLUMN decision_to_case_outcomes decision_outcome[];
+ADD COLUMN decision_to_case_outcomes varchar(50) [];
 
 -- +goose StatementEnd
 -- +goose Down

--- a/repositories/migrations/20240304105230_scenario_decision_to_case_settings.sql
+++ b/repositories/migrations/20240304105230_scenario_decision_to_case_settings.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scenarios
+ADD COLUMN decision_to_case_inbox_id UUID;
+
+ALTER TABLE scenarios
+ADD COLUMN decision_to_case_outcomes decision_outcome[];
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE scenarios
+DROP COLUMN decision_to_case_inbox_id;
+
+ALTER TABLE scenarios
+DROP COLUMN decision_to_case_outcomes;
+
+-- +goose StatementEnd

--- a/repositories/scenarios_write.go
+++ b/repositories/scenarios_write.go
@@ -49,11 +49,30 @@ func (repo *MarbleDbRepository) UpdateScenario(ctx context.Context, exec Executo
 		Update(dbmodels.TABLE_SCENARIOS).
 		Where("id = ?", scenario.Id)
 
-	if scenario.Name != nil {
-		sql = sql.Set("name", scenario.Name)
+	countApply := 0
+	if scenario.DecisionToCaseInboxId.Valid {
+		if scenario.DecisionToCaseInboxId.String == "" {
+			sql = sql.Set("decision_to_case_inbox_id", nil)
+		} else {
+			sql = sql.Set("decision_to_case_inbox_id", scenario.DecisionToCaseInboxId)
+		}
+		countApply++
+	}
+	if scenario.DecisionToCaseOutcomes != nil {
+		sql = sql.Set("decision_to_case_outcomes", scenario.DecisionToCaseOutcomes)
+		countApply++
 	}
 	if scenario.Description != nil {
 		sql = sql.Set("description", scenario.Description)
+		countApply++
+	}
+	if scenario.Name != nil {
+		sql = sql.Set("name", scenario.Name)
+		countApply++
+	}
+
+	if countApply == 0 {
+		return nil
 	}
 
 	if err := ExecBuilder(ctx, exec, sql); err != nil {

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -184,7 +184,7 @@ func (usecase *CaseUseCase) createCase(
 	} else {
 		if err = usecase.repository.CreateCaseEvent(ctx, tx, models.CreateCaseEventAttributes{
 			CaseId:    newCaseId,
-			EventType: models.CaseCreatedAutomatically,
+			EventType: models.CaseCreated,
 		}); err != nil {
 			return models.Case{}, err
 		}

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -236,10 +236,12 @@ func (usecase *DecisionUsecase) CreateDecision(
 			return models.Decision{}, fmt.Errorf("error storing decision: %w", err)
 		}
 
-		if true || slices.Contains(scenario.DecisionToCaseOutcomes, decision.Outcome) {
+		if scenario.DecisionToCaseOutcomes != nil &&
+			slices.Contains(scenario.DecisionToCaseOutcomes, decision.Outcome) &&
+			scenario.DecisionToCaseInboxId != nil {
 			_, err = usecase.caseCreator.CreateCaseAsWorkflow(ctx, tx, models.CreateCaseAttributes{
 				DecisionIds: []string{newDecisionId},
-				InboxId:     "54624b1f-09a2-4c86-ac7e-57f3b729b57a", // scenario.DecisionToCaseInboxId,
+				InboxId:     *scenario.DecisionToCaseInboxId,
 				Name: fmt.Sprintf(
 					"Case for %s: %s",
 					scenario.TriggerObjectType,

--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -152,7 +152,7 @@ func (usecase *ScenarioIterationUsecase) UpdateScenarioIteration(ctx context.Con
 		return iteration, err
 	}
 	body := scenarioIteration.Body
-	if body != nil && body.Schedule != nil && *body.Schedule != "" {
+	if body.Schedule != nil && *body.Schedule != "" {
 		gron := gronx.New()
 		ok := gron.IsValid(*body.Schedule)
 		if !ok {

--- a/usecases/scenario_usecase.go
+++ b/usecases/scenario_usecase.go
@@ -88,6 +88,14 @@ func (usecase *ScenarioUsecase) UpdateScenario(
 			if err := usecase.enforceSecurity.UpdateScenario(scenario); err != nil {
 				return models.Scenario{}, err
 			}
+			// the DecisionToCaseInboxId and DecisionToCaseOutcomes settings are of higher criticity (they
+			// influence how decisions are treated) so require a higher permission to update
+			if scenarioInput.DecisionToCaseInboxId.Valid ||
+				scenarioInput.DecisionToCaseOutcomes != nil {
+				if err := usecase.enforceSecurity.PublishScenario(scenario); err != nil {
+					return models.Scenario{}, err
+				}
+			}
 
 			err = usecase.repository.UpdateScenario(ctx, tx, scenarioInput)
 			if err != nil {

--- a/usecases/scenario_usecase.go
+++ b/usecases/scenario_usecase.go
@@ -2,6 +2,8 @@ package usecases
 
 import (
 	"context"
+	"fmt"
+	"slices"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
@@ -63,9 +65,18 @@ func (usecase *ScenarioUsecase) GetScenario(ctx context.Context, scenarioId stri
 	return scenario, nil
 }
 
-func (usecase *ScenarioUsecase) UpdateScenario(ctx context.Context,
+func (usecase *ScenarioUsecase) UpdateScenario(
+	ctx context.Context,
 	scenarioInput models.UpdateScenarioInput,
 ) (models.Scenario, error) {
+	for _, outcome := range scenarioInput.DecisionToCaseOutcomes {
+		if !slices.Contains(models.ValidOutcomes, outcome) {
+			return models.Scenario{}, errors.Wrap(
+				models.BadParameterError,
+				fmt.Sprintf("Invalid input outcome: %s", outcome))
+		}
+	}
+
 	return executor_factory.TransactionReturnValue(
 		ctx,
 		usecase.transactionFactory,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -87,6 +87,7 @@ func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 		repository:                 &usecases.Repositories.MarbleDbRepository,
 		evaluateRuleAstExpression:  usecases.NewEvaluateRuleAstExpression(),
 		organizationIdOfContext:    usecases.OrganizationIdOfContext,
+		caseCreator:                usecases.NewCaseUseCase(),
 	}
 }
 
@@ -257,7 +258,7 @@ func (usecases *UsecasesWithCreds) NewUserUseCase() UserUseCase {
 	}
 }
 
-func (usecases *UsecasesWithCreds) NewCaseUseCase() CaseUseCase {
+func (usecases *UsecasesWithCreds) NewCaseUseCase() *CaseUseCase {
 	var gcsRepository repositories.GcsRepository
 	if usecases.Configuration.FakeGcsRepository {
 		gcsRepository = &repositories.GcsRepositoryFake{}
@@ -268,7 +269,7 @@ func (usecases *UsecasesWithCreds) NewCaseUseCase() CaseUseCase {
 		EnforceSecurity: usecases.NewEnforceSecurity(),
 		Credentials:     usecases.Credentials,
 	}
-	return CaseUseCase{
+	return &CaseUseCase{
 		enforceSecurity:    usecases.NewEnforceCaseSecurity(),
 		transactionFactory: usecases.NewTransactionFactory(),
 		executorFactory:    usecases.NewExecutorFactory(),


### PR DESCRIPTION
 - New field `decision_to_case_inbox` and `decision_to_case_outcomes` on the scenario (models, dto, db).
 - If both are not nil and the decision's outcome is in decision_to_case_outcomes, then create a automatically
 - Permission check on inbox reading is bypassed: in API context, the inbox id on the scenario is the source of truth. 
 - Pending question (but the code is reviewable as it is): what level of permission to update those settings on the scenario -> Edit: publisher permission required to udpate the settings


Commit 5: [48c8313](https://github.com/checkmarble/marble-backend/pull/495/commits/48c831353629bf9bccb8c22de1a345f7013a4762): just cleaning up dtos & models, many line changes but no logic change

Related front PR: https://github.com/checkmarble/marble-frontend/pull/392

The idea for starters is to set it manually on our side for S&P, later we can add an interface of course.