### PR TITLE
return decision app link in API decision object

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ PG_PORT=5432
 PG_USER=postgres
 PG_PASSWORD=marble
 
+MARBLE_APP_HOST="localhost:3000"
 
 # Used by the firebase sdk to validate the id tokens
 FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"

--- a/api/api.go
+++ b/api/api.go
@@ -17,11 +17,13 @@ import (
 type API struct {
 	router   *gin.Engine
 	usecases usecases.Usecases
+	config   models.GlobalConfiguration
 }
 
 func New(
 	router *gin.Engine,
 	port string,
+	config models.GlobalConfiguration,
 	usecases usecases.Usecases,
 	auth *Authentication,
 	tokenHandler *TokenHandler,
@@ -29,6 +31,7 @@ func New(
 	s := &API{
 		router:   router,
 		usecases: usecases,
+		config:   config,
 	}
 
 	s.routes(auth, tokenHandler)

--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -29,7 +29,7 @@ func (api *API) handleGetDecision(c *gin.Context) {
 	if presentError(c, err) {
 		return
 	}
-	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision))
+	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision, api.config.MarbleAppHost))
 }
 
 func (api *API) handleListDecisions(c *gin.Context) {
@@ -73,7 +73,7 @@ func (api *API) handleListDecisions(c *gin.Context) {
 		"start_index": decisions[0].RankNumber,
 		"end_index":   decisions[len(decisions)-1].RankNumber,
 		"items": pure_utils.Map(decisions, func(d models.DecisionWithRank) dto.APIDecision {
-			return dto.NewAPIDecision(d.Decision)
+			return dto.NewAPIDecision(d.Decision, api.config.MarbleAppHost)
 		}),
 	})
 }
@@ -142,5 +142,5 @@ func (api *API) handlePostDecision(c *gin.Context) {
 		presentError(c, errors.Wrap(err, "Error creating decision in handlePostDecision"))
 		return
 	}
-	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision))
+	c.JSON(http.StatusOK, dto.NewAPIDecisionWithRule(decision, api.config.MarbleAppHost))
 }

--- a/dto/case_dto.go
+++ b/dto/case_dto.go
@@ -42,8 +42,10 @@ func AdaptCaseDto(c models.Case) APICase {
 
 func AdaptCaseWithDecisionsDto(c models.Case) APICaseWithDecisions {
 	return APICaseWithDecisions{
-		APICase:   AdaptCaseDto(c),
-		Decisions: pure_utils.Map(c.Decisions, NewAPIDecisionWithRule),
+		APICase: AdaptCaseDto(c),
+		Decisions: pure_utils.Map(c.Decisions, func(d models.DecisionWithRuleExecutions) APIDecisionWithRules {
+			return NewAPIDecisionWithRule(d, "")
+		}),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0
 	golang.org/x/net v0.18.0
 	golang.org/x/sync v0.3.0
+	golang.org/x/text v0.14.0
 	google.golang.org/api v0.138.0
 )
 
@@ -141,7 +142,6 @@ require (
 	golang.org/x/mod v0.12.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.12.1-0.20230815132531-74c255bcf846 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func runServer(ctx context.Context, appConfig AppConfiguration) {
 	}
 
 	router := initRouter(ctx, appConfig, deps)
-	server := api.New(router, appConfig.port, uc, deps.Authentication, deps.TokenHandler)
+	server := api.New(router, appConfig.port, appConfig.config, uc, deps.Authentication, deps.TokenHandler)
 
 	notify, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
@@ -165,6 +165,7 @@ func main() {
 			FakeGcsRepository:    utils.GetEnv("FAKE_GCS", false),
 			GcsIngestionBucket:   utils.GetRequiredEnv[string]("GCS_INGESTION_BUCKET"),
 			GcsCaseManagerBucket: utils.GetRequiredEnv[string]("GCS_CASE_MANAGER_BUCKET"),
+			MarbleAppHost:        utils.GetEnv("MARBLE_APP_HOST", ""),
 			SegmentWriteKey:      utils.GetRequiredEnv[string]("SEGMENT_WRITE_KEY"),
 			JwtSigningKey:        utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),
 		},

--- a/models/global_configuration.go
+++ b/models/global_configuration.go
@@ -6,6 +6,7 @@ type GlobalConfiguration struct {
 	GcsIngestionBucket   string
 	GcsCaseManagerBucket string
 	JwtSigningKey        string
+	MarbleAppHost        string
 	SegmentWriteKey      string
 	TokenLifetimeMinute  int
 }

--- a/usecases/scheduledexecution/export_schedule_execution.go
+++ b/usecases/scheduledexecution/export_schedule_execution.go
@@ -122,7 +122,7 @@ func (exporter *ExportScheduleExecution) ExportDecisions(ctx context.Context, sc
 	var number_of_exported_decisions int
 
 	for decision := range decisionChan {
-		err := encoder.Encode(dto.NewAPIDecisionWithRule(decision))
+		err := encoder.Encode(dto.NewAPIDecisionWithRule(decision, ""))
 		if err != nil {
 			allErrors = append(allErrors, err)
 		} else {


### PR DESCRIPTION
For an API response body like this 
```json
{
    "id": "585906d7-ea00-4181-9946-26246f561a58",
    "app_link": "https://localhost:3000/decisions/585906d7-ea00-4181-9946-26246f561a58",
    "created_at": "2024-03-26T13:52:17.238933+01:00",
[...]
}
```

Returns `null` if the env variable is not set, and also for decisions nested in the "cases" object return by the cases API

-----
Caveat: I use https:// by default as the scheme, which means if the url is used locally it will give an error "Ce site ne peut pas fournir de connexion sécurisée", but I still prefer that to exposing one more env variable to allow unsecured http links which will work only in dev mode anyway.