### PR TITLE
small changes for deployment with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
 # - by the opentelemetry tracing agent to send traces to the collector
 GOOGLE_CLOUD_PROJECT="tokyo-country-381508"
 
+# Enable to activate GCP tracing
+# If activated, you MUST have GCP application default credentials set up - see https://cloud.google.com/trace/docs/setup/go-ot
+# Will send error logs (but the app will still run) if an unexisting project is specified in GOOGLE_CLOUD_PROJECT or 
+# if the runner does not have the correct permissions to use tracing on the project
+ENABLE_GCP_TRACING=false
 
 # configure the document storage backend with optional fake backends
 GCS_INGESTION_BUCKET="data-ingestion-bucket"

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 ENV=development
 # port the servers listens on
-API_PORT=8080
+PORT=8080
 # replace me in a production environment
 AUTHENTICATION_JWT_SIGNING_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs+6r50m7qqLHHy7CvfmJPnAi+t/tubi7DPSM2jvA1etT1jEX\nrwbFbmooOu9LTgmjmxOq01p+XwkW1f7iPZViKrf7dEDEuqmpqYG9jPX4G/7xFcci\nGn1iSOiNx9awIKSYZa1wodlMCRM081DGqFNDMf1PScWIyM40nIwaGqLZht4HcOAq\nLbKDa15bxubBqZ9o/YnE1KmyBfq1tTnk0KzAb12Axt0xN4qB2zktsV/LLds+szMk\n/gRHjann1+fCZvxw1JzzRPtgeHLLYzn4ks3mwzy67RO3q/663KPZCsuYhlNCsMqp\n/HAbrF5PaihqzCZqLTDoIXXciCFFgwtLwm951wIDAQABAoIBAQCpb60tJX+1VYeQ\n06XK43rb8xjdiZUA+PYbYwZoUzBpwSq3Xo9g4E12hjzQEpqlJ+qKk+CfGm457AM3\nDMfbGhrRA2Oku4EGDdKYrnXikZVMN6yqx1RUAZJV+bfZYU+Fzbk8tjCEGG3DdfS8\n02nfBFkYb+MEIyGFhriAWmYSgxu4JTN0XRTyPqBytoSLqVCFbv0/yV2oJQDaXW08\nWAA8JtWhzqxACbFnPYe0hYUnrCA71t0v1P/N5uB4kKxI0tulGtW84noSyWA2LSdn\nJlKQW5WsyeMulGBMnIpj/OQJtQErupoITsh1TNi+6ffGgmuMCT1za70DHXVq9Ihu\nkpKBe0wRAoGBAOSarLfNvsS2lTH/8zPyhWBddCS5CfQAeUFLD5xWhQ7/6SenYzYY\n+oiiH2uL7d8grkobX5QLVvJ5ZXziYWoKgJe3SlrvRuNJZCAxvuynUCahhCT+chwW\nGz7ihXh3bGD0gtO6iogGBfrAkvRQnorkdSmVEZd1PsJV/lXp8LKgxJ91AoGBAMl+\ny/6NbzVHt9oQsrVrG/sCAOlqlfTt5KW6pI1WC4LoKBaGe+hy4emZ0G/M2feAJEPR\n92QrPRkVF5bVCjalJj42/7gQIl6r+DQ4+08gLB1MSpWua2M3UtEi/2gsMcQff/wg\n6kmNZObW5Jcnqpp6u72zQTQwF4H29XucV/Yw93abAoGADGvfIKmcSQIGv03CADuY\nRbEuQ2SOhuSTshmLApqs5jC/kXkF6gWXb18nx+c1iJ80+S/dlKS9F7XC7vM6CdIC\nRLwf3SsNNgJh32H0ltVMhJzYGk59EsuctWEHkZEjoW0HwstrBZMWNhbKpV3QD4n0\nV8sSxqEHRPX5ON/aRUp5BJUCgYEAlsymr2P6js2V80X7+Xqn/juJoyd6A0znioEd\nFgoHo3lMR09u/JC+Mq5DKOkPWAQ3H+rMU9NobpUyilf2xN7kuDtBNugcUO4zXCIp\nMxbI7URjrZJUHHUTLiIbNEOfG0DX8EJSFaoUkg7SFa5CKEsipt65Ne2oKkRBhLmF\nu2L6UXECgYBH1bpi0R6j7lIADtZtIJII/TezQbp+VK2R9qoNgkTnHoDjkRVR7v3m\n75wReMvTy1h0Qx/ROtStZz8d5uQuhdeJvbQPQR8KGFUFZDmVWxU+y15WI2H39FMA\nMireKxzCfGGtTsZnhDqYl9NuRPcAGYt5jvoERXlz7b69rkqQUrfy+Q==\n-----END RSA PRIVATE KEY-----"
 
