### PR TITLE
introduce hash field for api keys

### DIFF
--- a/dto/apikey_dto.go
+++ b/dto/apikey_dto.go
@@ -1,17 +1,23 @@
 package dto
 
-import "github.com/checkmarble/marble-backend/models"
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+)
 
 type ApiKey struct {
-	Id             string `json:"id"`
-	OrganizationId string `json:"organization_id"`
-	Description    string `json:"description"`
-	Role           string `json:"role"`
+	Id             string    `json:"id"`
+	CreatedAt      time.Time `json:"created_at"`
+	OrganizationId string    `json:"organization_id"`
+	Description    string    `json:"description"`
+	Role           string    `json:"role"`
 }
 
 func AdaptApiKeyDto(apiKey models.ApiKey) ApiKey {
 	return ApiKey{
 		Id:             apiKey.Id,
+		CreatedAt:      apiKey.CreatedAt,
 		OrganizationId: apiKey.OrganizationId,
 		Description:    apiKey.Description,
 		Role:           apiKey.Role.String(),
@@ -23,10 +29,10 @@ type CreatedApiKey struct {
 	Key string `json:"key"`
 }
 
-func AdaptCreatedApiKeyDto(apiKey models.CreatedApiKey) CreatedApiKey {
+func AdaptCreatedApiKeyDto(apiKey models.ApiKey) CreatedApiKey {
 	return CreatedApiKey{
-		ApiKey: AdaptApiKeyDto(apiKey.ApiKey),
-		Key:    apiKey.Value,
+		ApiKey: AdaptApiKeyDto(apiKey),
+		Key:    apiKey.Key,
 	}
 }
 

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -92,7 +92,7 @@ func setupApiCreds(ctx context.Context, t *testing.T, usecasesWithCreds usecases
 
 	// Generate creds from the created API Key
 	marbleTokenUsecase := usecasesWithCreds.NewMarbleTokenUseCase()
-	creds, err := marbleTokenUsecase.ValidateCredentials(ctx, "", apiKey.Hash)
+	creds, err := marbleTokenUsecase.ValidateCredentials(ctx, "", apiKey.Key)
 	assert.NoError(t, err, "Could not generate creds from api key")
 	return creds
 }

--- a/mocks/api_key_repository.go
+++ b/mocks/api_key_repository.go
@@ -23,7 +23,7 @@ func (r *ApiKeyRepository) ListApiKeys(ctx context.Context, exec repositories.Ex
 	return args.Get(0).([]models.ApiKey), args.Error(1)
 }
 
-func (r *ApiKeyRepository) CreateApiKey(ctx context.Context, exec repositories.Executor, apiKey models.CreateApiKey) error {
+func (r *ApiKeyRepository) CreateApiKey(ctx context.Context, exec repositories.Executor, apiKey models.ApiKey) error {
 	args := r.Called(exec, apiKey)
 	return args.Error(0)
 }

--- a/models/api_key.go
+++ b/models/api_key.go
@@ -1,26 +1,19 @@
 package models
 
+import "time"
+
 type ApiKey struct {
 	Id             string
-	OrganizationId string
-	Hash           string
+	CreatedAt      time.Time
 	Description    string
+	Key            string
+	Hash           []byte
+	OrganizationId string
 	Role           Role
-}
-
-type CreatedApiKey struct {
-	ApiKey
-	Value string
 }
 
 type CreateApiKeyInput struct {
-	OrganizationId string
 	Description    string
+	OrganizationId string
 	Role           Role
-}
-
-type CreateApiKey struct {
-	CreateApiKeyInput
-	Id   string
-	Hash string
 }

--- a/repositories/api_key_repository.go
+++ b/repositories/api_key_repository.go
@@ -54,12 +54,13 @@ func (repo *MarbleDbRepository) ListApiKeys(ctx context.Context, exec Executor, 
 			Select(dbmodels.ApiKeyFields...).
 			From(dbmodels.TABLE_APIKEYS).
 			Where("org_id = ?", organizationId).
-			Where("deleted_at IS NULL"),
+			Where("deleted_at IS NULL").
+			OrderBy("created_at DESC"),
 		dbmodels.AdaptApikey,
 	)
 }
 
-func (repo *MarbleDbRepository) CreateApiKey(ctx context.Context, exec Executor, apiKey models.CreateApiKey) error {
+func (repo *MarbleDbRepository) CreateApiKey(ctx context.Context, exec Executor, apiKey models.ApiKey) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
 	}
@@ -73,12 +74,14 @@ func (repo *MarbleDbRepository) CreateApiKey(ctx context.Context, exec Executor,
 				"id",
 				"org_id",
 				"key",
+				"key_hash",
 				"description",
 				"role",
 			).
 			Values(
 				apiKey.Id,
 				apiKey.OrganizationId,
+				apiKey.Key,
 				apiKey.Hash,
 				apiKey.Description,
 				apiKey.Role,

--- a/repositories/dbmodels/db_api_key.go
+++ b/repositories/dbmodels/db_api_key.go
@@ -1,6 +1,8 @@
 package dbmodels
 
 import (
+	"time"
+
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
 
@@ -9,8 +11,10 @@ import (
 
 type DBApiKey struct {
 	Id             string             `db:"id"`
+	CreatedAt      time.Time          `db:"created_at"`
 	OrganizationId string             `db:"org_id"`
-	Hash           string             `db:"key"` // TODO(hash-key): alter column name to "hash"
+	Key            string             `db:"key"` // TODO(hash-key): alter column name to "hash"
+	Hash           []byte             `db:"key_hash"`
 	Description    string             `db:"description"`
 	DeletedAt      pgtype.Timestamptz `db:"deleted_at"`
 	Role           int                `db:"role"`
@@ -23,9 +27,11 @@ var ApiKeyFields = utils.ColumnList[DBApiKey]()
 func AdaptApikey(db DBApiKey) (models.ApiKey, error) {
 	return models.ApiKey{
 		Id:             db.Id,
-		OrganizationId: db.OrganizationId,
-		Hash:           db.Hash,
+		CreatedAt:      db.CreatedAt,
 		Description:    db.Description,
+		Key:            db.Key,
+		Hash:           db.Hash,
+		OrganizationId: db.OrganizationId,
 		Role:           models.Role(db.Role),
 	}, nil
 }

--- a/repositories/migrations/20240304155400_hash_apikeys.sql
+++ b/repositories/migrations/20240304155400_hash_apikeys.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE apikeys
+ADD COLUMN key_hash bytea;
+
+ALTER TABLE apikeys
+ADD COLUMN created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now();
+
+UPDATE apikeys
+SET
+      key_hash = sha256(key::bytea)
+where
+      key_hash is null;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE apikeys
+DROP COLUMN key_hash;
+
+ALTER TABLE apikeys
+DROP COLUMN created_at;
+
+-- +goose StatementEnd

--- a/repositories/postgres/api_keys.go
+++ b/repositories/postgres/api_keys.go
@@ -11,19 +11,6 @@ import (
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 )
 
-func (db *Database) CreateApiKey(ctx context.Context, apiKey models.CreateApiKey) error {
-	query := `
-		INSERT INTO apikeys (id, org_id, key, description, role)
-		VALUES ($1, $2, $3)
-	`
-
-	_, err := db.pool.Exec(ctx, query, apiKey.Id, apiKey.OrganizationId, apiKey.Hash, apiKey.Description, apiKey.Role)
-	if err != nil {
-		return fmt.Errorf("pool.Exec error: %w", err)
-	}
-	return nil
-}
-
 func (db *Database) GetApiKeyByKey(ctx context.Context, key string) (models.ApiKey, error) {
 	query := `
 		SELECT id, org_id, key, description, role
@@ -33,8 +20,13 @@ func (db *Database) GetApiKeyByKey(ctx context.Context, key string) (models.ApiK
 	`
 
 	var apiKey dbmodels.DBApiKey
-	err := db.pool.QueryRow(ctx, query, key).Scan(&apiKey.Id, &apiKey.OrganizationId,
-		&apiKey.Hash, &apiKey.Description, &apiKey.Role)
+	err := db.pool.QueryRow(ctx, query, key).Scan(
+		&apiKey.Id,
+		&apiKey.OrganizationId,
+		&apiKey.Key,
+		&apiKey.Description,
+		&apiKey.Role,
+	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return models.ApiKey{}, models.NotFoundError
 	}
@@ -42,48 +34,4 @@ func (db *Database) GetApiKeyByKey(ctx context.Context, key string) (models.ApiK
 		return models.ApiKey{}, fmt.Errorf("pool.QueryRow error: %w", err)
 	}
 	return dbmodels.AdaptApikey(apiKey)
-}
-
-func (db *Database) GetApiKeysOfOrganization(ctx context.Context, organizationID string) ([]models.ApiKey, error) {
-	query := `
-		SELECT id, org_id, key, description, role
-		FROM apikeys
-		WHERE org_id = $1
-		AND deleted_at IS NULL
-	`
-
-	rows, err := db.pool.Query(ctx, query, organizationID)
-	if err != nil {
-		return nil, fmt.Errorf("pool.QueryRow error: %w", err)
-	}
-
-	apiKeys, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (models.ApiKey, error) {
-		var apiKey dbmodels.DBApiKey
-		if err := row.Scan(&apiKey.Id, &apiKey.OrganizationId, &apiKey.Hash,
-			&apiKey.Description, &apiKey.Role); err != nil {
-			return models.ApiKey{}, fmt.Errorf("row.Scan error: %w", err)
-		}
-		return dbmodels.AdaptApikey(apiKey)
-	})
-	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, models.NotFoundError
-	}
-	if err != nil {
-		return nil, fmt.Errorf("pgx.CollectRows error: %w", err)
-	}
-	return apiKeys, nil
-}
-
-func (db *Database) DeleteApiKey(ctx context.Context, apiKeyId string) error {
-	query := `
-		UPDATE apikeys
-		SET deleted_at = NOW()
-		WHERE id = $1
-	`
-
-	_, err := db.pool.Exec(ctx, query, apiKeyId)
-	if err != nil {
-		return fmt.Errorf("pool.Exec error: %w", err)
-	}
-	return nil
 }

--- a/usecases/token/generator_test.go
+++ b/usecases/token/generator_test.go
@@ -18,7 +18,7 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 	key := models.ApiKey{
 		Id:             "api_key_id",
 		OrganizationId: "organization_id",
-		Hash:           apiKeyHash,
+		Key:            apiKeyHash,
 		Role:           models.ADMIN,
 	}
 

--- a/usecases/token/generator_test.go
+++ b/usecases/token/generator_test.go
@@ -14,11 +14,11 @@ import (
 )
 
 func TestGenerator_GenerateToken_APIKey(t *testing.T) {
-	apiKeyHash := "api_key"
-	key := models.ApiKey{
+	key := "api_key"
+	apiKey := models.ApiKey{
 		Id:             "api_key_id",
 		OrganizationId: "organization_id",
-		Key:            apiKeyHash,
+		Key:            key,
 		Role:           models.ADMIN,
 	}
 
@@ -32,8 +32,8 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 
 	t.Run("nominal", func(t *testing.T) {
 		mockRepository := new(mocks.Database)
-		mockRepository.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
-			Return(key, nil)
+		mockRepository.On("GetApiKeyByKey", mock.Anything, key).
+			Return(apiKey, nil)
 		mockRepository.On("GetOrganizationByID", mock.Anything, "organization_id").
 			Return(organization, nil)
 
@@ -54,7 +54,7 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 			tokenLifetime: 60 * time.Second,
 		}
 
-		receivedToken, expirationTime, err := generator.GenerateToken(context.Background(), apiKeyHash, "")
+		receivedToken, expirationTime, err := generator.GenerateToken(context.Background(), key, "")
 		assert.NoError(t, err)
 		assert.Equal(t, token, receivedToken)
 		assert.Equal(t, now.Add(60*time.Second), expirationTime)
@@ -65,14 +65,14 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 
 	t.Run("GetApiKeyByKey error", func(t *testing.T) {
 		mockRepository := new(mocks.Database)
-		mockRepository.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
+		mockRepository.On("GetApiKeyByKey", mock.Anything, key).
 			Return(models.ApiKey{}, assert.AnError)
 
 		generator := Generator{
 			repository: mockRepository,
 		}
 
-		_, _, err := generator.GenerateToken(context.Background(), apiKeyHash, "")
+		_, _, err := generator.GenerateToken(context.Background(), key, "")
 		assert.Error(t, err)
 
 		mockRepository.AssertExpectations(t)
@@ -80,8 +80,8 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 
 	t.Run("GetOrganizationByID error", func(t *testing.T) {
 		mockRepository := new(mocks.Database)
-		mockRepository.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
-			Return(key, nil)
+		mockRepository.On("GetApiKeyByKey", mock.Anything, key).
+			Return(apiKey, nil)
 		mockRepository.On("GetOrganizationByID", mock.Anything, "organization_id").
 			Return(models.Organization{}, assert.AnError)
 
@@ -89,7 +89,7 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 			repository: mockRepository,
 		}
 
-		_, _, err := generator.GenerateToken(context.Background(), apiKeyHash, "")
+		_, _, err := generator.GenerateToken(context.Background(), key, "")
 		assert.Error(t, err)
 
 		mockRepository.AssertExpectations(t)
@@ -97,8 +97,8 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 
 	t.Run("EncodeMarbleToken error", func(t *testing.T) {
 		mockRepository := new(mocks.Database)
-		mockRepository.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
-			Return(key, nil)
+		mockRepository.On("GetApiKeyByKey", mock.Anything, key).
+			Return(apiKey, nil)
 		mockRepository.On("GetOrganizationByID", mock.Anything, "organization_id").
 			Return(organization, nil)
 
@@ -119,7 +119,7 @@ func TestGenerator_GenerateToken_APIKey(t *testing.T) {
 			tokenLifetime: 60 * time.Second,
 		}
 
-		receivedToken, expirationTime, err := generator.GenerateToken(context.Background(), apiKeyHash, "")
+		receivedToken, expirationTime, err := generator.GenerateToken(context.Background(), key, "")
 		assert.NoError(t, err)
 		assert.Equal(t, token, receivedToken)
 		assert.Equal(t, now.Add(60*time.Second), expirationTime)

--- a/usecases/token/validator_test.go
+++ b/usecases/token/validator_test.go
@@ -17,7 +17,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 	apiKey := models.ApiKey{
 		Id:             "api_key_id",
 		OrganizationId: "organization_id",
-		Hash:           apiKeyHash,
+		Key:            apiKeyHash,
 		Role:           models.ADMIN,
 	}
 

--- a/usecases/token/validator_test.go
+++ b/usecases/token/validator_test.go
@@ -12,12 +12,12 @@ import (
 )
 
 func TestValidator_Validate_APIKey(t *testing.T) {
-	apiKeyHash := "api_key"
+	key := "api_key"
 
 	apiKey := models.ApiKey{
 		Id:             "api_key_id",
 		OrganizationId: "organization_id",
-		Key:            apiKeyHash,
+		Key:            key,
 		Role:           models.ADMIN,
 	}
 
@@ -36,7 +36,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 
 	t.Run("nominal", func(t *testing.T) {
 		mockKeyAndOrganizationGetter := new(mocks.Database)
-		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
+		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, key).
 			Return(apiKey, nil)
 		mockKeyAndOrganizationGetter.On("GetOrganizationByID", mock.Anything, apiKey.OrganizationId).
 			Return(organization, nil)
@@ -45,7 +45,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		credentials, err := v.Validate(context.Background(), "", apiKeyHash)
+		credentials, err := v.Validate(context.Background(), "", key)
 		assert.NoError(t, err)
 		assert.Equal(t, creds, credentials)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
@@ -53,21 +53,21 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 
 	t.Run("GetApiKeyByKey error", func(t *testing.T) {
 		mockKeyAndOrganizationGetter := new(mocks.Database)
-		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
+		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, key).
 			Return(models.ApiKey{}, assert.AnError)
 
 		v := Validator{
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		_, err := v.Validate(context.Background(), "", apiKeyHash)
+		_, err := v.Validate(context.Background(), "", key)
 		assert.Error(t, err)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
 	})
 
 	t.Run("nominal", func(t *testing.T) {
 		mockKeyAndOrganizationGetter := new(mocks.Database)
-		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, apiKeyHash).
+		mockKeyAndOrganizationGetter.On("GetApiKeyByKey", mock.Anything, key).
 			Return(apiKey, nil)
 		mockKeyAndOrganizationGetter.On("GetOrganizationByID", mock.Anything, apiKey.OrganizationId).
 			Return(models.Organization{}, assert.AnError)
@@ -76,7 +76,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		_, err := v.Validate(context.Background(), "", apiKeyHash)
+		_, err := v.Validate(context.Background(), "", key)
 		assert.Error(t, err)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
 	})

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -341,7 +341,6 @@ func (usecases *UsecasesWithCreds) NewTagUseCase() TagUseCase {
 
 func (usecases *UsecasesWithCreds) NewApiKeyUseCase() ApiKeyUseCase {
 	return ApiKeyUseCase{
-		transactionFactory:      usecases.NewTransactionFactory(),
 		executorFactory:         usecases.NewExecutorFactory(),
 		organizationIdOfContext: usecases.OrganizationIdOfContext,
 		enforceSecurity: &security.EnforceSecurityApiKeyImpl{


### PR DESCRIPTION
- introduce new field on api keys "hash", store it on creation and backfill it with the old keys hashed value
- for now continue using the non hashed key for matching
- in follow-up PR, use the hashed key for matching
- then finally, drop the key column (or reuse it to store just the prefix of the key, for display like `123##############`)
- while I'm at it, add a created_at field to return them in order


Security:
- we use 32 bytes of entropy to generate the keys, so no need to salt them
- SHA256 to hash the keys (industry standard)