### PR TITLE
feat(api): add decision rule ast to decision response

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -29,7 +29,7 @@ func (api *API) handleGetDecision(c *gin.Context) {
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, dto.NewAPIDecision(decision))
+	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision))
 }
 
 func (api *API) handleListDecisions(c *gin.Context) {
@@ -141,5 +141,5 @@ func (api *API) handlePostDecision(c *gin.Context) {
 		presentError(c, errors.Wrap(err, "Error creating decision in handlePostDecision"))
 		return
 	}
-	c.JSON(http.StatusOK, dto.NewAPIDecision(decision))
+	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision))
 }

--- a/dto/case_dto.go
+++ b/dto/case_dto.go
@@ -22,7 +22,7 @@ type APICase struct {
 
 type APICaseWithDecisions struct {
 	APICase
-	Decisions []APIDecision `json:"decisions"`
+	Decisions []APIDecisionWithRules `json:"decisions"`
 }
 
 func AdaptCaseDto(c models.Case) APICase {
@@ -43,7 +43,7 @@ func AdaptCaseDto(c models.Case) APICase {
 func AdaptCaseWithDecisionsDto(c models.Case) APICaseWithDecisions {
 	return APICaseWithDecisions{
 		APICase:   AdaptCaseDto(c),
-		Decisions: pure_utils.Map(c.Decisions, NewAPIDecision),
+		Decisions: pure_utils.Map(c.Decisions, NewAPIDecisionWithRule),
 	}
 }
 

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -61,9 +61,13 @@ type APIDecision struct {
 	TriggerObjectType    string              `json:"trigger_object_type"`
 	Outcome              string              `json:"outcome"`
 	Scenario             APIDecisionScenario `json:"scenario"`
-	Rules                []APIDecisionRule   `json:"rules"`
 	Score                int                 `json:"score"`
 	ScheduledExecutionId *string             `json:"scheduled_execution_id,omitempty"`
+}
+
+type APIDecisionWithRules struct {
+	APIDecision
+	Rules []APIDecisionRule `json:"rules"`
 }
 
 func NewAPIDecision(decision models.Decision) APIDecision {
@@ -81,16 +85,25 @@ func NewAPIDecision(decision models.Decision) APIDecision {
 			Version:             decision.ScenarioVersion,
 		},
 		Score:                decision.Score,
-		Rules:                make([]APIDecisionRule, len(decision.RuleExecutions)),
 		ScheduledExecutionId: decision.ScheduledExecutionId,
+	}
+
+	if decision.Case != nil {
+		c := AdaptCaseDto(*decision.Case)
+		apiDecision.Case = &c
+	}
+
+	return apiDecision
+}
+
+func NewAPIDecisionWithRule(decision models.DecisionWithRuleExecutions) APIDecisionWithRules {
+	apiDecision := APIDecisionWithRules{
+		APIDecision: NewAPIDecision(decision.Decision),
+		Rules:       make([]APIDecisionRule, len(decision.RuleExecutions)),
 	}
 
 	for i, ruleExecution := range decision.RuleExecutions {
 		apiDecision.Rules[i] = NewAPIDecisionRule(ruleExecution)
-	}
-	if decision.Case != nil {
-		c := AdaptCaseDto(*decision.Case)
-		apiDecision.Case = &c
 	}
 
 	return apiDecision

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -517,7 +517,7 @@ func createDecisions(t *testing.T, table models.Table, usecasesWithCreds usecase
 func createAndTestDecision(t *testing.T, transactionPayloadJson []byte, table models.Table,
 	decisionUsecase usecases.DecisionUsecase, usecasesWithCreds usecases.UsecasesWithCreds,
 	organizationId, scenarioId string, logger *slog.Logger,
-) models.Decision {
+) models.DecisionWithRuleExecutions {
 	parser := payload_parser.NewParser()
 	transactionPayload, validationErrors, err :=
 		parser.ParsePayload(table, transactionPayloadJson)

--- a/models/case.go
+++ b/models/case.go
@@ -9,7 +9,7 @@ type Case struct {
 	Id             string
 	Contributors   []CaseContributor
 	CreatedAt      time.Time
-	Decisions      []Decision
+	Decisions      []DecisionWithRuleExecutions
 	DecisionsCount int
 	Events         []CaseEvent
 	InboxId        string

--- a/models/decision.go
+++ b/models/decision.go
@@ -16,10 +16,14 @@ type Decision struct {
 	ScenarioName         string
 	ScenarioDescription  string
 	ScenarioVersion      int
-	RuleExecutions       []RuleExecution
 	Score                int
 	ScheduledExecutionId *string
 	ScenarioIterationId  string
+}
+
+type DecisionWithRuleExecutions struct {
+	Decision
+	RuleExecutions []RuleExecution
 }
 
 type DecisionWithRank struct {

--- a/repositories/analytics_repository.go
+++ b/repositories/analytics_repository.go
@@ -29,7 +29,7 @@ func (repo *MarbleAnalyticsRepository) ListAnalytics(ctx context.Context, organi
 	return analytics, nil
 }
 
-func (repo *MarbleAnalyticsRepository) getAnalytics(ctx context.Context, organizationId string,
+func (repo *MarbleAnalyticsRepository) getAnalytics(_ context.Context, organizationId string,
 	analyticsCustomClaims models.AnalyticsCustomClaims,
 ) (models.Analytics, error) {
 	generalDashboardUrl, err := repo.metabase.GenerateSignedEmbeddingURL(analyticsCustomClaims)

--- a/repositories/dbmodels/db_decision.go
+++ b/repositories/dbmodels/db_decision.go
@@ -48,7 +48,7 @@ type DBPaginatedDecisions struct {
 
 var SelectDecisionColumn = utils.ColumnList[DbDecision]()
 
-func AdaptDecision(db DbDecision, ruleExecutions []models.RuleExecution, decisionCase *models.Case) models.Decision {
+func AdaptDecision(db DbDecision, decisionCase *models.Case) models.Decision {
 	triggerObject := make(map[string]any)
 	err := json.Unmarshal(db.TriggerObjectRaw, &triggerObject)
 	if err != nil {
@@ -67,14 +67,20 @@ func AdaptDecision(db DbDecision, ruleExecutions []models.RuleExecution, decisio
 		ScenarioName:         db.ScenarioName,
 		ScenarioDescription:  db.ScenarioDescription,
 		ScenarioVersion:      db.ScenarioVersion,
-		RuleExecutions:       ruleExecutions,
 		Score:                db.Score,
 		ScheduledExecutionId: db.ScheduledExecutionId,
 	}
 }
 
+func AdaptDecisionWithRuleExecutions(db DbDecision, ruleExecutions []models.RuleExecution,
+	decisionCase *models.Case,
+) models.DecisionWithRuleExecutions {
+	decision := AdaptDecision(db, decisionCase)
+	return models.DecisionWithRuleExecutions{Decision: decision, RuleExecutions: ruleExecutions}
+}
+
 func AdaptDecisionWithRank(db DbDecision, decisionCase *models.Case, rankNumber, total int) models.DecisionWithRank {
-	decision := AdaptDecision(db, nil, decisionCase)
+	decision := AdaptDecision(db, decisionCase)
 	return models.DecisionWithRank{
 		Decision:   decision,
 		RankNumber: rankNumber,

--- a/repositories/scenario_iterations_write.go
+++ b/repositories/scenario_iterations_write.go
@@ -38,7 +38,7 @@ func (repo *MarbleDbRepository) CreateScenarioIterationAndRules(ctx context.Cont
 	if scenarioIterationBodyInput != nil {
 
 		var triggerCondition *[]byte
-		if scenarioIterationBodyInput != nil && scenarioIterationBodyInput.TriggerConditionAstExpression != nil {
+		if scenarioIterationBodyInput.TriggerConditionAstExpression != nil {
 			var err error
 			triggerCondition, err = dbmodels.SerializeFormulaAstExpression(
 				scenarioIterationBodyInput.TriggerConditionAstExpression)

--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -285,7 +285,6 @@ func (usecase *ScenarioIterationUsecase) CommitScenarioIterationVersion(
 				tx,
 				scenarioAndIteration.Scenario.OrganizationId,
 				scenarioAndIteration.Scenario.Id,
-				iterationId,
 			)
 			if err != nil {
 				return iteration, err
@@ -325,7 +324,7 @@ func replaceTriggerOrRule(scenarioAndIteration models.ScenarioAndIteration,
 func (usecase *ScenarioIterationUsecase) getScenarioVersion(
 	ctx context.Context,
 	exec repositories.Executor,
-	organizationId, scenarioId, iterationId string,
+	organizationId, scenarioId string,
 ) (int, error) {
 	scenarioIterations, err := usecase.repository.ListScenarioIterations(
 		ctx,

--- a/usecases/scheduledexecution/export_schedule_execution.go
+++ b/usecases/scheduledexecution/export_schedule_execution.go
@@ -122,7 +122,7 @@ func (exporter *ExportScheduleExecution) ExportDecisions(ctx context.Context, sc
 	var number_of_exported_decisions int
 
 	for decision := range decisionChan {
-		err := encoder.Encode(dto.NewAPIDecision(decision))
+		err := encoder.Encode(dto.NewAPIDecisionWithRule(decision))
 		if err != nil {
 			allErrors = append(allErrors, err)
 		} else {

--- a/usecases/scheduledexecution/run_scheduled_execution.go
+++ b/usecases/scheduledexecution/run_scheduled_execution.go
@@ -290,17 +290,19 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 				return errors.Wrap(err, fmt.Sprintf("error evaluating scenario in executeScheduledScenario %s", scenario.Id))
 			}
 
-			decisionInput := models.Decision{
-				ClientObject:         object,
-				Outcome:              scenarioExecution.Outcome,
-				ScenarioId:           scenarioExecution.ScenarioId,
-				ScenarioIterationId:  scenarioExecution.ScenarioIterationId,
-				ScenarioName:         scenarioExecution.ScenarioName,
-				ScenarioDescription:  scenarioExecution.ScenarioDescription,
-				ScenarioVersion:      scenarioExecution.ScenarioVersion,
-				RuleExecutions:       scenarioExecution.RuleExecutions,
-				Score:                scenarioExecution.Score,
-				ScheduledExecutionId: &scheduledExecutionId,
+			decisionInput := models.DecisionWithRuleExecutions{
+				Decision: models.Decision{
+					ClientObject:         object,
+					Outcome:              scenarioExecution.Outcome,
+					ScenarioId:           scenarioExecution.ScenarioId,
+					ScenarioIterationId:  scenarioExecution.ScenarioIterationId,
+					ScenarioName:         scenarioExecution.ScenarioName,
+					ScenarioDescription:  scenarioExecution.ScenarioDescription,
+					ScenarioVersion:      scenarioExecution.ScenarioVersion,
+					Score:                scenarioExecution.Score,
+					ScheduledExecutionId: &scheduledExecutionId,
+				},
+				RuleExecutions: scenarioExecution.RuleExecutions,
 			}
 
 			err = usecase.DecisionRepository.StoreDecision(ctx, tx, decisionInput,


### PR DESCRIPTION
When getting a decision by id, populate rule asts

EDIT: I needed to add `score_modifier` since on the DTO we expose the "result" score as `score_modifier` (I need the real score modif of the rule for detail display)

What I really need here, is a validation of the direction I took. I'm not sure the way I build struct is the good one... Still, I choose to create `rule_detail` in order to avoid breaking change on the API (IIUC, this endpoint is on the public API inside the readme, we may need to update it)