### PR TITLE
fix: make id the primary key of the ingested tables

### DIFF
--- a/repositories/migrations/20240325143700_introduce_partners.sql
+++ b/repositories/migrations/20240325143700_introduce_partners.sql
@@ -8,14 +8,14 @@ CREATE TABLE IF NOT EXISTS
       );
 
 ALTER TABLE api_keys
-ADD COLUMN partner_id uuid REFERENCES partners (id) ON DELETE SET NULL;
+ADD COLUMN IF NOT EXISTS partner_id uuid REFERENCES partners (id) ON DELETE SET NULL;
 
 DELETE FROM transfer_mappings
 WHERE
       TRUE;
 
 ALTER TABLE transfer_mappings
-ADD COLUMN partner_id uuid NOT NULL REFERENCES partners (id) ON DELETE SET NULL;
+ADD COLUMN IF NOT EXISTS partner_id uuid NOT NULL REFERENCES partners (id) ON DELETE SET NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS transfer_mappings_client_transfer_id_idx ON transfer_mappings (organization_id, partner_id, client_transfer_id);
 

--- a/repositories/migrations/20240327153500_ingested_tables_primary_keys.sql
+++ b/repositories/migrations/20240327153500_ingested_tables_primary_keys.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+DECLARE rec record;
+BEGIN
+	FOR rec IN 
+	    SELECT table_schema, table_name, concat(table_name,'_pkey') AS constraint_name
+	    FROM information_schema.tables 
+	    WHERE table_schema NOT IN ('marble','analytics','public', 'pg_catalog', 'information_schema')
+	LOOP 
+		EXECUTE format('ALTER TABLE %I.%I drop constraint if exists %I;', rec.table_schema, rec.table_name, rec.constraint_name);
+		RAISE NOTICE 'done for %', rec.table_name;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+DECLARE rec record;
+BEGIN
+	FOR rec IN 
+	    SELECT table_schema, table_name
+	    FROM information_schema.tables 
+	    WHERE table_schema NOT IN ('marble','analytics','public', 'pg_catalog', 'information_schema')
+	LOOP 
+		EXECUTE format('ALTER TABLE %I.%I ADD PRIMARY KEY (ID);', rec.table_schema, rec.table_name);
+		RAISE NOTICE 'done for %', rec.table_name;
+	END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/repositories/organization_schema_repository.go
+++ b/repositories/organization_schema_repository.go
@@ -49,7 +49,7 @@ func (repo *OrganizationSchemaRepositoryPostgresql) CreateTable(ctx context.Cont
 
 	sanitizedTableName := pgx.Identifier.Sanitize([]string{exec.DatabaseSchema().Schema, tableName})
 	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		id UUID NOT NULL DEFAULT uuid_generate_v4(),
+		id UUID NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
 		object_id TEXT NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		valid_from TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
Fix: stupid: the ingested tables were missing a primary key (& its related index). This was causing really slow updates at insertion time.
The attached migration is a one-of migration script that will drop all primary keys (should be none, except the one I just manually created in prod) and recreates them

<img width="1657" alt="Capture d’écran 2024-03-27 à 15 47 54" src="https://github.com/checkmarble/marble-backend/assets/128643171/565271d8-ddc9-47a9-afde-e62679e17be8">
