### PR TITLE
feat(organization): expose user deleted_at

### DIFF
--- a/dto/organization_dto.go
+++ b/dto/organization_dto.go
@@ -17,8 +17,7 @@ func AdaptOrganizationDto(org models.Organization) APIOrganization {
 }
 
 type CreateOrganizationBodyDto struct {
-	Name         string `json:"name"`
-	DatabaseName string `json:"databaseName"`
+	Name string `json:"name"`
 }
 
 type CreateOrganizationInputDto struct {
@@ -27,7 +26,6 @@ type CreateOrganizationInputDto struct {
 
 type UpdateOrganizationBodyDto struct {
 	Name                       *string `json:"name,omitempty"`
-	DatabaseName               *string `json:"databaseName,omitempty"`
 	ExportScheduledExecutionS3 *string `json:"export_scheduled_execution_s3,omitempty"`
 }
 

--- a/dto/user_dto.go
+++ b/dto/user_dto.go
@@ -1,14 +1,19 @@
 package dto
 
-import "github.com/checkmarble/marble-backend/models"
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+)
 
 type User struct {
-	UserId         string `json:"user_id"`
-	Email          string `json:"email"`
-	Role           string `json:"role"`
-	OrganizationId string `json:"organization_id"`
-	FirstName      string `json:"first_name"`
-	LastName       string `json:"last_name"`
+	UserId         string     `json:"user_id"`
+	Email          string     `json:"email"`
+	Role           string     `json:"role"`
+	OrganizationId string     `json:"organization_id"`
+	FirstName      string     `json:"first_name"`
+	LastName       string     `json:"last_name"`
+	DeletedAt      *time.Time `json:"deleted_at,omitempty"`
 }
 
 func AdaptUserDto(user models.User) User {
@@ -19,6 +24,7 @@ func AdaptUserDto(user models.User) User {
 		OrganizationId: user.OrganizationId,
 		FirstName:      user.FirstName,
 		LastName:       user.LastName,
+		DeletedAt:      user.DeletedAt,
 	}
 }
 

--- a/repositories/dbmodels/db_user.go
+++ b/repositories/dbmodels/db_user.go
@@ -21,22 +21,22 @@ const TABLE_USERS = "users"
 var UserFields = utils.ColumnList[DBUserResult]()
 
 func AdaptUser(db DBUserResult) (models.User, error) {
-	var organizationId, firstName, lastName string
+	user := models.User{
+		UserId: models.UserId(db.Id),
+		Email:  db.Email,
+		Role:   models.Role(db.Role),
+	}
 	if db.OrganizationId != nil {
-		organizationId = *db.OrganizationId
+		user.OrganizationId = *db.OrganizationId
 	}
 	if db.FirstName.Valid {
-		firstName = db.FirstName.String
+		user.FirstName = db.FirstName.String
 	}
 	if db.LastName.Valid {
-		lastName = db.LastName.String
+		user.LastName = db.LastName.String
 	}
-	return models.User{
-		UserId:         models.UserId(db.Id),
-		Email:          db.Email,
-		Role:           models.Role(db.Role),
-		OrganizationId: organizationId,
-		FirstName:      firstName,
-		LastName:       lastName,
-	}, nil
+	if db.DeletedAt.Valid {
+		user.DeletedAt = &db.DeletedAt.Time
+	}
+	return user, nil
 }


### PR DESCRIPTION
Small update :
- cleanup some old deprecated DTO
- expose user `deleted_at`

PS: the API endpoint already return deleted users but there is no possibility to know if the user is "soft deleted" or not. The endpoint is also consumed in the frontend (to feed the Org User context)