@@ -24,6 +24,11 @@ GOOGLE_CLOUD_PROJECT="tokyo-country-381508"
 # Will send error logs (but the app will still run) if an unexisting project is specified in GOOGLE_CLOUD_PROJECT or 
 # if the runner does not have the correct permissions to use tracing on the project
 ENABLE_GCP_TRACING=false
+
+# 'liveness' (only log liveness requests) || 'all' (log all requests) || any other value for no request logs
+REQUEST_LOGGING_LEVEL=all
+# 'json' || 'text'
+LOGGING_FORMAT=text
 
 # configure the document storage backend with optional fake backends
 GCS_INGESTION_BUCKET="data-ingestion-bucket"

--- a/.env.example
+++ b/.env.example
@@ -1,33 +1,45 @@
 ENV=development
-PORT=8080
+# port the servers listens on
+API_PORT=8080
+# replace me in a production environment
+AUTHENTICATION_JWT_SIGNING_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs+6r50m7qqLHHy7CvfmJPnAi+t/tubi7DPSM2jvA1etT1jEX\nrwbFbmooOu9LTgmjmxOq01p+XwkW1f7iPZViKrf7dEDEuqmpqYG9jPX4G/7xFcci\nGn1iSOiNx9awIKSYZa1wodlMCRM081DGqFNDMf1PScWIyM40nIwaGqLZht4HcOAq\nLbKDa15bxubBqZ9o/YnE1KmyBfq1tTnk0KzAb12Axt0xN4qB2zktsV/LLds+szMk\n/gRHjann1+fCZvxw1JzzRPtgeHLLYzn4ks3mwzy67RO3q/663KPZCsuYhlNCsMqp\n/HAbrF5PaihqzCZqLTDoIXXciCFFgwtLwm951wIDAQABAoIBAQCpb60tJX+1VYeQ\n06XK43rb8xjdiZUA+PYbYwZoUzBpwSq3Xo9g4E12hjzQEpqlJ+qKk+CfGm457AM3\nDMfbGhrRA2Oku4EGDdKYrnXikZVMN6yqx1RUAZJV+bfZYU+Fzbk8tjCEGG3DdfS8\n02nfBFkYb+MEIyGFhriAWmYSgxu4JTN0XRTyPqBytoSLqVCFbv0/yV2oJQDaXW08\nWAA8JtWhzqxACbFnPYe0hYUnrCA71t0v1P/N5uB4kKxI0tulGtW84noSyWA2LSdn\nJlKQW5WsyeMulGBMnIpj/OQJtQErupoITsh1TNi+6ffGgmuMCT1za70DHXVq9Ihu\nkpKBe0wRAoGBAOSarLfNvsS2lTH/8zPyhWBddCS5CfQAeUFLD5xWhQ7/6SenYzYY\n+oiiH2uL7d8grkobX5QLVvJ5ZXziYWoKgJe3SlrvRuNJZCAxvuynUCahhCT+chwW\nGz7ihXh3bGD0gtO6iogGBfrAkvRQnorkdSmVEZd1PsJV/lXp8LKgxJ91AoGBAMl+\ny/6NbzVHt9oQsrVrG/sCAOlqlfTt5KW6pI1WC4LoKBaGe+hy4emZ0G/M2feAJEPR\n92QrPRkVF5bVCjalJj42/7gQIl6r+DQ4+08gLB1MSpWua2M3UtEi/2gsMcQff/wg\n6kmNZObW5Jcnqpp6u72zQTQwF4H29XucV/Yw93abAoGADGvfIKmcSQIGv03CADuY\nRbEuQ2SOhuSTshmLApqs5jC/kXkF6gWXb18nx+c1iJ80+S/dlKS9F7XC7vM6CdIC\nRLwf3SsNNgJh32H0ltVMhJzYGk59EsuctWEHkZEjoW0HwstrBZMWNhbKpV3QD4n0\nV8sSxqEHRPX5ON/aRUp5BJUCgYEAlsymr2P6js2V80X7+Xqn/juJoyd6A0znioEd\nFgoHo3lMR09u/JC+Mq5DKOkPWAQ3H+rMU9NobpUyilf2xN7kuDtBNugcUO4zXCIp\nMxbI7URjrZJUHHUTLiIbNEOfG0DX8EJSFaoUkg7SFa5CKEsipt65Ne2oKkRBhLmF\nu2L6UXECgYBH1bpi0R6j7lIADtZtIJII/TezQbp+VK2R9qoNgkTnHoDjkRVR7v3m\n75wReMvTy1h0Qx/ROtStZz8d5uQuhdeJvbQPQR8KGFUFZDmVWxU+y15WI2H39FMA\nMireKxzCfGGtTsZnhDqYl9NuRPcAGYt5jvoERXlz7b69rkqQUrfy+Q==\n-----END RSA PRIVATE KEY-----"
+
+# Env variables for the postgresql database
 PG_HOSTNAME=localhost
 PG_PORT=5432
 PG_USER=postgres
 PG_PASSWORD=marble
 
