### PR TITLE
add fuzzy matching operators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/gin-contrib/size v0.0.0-20231211133737-500859255df8
 	github.com/gin-contrib/timeout v0.0.6
 	github.com/gin-gonic/gin v1.9.1
-	github.com/gofrs/uuid v4.4.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/uuid v1.3.1
 	github.com/guregu/null/v5 v5.0.0
@@ -28,6 +27,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/ory/dockertest/v3 v3.10.0
+	github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e
 	github.com/pkg/errors v0.9.1
 	github.com/pressly/goose/v3 v3.15.0
 	github.com/segmentio/analytics-go/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,6 @@ github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
@@ -300,6 +298,8 @@ github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf
 github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
+github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e h1:UMX/0xkc/jcivgGjoBumSA1YwxT3eq6rYeWOOEuPU38=
+github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e/go.mod h1:AMWhKRluACdXhJMWJiVOuqwmZvJOcdmjgbla/9zOKzE=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -55,6 +55,8 @@ const (
 	FUNC_AGGREGATOR
 	FUNC_LIST
 	FUNC_FILTER
+	FUNC_FUZZY_MATCH
+	FUNC_FUZZY_MATCH_ANY_OF
 	FUNC_UNDEFINED Function = -1
 	FUNC_UNKNOWN   Function = -2
 )
@@ -198,6 +200,18 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 	FUNC_LIST: {
 		DebugName: "FUNC_LIST",
 		AstName:   "List",
+	},
+	FUNC_FUZZY_MATCH: {
+		DebugName:         "FUNC_FUZZY_MATCH",
+		AstName:           "FuzzyMatch",
+		NumberOfArguments: 2,
+		NamedArguments:    []string{"algorithm"},
+	},
+	FUNC_FUZZY_MATCH_ANY_OF: {
+		DebugName:         "FUNC_FUZZY_MATCH_ANY_OF",
+		AstName:           "FuzzyMatchAnyOf",
+		NumberOfArguments: 2,
+		NamedArguments:    []string{"algorithm"},
 	},
 	FUNC_FILTER: FuncFilterAttributes,
 }

--- a/pure_utils/strings.go
+++ b/pure_utils/strings.go
@@ -1,9 +1,41 @@
 package pure_utils
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+
+	fuzzy "github.com/paul-mannino/go-fuzzywuzzy"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+)
 
 func Capitalize(str string) string {
 	runes := []rune(str)
 	runes[0] = unicode.ToUpper(runes[0])
 	return string(runes)
+}
+
+func Normalize(s string) string {
+	result, _, _ := transform.String(norm.NFC, s)
+	return result
+}
+
+func NormalizeAndRemoveDiacritics(s string) string {
+	t := transform.Chain(
+		norm.NFD,
+		runes.Remove(runes.In(unicode.Mn)),
+		norm.NFC,
+	)
+	result, _, _ := transform.String(t, s)
+	return result
+}
+
+func CleanseString(s string) string {
+	// - normalize
+	// - remove diacritics
+	// - set to lower case
+	// - keep only letters and numbers
+	// - keep non-ASCII characters
+	return strings.TrimSpace(fuzzy.Cleanse(NormalizeAndRemoveDiacritics(s), false))
 }

--- a/pure_utils/strings.go
+++ b/pure_utils/strings.go
@@ -31,11 +31,11 @@ func NormalizeAndRemoveDiacritics(s string) string {
 	return result
 }
 
+// - normalize
+// - remove diacritics
+// - set to lower case
+// - keep only letters and numbers
+// - keep non-ASCII characters
 func CleanseString(s string) string {
-	// - normalize
-	// - remove diacritics
-	// - set to lower case
-	// - keep only letters and numbers
-	// - keep non-ASCII characters
 	return strings.TrimSpace(fuzzy.Cleanse(NormalizeAndRemoveDiacritics(s), false))
 }

--- a/usecases/ast_eval/evaluate/adaptArgument.go
+++ b/usecases/ast_eval/evaluate/adaptArgument.go
@@ -57,11 +57,13 @@ func adaptArgumentToString(argument any) (string, error) {
 	}
 
 	if result, ok := argument.(string); ok {
-		return result, nil
+		return pure_utils.Normalize(result), nil
 	}
 
