### PR TITLE
fix: ingestion in batch was broken because of context org id in batch job mode

### DIFF
--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -219,7 +219,7 @@ func (usecases *UsecasesWithCreds) NewIngestionUseCase() IngestionUseCase {
 		executorFactory:     usecases.NewExecutorFactory(),
 		ingestionRepository: usecases.Repositories.IngestionRepository,
 		gcsRepository:       gcsRepository,
-		dataModelUseCase:    usecases.NewDataModelUseCase(),
+		dataModelRepository: usecases.Repositories.DataModelRepository,
 		uploadLogRepository: usecases.Repositories.UploadLogRepository,
 		GcsIngestionBucket:  usecases.Configuration.GcsIngestionBucket,
 	}


### PR DESCRIPTION
To keep it short: when running in batch as a cron script, rather than from a server query, we don't have a specific org's id in the "usecase with credentials".
It's really a limitation of how we currently inject those dependencies & context into usecases, and something I want to review at some point - but for today this quick fix will have to do (here, the GetDataModel in the usecase was failing because it's reading the indexes which requires the context org id to get the relevant schema, while the repository method of the same name "only" reads the tables as described in data_model_tables/fields/links, which does not require access to the client schema)