### PR TITLE
feat: retry ingestion in case of conflict

### DIFF
--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -76,10 +76,7 @@ func (api *API) handleIngestion(c *gin.Context) {
 	err = usecase.IngestObjects(c.Request.Context(), organizationId, []models.ClientObject{
 		payload,
 	}, table, logger)
-	if err != nil {
-		logger.ErrorContext(c.Request.Context(),
-			fmt.Sprintf("Error while ingesting object: %v", err))
-		http.Error(c.Writer, "", http.StatusInternalServerError)
+	if presentError(c, err) {
 		return
 	}
 	c.Status(http.StatusCreated)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.45.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/adhocore/gronx v1.7.0
+	github.com/avast/retry-go/v4 v4.5.1
 	github.com/aws/aws-sdk-go-v2 v1.21.0
 	github.com/aws/aws-sdk-go-v2/config v1.18.36
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.80
@@ -58,7 +59,6 @@ require (
 	github.com/MicahParks/keyfunc v1.9.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/avast/retry-go/v4 v4.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.13 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.35 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/MicahParks/keyfunc v1.9.0 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/avast/retry-go/v4 v4.5.1 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.13 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.35 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.13.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/adhocore/gronx v1.7.0 h1:J4+OUsKY9u61nBtaoZs6AZkDCMOvc1Y4jgopxX7HtZg=
 github.com/adhocore/gronx v1.7.0/go.mod h1:7oUY1WAU8rEJWmAxXR2DN0JaO4gi9khSgKjiRypqteg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/avast/retry-go/v4 v4.5.1 h1:AxIx0HGi4VZ3I02jr78j5lZ3M6x1E0Ivxa6b0pUUh7o=
+github.com/avast/retry-go/v4 v4.5.1/go.mod h1:/sipNsvNB3RRuT5iNcb6h73nw3IBmXJ/H3XrCQYSOpc=
 github.com/aws/aws-sdk-go-v2 v1.21.0 h1:gMT0IW+03wtYJhRqTVYn0wLzwdnK9sRMcxmtfGzRdJc=
 github.com/aws/aws-sdk-go-v2 v1.21.0/go.mod h1:/RfNgGmRxI+iFOB1OeJUyxiU+9s88k3pfHvDagGEp0M=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.13 h1:OPLEkmhXf6xFPiz0bLeDArZIDx1NNS4oJyG4nv3Gct0=

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -87,7 +87,7 @@ func (repo *IngestionRepositoryImpl) mostRecentPayloadsByObjectId(payloads []mod
 		mostRecentPayloads = append(mostRecentPayloads, obj)
 	}
 
-	return mostRecentObjectIds, payloads
+	return mostRecentObjectIds, mostRecentPayloads
 }
 
 type DBObject struct {

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/checkmarble/marble-backend/models"
 )
@@ -86,7 +87,7 @@ func (repo *IngestionRepositoryImpl) mostRecentPayloadsByObjectId(payloads []mod
 		mostRecentPayloads = append(mostRecentPayloads, obj)
 	}
 
-	return mostRecentObjectIds, mostRecentPayloads
+	return mostRecentObjectIds, payloads
 }
 
 type DBObject struct {
@@ -179,6 +180,9 @@ func (repo *IngestionRepositoryImpl) batchInsertPayloadsAndEnumValues(ctx contex
 	query = query.Columns(columnNames...)
 
 	err = ExecBuilder(ctx, exec, query)
+	if IsUniqueViolationError(err) {
+		return errors.Wrap(models.ConflictError, "unique constraint violation during ingestion")
+	}
 
 	return err
 }


### PR DESCRIPTION
The context is that, since the introduction of a unique index on object_id on ingested tables, we can have conflicts at insertion.
Actually, also on unique fields other than the object_id, which is kind of annoying.
In here, I propose to retry (3 times) the repository ingestPayload method, if a conflict is detected.
The problem is that conflicts on object_id are sort of expected (can happen in case of concurrent calls) and should be retried (normally, it should pass on the first retry, unless there is an unreasonable number of concurrent calls on the same object). While conflict errors on other unique fields really shouldn't be retried (because we don't have logic in the code that looks it up by that key, and updates accordingly).

But in practice it's hard for me to differenciate between the two scenarios, so I just retry 3 times. In the worst case it leads to some extra work by the db if the used sends a conflicting row (different object_id but same value of another unique field).