-	return "", errors.Wrap(ast.ErrArgumentMustBeString,
-		fmt.Sprintf("can't promote argument %v to string", argument))
+	return "", errors.Wrap(
+		ast.ErrArgumentMustBeString,
+		fmt.Sprintf("can't promote argument %v to string", argument),
+	)
 }
 
 func adaptArgumentToTime(argument any) (time.Time, error) {
@@ -129,7 +131,11 @@ func adaptArgumentToListOfThings[T any](argument any) ([]T, error) {
 }
 
 func adaptArgumentToListOfStrings(argument any) ([]string, error) {
-	return adaptArgumentToListOfThings[string](argument)
+	arr, err := adaptArgumentToListOfThings[string](argument)
+	if err != nil {
+		return nil, err
+	}
+	return pure_utils.Map(arr, pure_utils.Normalize), nil
 }
 
 func adaptArgumentToBool(argument any) (bool, error) {

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match.go
@@ -10,8 +10,6 @@ import (
 	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
-type FuzzyMatch struct{}
-
 // Implements a fuzzy match using the go-fuzzywuzzy library.
 // List of strign cleaning steps applied:
 // - normalize
@@ -19,11 +17,12 @@ type FuzzyMatch struct{}
 // - set to lower case
 // - keep only letters and numbers
 // (- keep non-ASCII characters)
+type FuzzyMatch struct{}
 
 func (fuzzyMatcher FuzzyMatch) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	leftAny, rightAny, err := leftAndRight(arguments.Args)
 	if err != nil {
-		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function StringInList"))
+		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function FuzzyMatch"))
 	}
 
 	left, errLeft := adaptArgumentToString(leftAny)
@@ -50,7 +49,7 @@ type FuzzyMatchAnyOf struct{}
 func (fuzzyMatcher FuzzyMatchAnyOf) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	leftAny, rightAny, err := leftAndRight(arguments.Args)
 	if err != nil {
-		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function StringInList"))
+		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function FuzzyMatchAnyOf"))
 	}
 
 	left, errLeft := adaptArgumentToString(leftAny)

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match.go
@@ -1,0 +1,88 @@
+package evaluate
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	fuzzy "github.com/paul-mannino/go-fuzzywuzzy"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+type FuzzyMatch struct{}
+
+func (fuzzyMatcher FuzzyMatch) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
+	leftAny, rightAny, err := leftAndRight(arguments.Args)
+	if err != nil {
+		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function StringInList"))
+	}
+
+	left, errLeft := adaptArgumentToString(leftAny)
+	right, errRight := adaptArgumentToString(rightAny)
+	algorithm, algorithmErr := AdaptNamedArgument(arguments.NamedArgs, "algorithm", adaptArgumentToString)
+
+	errs := MakeAdaptedArgsErrors([]error{errLeft, errRight, algorithmErr})
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	f, err := getSimilarityAlgo(algorithm)
+	if err != nil {
+		return MakeEvaluateError(err)
+	}
+
+	return f(left, right), nil
+}
+
+type FuzzyMatchAnyOf struct{}
+
+func (fuzzyMatcher FuzzyMatchAnyOf) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
+	leftAny, rightAny, err := leftAndRight(arguments.Args)
+	if err != nil {
+		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function StringInList"))
+	}
+
+	left, errLeft := adaptArgumentToString(leftAny)
+	right, errRight := adaptArgumentToListOfStrings(rightAny)
+	algorithm, algorithmErr := AdaptNamedArgument(arguments.NamedArgs, "algorithm", adaptArgumentToString)
+
+	errs := MakeAdaptedArgsErrors([]error{errLeft, errRight, algorithmErr})
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	f, err := getSimilarityAlgo(algorithm)
+	if err != nil {
+		return MakeEvaluateError(err)
+	}
+
+	maxScore := 0
+	for _, rVal := range right {
+		maxScore = max(maxScore, f(left, rVal))
+		if maxScore == 100 {
+			break
+		}
+	}
+	return maxScore, nil
+}
+
+func getSimilarityAlgo(s string) (func(s1 string, s2 string, opts ...bool) int, error) {
+	var f func(s1 string, s2 string, opts ...bool) int
+	switch s {
+	case "ratio":
+		f = func(s1 string, s2 string, opts ...bool) int { return fuzzy.Ratio(s1, s2) }
+	case "partial_ratio":
+		f = func(s1 string, s2 string, opts ...bool) int { return fuzzy.PartialRatio(s1, s2) }
+	case "token_sort_ratio":
+		f = fuzzy.TokenSortRatio
+	case "token_set_ratio":
+		f = fuzzy.TokenSetRatio
+	case "partial_token_set_ratio":
+		f = fuzzy.PartialTokenSetRatio
+	case "partial_token_sort_ratio":
+		f = fuzzy.PartialTokenSortRatio
+	default:
+		return f, errors.New("Unknown algorithm: " + s)
+	}
+	return f, nil
+}

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
@@ -41,6 +41,12 @@ func TestFuzzyMatch(t *testing.T) {
 			algo:   "unknown",
 			errors: []error{errors.New("Unknown algorithm: unknown")},
 		},
+		{
+			name: "with accents",
+			args: []any{"ça, c'est une théière", "la theier a une typo"},
+			algo: "token_set_ratio",
+			want: 65,
+		},
 	}
 
 	for _, tt := range tests {
@@ -76,7 +82,7 @@ func TestFuzzyMatchAnyOf(t *testing.T) {
 			name: "token_set_ratio",
 			args: []any{"old mc donald had a farm", []string{"E I E I O"}},
 			algo: "token_set_ratio",
-			want: 14,
+			want: 21,
 		},
 		{
 			name: "partial_ratio",
@@ -106,6 +112,41 @@ func TestFuzzyMatchAnyOf(t *testing.T) {
 				assert.ErrorContains(t, errs[0], tt.errors[0].Error())
 			}
 			assert.Equal(t, tt.want, r)
+		})
+	}
+}
+
+func TestCleanseString(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "cleanse string",
+			args: "old mc donald had a farm",
+			want: "old mc donald had a farm",
+		},
+		{
+			name: "cleanse string with special characters",
+			args: "old mc donald had a farm!@#$%^&*()",
+			want: "old mc donald had a farm",
+		},
+		{
+			name: "cleanse string with accents",
+			args: "il était une fois une belle théière à ma sœur et ça c'est beau",
+			want: "il etait une fois une belle theiere a ma sœur et ca c est beau",
+		},
+		{
+			name: "various accents with upper case",
+			args: "AÉÇÀÈÙÎÏ",
+			want: "aecaeuii",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cleanseString(tt.args))
 		})
 	}
 }

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -146,7 +147,7 @@ func TestCleanseString(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, cleanseString(tt.args))
+			assert.Equal(t, tt.want, pure_utils.CleanseString(tt.args))
 		})
 	}
 }

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
@@ -1,0 +1,111 @@
+package evaluate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuzzyMatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []any
+		algo   string
+		want   any
+		errors []error
+	}{
+		{
+			name: "partial_token_set_ratio",
+			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
+			algo: "partial_token_set_ratio",
+			want: 100,
+		},
+		{
+			name: "token_set_ratio",
+			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
+			algo: "token_set_ratio",
+			want: 100,
+		},
+		{
+			name: "partial_ratio",
+			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
+			algo: "partial_ratio",
+			want: 75,
+		},
+		{
+			name:   "error algo",
+			args:   []any{"old mc donald had a farm", "old mc donald may have had a farm"},
+			algo:   "unknown",
+			errors: []error{errors.New("Unknown algorithm: unknown")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, errs := FuzzyMatch{}.Evaluate(context.TODO(), ast.Arguments{
+				Args:      tt.args,
+				NamedArgs: map[string]any{"algorithm": tt.algo},
+			})
+			assert.Equal(t, len(tt.errors), len(errs))
+			if len(errs) > 0 {
+				assert.ErrorContains(t, errs[0], tt.errors[0].Error())
+			}
+			assert.Equal(t, tt.want, r)
+		})
+	}
+}
+
+func TestFuzzyMatchAnyOf(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []any
+		algo   string
+		want   any
+		errors []error
+	}{
+		{
+			name: "partial_token_set_ratio",
+			args: []any{"old mc donald had a farm", []string{"old mc donald may have had a farm", "E I E I O"}},
+			algo: "partial_token_set_ratio",
+			want: 100,
+		},
+		{
+			name: "token_set_ratio",
+			args: []any{"old mc donald had a farm", []string{"E I E I O"}},
+			algo: "token_set_ratio",
+			want: 14,
+		},
+		{
+			name: "partial_ratio",
+			args: []any{"old mc donald had a farm", []string{
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+				"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+			}},
+			algo: "partial_ratio",
+			want: 46,
+		},
+		{
+			name:   "error algo",
+			args:   []any{"old mc donald had a farm", "old mc donald may have had a farm"},
+			algo:   "unknown",
+			errors: []error{errors.New("arguments must be a list")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, errs := FuzzyMatchAnyOf{}.Evaluate(context.TODO(), ast.Arguments{
+				Args:      tt.args,
+				NamedArgs: map[string]any{"algorithm": tt.algo},
+			})
+			assert.Equal(t, len(tt.errors), len(errs))
+			if len(errs) > 0 {
+				assert.ErrorContains(t, errs[0], tt.errors[0].Error())
+			}
+			assert.Equal(t, tt.want, r)
+		})
+	}
+}

--- a/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
+++ b/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
@@ -58,6 +58,6 @@ func (clva CustomListValuesAccess) Evaluate(ctx context.Context, arguments ast.A
 
 	return pure_utils.Map(
 		listValues,
-		func(v models.CustomListValue) string { return v.Value },
+		func(v models.CustomListValue) string { return pure_utils.Normalize(v.Value) },
 	), nil
 }

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 )
@@ -62,6 +63,11 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 		objectId, _ := d.getDbField(ctx, tableName, "object_id", pathStringArr)
 		return MakeEvaluateError(errors.Wrap(ast.ErrNullFieldRead,
 			fmt.Sprintf("value is null for object_id %s, in %s", objectId, errorMsg)))