-AUTHENTICATION_JWT_SIGNING_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs+6r50m7qqLHHy7CvfmJPnAi+t/tubi7DPSM2jvA1etT1jEX\nrwbFbmooOu9LTgmjmxOq01p+XwkW1f7iPZViKrf7dEDEuqmpqYG9jPX4G/7xFcci\nGn1iSOiNx9awIKSYZa1wodlMCRM081DGqFNDMf1PScWIyM40nIwaGqLZht4HcOAq\nLbKDa15bxubBqZ9o/YnE1KmyBfq1tTnk0KzAb12Axt0xN4qB2zktsV/LLds+szMk\n/gRHjann1+fCZvxw1JzzRPtgeHLLYzn4ks3mwzy67RO3q/663KPZCsuYhlNCsMqp\n/HAbrF5PaihqzCZqLTDoIXXciCFFgwtLwm951wIDAQABAoIBAQCpb60tJX+1VYeQ\n06XK43rb8xjdiZUA+PYbYwZoUzBpwSq3Xo9g4E12hjzQEpqlJ+qKk+CfGm457AM3\nDMfbGhrRA2Oku4EGDdKYrnXikZVMN6yqx1RUAZJV+bfZYU+Fzbk8tjCEGG3DdfS8\n02nfBFkYb+MEIyGFhriAWmYSgxu4JTN0XRTyPqBytoSLqVCFbv0/yV2oJQDaXW08\nWAA8JtWhzqxACbFnPYe0hYUnrCA71t0v1P/N5uB4kKxI0tulGtW84noSyWA2LSdn\nJlKQW5WsyeMulGBMnIpj/OQJtQErupoITsh1TNi+6ffGgmuMCT1za70DHXVq9Ihu\nkpKBe0wRAoGBAOSarLfNvsS2lTH/8zPyhWBddCS5CfQAeUFLD5xWhQ7/6SenYzYY\n+oiiH2uL7d8grkobX5QLVvJ5ZXziYWoKgJe3SlrvRuNJZCAxvuynUCahhCT+chwW\nGz7ihXh3bGD0gtO6iogGBfrAkvRQnorkdSmVEZd1PsJV/lXp8LKgxJ91AoGBAMl+\ny/6NbzVHt9oQsrVrG/sCAOlqlfTt5KW6pI1WC4LoKBaGe+hy4emZ0G/M2feAJEPR\n92QrPRkVF5bVCjalJj42/7gQIl6r+DQ4+08gLB1MSpWua2M3UtEi/2gsMcQff/wg\n6kmNZObW5Jcnqpp6u72zQTQwF4H29XucV/Yw93abAoGADGvfIKmcSQIGv03CADuY\nRbEuQ2SOhuSTshmLApqs5jC/kXkF6gWXb18nx+c1iJ80+S/dlKS9F7XC7vM6CdIC\nRLwf3SsNNgJh32H0ltVMhJzYGk59EsuctWEHkZEjoW0HwstrBZMWNhbKpV3QD4n0\nV8sSxqEHRPX5ON/aRUp5BJUCgYEAlsymr2P6js2V80X7+Xqn/juJoyd6A0znioEd\nFgoHo3lMR09u/JC+Mq5DKOkPWAQ3H+rMU9NobpUyilf2xN7kuDtBNugcUO4zXCIp\nMxbI7URjrZJUHHUTLiIbNEOfG0DX8EJSFaoUkg7SFa5CKEsipt65Ne2oKkRBhLmF\nu2L6UXECgYBH1bpi0R6j7lIADtZtIJII/TezQbp+VK2R9qoNgkTnHoDjkRVR7v3m\n75wReMvTy1h0Qx/ROtStZz8d5uQuhdeJvbQPQR8KGFUFZDmVWxU+y15WI2H39FMA\nMireKxzCfGGtTsZnhDqYl9NuRPcAGYt5jvoERXlz7b69rkqQUrfy+Q==\n-----END RSA PRIVATE KEY-----"
-GCS_INGESTION_BUCKET="data-ingestion-bucket"
-GCS_CASE_MANAGER_BUCKET="case-manager-bucket"
 
