### PR TITLE
tentative fix for timezone load

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.version=`git rev-pa
 FROM alpine:3.19
 
 COPY --from=build /go/bin/app /
+COPY --from=build /usr/local/go/lib/time/zoneinfo.zip /
+ENV ZONEINFO=/zoneinfo.zip
 
 ENV PORT=${PORT:-8080}
 EXPOSE $PORT


### PR DESCRIPTION
See
https://lalatron.hashnode.dev/a-story-about-go-docker-and-time-zones
https://stackoverflow.com/questions/59094236/error-unknown-time-zone-america-los-angeles-in-time-loadlocation

The error was introduced by using alpine as the base image, which does not include the tz definitions by default (turns out the tz info is handled by the environment not hard coded in the std lib)