+	}
+
+	fieldValueStr, ok := fieldValue.(string)
+	if ok {
+		return pure_utils.Normalize(fieldValueStr), nil
 	}
 
 	return fieldValue, nil

--- a/usecases/ast_eval/evaluate/evaluate_read_payload.go
+++ b/usecases/ast_eval/evaluate/evaluate_read_payload.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
 type Payload struct {
@@ -37,6 +38,11 @@ func (p Payload) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []
 	if value == nil {
 		return MakeEvaluateError(errors.Wrap(ast.ErrNullFieldRead,
 			fmt.Sprintf("value is null in payload field '%s'", payloadFieldName)))
+	}
+
+	valueStr, ok := value.(string)
+	if ok {
+		return pure_utils.Normalize(valueStr), nil
 	}
 
 	return value, nil

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -65,5 +65,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_PARSE_TIME,
 		evaluate.NewTimeFunctions(ast.FUNC_PARSE_TIME))
 	environment.AddEvaluator(ast.FUNC_LIST, evaluate.List{})
+	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH, evaluate.FuzzyMatch{})
+	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH_ANY_OF, evaluate.FuzzyMatchAnyOf{})
 	return environment
 }

--- a/utils/uuid.go
+++ b/utils/uuid.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 )
 
 func ValidateUuid(uuidParam string) error {
-	_, err := uuid.FromString(uuidParam)
+	_, err := uuid.Parse(uuidParam)
 	if err != nil {
 		err = fmt.Errorf("'%s' is not a valid UUID: %w", uuidParam, models.BadParameterError)
 	}


### PR DESCRIPTION
Scope:
- integrate a new operator for string to string matching
- also for string to list of strings matching (similar to what we did on "contains")
- clean up the input strings as best as possible

-----
Below copy paste from Slack conv for context 

Ok, après réflexion, mon plan pour le fuzzy matching:
- J'implémente un opérateur FuzzyMatch
    - Il prend en opérande 1 et 2 deux strings
    - il prend en named operand "algorithm" un choix parmi les algos pertinents de scoring (ratio, partial_ratio, etc, comme dans la lib de référence en python - portée en go)
    - il retourne un score (nombre) entre 0 et 100
- De même un opérateur FuzzyMatchAnyOf, qui fait la même chose mais reçoit une string et une liste de strings
- ⚠️   comme discuté, je commence par ça mais il ne marchera pas en tant que filtre dans les agrégats (y a des pistes pour faire quelque chose, mais ça sera  - presque - forcément différent)

Dans tous les cas, ça ne nous ferme aucune porte sur ce qu'on veut/peut faire côté front: on garde le choix de ne pas exposer tous les algos existants, etc. A discuter en fin de semaine.

Je vais regarder ce que je peux trouver comme lib existante pour faire un max de string cleaning à l'input (les trucs obvious c'est le case, les accents et caractères spéciaux, dans le plus tricky y a les alphabets similaires mais différents, la gestion de la ponctuation)

Pour contexte, avec ça dans tous les cas on est assez bas niveau pour que fondamentalement Swan puissent faire ce qu'ils veulent sur le besoin remonté ([thread](https://checkmarble.slack.com/archives/C06P1FJV405/p1711381549526829)) moyennant possiblement une règle qu'on écrit pour eux, même s'il reste à voir si ce qu'ils veulent faire sera faisable immédiatement dans le front.
([la lib en go](https://github.com/paul-mannino/go-fuzzywuzzy), [la lib python](https://github.com/seatgeek/thefuzz) dont c'est la port en go - 9k stars avant migration sur un nouveau repo)

---- 

Pistes de réflexion pour faire du string matching dans les filtres en DB (possibilités plus limitées):
- [article qui décrit bien](https://www.freecodecamp.org/news/fuzzy-string-matching-with-postgresql/)
- postgresql [fuzzystrmatch module doc](https://www.postgresql.org/docs/current/fuzzystrmatch.html#FUZZYSTRMATCH-LEVENSHTEIN)
- postgresql [pg_trgm (trigram matching) module doc](https://www.postgresql.org/docs/current/pgtrgm.html)

---------

Plus addition: use normalize (NFC) everywhere we manipulate strings in AST