-# The frontend sign
+# Used by the firebase sdk to validate the id tokens
 FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
 
-# When using firebase emulator, JWT Token are issued for this audience
-GOOGLE_CLOUD_PROJECT="fake-project-id"
+# Used:
+# - by the firebase sdk to validate the id tokens
+# - by the opentelemetry tracing agent to send traces to the collector
+GOOGLE_CLOUD_PROJECT="tokyo-country-381508"
 
-MARBLE_ADMIN_EMAIL=admin@checkmarble.com
 
-# Required if FAKE_AWS_S3 is false
-# AWS_REGION=eu-west-3
-# AWS_ACCESS_KEY=
-# AWS_SECRET_KEY=
-
-FAKE_AWS_S3=true
+# configure the document storage backend with optional fake backends
+GCS_INGESTION_BUCKET="data-ingestion-bucket"
+GCS_CASE_MANAGER_BUCKET="case-manager-bucket"
 FAKE_GCS=true
 
+# Configure the AWS S3 backend for sending decision files
+FAKE_AWS_S3=true
+# The 3 below are required if FAKE_AWS_S3 is false
+AWS_REGION=eu-west-3
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+
+# Othe dependency configurations
 SEGMENT_WRITE_KEY=UgkImFmHmBZAWh5fxIKBY3QtvlcBrhqQ
 SENTRY_DSN=
 
+# Metabase configuration
 METABASE_SITE_URL="https://your_subdomain.metabaseapp.com"
 METABASE_JWT_SIGNING_KEY="dummy"
 METABASE_GLOBAL_DASHBOARD_ID=123
+
+# Used to create a first default admin user if no user exists
+MARBLE_ADMIN_EMAIL=admin@checkmarble.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.19
 
 COPY --from=build /go/bin/app /
 
-ENV API_PORT=${API_PORT:-8080}
-EXPOSE $API_PORT
+ENV PORT=${PORT:-8080}
+EXPOSE $PORT
 
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM alpine:3.19
 
 COPY --from=build /go/bin/app /
 
-ENV PORT=8080
-EXPOSE $PORT
+ENV API_PORT=${API_PORT:-8080}
+EXPOSE $API_PORT
 
 ENTRYPOINT ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go get
 
 RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.version=`git rev-parse --short HEAD`'"
 
