### PR TITLE
feature: audit trail on custom list value insertion

### DIFF
--- a/mocks/custom_list_repository.go
+++ b/mocks/custom_list_repository.go
@@ -54,8 +54,12 @@ func (cl *CustomListRepository) SoftDeleteCustomList(ctx context.Context, exec r
 	return args.Error(0)
 }
 
-func (cl *CustomListRepository) AddCustomListValue(ctx context.Context, exec repositories.Executor,
-	addCustomListValue models.AddCustomListValueInput, newCustomListId string,
+func (cl *CustomListRepository) AddCustomListValue(
+	ctx context.Context,
+	exec repositories.Executor,
+	addCustomListValue models.AddCustomListValueInput,
+	newCustomListId string,
+	userId *models.UserId,
 ) error {
 	args := cl.Called(exec, addCustomListValue)
 	return args.Error(0)

--- a/mocks/custom_list_repository.go
+++ b/mocks/custom_list_repository.go
@@ -61,13 +61,16 @@ func (cl *CustomListRepository) AddCustomListValue(
 	newCustomListId string,
 	userId *models.UserId,
 ) error {
-	args := cl.Called(exec, addCustomListValue)
+	args := cl.Called(ctx, exec, addCustomListValue, userId)
 	return args.Error(0)
 }
 
-func (cl *CustomListRepository) DeleteCustomListValue(ctx context.Context,
-	exec repositories.Executor, deleteCustomListValue models.DeleteCustomListValueInput,
+func (cl *CustomListRepository) DeleteCustomListValue(
+	ctx context.Context,
+	exec repositories.Executor,
+	deleteCustomListValue models.DeleteCustomListValueInput,
+	userId *models.UserId,
 ) error {
-	args := cl.Called(exec, deleteCustomListValue)
+	args := cl.Called(ctx, exec, deleteCustomListValue, userId)
 	return args.Error(0)
 }

--- a/repositories/custom_list_repository.go
+++ b/repositories/custom_list_repository.go
@@ -25,7 +25,12 @@ type CustomListRepository interface {
 		newCustomListId string,
 		userId *models.UserId,
 	) error
-	DeleteCustomListValue(ctx context.Context, exec Executor, deleteCustomListValue models.DeleteCustomListValueInput) error
+	DeleteCustomListValue(
+		ctx context.Context,
+		exec Executor,
+		deleteCustomListValue models.DeleteCustomListValueInput,
+		userId *models.UserId,
+	) error
 }
 
 type CustomListRepositoryPostgresql struct{}
@@ -201,9 +206,16 @@ func (repo *CustomListRepositoryPostgresql) DeleteCustomListValue(
 	ctx context.Context,
 	exec Executor,
 	deleteCustomListValue models.DeleteCustomListValueInput,
+	userId *models.UserId,
 ) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
+	}
+
+	if userId != nil {
+		if err := setCurrentUserIdContext(ctx, exec, userId); err != nil {
+			return err
+		}
 	}
 
 	deleteRequest := NewQueryBuilder().Update(dbmodels.TABLE_CUSTOM_LIST_VALUE)

--- a/repositories/migrations/20240402153800_audit_trail_trigger.sql
+++ b/repositories/migrations/20240402153800_audit_trail_trigger.sql
@@ -1,0 +1,55 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TYPE audit_operation AS ENUM('INSERT', 'UPDATE', 'DELETE');
+
+-- CreateTable
+CREATE TABLE
+	audit (
+		"id" UUID NOT NULL DEFAULT gen_random_uuid () PRIMARY KEY,
+		"operation" audit_operation NOT NULL,
+		"user_id" TEXT,
+		"table" VARCHAR NOT NULL,
+		"entity_id" UUID NOT NULL,
+		"data" JSONB NOT NULL DEFAULT '{}',
+		"created_at" TIMESTAMPTZ (6) NOT NULL DEFAULT CURRENT_TIMESTAMP
+	);
+
+-- Order audit trigger function
+CREATE
+OR REPLACE FUNCTION global_audit () RETURNS TRIGGER AS $$
+    BEGIN
+        IF (TG_OP = 'DELETE') THEN
+            INSERT INTO audit ("operation", "user_id", "table", "entity_id", "data", "created_at")
+            VALUES ('DELETE', current_setting('custom.current_user_id', TRUE), TG_TABLE_NAME, OLD.id, to_jsonb(OLD), now());
+
+        ELSIF (TG_OP = 'UPDATE') THEN
+            INSERT INTO audit ("operation", "user_id", "table", "entity_id", "data", "created_at")
+            VALUES ('UPDATE', current_setting('custom.current_user_id', TRUE), TG_TABLE_NAME, NEW.id, to_jsonb(NEW), now());
+
+        ELSIF (TG_OP = 'INSERT') THEN
+            INSERT INTO audit ("operation", "user_id", "table", "entity_id", "data", "created_at")
+            VALUES ('INSERT', current_setting('custom.current_user_id', TRUE), TG_TABLE_NAME, NEW.id, to_jsonb(NEW), now());
+        END IF;
+        RETURN NULL;
+    END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit
+AFTER INSERT
+OR
+UPDATE
+OR DELETE ON custom_list_values FOR EACH ROW
+EXECUTE FUNCTION global_audit ();
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER audit ON custom_list_values;
+
+DROP FUNCTION global_audit;
+
+DROP TABLE audit;
+
+DROP TYPE audit_operation;
+
+-- +goose StatementEnd

--- a/repositories/utils.go
+++ b/repositories/utils.go
@@ -1,10 +1,26 @@
 package repositories
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 )
+
+const postgres_audit_user_id_parameter = "custom.current_user_id"
+
+func setCurrentUserIdContext(ctx context.Context, exec Executor, userId *models.UserId) error {
+	if userId != nil {
+		_, err := exec.Exec(
+			ctx,
+			fmt.Sprintf("SELECT SET_CONFIG('%s', $1, false)", postgres_audit_user_id_parameter),
+			*userId,
+		)
+		return err
+	}
+	return nil
+}
 
 func columnsNames(tablename string, fields []string) []string {
 	return pure_utils.Map(fields, func(f string) string {

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/security"
 	"github.com/checkmarble/marble-backend/usecases/tracking"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 type CustomListUseCase struct {
@@ -154,6 +155,12 @@ func (usecase *CustomListUseCase) GetCustomListValues(ctx context.Context,
 func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 	addCustomListValue models.AddCustomListValueInput,
 ) (models.CustomListValue, error) {
+	var userId *models.UserId
+	creds, found := utils.CredentialsFromCtx(ctx)
+	if found {
+		userId = &creds.ActorIdentity.UserId
+	}
+
 	value, err := executor_factory.TransactionReturnValue(ctx, usecase.transactionFactory, func(
 		tx repositories.Executor,
 	) (models.CustomListValue, error) {
@@ -166,7 +173,7 @@ func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 		}
 		newCustomListValueId := uuid.NewString()
 
-		err = usecase.CustomListRepository.AddCustomListValue(ctx, tx, addCustomListValue, newCustomListValueId)
+		err = usecase.CustomListRepository.AddCustomListValue(ctx, tx, addCustomListValue, newCustomListValueId, userId)
 		if err != nil {
 			return models.CustomListValue{}, err
 		}

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -193,6 +193,12 @@ func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 func (usecase *CustomListUseCase) DeleteCustomListValue(ctx context.Context,
 	deleteCustomListValue models.DeleteCustomListValueInput,
 ) error {
+	var userId *models.UserId
+	creds, found := utils.CredentialsFromCtx(ctx)
+	if found {
+		userId = &creds.ActorIdentity.UserId
+	}
+
 	err := usecase.transactionFactory.Transaction(ctx, func(tx repositories.Executor) error {
 		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, deleteCustomListValue.CustomListId)
 		if err != nil {
@@ -201,7 +207,7 @@ func (usecase *CustomListUseCase) DeleteCustomListValue(ctx context.Context,
 		if err := usecase.enforceSecurity.ModifyCustomList(customList); err != nil {
 			return err
 		}
-		return usecase.CustomListRepository.DeleteCustomListValue(ctx, tx, deleteCustomListValue)
+		return usecase.CustomListRepository.DeleteCustomListValue(ctx, tx, deleteCustomListValue, userId)
 	})
 	if err != nil {
 		return err

--- a/usecases/organization/organization_creator.go
+++ b/usecases/organization/organization_creator.go
@@ -69,11 +69,11 @@ func (creator *OrganizationCreator) seedDefaultList(ctx context.Context, organiz
 		CustomListId: newCustomListId,
 		Value:        "Welcome",
 	}
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString())
+	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 	addCustomListValueInput.Value = "to"
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString())
+	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 	addCustomListValueInput.Value = "marble"
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString())
+	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 
 	logger.InfoContext(ctx, "Finish to create the default custom list for the organization")
 	return nil


### PR DESCRIPTION
The three options on the table were:
1. audit information directly on the table (e.g. "added_by", "deleted_by" columns, etc)
2. centralized audit table, handled in our code (run the actions in transactions, try to insert rows by calling a repo from the usecase, etc)
3. or as done here: use postgresql triggers to handle the logic.

Pros:
- it kind of just works out of the box
- very low code overhead
- could be branched off to solution 2 if needed sometime later
Cons:
- it's a bit too magic to be totally reliable (in the sense of "people are aware of it and won't accidentally break it")
- harder to have really fine control on which events we want to audit or not (well, we can possibly fine tune it more but at the cost of making the point above even worse)

All in all, I'm happy with what this does in 100 lines of code, and it would be super easy to replicate this for the other tables that have events to audit (scenario publication, ...)