-FROM gcr.io/distroless/static
+FROM alpine:3.19
 
 COPY --from=build /go/bin/app /
 

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -26,14 +25,13 @@ func New(
 	usecases usecases.Usecases,
 	auth *Authentication,
 	tokenHandler *TokenHandler,
-	logger *slog.Logger,
 ) *http.Server {
 	s := &API{
 		router:   router,
 		usecases: usecases,
 	}
 
-	s.routes(auth, tokenHandler, logger)
+	s.routes(auth, tokenHandler)
 
 	return &http.Server{
 		Addr:         fmt.Sprintf("0.0.0.0:%s", port),

--- a/api/middleware/logging.go
+++ b/api/middleware/logging.go
@@ -26,7 +26,7 @@ func WithIgnorePath(s []string) LoggerOption {
 	}
 }
 
-func NewLogging(logger *slog.Logger, options ...LoggerOption) gin.HandlerFunc {
+func NewLogging(logger *slog.Logger, level string, options ...LoggerOption) gin.HandlerFunc {
 	l := &config{
 		logger:           logger,
 		defaultLevel:     slog.LevelInfo,
@@ -44,6 +44,17 @@ func NewLogging(logger *slog.Logger, options ...LoggerOption) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
+		switch level {
+		case "liveness":
+			if c.Request.URL.Path != "/liveness" {
+				return
+			}
+		case "all":
+			// continue
+		default:
+			return
+		}
+
 		if _, ok := ignore[c.Request.URL.Path]; ok {
 			return
 		}

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,11 +1,9 @@
 package api
 
 import (
-	"log/slog"
 	"net/http"
 	"time"
 
-	"github.com/checkmarble/marble-backend/api/middleware"
 	limits "github.com/gin-contrib/size"
 	"github.com/gin-contrib/timeout"
 	"github.com/gin-gonic/gin"
@@ -25,8 +23,8 @@ func timeoutMiddleware(duration time.Duration) gin.HandlerFunc {
 	)
 }
 
-func (api *API) routes(auth *Authentication, tokenHandler *TokenHandler, logger *slog.Logger) {
-	api.router.GET("/liveness", middleware.NewLogging(logger), HandleLivenessProbe)
+func (api *API) routes(auth *Authentication, tokenHandler *TokenHandler) {
+	api.router.GET("/liveness", HandleLivenessProbe)
 	api.router.POST("/crash", HandleCrash)
 	api.router.POST("/token", tokenHandler.GenerateToken)
 

--- a/infra/parse_signing_key.go
+++ b/infra/parse_signing_key.go
@@ -5,9 +5,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"log"
+	"strings"
 )
 
 func MustParseSigningKey(privateKeyString string) *rsa.PrivateKey {
+	// when a multi-line env variable is passed to the docker container by docker-compose, it escapes the newlines
+	privateKeyString = strings.Replace(privateKeyString, "\\n", "\n", -1)
 	block, _ := pem.Decode([]byte(privateKeyString))
 	if block == nil || block.Type != "RSA PRIVATE KEY" {
 		log.Fatalf("failed to decode PEM block containing RSA private key")

--- a/repositories/firebase/client.go
+++ b/repositories/firebase/client.go
@@ -11,7 +11,6 @@ import (
 
 type tokenCookieVerifier interface {
 	VerifyIDToken(ctx context.Context, idToken string) (*auth.Token, error)
-	VerifySessionCookie(ctx context.Context, sessionCookie string) (*auth.Token, error)
 }
 
 type Client struct {
@@ -20,9 +19,6 @@ type Client struct {
 
 func (c *Client) verifyTokenOrCookie(ctx context.Context, firebaseToken string) (*auth.Token, error) {
 	token, err := c.verifier.VerifyIDToken(ctx, firebaseToken)
-	if err != nil {
-		token, err = c.verifier.VerifySessionCookie(ctx, firebaseToken)
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/repositories/firebase/client_test.go
+++ b/repositories/firebase/client_test.go
@@ -20,11 +20,6 @@ func (m *mockTokenCookieVerifier) VerifyIDToken(ctx context.Context, idToken str
 	return args.Get(0).(*auth.Token), args.Error(1)
 }
 
-func (m *mockTokenCookieVerifier) VerifySessionCookie(ctx context.Context, sessionCookie string) (*auth.Token, error) {
-	args := m.Called(ctx, sessionCookie)
-	return args.Get(0).(*auth.Token), args.Error(1)
-}
-
 func TestClient_VerifyFirebaseToken(t *testing.T) {
 	token := auth.Token{
 		Subject: "token_subject",
@@ -55,27 +50,6 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 	t.Run("VerifyIDToken error", func(t *testing.T) {
 		mockVerifier := new(mockTokenCookieVerifier)
 		mockVerifier.On("VerifyIDToken", mock.Anything, "token").
-			Return(&auth.Token{}, assert.AnError)
-		mockVerifier.On("VerifySessionCookie", mock.Anything, "token").
-			Return(&token, nil)
-
-		c := Client{
-			verifier: mockVerifier,
-		}
-
-		identity, err := c.VerifyFirebaseToken(context.Background(), "token")
-		assert.NoError(t, err)
-		assert.Equal(t, models.FirebaseIdentity{
-			Email: "user@email.com",
-		}, identity)
-		mockVerifier.AssertExpectations(t)
-	})
-
-	t.Run("VerifySessionCookie error", func(t *testing.T) {
-		mockVerifier := new(mockTokenCookieVerifier)
-		mockVerifier.On("VerifyIDToken", mock.Anything, "token").
-			Return(&auth.Token{}, assert.AnError)
-		mockVerifier.On("VerifySessionCookie", mock.Anything, "token").
 			Return(&auth.Token{}, assert.AnError)
 
 		c := Client{

--- a/router.go
+++ b/router.go
@@ -79,7 +79,9 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	r.Use(otelgin.Middleware("marble-backend"))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))
 	r.Use(utils.StoreSegmentClientInContextMiddleware(deps.SegmentClient))
-	r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(deps.OpenTelemetryTracer))
+	if deps.OpenTelemetryTracer != nil {
+		r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(*deps.OpenTelemetryTracer))
+	}
 
 	return r
 }

--- a/router.go
+++ b/router.go
@@ -72,10 +72,7 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	r.Use(gin.Recovery())
 	r.Use(sentrygin.New(sentrygin.Options{Repanic: true}))
 	r.Use(cors.New(corsOption(conf.env)))
-	if conf.env == "development" {
-		// GCP already logs those elements
-		r.Use(middleware.NewLogging(logger))
-	}
+	r.Use(middleware.NewLogging(logger, conf.requestLoggingLevel))
 	r.Use(otelgin.Middleware("marble-backend"))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))
 	r.Use(utils.StoreSegmentClientInContextMiddleware(deps.SegmentClient))

--- a/router.go
+++ b/router.go
@@ -79,9 +79,7 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	r.Use(otelgin.Middleware("marble-backend"))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))
 	r.Use(utils.StoreSegmentClientInContextMiddleware(deps.SegmentClient))
-	if deps.OpenTelemetryTracer != nil {
-		r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(*deps.OpenTelemetryTracer))
-	}
+	r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(deps.OpenTelemetryTracer))
 
 	return r
 }

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -190,7 +190,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 
 	suite.repositoryError = errors.New("some repository error")
 	suite.securityError = errors.New("some security error")
-	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("test"))
+	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
 }
 
 func (suite *DatamodelUsecaseTestSuite) makeUsecase() *DataModelUseCase {

--- a/usecases/indexes/aggregate_query_test.go
+++ b/usecases/indexes/aggregate_query_test.go
@@ -15,7 +15,7 @@ import (
 
 func makeTestContext() context.Context {
 	ctx := context.Background()
-	return utils.StoreLoggerInContext(ctx, utils.NewLogger("test"))
+	return utils.StoreLoggerInContext(ctx, utils.NewLogger("text"))
 }
 
 func TestAggregationNodeToQueryFamily(t *testing.T) {

--- a/usecases/indexes/index_editor_test.go
+++ b/usecases/indexes/index_editor_test.go
@@ -133,7 +133,7 @@ func (suite *ClientDbIndexEditorTestSuite) SetupTest() {
 
 	suite.repositoryError = errors.New("some repository error")
 	suite.securityError = errors.New("some security error")
-	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("test"))
+	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
 }
 
 func (suite *ClientDbIndexEditorTestSuite) makeUsecase() ClientDbIndexEditor {

--- a/usecases/scenario_publication_usecase_test.go
+++ b/usecases/scenario_publication_usecase_test.go
@@ -138,7 +138,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) SetupTest() {
 
 	suite.repositoryError = errors.New("some repository error")
 	suite.securityError = errors.New("some security error")
-	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("test"))
+	suite.ctx = utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
 }
 
 func (suite *ScenarioPublicationUsecaseTestSuite) makeUsecase() *ScenarioPublicationUsecase {

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
-	ctx := utils.StoreLoggerInContext(context.Background(), utils.NewLogger("test"))
+	ctx := utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
 	scenario := models.Scenario{
 		Id:                uuid.New().String(),
 		OrganizationId:    uuid.New().String(),

--- a/utils/context_logging.go
+++ b/utils/context_logging.go
@@ -7,21 +7,26 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"slices"
 
 	"github.com/gin-gonic/gin"
 )
 
-func NewLogger(env string) *slog.Logger {
+func NewLogger(format string) *slog.Logger {
 	var logger *slog.Logger
+	if !slices.Contains([]string{"text", "json"}, format) {
+		fmt.Printf("invalid log format '%s', falling back to 'text'\n", format)
+		format = "text"
+	}
 
-	isDevEnv := env == "development"
-	if isDevEnv {
+	switch format {
+	case "text":
 		logHandler := LocalDevHandlerOptions{
 			SlogOpts: slog.HandlerOptions{Level: slog.LevelDebug},
 			UseColor: true,
 		}.NewLocalDevHandler(os.Stdout)
 		logger = slog.New(logHandler)
-	} else {
+	case "json":
 		slogOption := slog.HandlerOptions{ReplaceAttr: GCPLoggerAttributeReplacer}
 		jsonHandler := slog.NewJSONHandler(os.Stdout, &slogOption)
 		logger = slog.New(jsonHandler)


### PR DESCRIPTION
- new env variable "enable_gc_tracing" (requires application default credentials to run)
- use alpine instead of distroless image to have access to wget to use in docker-compose health checks
- better documentation of what env variables do
- drop "VerifySessionCookie" logic in auth middleware, that was no longer supposed to be used but messed up all our error logging related to token validation