### PR TITLE
remove data model custom types

### DIFF
--- a/api/handle_datamodel.go
+++ b/api/handle_datamodel.go
@@ -90,7 +90,7 @@ func (api *API) CreateField(c *gin.Context) {
 	tableID := c.Param("tableID")
 	field := models.CreateFieldInput{
 		TableId:     tableID,
-		Name:        models.FieldName(input.Name),
+		Name:        input.Name,
 		Description: input.Description,
 		DataType:    models.DataTypeFrom(input.Type),
 		Nullable:    input.Nullable,

--- a/api/handle_datamodel.go
+++ b/api/handle_datamodel.go
@@ -156,7 +156,7 @@ func (api *API) CreateLink(c *gin.Context) {
 
 	link := models.DataModelLinkCreateInput{
 		OrganizationID: organizationID,
-		Name:           models.LinkName(input.Name),
+		Name:           input.Name,
 		ParentTableID:  input.ParentTableID,
 		ParentFieldID:  input.ParentFieldID,
 		ChildTableID:   input.ChildTableID,

--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -49,7 +49,7 @@ func (api *API) handleIngestion(c *gin.Context) {
 	logger = logger.With(slog.String("object_type", objectType))
 
 	tables := dataModel.Tables
-	table, ok := tables[models.TableName(objectType)]
+	table, ok := tables[objectType]
 	if !ok {
 		logger.ErrorContext(c.Request.Context(), "Table not found in data model for organization")
 		http.Error(c.Writer, "", http.StatusNotFound)

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -6,9 +6,9 @@ import (
 )
 
 type LinkToSingle struct {
-	LinkedTableName models.TableName `json:"linked_table_name"`
-	ParentFieldName string           `json:"parent_field_name"`
-	ChildFieldName  string           `json:"child_field_name"`
+	LinkedTableName string `json:"linked_table_name"`
+	ParentFieldName string `json:"parent_field_name"`
+	ChildFieldName  string `json:"child_field_name"`
 }
 
 type Field struct {
@@ -30,8 +30,8 @@ type Table struct {
 }
 
 type DataModel struct {
-	Version string                     `json:"version"`
-	Tables  map[models.TableName]Table `json:"tables"`
+	Version string           `json:"version"`
+	Tables  map[string]Table `json:"tables"`
 }
 
 type PostDataModel struct {

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -22,11 +22,11 @@ type Field struct {
 }
 
 type Table struct {
-	ID            string                           `json:"id,omitempty"`
-	Name          string                           `json:"name"`
-	Description   string                           `json:"description"`
-	Fields        map[models.FieldName]Field       `json:"fields"`
-	LinksToSingle map[models.LinkName]LinkToSingle `json:"links_to_single,omitempty"`
+	ID            string                     `json:"id,omitempty"`
+	Name          string                     `json:"name"`
+	Description   string                     `json:"description"`
+	Fields        map[models.FieldName]Field `json:"fields"`
+	LinksToSingle map[string]LinkToSingle    `json:"links_to_single,omitempty"`
 }
 
 type DataModel struct {

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -7,8 +7,8 @@ import (
 
 type LinkToSingle struct {
 	LinkedTableName models.TableName `json:"linked_table_name"`
-	ParentFieldName models.FieldName `json:"parent_field_name"`
-	ChildFieldName  models.FieldName `json:"child_field_name"`
+	ParentFieldName string           `json:"parent_field_name"`
+	ChildFieldName  string           `json:"child_field_name"`
 }
 
 type Field struct {
@@ -22,11 +22,11 @@ type Field struct {
 }
 
 type Table struct {
-	ID            string                     `json:"id,omitempty"`
-	Name          string                     `json:"name"`
-	Description   string                     `json:"description"`
-	Fields        map[models.FieldName]Field `json:"fields"`
-	LinksToSingle map[string]LinkToSingle    `json:"links_to_single,omitempty"`
+	ID            string                  `json:"id,omitempty"`
+	Name          string                  `json:"name"`
+	Description   string                  `json:"description"`
+	Fields        map[string]Field        `json:"fields"`
+	LinksToSingle map[string]LinkToSingle `json:"links_to_single,omitempty"`
 }
 
 type DataModel struct {

--- a/models/aggregate_query.go
+++ b/models/aggregate_query.go
@@ -9,17 +9,17 @@ import (
 
 type AggregateQueryFamily struct {
 	TableName               TableName
-	EqConditions            *set.Set[FieldName]
-	IneqConditions          *set.Set[FieldName]
-	SelectOrOtherConditions *set.Set[FieldName]
+	EqConditions            *set.Set[string]
+	IneqConditions          *set.Set[string]
+	SelectOrOtherConditions *set.Set[string]
 }
 
 func NewAggregateQueryFamily(tableName string) AggregateQueryFamily {
 	return AggregateQueryFamily{
 		TableName:               TableName(tableName),
-		EqConditions:            set.New[FieldName](0),
-		IneqConditions:          set.New[FieldName](0),
-		SelectOrOtherConditions: set.New[FieldName](0),
+		EqConditions:            set.New[string](0),
+		IneqConditions:          set.New[string](0),
+		SelectOrOtherConditions: set.New[string](0),
 	}
 }
 
@@ -73,13 +73,13 @@ func (qFamily AggregateQueryFamily) ToIndexFamilies() *set.HashSet[IndexFamily, 
 	base := NewIndexFamily()
 	base.TableName = qFamily.TableName
 	if qFamily.EqConditions != nil {
-		qFamily.EqConditions.ForEach(func(f FieldName) bool {
+		qFamily.EqConditions.ForEach(func(f string) bool {
 			base.Flex.Insert(f)
 			return true
 		})
 	}
 	if qFamily.SelectOrOtherConditions != nil {
-		qFamily.SelectOrOtherConditions.ForEach(func(f FieldName) bool {
+		qFamily.SelectOrOtherConditions.ForEach(func(f string) bool {
 			base.Included.Insert(f)
 			return true
 		})
@@ -91,13 +91,13 @@ func (qFamily AggregateQueryFamily) ToIndexFamilies() *set.HashSet[IndexFamily, 
 
 	// If inequality conditions are involved, we need to create a family for each column involved
 	// in the inequality conditions (and complete the "other" columns)
-	qFamily.IneqConditions.ForEach(func(f FieldName) bool {
+	qFamily.IneqConditions.ForEach(func(f string) bool {
 		// we create a copy of the base family
 		family := base.Copy()
 		// we add the current column as the "last" column
 		family.Last = f
 		// we add all the other columns as "other" columns
-		qFamily.IneqConditions.ForEach(func(o FieldName) bool {
+		qFamily.IneqConditions.ForEach(func(o string) bool {
 			if o != f {
 				family.Included.Insert(o)
 			}

--- a/models/aggregate_query.go
+++ b/models/aggregate_query.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AggregateQueryFamily struct {
-	TableName               TableName
+	TableName               string
 	EqConditions            *set.Set[string]
 	IneqConditions          *set.Set[string]
 	SelectOrOtherConditions *set.Set[string]
@@ -16,7 +16,7 @@ type AggregateQueryFamily struct {
 
 func NewAggregateQueryFamily(tableName string) AggregateQueryFamily {
 	return AggregateQueryFamily{
-		TableName:               TableName(tableName),
+		TableName:               tableName,
 		EqConditions:            set.New[string](0),
 		IneqConditions:          set.New[string](0),
 		SelectOrOtherConditions: set.New[string](0),

--- a/models/concrete_index.go
+++ b/models/concrete_index.go
@@ -9,14 +9,14 @@ import (
 )
 
 type UnicityIndex struct {
-	TableName         TableName
+	TableName         string
 	Fields            []string
 	Included          []string
 	CreationInProcess bool
 }
 
 type ConcreteIndex struct {
-	TableName TableName
+	TableName string
 	Indexed   []string
 	Included  []string
 }
@@ -33,13 +33,13 @@ func (i ConcreteIndex) Covers(f IndexFamily) bool {
 	// far as identifiers are concerned (unless quoted)
 	// and as such will return names will all lower case
 	f = f.Copy()
-	f.TableName = TableName(strings.ToUpper(string(f.TableName)))
+	f.TableName = strings.ToUpper(string(f.TableName))
 	f.Last = fieldNameToUpper(f.Last)
 	f.Fixed = pure_utils.Map(f.Fixed, fieldNameToUpper)
 	f.Flex = set.From(pure_utils.Map(f.Flex.Slice(), fieldNameToUpper))
 	f.Included = set.From(pure_utils.Map(f.Included.Slice(), fieldNameToUpper))
 	i = ConcreteIndex{
-		TableName: TableName(strings.ToUpper(string(i.TableName))),
+		TableName: strings.ToUpper(string(i.TableName)),
 		Indexed:   pure_utils.Map(i.Indexed, fieldNameToUpper),
 		Included:  pure_utils.Map(i.Included, fieldNameToUpper),
 	}

--- a/models/concrete_index.go
+++ b/models/concrete_index.go
@@ -10,15 +10,15 @@ import (
 
 type UnicityIndex struct {
 	TableName         TableName
-	Fields            []FieldName
-	Included          []FieldName
+	Fields            []string
+	Included          []string
 	CreationInProcess bool
 }
 
 type ConcreteIndex struct {
 	TableName TableName
-	Indexed   []FieldName
-	Included  []FieldName
+	Indexed   []string
+	Included  []string
 }
 
 func (i ConcreteIndex) Equal(other ConcreteIndex) bool {
@@ -104,6 +104,6 @@ func (i ConcreteIndex) Covers(f IndexFamily) bool {
 	return true
 }
 
-func fieldNameToUpper(f FieldName) FieldName {
-	return FieldName(strings.ToUpper(string(f)))
+func fieldNameToUpper(f string) string {
+	return string(strings.ToUpper(string(f)))
 }

--- a/models/concrete_index_test.go
+++ b/models/concrete_index_test.go
@@ -9,18 +9,18 @@ import (
 func TestCovers(t *testing.T) {
 	idx := ConcreteIndex{
 		TableName: "table",
-		Indexed:   []FieldName{"a", "b", "c", "d", "e"},
-		Included:  []FieldName{"f", "g"},
+		Indexed:   []string{"a", "b", "c", "d", "e"},
+		Included:  []string{"f", "g"},
 	}
 
 	t.Run("With fixed & flex & last - true", func(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b"}
-		family.Flex.InsertSlice([]FieldName{"c", "d"})
+		family.Fixed = []string{"a", "b"}
+		family.Flex.InsertSlice([]string{"c", "d"})
 		family.SetLast("e")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -29,10 +29,10 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b"}
-		family.Flex.InsertSlice([]FieldName{"c"})
+		family.Fixed = []string{"a", "b"}
+		family.Flex.InsertSlice([]string{"c"})
 		family.SetLast("X")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index not an instance of the family")
 	})
@@ -41,9 +41,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b", "c"}
+		family.Fixed = []string{"a", "b", "c"}
 		family.SetLast("d")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -52,9 +52,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b", "c"}
+		family.Fixed = []string{"a", "b", "c"}
 		family.SetLast("e")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -63,8 +63,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b", "c", "d"}
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Fixed = []string{"a", "b", "c", "d"}
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -73,8 +73,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b", "d"}
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Fixed = []string{"a", "b", "d"}
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -83,9 +83,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b"}
-		family.Flex.InsertSlice([]FieldName{"c", "d"})
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Fixed = []string{"a", "b"}
+		family.Flex.InsertSlice([]string{"c", "d"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -94,9 +94,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b"}
-		family.Flex.InsertSlice([]FieldName{"c"})
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Fixed = []string{"a", "b"}
+		family.Flex.InsertSlice([]string{"c"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -105,9 +105,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Fixed = []FieldName{"a", "b"}
-		family.Flex.InsertSlice([]FieldName{"c", "e"})
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Fixed = []string{"a", "b"}
+		family.Flex.InsertSlice([]string{"c", "e"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -116,9 +116,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"a", "b"})
+		family.Flex.InsertSlice([]string{"a", "b"})
 		family.SetLast("c")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -127,9 +127,9 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"a", "b"})
+		family.Flex.InsertSlice([]string{"a", "b"})
 		family.SetLast("d")
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -138,8 +138,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"a", "b", "c"})
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Flex.InsertSlice([]string{"a", "b", "c"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
@@ -148,8 +148,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"a", "b", "d"})
-		family.Included.InsertSlice([]FieldName{"f"})
+		family.Flex.InsertSlice([]string{"a", "b", "d"})
+		family.Included.InsertSlice([]string{"f"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -158,8 +158,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"a", "b", "c"})
-		family.Included.InsertSlice([]FieldName{"f", "h"})
+		family.Flex.InsertSlice([]string{"a", "b", "c"})
+		family.Included.InsertSlice([]string{"f", "h"})
 
 		asserts.False(idx.Covers(family), "The index is not an instance of the family")
 	})
@@ -168,8 +168,8 @@ func TestCovers(t *testing.T) {
 		asserts := assert.New(t)
 		family := NewIndexFamily()
 		family.TableName = "table"
-		family.Flex.InsertSlice([]FieldName{"A", "B", "c"})
-		family.Included.InsertSlice([]FieldName{"f", "g"})
+		family.Flex.InsertSlice([]string{"A", "B", "c"})
+		family.Included.InsertSlice([]string{"f", "g"})
 		family.Last = "D"
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -57,7 +57,6 @@ type DataModel struct {
 
 type (
 	TableName string
-	FieldName string
 )
 
 func (dm DataModel) Copy() DataModel {
@@ -79,12 +78,12 @@ type Table struct {
 	ID            string
 	Name          TableName
 	Description   string
-	Fields        map[FieldName]Field
+	Fields        map[string]Field
 	LinksToSingle map[string]LinkToSingle
 }
 
 func (t Table) Copy() Table {
-	fields := make(map[FieldName]Field)
+	fields := make(map[string]Field)
 	for k, v := range t.Fields {
 		fields[k] = v
 	}
@@ -124,7 +123,7 @@ type Field struct {
 	DataType          DataType
 	Description       string
 	IsEnum            bool
-	Name              FieldName
+	Name              string
 	Nullable          bool
 	TableId           string
 	Values            []any
@@ -175,7 +174,7 @@ func UnicityConstraintFromString(s string) UnicityConstraint {
 
 type CreateFieldInput struct {
 	TableId     string
-	Name        FieldName
+	Name        string
 	Description string
 	DataType    DataType
 	Nullable    bool
@@ -195,9 +194,9 @@ type UpdateFieldInput struct {
 type LinkToSingle struct {
 	Name            string
 	LinkedTableName TableName
-	ParentFieldName FieldName
+	ParentFieldName string
 	ChildTableName  TableName
-	ChildFieldName  FieldName
+	ChildFieldName  string
 }
 
 type DataModelLinkCreateInput struct {

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -52,15 +52,11 @@ func DataTypeFrom(s string) DataType {
 
 type DataModel struct {
 	Version string
-	Tables  map[TableName]Table
+	Tables  map[string]Table
 }
 
-type (
-	TableName string
-)
-
 func (dm DataModel) Copy() DataModel {
-	tables := make(map[TableName]Table)
+	tables := make(map[string]Table)
 	for k, v := range dm.Tables {
 		tables[k] = v.Copy()
 	}
@@ -76,7 +72,7 @@ func (dm DataModel) Copy() DataModel {
 
 type Table struct {
 	ID            string
-	Name          TableName
+	Name          string
 	Description   string
 	Fields        map[string]Field
 	LinksToSingle map[string]LinkToSingle
@@ -193,9 +189,9 @@ type UpdateFieldInput struct {
 // ///////////////////////////////
 type LinkToSingle struct {
 	Name            string
-	LinkedTableName TableName
+	LinkedTableName string
 	ParentFieldName string
-	ChildTableName  TableName
+	ChildTableName  string
 	ChildFieldName  string
 }
 

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -58,16 +58,7 @@ type DataModel struct {
 type (
 	TableName string
 	FieldName string
-	LinkName  string
 )
-
-func ToLinkNames(arr []string) []LinkName {
-	var result []LinkName
-	for _, s := range arr {
-		result = append(result, LinkName(s))
-	}
-	return result
-}
 
 func (dm DataModel) Copy() DataModel {
 	tables := make(map[TableName]Table)
@@ -89,7 +80,7 @@ type Table struct {
 	Name          TableName
 	Description   string
 	Fields        map[FieldName]Field
-	LinksToSingle map[LinkName]LinkToSingle
+	LinksToSingle map[string]LinkToSingle
 }
 
 func (t Table) Copy() Table {
@@ -97,7 +88,7 @@ func (t Table) Copy() Table {
 	for k, v := range t.Fields {
 		fields[k] = v
 	}
-	links := make(map[LinkName]LinkToSingle)
+	links := make(map[string]LinkToSingle)
 	for k, v := range t.LinksToSingle {
 		links[k] = v
 	}
@@ -202,7 +193,7 @@ type UpdateFieldInput struct {
 // Data Model Link
 // ///////////////////////////////
 type LinkToSingle struct {
-	Name            LinkName
+	Name            string
 	LinkedTableName TableName
 	ParentFieldName FieldName
 	ChildTableName  TableName
@@ -211,7 +202,7 @@ type LinkToSingle struct {
 
 type DataModelLinkCreateInput struct {
 	OrganizationID string
-	Name           LinkName
+	Name           string
 	ParentTableID  string
 	ParentFieldID  string
 	ChildTableID   string

--- a/models/decisions.go
+++ b/models/decisions.go
@@ -70,7 +70,7 @@ type DecisionFilters struct {
 	StartDate             time.Time
 	EndDate               time.Time
 	Outcomes              []Outcome
-	TriggerObjects        []TableName
+	TriggerObjects        []string
 	HasCase               *bool
 	CaseIds               []string
 	ScheduledExecutionIds []string

--- a/models/index_family.go
+++ b/models/index_family.go
@@ -9,18 +9,18 @@ import (
 
 type IndexFamily struct {
 	TableName TableName
-	Fixed     []FieldName
-	Flex      *set.Set[FieldName]
-	Last      FieldName
-	Included  *set.Set[FieldName]
+	Fixed     []string
+	Flex      *set.Set[string]
+	Last      string
+	Included  *set.Set[string]
 }
 
 func NewIndexFamily() IndexFamily {
 	return IndexFamily{
-		Fixed:    make([]FieldName, 0),
-		Flex:     set.New[FieldName](0),
+		Fixed:    make([]string, 0),
+		Flex:     set.New[string](0),
 		Last:     "",
-		Included: set.New[FieldName](0),
+		Included: set.New[string](0),
 	}
 }
 
@@ -58,7 +58,7 @@ func (f IndexFamily) Copy() IndexFamily {
 	}
 }
 
-func (f IndexFamily) AllIndexedValues() set.Collection[FieldName] {
+func (f IndexFamily) AllIndexedValues() set.Collection[string] {
 	out := f.Flex.Union(set.From(f.Fixed))
 	if f.Last != "" {
 		out.Insert(f.Last)
@@ -74,7 +74,7 @@ func (f IndexFamily) Size() int {
 	return s
 }
 
-func (f IndexFamily) RemoveFixedPrefix(prefix []FieldName) IndexFamily {
+func (f IndexFamily) RemoveFixedPrefix(prefix []string) IndexFamily {
 	if len(prefix) > len(f.Fixed) {
 		return IndexFamily{}
 	}
@@ -89,7 +89,7 @@ func (f IndexFamily) RemoveFixedPrefix(prefix []FieldName) IndexFamily {
 	}
 }
 
-func (f IndexFamily) PrependPrefix(prefix []FieldName) IndexFamily {
+func (f IndexFamily) PrependPrefix(prefix []string) IndexFamily {
 	return IndexFamily{
 		Fixed:    append(prefix, f.Fixed...),
 		Flex:     f.Flex.Copy(),
@@ -98,7 +98,7 @@ func (f IndexFamily) PrependPrefix(prefix []FieldName) IndexFamily {
 	}
 }
 
-func (f *IndexFamily) SetLast(last FieldName) {
+func (f *IndexFamily) SetLast(last string) {
 	if last == "" {
 		f.Last = ""
 		return
@@ -114,7 +114,7 @@ func (f *IndexFamily) SetLast(last FieldName) {
 
 func (f IndexFamily) MergeIncluded(B IndexFamily) IndexFamily {
 	out := f.Copy()
-	out.Included = out.Included.Union(B.Included).(*set.Set[FieldName])
-	out.Included = out.Included.Difference(out.AllIndexedValues()).(*set.Set[FieldName])
+	out.Included = out.Included.Union(B.Included).(*set.Set[string])
+	out.Included = out.Included.Difference(out.AllIndexedValues()).(*set.Set[string])
 	return out
 }

--- a/models/index_family.go
+++ b/models/index_family.go
@@ -8,7 +8,7 @@ import (
 )
 
 type IndexFamily struct {
-	TableName TableName
+	TableName string
 	Fixed     []string
 	Flex      *set.Set[string]
 	Last      string

--- a/models/payload.go
+++ b/models/payload.go
@@ -2,7 +2,7 @@ package models
 
 type DbFieldReadParams struct {
 	TriggerTableName TableName
-	Path             []LinkName
+	Path             []string
 	FieldName        FieldName
 	DataModel        DataModel
 	ClientObject     ClientObject

--- a/models/payload.go
+++ b/models/payload.go
@@ -1,7 +1,7 @@
 package models
 
 type DbFieldReadParams struct {
-	TriggerTableName TableName
+	TriggerTableName string
 	Path             []string
 	FieldName        string
 	DataModel        DataModel
@@ -9,6 +9,6 @@ type DbFieldReadParams struct {
 }
 
 type ClientObject struct {
-	TableName TableName
+	TableName string
 	Data      map[string]any
 }

--- a/models/payload.go
+++ b/models/payload.go
@@ -3,7 +3,7 @@ package models
 type DbFieldReadParams struct {
 	TriggerTableName TableName
 	Path             []string
-	FieldName        FieldName
+	FieldName        string
 	DataModel        DataModel
 	ClientObject     ClientObject
 }

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -53,12 +53,10 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 	}
 
 	dataModel := models.DataModel{
-		Tables: make(map[models.TableName]models.Table),
+		Tables: make(map[string]models.Table),
 	}
 
 	for _, field := range fields {
-		tableName := models.TableName(field.TableName)
-
 		var values []any
 		if field.FieldIsEnum && fetchEnumValues {
 			values, err = repo.GetEnumValues(ctx, exec, field.FieldID)
@@ -67,17 +65,17 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 			}
 		}
 
-		_, ok := dataModel.Tables[tableName]
+		_, ok := dataModel.Tables[field.TableName]
 		if !ok {
-			dataModel.Tables[tableName] = models.Table{
+			dataModel.Tables[field.TableName] = models.Table{
 				ID:            field.TableID,
-				Name:          tableName,
+				Name:          field.TableName,
 				Description:   field.TableDescription,
 				Fields:        map[string]models.Field{},
 				LinksToSingle: make(map[string]models.LinkToSingle),
 			}
 		}
-		dataModel.Tables[tableName].Fields[field.FieldName] = models.Field{
+		dataModel.Tables[field.TableName].Fields[field.FieldName] = models.Field{
 			ID:          field.FieldID,
 			Description: field.FieldDescription,
 			DataType:    models.DataTypeFrom(field.FieldType),

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -58,7 +58,6 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 
 	for _, field := range fields {
 		tableName := models.TableName(field.TableName)
-		fieldName := models.FieldName(field.FieldName)
 
 		var values []any
 		if field.FieldIsEnum && fetchEnumValues {
@@ -74,15 +73,15 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 				ID:            field.TableID,
 				Name:          tableName,
 				Description:   field.TableDescription,
-				Fields:        map[models.FieldName]models.Field{},
+				Fields:        map[string]models.Field{},
 				LinksToSingle: make(map[string]models.LinkToSingle),
 			}
 		}
-		dataModel.Tables[tableName].Fields[fieldName] = models.Field{
+		dataModel.Tables[tableName].Fields[field.FieldName] = models.Field{
 			ID:          field.FieldID,
 			Description: field.FieldDescription,
 			DataType:    models.DataTypeFrom(field.FieldType),
-			Name:        fieldName,
+			Name:        field.FieldName,
 			Nullable:    field.FieldNullable,
 			IsEnum:      field.FieldIsEnum,
 			Values:      values,

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -75,7 +75,7 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 				Name:          tableName,
 				Description:   field.TableDescription,
 				Fields:        map[models.FieldName]models.Field{},
-				LinksToSingle: make(map[models.LinkName]models.LinkToSingle),
+				LinksToSingle: make(map[string]models.LinkToSingle),
 			}
 		}
 		dataModel.Tables[tableName].Fields[fieldName] = models.Field{

--- a/repositories/dbmodels/db_data_model.go
+++ b/repositories/dbmodels/db_data_model.go
@@ -85,8 +85,8 @@ func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
 	return models.LinkToSingle{
 		Name:            dbDataModelLink.Name,
 		LinkedTableName: models.TableName(dbDataModelLink.ParentTable),
-		ParentFieldName: models.FieldName(dbDataModelLink.ParentField),
+		ParentFieldName: dbDataModelLink.ParentField,
 		ChildTableName:  models.TableName(dbDataModelLink.ChildTable),
-		ChildFieldName:  models.FieldName(dbDataModelLink.ChildField),
+		ChildFieldName:  dbDataModelLink.ChildField,
 	}
 }

--- a/repositories/dbmodels/db_data_model.go
+++ b/repositories/dbmodels/db_data_model.go
@@ -83,7 +83,7 @@ type DbDataModelLink struct {
 
 func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
 	return models.LinkToSingle{
-		Name:            models.LinkName(dbDataModelLink.Name),
+		Name:            dbDataModelLink.Name,
 		LinkedTableName: models.TableName(dbDataModelLink.ParentTable),
 		ParentFieldName: models.FieldName(dbDataModelLink.ParentField),
 		ChildTableName:  models.TableName(dbDataModelLink.ChildTable),

--- a/repositories/dbmodels/db_data_model.go
+++ b/repositories/dbmodels/db_data_model.go
@@ -24,7 +24,7 @@ const TABLE_DATA_MODELS = "data_models"
 var SelectDataModelColumn = utils.ColumnList[DbDataModel]()
 
 func AdaptDataModel(dbDataModel DbDataModel) (models.DataModel, error) {
-	var tables map[models.TableName]models.Table
+	var tables map[string]models.Table
 	if err := json.Unmarshal(dbDataModel.Tables, &tables); err != nil {
 		return models.DataModel{}, fmt.Errorf("unable to unmarshal data model tables: %w", err)
 	}
@@ -84,9 +84,9 @@ type DbDataModelLink struct {
 func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
 	return models.LinkToSingle{
 		Name:            dbDataModelLink.Name,
-		LinkedTableName: models.TableName(dbDataModelLink.ParentTable),
+		LinkedTableName: dbDataModelLink.ParentTable,
 		ParentFieldName: dbDataModelLink.ParentField,
-		ChildTableName:  models.TableName(dbDataModelLink.ChildTable),
+		ChildTableName:  dbDataModelLink.ChildTable,
 		ChildFieldName:  dbDataModelLink.ChildField,
 	}
 }

--- a/repositories/dbmodels/db_decision.go
+++ b/repositories/dbmodels/db_decision.go
@@ -57,7 +57,7 @@ func AdaptDecision(db DbDecision, decisionCase *models.Case) models.Decision {
 		OrganizationId:       db.OrganizationId,
 		Case:                 decisionCase,
 		CreatedAt:            db.CreatedAt,
-		ClientObject:         models.ClientObject{TableName: models.TableName(db.TriggerObjectType), Data: triggerObject},
+		ClientObject:         models.ClientObject{TableName: db.TriggerObjectType, Data: triggerObject},
 		Outcome:              models.OutcomeFrom(db.Outcome),
 		ScenarioId:           db.ScenarioId,
 		ScenarioIterationId:  db.ScenarioIterationId,

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -194,10 +194,7 @@ func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteInd
 	if len(includedColumns) > 0 {
 		sql += fmt.Sprintf(
 			" INCLUDE (%s)",
-			strings.Join(
-				pure_utils.Map(includedColumns, func(s models.FieldName) string { return string(s) }),
-				",",
-			),
+			strings.Join(includedColumns, ","),
 		)
 	}
 	sql += "WHERE valid_until='infinity'"
@@ -221,34 +218,22 @@ func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteInd
 	return nil
 }
 
-func withDesc(s models.FieldName) string {
+func withDesc(s string) string {
 	return fmt.Sprintf("%s DESC", s)
 }
 
-func indexToIndexName(fields []models.FieldName, table models.TableName) string {
+func indexToIndexName(fields []string, table models.TableName) string {
 	// postgresql enforces a 63 character length limit on all identifiers
-	indexedNames := strings.Join(
-		pure_utils.Map(
-			fields,
-			func(s models.FieldName) string { return string(s) },
-		),
-		"-",
-	)
+	indexedNames := strings.Join(fields, "-")
 	out := fmt.Sprintf("idx_%s_%s", table, indexedNames)
 	randomId := uuid.NewString()
 	length := min(len(out), 53)
 	return pgx.Identifier.Sanitize([]string{out[:length] + "_" + randomId})
 }
 
-func toUniqIndexName(fields []models.FieldName, table models.TableName) string {
+func toUniqIndexName(fields []string, table models.TableName) string {
 	// postgresql enforces a 63 character length limit on all identifiers
-	indexedNames := strings.Join(
-		pure_utils.Map(
-			fields,
-			func(s models.FieldName) string { return string(s) },
-		),
-		"-",
-	)
+	indexedNames := strings.Join(fields, "-")
 	out := fmt.Sprintf("uniq_idx_%s_%s", table, indexedNames)
 	length := min(len(out), 53)
 	return out[:length]
@@ -303,10 +288,7 @@ func createUniqueIndex(ctx context.Context, exec Executor, index models.UnicityI
 	if len(index.Included) > 0 {
 		sql += fmt.Sprintf(
 			" INCLUDE (%s)",
-			strings.Join(
-				pure_utils.Map(index.Included, func(s models.FieldName) string { return string(s) }),
-				",",
-			),
+			strings.Join(index.Included, ","),
 		)
 	}
 	sql += " WHERE valid_until='infinity'"

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -222,7 +222,7 @@ func withDesc(s string) string {
 	return fmt.Sprintf("%s DESC", s)
 }
 
-func indexToIndexName(fields []string, table models.TableName) string {
+func indexToIndexName(fields []string, table string) string {
 	// postgresql enforces a 63 character length limit on all identifiers
 	indexedNames := strings.Join(fields, "-")
 	out := fmt.Sprintf("idx_%s_%s", table, indexedNames)
@@ -231,7 +231,7 @@ func indexToIndexName(fields []string, table models.TableName) string {
 	return pgx.Identifier.Sanitize([]string{out[:length] + "_" + randomId})
 }
 
-func toUniqIndexName(fields []string, table models.TableName) string {
+func toUniqIndexName(fields []string, table string) string {
 	// postgresql enforces a 63 character length limit on all identifiers
 	indexedNames := strings.Join(fields, "-")
 	out := fmt.Sprintf("uniq_idx_%s_%s", table, indexedNames)

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -24,7 +24,7 @@ type IngestedDataReadRepository interface {
 	QueryAggregatedValue(
 		ctx context.Context,
 		exec Executor,
-		tableName models.TableName,
+		tableName string,
 		fieldName string,
 		aggregator ast.Aggregator,
 		filters []ast.Filter,
@@ -295,7 +295,7 @@ func queryWithDynamicColumnList(
 	return output, nil
 }
 
-func createQueryAggregated(exec Executor, tableName models.TableName,
+func createQueryAggregated(exec Executor, tableName string,
 	fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (squirrel.SelectBuilder, error) {
 	var selectExpression string
@@ -327,7 +327,7 @@ func createQueryAggregated(exec Executor, tableName models.TableName,
 }
 
 func (repo *IngestedDataReadRepositoryImpl) QueryAggregatedValue(ctx context.Context, exec Executor,
-	tableName models.TableName, fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
+	tableName string, fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (any, error) {
 	if err := validateClientDbExecutor(exec); err != nil {
 		return nil, err

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -25,7 +25,7 @@ type IngestedDataReadRepository interface {
 		ctx context.Context,
 		exec Executor,
 		tableName models.TableName,
-		fieldName models.FieldName,
+		fieldName string,
 		aggregator ast.Aggregator,
 		filters []ast.Filter,
 	) (any, error)
@@ -114,7 +114,7 @@ func createQueryDbForField(exec Executor, readParams models.DbFieldReadParams) (
 	return addJoinsOnIntermediateTables(exec, query, readParams, firstTable)
 }
 
-func getParentTableJoinField(payload models.ClientObject, fieldName models.FieldName) (string, error) {
+func getParentTableJoinField(payload models.ClientObject, fieldName string) (string, error) {
 	parentFieldItf := payload.Data[string(fieldName)]
 	if parentFieldItf == nil {
 		return "", errors.Wrap(
@@ -296,7 +296,7 @@ func queryWithDynamicColumnList(
 }
 
 func createQueryAggregated(exec Executor, tableName models.TableName,
-	fieldName models.FieldName, aggregator ast.Aggregator, filters []ast.Filter,
+	fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (squirrel.SelectBuilder, error) {
 	var selectExpression string
 	if aggregator == ast.AGGREGATOR_COUNT_DISTINCT {
@@ -327,7 +327,7 @@ func createQueryAggregated(exec Executor, tableName models.TableName,
 }
 
 func (repo *IngestedDataReadRepositoryImpl) QueryAggregatedValue(ctx context.Context, exec Executor,
-	tableName models.TableName, fieldName models.FieldName, aggregator ast.Aggregator, filters []ast.Filter,
+	tableName models.TableName, fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (any, error) {
 	if err := validateClientDbExecutor(exec); err != nil {
 		return nil, err

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -52,7 +52,7 @@ func (tx TransactionTest) Exec(ctx context.Context, query string, args ...interf
 }
 
 func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
-	path := []models.LinkName{models.LinkName(utils.DummyTableNameSecond)}
+	path := []string{string(utils.DummyTableNameSecond)}
 
 	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
 		TriggerTableName: utils.DummyTableNameFirst,
@@ -75,9 +75,9 @@ func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 }
 
 func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {
-	path := []models.LinkName{
-		models.LinkName(utils.DummyTableNameSecond),
-		models.LinkName(utils.DummyTableNameThird),
+	path := []string{
+		string(utils.DummyTableNameSecond),
+		string(utils.DummyTableNameThird),
 	}
 
 	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -208,7 +208,7 @@ func (repo *IngestionRepositoryImpl) generateInsertValues(payload models.ClientO
 	insertValues := make([]interface{}, len(columnNames))
 	i := 0
 	for _, columnName := range columnNames {
-		fieldName := models.FieldName(columnName)
+		fieldName := columnName
 		insertValues[i] = payload.Data[string(fieldName)]
 		i++
 	}
@@ -241,8 +241,8 @@ func (repo *IngestionRepositoryImpl) batchInsertEnumValues(ctx context.Context, 
 	var shouldInsertFloatValues bool
 
 	for fieldName, values := range enumValues {
-		fieldId := table.Fields[models.FieldName(fieldName)].ID
-		dataType := table.Fields[models.FieldName(fieldName)].DataType
+		fieldId := table.Fields[fieldName].ID
+		dataType := table.Fields[fieldName].DataType
 
 		for value := range values {
 			if dataType == models.String {

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -106,7 +106,7 @@ type IngestedObject struct {
 }
 
 func (repo *IngestionRepositoryImpl) loadPreviouslyIngestedObjects(ctx context.Context,
-	exec Executor, objectIds []string, tableName models.TableName,
+	exec Executor, objectIds []string, tableName string,
 ) ([]IngestedObject, error) {
 	query := NewQueryBuilder().
 		Select("id, object_id, updated_at").
@@ -145,7 +145,7 @@ func (repo *IngestionRepositoryImpl) comparePayloadsToIngestedObjects(
 }
 
 func (repo *IngestionRepositoryImpl) batchUpdateValidUntilOnObsoleteObjects(ctx context.Context,
-	exec Executor, tableName models.TableName, obsoleteIngestedObjectIds []string,
+	exec Executor, tableName string, obsoleteIngestedObjectIds []string,
 ) error {
 	sql := NewQueryBuilder().
 		Update(tableNameWithSchema(exec, tableName)).

--- a/repositories/pg_indexes/pg_indexes.go
+++ b/repositories/pg_indexes/pg_indexes.go
@@ -56,7 +56,7 @@ func parseCreateIndexStatement(sql string) models.ConcreteIndex {
 func (pgIndex PGIndex) AdaptConcreteIndex() models.ConcreteIndex {
 	idx := parseCreateIndexStatement(pgIndex.Definition)
 
-	idx.TableName = models.TableName(pgIndex.TableName)
+	idx.TableName = pgIndex.TableName
 	return idx
 }
 

--- a/repositories/pg_indexes/pg_indexes.go
+++ b/repositories/pg_indexes/pg_indexes.go
@@ -31,19 +31,19 @@ func parseCreateIndexStatement(sql string) models.ConcreteIndex {
 
 	// len(matches) is expected to be > 0 because the sql statement is expected to be a proper CREATE INDEX statement
 	indexedColumnsRaw := strings.Split(strings.Trim(matches[0], "() "), ",")
-	indexedColumnNames := pure_utils.Map(indexedColumnsRaw, func(s string) models.FieldName {
+	indexedColumnNames := pure_utils.Map(indexedColumnsRaw, func(s string) string {
 		// We discard the order of the index (ASC/DESC) because this is not relevant or modelized (yet) for our purposes
 		parts := strings.Split(strings.Trim(s, " "), " ")
 		// the first part of the string must be the column name
-		return models.FieldName(parts[0])
+		return parts[0]
 	})
 
-	var includedColumnNames []models.FieldName
+	var includedColumnNames []string
 	// if there is a second match, it is the list of included columns (optional)
 	if len(matches) > 1 {
 		names := strings.Split(strings.Trim(matches[1], "() "), ",")
-		includedColumnNames = pure_utils.Map(names, func(s string) models.FieldName {
-			return models.FieldName(strings.Trim(s, " "))
+		includedColumnNames = pure_utils.Map(names, func(s string) string {
+			return strings.Trim(s, " ")
 		})
 	}
 

--- a/repositories/pg_indexes/pg_indexes_test.go
+++ b/repositories/pg_indexes/pg_indexes_test.go
@@ -16,8 +16,8 @@ func TestParseCreateIndexStatement(t *testing.T) {
 		)
 		asserts.Equal(
 			models.ConcreteIndex{
-				Indexed:  []models.FieldName{"userpublicid", "eventdate"},
-				Included: []models.FieldName{"object_id", "transactionamount", "operationdirection", "operationcode"},
+				Indexed:  []string{"userpublicid", "eventdate"},
+				Included: []string{"object_id", "transactionamount", "operationdirection", "operationcode"},
 			},
 			idx,
 		)
@@ -30,8 +30,8 @@ func TestParseCreateIndexStatement(t *testing.T) {
 		)
 		asserts.Equal(
 			models.ConcreteIndex{
-				Indexed:  []models.FieldName{"userpublicid", "eventdate"},
-				Included: []models.FieldName{"object_id", "transactionamount", "operationdirection", "operationcode"},
+				Indexed:  []string{"userpublicid", "eventdate"},
+				Included: []string{"object_id", "transactionamount", "operationdirection", "operationcode"},
 			},
 			idx,
 		)
@@ -43,7 +43,7 @@ func TestParseCreateIndexStatement(t *testing.T) {
 		fmt.Println(idx)
 		asserts.Equal(
 			models.ConcreteIndex{
-				Indexed:  []models.FieldName{"userpublicid"},
+				Indexed:  []string{"userpublicid"},
 				Included: nil,
 			},
 			idx,

--- a/repositories/table_name_with_schema.go
+++ b/repositories/table_name_with_schema.go
@@ -1,14 +1,9 @@
 package repositories
 
 import (
-	"github.com/checkmarble/marble-backend/models"
-
 	"github.com/jackc/pgx/v5"
 )
 
-func tableNameWithSchema(exec Executor, tableName models.TableName) string {
-	return pgx.Identifier.Sanitize([]string{
-		exec.DatabaseSchema().Schema,
-		string(tableName),
-	})
+func tableNameWithSchema(exec Executor, tableName string) string {
+	return pgx.Identifier.Sanitize([]string{exec.DatabaseSchema().Schema, tableName})
 }

--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -21,7 +21,7 @@ func DryRunPayload(table models.Table) map[string]any {
 	return result
 }
 
-func DryRunGetDbField(dataModel models.DataModel, triggerTableName models.TableName, path []string, fieldName string) (any, error) {
+func DryRunGetDbField(dataModel models.DataModel, triggerTableName string, path []string, fieldName string) (any, error) {
 	table, ok := dataModel.Tables[triggerTableName]
 	if !ok {
 		return nil, fmt.Errorf("table %s not found in data model", triggerTableName)
@@ -65,9 +65,7 @@ func DryRunValue(prefix string, fieldName string, field models.Field) any {
 	}
 }
 
-func DryRunQueryAggregatedValue(datamodel models.DataModel, tableName models.TableName,
-	fieldName string, aggregator ast.Aggregator,
-) (any, error) {
+func DryRunQueryAggregatedValue(datamodel models.DataModel, tableName string, fieldName string, aggregator ast.Aggregator) (any, error) {
 	table, ok := datamodel.Tables[tableName]
 	if !ok {
 		return nil, fmt.Errorf("table %s not found in data model", tableName)

--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -28,7 +28,7 @@ func DryRunGetDbField(dataModel models.DataModel, triggerTableName models.TableN
 	}
 
 	for _, linkName := range path {
-		link, ok := table.LinksToSingle[models.LinkName(linkName)]
+		link, ok := table.LinksToSingle[linkName]
 		if !ok {
 			return nil, errors.New(fmt.Sprintf("link %s not found in table %s", linkName, table.Name))
 		}

--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -21,7 +21,7 @@ func DryRunPayload(table models.Table) map[string]any {
 	return result
 }
 
-func DryRunGetDbField(dataModel models.DataModel, triggerTableName models.TableName, path []string, fieldName models.FieldName) (any, error) {
+func DryRunGetDbField(dataModel models.DataModel, triggerTableName models.TableName, path []string, fieldName string) (any, error) {
 	table, ok := dataModel.Tables[triggerTableName]
 	if !ok {
 		return nil, fmt.Errorf("table %s not found in data model", triggerTableName)
@@ -66,7 +66,7 @@ func DryRunValue(prefix string, fieldName string, field models.Field) any {
 }
 
 func DryRunQueryAggregatedValue(datamodel models.DataModel, tableName models.TableName,
-	fieldName models.FieldName, aggregator ast.Aggregator,
+	fieldName string, aggregator ast.Aggregator,
 ) (any, error) {
 	table, ok := datamodel.Tables[tableName]
 	if !ok {

--- a/usecases/ast_eval/evaluate/evaluate_aggregator.go
+++ b/usecases/ast_eval/evaluate/evaluate_aggregator.go
@@ -32,7 +32,7 @@ var ValidTypesForAggregator = map[ast.Aggregator][]models.DataType{
 }
 
 func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
-	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
+	tableName, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
 	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 	_, labelErr := AdaptNamedArgument(arguments.NamedArgs, "label", adaptArgumentToString)
 	aggregatorStr, aggregatorErr := AdaptNamedArgument(arguments.NamedArgs, "aggregator", adaptArgumentToString)
@@ -44,7 +44,6 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 		return nil, errs
 	}
 
-	tableName := models.TableName(tableNameStr)
 	aggregator := ast.Aggregator(aggregatorStr)
 
 	// Aggregator validation
@@ -76,7 +75,7 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 	// Filters validation
 	if len(filters) > 0 {
 		for _, filter := range filters {
-			if filter.TableName != tableNameStr {
+			if filter.TableName != tableName {
 				return MakeEvaluateError(errors.Join(
 					errors.Wrap(ast.ErrRuntimeExpression,
 						"filters must be applied on the same table"),
@@ -98,7 +97,7 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 	return result, nil
 }
 
-func (a AggregatorEvaluator) runQueryInRepository(ctx context.Context, tableName models.TableName,
+func (a AggregatorEvaluator) runQueryInRepository(ctx context.Context, tableName string,
 	fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (any, error) {
 	if a.ReturnFakeValue {

--- a/usecases/ast_eval/evaluate/evaluate_aggregator.go
+++ b/usecases/ast_eval/evaluate/evaluate_aggregator.go
@@ -33,7 +33,7 @@ var ValidTypesForAggregator = map[ast.Aggregator][]models.DataType{
 
 func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
-	fieldNameStr, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
+	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 	_, labelErr := AdaptNamedArgument(arguments.NamedArgs, "label", adaptArgumentToString)
 	aggregatorStr, aggregatorErr := AdaptNamedArgument(arguments.NamedArgs, "aggregator", adaptArgumentToString)
 	filters, filtersErr := AdaptNamedArgument(arguments.NamedArgs, "filters",
@@ -45,7 +45,6 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 	}
 
 	tableName := models.TableName(tableNameStr)
-	fieldName := models.FieldName(fieldNameStr)
 	aggregator := ast.Aggregator(aggregatorStr)
 
 	// Aggregator validation
@@ -100,7 +99,7 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 }
 
 func (a AggregatorEvaluator) runQueryInRepository(ctx context.Context, tableName models.TableName,
-	fieldName models.FieldName, aggregator ast.Aggregator, filters []ast.Filter,
+	fieldName string, aggregator ast.Aggregator, filters []ast.Filter,
 ) (any, error) {
 	if a.ReturnFakeValue {
 		return DryRunQueryAggregatedValue(a.DataModel, tableName, fieldName, aggregator)

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -23,7 +23,7 @@ type DatabaseAccess struct {
 }
 
 func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
-	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
+	tableName, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
 	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 
 	errs := filterNilErrors(tableNameErr, fieldNameErr)
@@ -32,7 +32,6 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 	}
 
 	var pathStringArr []string
-	tableName := models.TableName(tableNameStr)
 
 	path, ok := arguments.NamedArgs["path"].([]any)
 	if !ok {
@@ -72,7 +71,7 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 	return fieldValue, nil
 }
 
-func (d DatabaseAccess) getDbField(ctx context.Context, tableName models.TableName,
+func (d DatabaseAccess) getDbField(ctx context.Context, tableName string,
 	fieldName string, path []string,
 ) (interface{}, error) {
 	if d.ReturnFakeValue {
@@ -84,7 +83,7 @@ func (d DatabaseAccess) getDbField(ctx context.Context, tableName models.TableNa
 		return nil, err
 	}
 	return d.IngestedDataReadRepository.GetDbField(ctx, db, models.DbFieldReadParams{
-		TriggerTableName: models.TableName(tableName),
+		TriggerTableName: tableName,
 		Path:             path,
 		FieldName:        fieldName,
 		DataModel:        d.DataModel,

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -24,7 +24,7 @@ type DatabaseAccess struct {
 
 func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
-	fieldNameStr, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
+	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 
 	errs := filterNilErrors(tableNameErr, fieldNameErr)
 	if len(errs) > 0 {
@@ -33,7 +33,6 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 
 	var pathStringArr []string
 	tableName := models.TableName(tableNameStr)
-	fieldName := models.FieldName(fieldNameStr)
 
 	path, ok := arguments.NamedArgs["path"].([]any)
 	if !ok {
@@ -74,7 +73,7 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 }
 
 func (d DatabaseAccess) getDbField(ctx context.Context, tableName models.TableName,
-	fieldName models.FieldName, path []string,
+	fieldName string, path []string,
 ) (interface{}, error) {
 	if d.ReturnFakeValue {
 		return DryRunGetDbField(d.DataModel, tableName, path, fieldName)
@@ -87,7 +86,7 @@ func (d DatabaseAccess) getDbField(ctx context.Context, tableName models.TableNa
 	return d.IngestedDataReadRepository.GetDbField(ctx, db, models.DbFieldReadParams{
 		TriggerTableName: models.TableName(tableName),
 		Path:             path,
-		FieldName:        models.FieldName(fieldName),
+		FieldName:        fieldName,
 		DataModel:        d.DataModel,
 		ClientObject:     d.ClientObject,
 	})

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -86,7 +86,7 @@ func (d DatabaseAccess) getDbField(ctx context.Context, tableName models.TableNa
 	}
 	return d.IngestedDataReadRepository.GetDbField(ctx, db, models.DbFieldReadParams{
 		TriggerTableName: models.TableName(tableName),
-		Path:             models.ToLinkNames(path),
+		Path:             path,
 		FieldName:        models.FieldName(fieldName),
 		DataModel:        d.DataModel,
 		ClientObject:     d.ClientObject,

--- a/usecases/ast_eval/evaluate/evaluate_filter.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter.go
@@ -28,7 +28,7 @@ var ValidTypeForFilterOperators = map[ast.FilterOperator][]models.DataType{
 }
 
 func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
-	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
+	tableName, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
 	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 	operatorStr, operatorErr := AdaptNamedArgument(arguments.NamedArgs, "operator", adaptArgumentToString)
 
@@ -37,10 +37,10 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 		return nil, errs
 	}
 
-	fieldType, err := getFieldType(f.DataModel, models.TableName(tableNameStr), fieldName)
+	fieldType, err := getFieldType(f.DataModel, tableName, fieldName)
 	if err != nil {
 		return MakeEvaluateError(errors.Join(
-			errors.Wrap(err, fmt.Sprintf("field type for %s.%s not found in data model in Evaluate filter", tableNameStr, fieldName)),
+			errors.Wrap(err, fmt.Sprintf("field type for %s.%s not found in data model in Evaluate filter", tableName, fieldName)),
 			ast.NewNamedArgumentError("fieldName"),
 		))
 	}
@@ -80,7 +80,7 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 		if err != nil {
 			return MakeEvaluateError(errors.Join(
 				errors.Wrap(ast.ErrArgumentInvalidType,
-					fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableNameStr, fieldName)),
+					fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableName, fieldName)),
 				ast.NewNamedArgumentError("value"),
 				err,
 			))
@@ -88,7 +88,7 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 	}
 
 	returnValue := ast.Filter{
-		TableName: tableNameStr,
+		TableName: tableName,
 		FieldName: fieldName,
 		Operator:  operator,
 		Value:     promotedValue,

--- a/usecases/ast_eval/evaluate/evaluate_filter.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter.go
@@ -29,7 +29,7 @@ var ValidTypeForFilterOperators = map[ast.FilterOperator][]models.DataType{
 
 func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	tableNameStr, tableNameErr := AdaptNamedArgument(arguments.NamedArgs, "tableName", adaptArgumentToString)
-	fieldNameStr, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
+	fieldName, fieldNameErr := AdaptNamedArgument(arguments.NamedArgs, "fieldName", adaptArgumentToString)
 	operatorStr, operatorErr := AdaptNamedArgument(arguments.NamedArgs, "operator", adaptArgumentToString)
 
 	errs := filterNilErrors(tableNameErr, fieldNameErr, operatorErr)
@@ -37,10 +37,10 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 		return nil, errs
 	}
 
-	fieldType, err := getFieldType(f.DataModel, models.TableName(tableNameStr), models.FieldName(fieldNameStr))
+	fieldType, err := getFieldType(f.DataModel, models.TableName(tableNameStr), fieldName)
 	if err != nil {
 		return MakeEvaluateError(errors.Join(
-			errors.Wrap(err, fmt.Sprintf("field type for %s.%s not found in data model in Evaluate filter", tableNameStr, fieldNameStr)),
+			errors.Wrap(err, fmt.Sprintf("field type for %s.%s not found in data model in Evaluate filter", tableNameStr, fieldName)),
 			ast.NewNamedArgumentError("fieldName"),
 		))
 	}
@@ -80,7 +80,7 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 		if err != nil {
 			return MakeEvaluateError(errors.Join(
 				errors.Wrap(ast.ErrArgumentInvalidType,
-					fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableNameStr, fieldNameStr)),
+					fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableNameStr, fieldName)),
 				ast.NewNamedArgumentError("value"),
 				err,
 			))
@@ -89,7 +89,7 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 
 	returnValue := ast.Filter{
 		TableName: tableNameStr,
-		FieldName: fieldNameStr,
+		FieldName: fieldName,
 		Operator:  operator,
 		Value:     promotedValue,
 	}

--- a/usecases/ast_eval/evaluate/evaluate_filter_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter_test.go
@@ -14,7 +14,7 @@ var dataModel = models.DataModel{
 	Tables: map[models.TableName]models.Table{
 		"table1": {
 			Name: "table1",
-			Fields: map[models.FieldName]models.Field{
+			Fields: map[string]models.Field{
 				"field1": {
 					DataType: models.Bool,
 					Nullable: false,
@@ -141,7 +141,7 @@ var dataModelWithInt = models.DataModel{
 	Tables: map[models.TableName]models.Table{
 		"table1": {
 			Name: "table1",
-			Fields: map[models.FieldName]models.Field{
+			Fields: map[string]models.Field{
 				"field1": {
 					DataType: models.Int,
 					Nullable: false,
@@ -178,7 +178,7 @@ var dataModelWithString = models.DataModel{
 	Tables: map[models.TableName]models.Table{
 		"table1": {
 			Name: "table1",
-			Fields: map[models.FieldName]models.Field{
+			Fields: map[string]models.Field{
 				"field1": {
 					DataType: models.String,
 					Nullable: false,

--- a/usecases/ast_eval/evaluate/evaluate_filter_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var dataModel = models.DataModel{
-	Tables: map[models.TableName]models.Table{
+	Tables: map[string]models.Table{
 		"table1": {
 			Name: "table1",
 			Fields: map[string]models.Field{
@@ -138,7 +138,7 @@ func TestFilter_value_incompatible(t *testing.T) {
 }
 
 var dataModelWithInt = models.DataModel{
-	Tables: map[models.TableName]models.Table{
+	Tables: map[string]models.Table{
 		"table1": {
 			Name: "table1",
 			Fields: map[string]models.Field{
@@ -175,7 +175,7 @@ func TestFilter_value_float(t *testing.T) {
 }
 
 var dataModelWithString = models.DataModel{
-	Tables: map[models.TableName]models.Table{
+	Tables: map[string]models.Table{
 		"table1": {
 			Name: "table1",
 			Fields: map[string]models.Field{

--- a/usecases/ast_eval/evaluate/helpers.go
+++ b/usecases/ast_eval/evaluate/helpers.go
@@ -93,7 +93,7 @@ func MakeEvaluateError(err error) (any, []error) {
 	return nil, []error{err}
 }
 
-func getFieldType(dataModel models.DataModel, tableName models.TableName, fieldName models.FieldName) (models.DataType, error) {
+func getFieldType(dataModel models.DataModel, tableName models.TableName, fieldName string) (models.DataType, error) {
 	table, ok := dataModel.Tables[tableName]
 	if !ok {
 		return models.UnknownDataType, errors.Wrap(

--- a/usecases/ast_eval/evaluate/helpers.go
+++ b/usecases/ast_eval/evaluate/helpers.go
@@ -93,7 +93,7 @@ func MakeEvaluateError(err error) (any, []error) {
 	return nil, []error{err}
 }
 
-func getFieldType(dataModel models.DataModel, tableName models.TableName, fieldName string) (models.DataType, error) {
+func getFieldType(dataModel models.DataModel, tableName string, fieldName string) (models.DataType, error) {
 	table, ok := dataModel.Tables[tableName]
 	if !ok {
 		return models.UnknownDataType, errors.Wrap(

--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -34,7 +34,7 @@ type EditorOperators struct {
 
 func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario models.Scenario, dataModel models.DataModel) ([]ast.Node, error) {
 	dataAccessors := []ast.Node{}
-	var recursiveDatabaseAccessor func(path []string, links map[models.LinkName]models.LinkToSingle) error
+	var recursiveDatabaseAccessor func(path []string, links map[string]models.LinkToSingle) error
 
 	triggerObjectTable, found := dataModel.Tables[models.TableName(scenario.TriggerObjectType)]
 	if !found {
@@ -42,7 +42,7 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 	}
 
 	var visited []string
-	recursiveDatabaseAccessor = func(path []string, links map[models.LinkName]models.LinkToSingle) error {
+	recursiveDatabaseAccessor = func(path []string, links map[string]models.LinkToSingle) error {
 		for linkName, link := range links {
 			table, found := dataModel.Tables[link.LinkedTableName]
 			if !found {

--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -36,7 +36,7 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 	dataAccessors := []ast.Node{}
 	var recursiveDatabaseAccessor func(path []string, links map[string]models.LinkToSingle) error
 
-	triggerObjectTable, found := dataModel.Tables[models.TableName(scenario.TriggerObjectType)]
+	triggerObjectTable, found := dataModel.Tables[scenario.TriggerObjectType]
 	if !found {
 		return nil, fmt.Errorf("triggerObjectTable %s not found in data model", scenario.TriggerObjectType)
 	}
@@ -84,7 +84,7 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 func (usecase *AstExpressionUsecase) getPayloadIdentifiers(scenario models.Scenario, dataModel models.DataModel) ([]ast.Node, error) {
 	dataAccessors := []ast.Node{}
 
-	triggerObjectTable, found := dataModel.Tables[models.TableName(scenario.TriggerObjectType)]
+	triggerObjectTable, found := dataModel.Tables[scenario.TriggerObjectType]
 	if !found {
 		// unexpected error: must be a valid table
 		return nil, fmt.Errorf("triggerObjectTable %s not found in data model", scenario.TriggerObjectType)

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -14,7 +14,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 	}
 
 	model := models.DataModel{
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			"accounts": {
 				Name: "accounts",
 				Fields: map[string]models.Field{

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -21,7 +21,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 					"id":                  {},
 					"last_transaction_id": {},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"last_transactions": {
 						LinkedTableName: "transactions",
 						ParentFieldName: "id",
@@ -35,7 +35,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 					"id":         {},
 					"account_id": {},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						LinkedTableName: "accounts",
 						ParentFieldName: "id",

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -17,7 +17,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 		Tables: map[models.TableName]models.Table{
 			"accounts": {
 				Name: "accounts",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"id":                  {},
 					"last_transaction_id": {},
 				},
@@ -31,7 +31,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 			},
 			"transactions": {
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"id":         {},
 					"account_id": {},
 				},

--- a/usecases/data_model_helpers_test.go
+++ b/usecases/data_model_helpers_test.go
@@ -12,7 +12,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 		Tables: map[models.TableName]models.Table{
 			"transactions": {
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType: models.String,
 						Name:     "object_id",
@@ -56,7 +56,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 			},
 			"accounts": {
 				Name: "accounts",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType: models.String,
 						Name:     "object_id",
@@ -77,7 +77,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 		Tables: map[models.TableName]models.Table{
 			"transactions": {
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType:          models.String,
 						Name:              "object_id",
@@ -124,7 +124,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 			},
 			"accounts": {
 				Name: "accounts",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType:          models.String,
 						Name:              "object_id",

--- a/usecases/data_model_helpers_test.go
+++ b/usecases/data_model_helpers_test.go
@@ -45,7 +45,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 						Name:     "timestamp",
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
 						LinkedTableName: "accounts",
@@ -69,7 +69,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 						IsEnum:   true,
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{},
+				LinksToSingle: map[string]models.LinkToSingle{},
 			},
 		},
 	}
@@ -113,7 +113,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 						Name:     "timestamp",
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
 						LinkedTableName: "accounts",
@@ -138,7 +138,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 						IsEnum:   true,
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{},
+				LinksToSingle: map[string]models.LinkToSingle{},
 			},
 		},
 	}

--- a/usecases/data_model_helpers_test.go
+++ b/usecases/data_model_helpers_test.go
@@ -9,7 +9,7 @@ import (
 
 func getTestDataModel() (models.DataModel, models.DataModel) {
 	dataModel := models.DataModel{
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			"transactions": {
 				Name: "transactions",
 				Fields: map[string]models.Field{
@@ -74,7 +74,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 		},
 	}
 	dataModelWithUnique := models.DataModel{
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			"transactions": {
 				Name: "transactions",
 				Fields: map[string]models.Field{

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -43,7 +43,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 
 	suite.organizationId = "organizationId"
 	suite.dataModel = models.DataModel{
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			"transactions": {
 				Name: "transactions",
 				Fields: map[string]models.Field{
@@ -104,7 +104,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 		},
 	}
 	suite.dataModelWithUnique = models.DataModel{
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			"transactions": {
 				Name: "transactions",
 				Fields: map[string]models.Field{
@@ -299,7 +299,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelTable_nominal() {
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndex",
 		suite.ctx, suite.transaction, models.UnicityIndex{
-			TableName: models.TableName(tableName),
+			TableName: tableName,
 			Fields:    []string{"object_id"},
 			Included:  []string{"updated_at", "id"},
 		}).
@@ -491,7 +491,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelField_nominal_unique(
 	suite.organizationSchemaRepository.On("CreateField", suite.ctx, suite.transaction, table.Name, field).
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
-		TableName: models.TableName(table.Name),
+		TableName: table.Name,
 		Fields:    []string{field.Name},
 	}).Return(nil)
 
@@ -855,7 +855,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
-		TableName: models.TableName("transactions"),
+		TableName: "transactions",
 		Fields:    []string{"not_yet_unique_id"},
 	}).Return(nil)
 
@@ -888,7 +888,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
 	suite.clientDbIndexEditor.On("DeleteUniqueIndex", suite.ctx, models.UnicityIndex{
-		TableName: models.TableName("transactions"),
+		TableName: "transactions",
 		Fields:    []string{"unique_id"},
 	}).Return(nil)
 	// for GetDataModel (reused in UpdateDataModelField), copied from TestGetDataModel_nominal_with_unique

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -46,7 +46,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 		Tables: map[models.TableName]models.Table{
 			"transactions": {
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType: models.String,
 						Name:     "object_id",
@@ -86,7 +86,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 			},
 			"accounts": {
 				Name: "accounts",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType: models.String,
 						Name:     "object_id",
@@ -107,7 +107,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 		Tables: map[models.TableName]models.Table{
 			"transactions": {
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType:          models.String,
 						Name:              "object_id",
@@ -150,7 +150,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 			},
 			"accounts": {
 				Name: "accounts",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"object_id": {
 						DataType:          models.String,
 						Name:              "object_id",
@@ -171,20 +171,20 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 	suite.uniqueIndexes = []models.UnicityIndex{
 		{
 			TableName: "transactions",
-			Fields:    []models.FieldName{"object_id"},
+			Fields:    []string{"object_id"},
 		},
 		{
 			TableName:         "transactions",
-			Fields:            []models.FieldName{"reference_id"},
+			Fields:            []string{"reference_id"},
 			CreationInProcess: true,
 		},
 		{
 			TableName: "transactions",
-			Fields:    []models.FieldName{"unique_id"},
+			Fields:    []string{"unique_id"},
 		},
 		{
 			TableName: "accounts",
-			Fields:    []models.FieldName{"object_id"},
+			Fields:    []string{"object_id"},
 		},
 	}
 
@@ -300,8 +300,8 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelTable_nominal() {
 	suite.clientDbIndexEditor.On("CreateUniqueIndex",
 		suite.ctx, suite.transaction, models.UnicityIndex{
 			TableName: models.TableName(tableName),
-			Fields:    []models.FieldName{"object_id"},
-			Included:  []models.FieldName{"updated_at", "id"},
+			Fields:    []string{"object_id"},
+			Included:  []string{"updated_at", "id"},
 		}).
 		Return(nil)
 
@@ -492,7 +492,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelField_nominal_unique(
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
 		TableName: models.TableName(table.Name),
-		Fields:    []models.FieldName{field.Name},
+		Fields:    []string{field.Name},
 	}).Return(nil)
 
 	_, err := usecase.CreateDataModelField(suite.ctx, field)
@@ -856,7 +856,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
 		TableName: models.TableName("transactions"),
-		Fields:    []models.FieldName{"not_yet_unique_id"},
+		Fields:    []string{"not_yet_unique_id"},
 	}).Return(nil)
 
 	err := usecase.UpdateDataModelField(suite.ctx, fieldId, input)
@@ -889,7 +889,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 		Return(nil)
 	suite.clientDbIndexEditor.On("DeleteUniqueIndex", suite.ctx, models.UnicityIndex{
 		TableName: models.TableName("transactions"),
-		Fields:    []models.FieldName{"unique_id"},
+		Fields:    []string{"unique_id"},
 	}).Return(nil)
 	// for GetDataModel (reused in UpdateDataModelField), copied from TestGetDataModel_nominal_with_unique
 	suite.enforceSecurity.On("ReadDataModel").Return(nil)

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -75,7 +75,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 						Name:     "unique_id",
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
 						LinkedTableName: "accounts",
@@ -99,7 +99,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 						IsEnum:   true,
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{},
+				LinksToSingle: map[string]models.LinkToSingle{},
 			},
 		},
 	}
@@ -139,7 +139,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 						UnicityConstraint: models.ActiveUniqueConstraint,
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{
+				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
 						LinkedTableName: "accounts",
@@ -164,7 +164,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 						IsEnum:   true,
 					},
 				},
-				LinksToSingle: map[models.LinkName]models.LinkToSingle{},
+				LinksToSingle: map[string]models.LinkToSingle{},
 			},
 		},
 	}

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -162,17 +162,17 @@ func (usecase *DecisionUsecase) validateOutcomes(_ context.Context, filtersOutco
 
 func (usecase *DecisionUsecase) validateTriggerObjects(ctx context.Context,
 	filtersTriggerObjects []string, organizationId string,
-) ([]models.TableName, error) {
+) ([]string, error) {
 	dataModel, err := usecase.datamodelRepository.GetDataModel(ctx,
 		usecase.executorFactory.NewExecutor(), organizationId, true)
 	if err != nil {
-		return []models.TableName{}, err
+		return nil, err
 	}
-	triggerObjectTypes := make([]models.TableName, len(filtersTriggerObjects))
+	triggerObjectTypes := make([]string, len(filtersTriggerObjects))
 	for i, triggerObject := range filtersTriggerObjects {
-		triggerObjectTypes[i] = models.TableName(triggerObject)
+		triggerObjectTypes[i] = triggerObject
 		if _, ok := dataModel.Tables[triggerObjectTypes[i]]; !ok {
-			return []models.TableName{}, fmt.Errorf(
+			return nil, fmt.Errorf(
 				"table %s not found on data model: %w", triggerObject, models.BadParameterError)
 		}
 	}
@@ -419,7 +419,7 @@ func (usecase DecisionUsecase) validatePayload(
 	}
 
 	tables := dataModel.Tables
-	table, ok := tables[models.TableName(triggerObjectTable)]
+	table, ok := tables[triggerObjectTable]
 	if !ok {
 		err = errors.Wrap(
 			models.NotFoundError,

--- a/usecases/evaluate_scenario/data_accessor.go
+++ b/usecases/evaluate_scenario/data_accessor.go
@@ -27,7 +27,7 @@ func (d *DataAccessor) GetDbField(ctx context.Context, triggerTableName string, 
 		models.DbFieldReadParams{
 			TriggerTableName: models.TableName(triggerTableName),
 			Path:             path,
-			FieldName:        models.FieldName(fieldName),
+			FieldName:        fieldName,
 			DataModel:        d.DataModel,
 			ClientObject:     d.ClientObject,
 		})

--- a/usecases/evaluate_scenario/data_accessor.go
+++ b/usecases/evaluate_scenario/data_accessor.go
@@ -25,7 +25,7 @@ func (d *DataAccessor) GetDbField(ctx context.Context, triggerTableName string, 
 		ctx,
 		db,
 		models.DbFieldReadParams{
-			TriggerTableName: models.TableName(triggerTableName),
+			TriggerTableName: triggerTableName,
 			Path:             path,
 			FieldName:        fieldName,
 			DataModel:        d.DataModel,

--- a/usecases/evaluate_scenario/data_accessor.go
+++ b/usecases/evaluate_scenario/data_accessor.go
@@ -26,7 +26,7 @@ func (d *DataAccessor) GetDbField(ctx context.Context, triggerTableName string, 
 		db,
 		models.DbFieldReadParams{
 			TriggerTableName: models.TableName(triggerTableName),
-			Path:             models.ToLinkNames(path),
+			Path:             path,
 			FieldName:        models.FieldName(fieldName),
 			DataModel:        d.DataModel,
 			ClientObject:     d.ClientObject,

--- a/usecases/indexes/aggregate_query.go
+++ b/usecases/indexes/aggregate_query.go
@@ -96,12 +96,11 @@ func aggregationNodeToQueryFamily(node ast.Node) (models.AggregateQueryFamily, e
 			"Error reading tableName in aggregation node: "+err.Error())
 	}
 
-	aggregatedFieldNameStr, err := node.ReadConstantNamedChildString("fieldName")
+	aggregatedFieldName, err := node.ReadConstantNamedChildString("fieldName")
 	if err != nil {
 		return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
 			"Error reading fieldName in aggregation node: "+err.Error())
 	}
-	aggregatedFieldName := models.FieldName(aggregatedFieldNameStr)
 
 	family := models.NewAggregateQueryFamily(queryTableName)
 
@@ -118,14 +117,13 @@ func aggregationNodeToQueryFamily(node ast.Node) (models.AggregateQueryFamily, e
 				"Filter tableName empty or is different from parent aggregator node's tableName")
 		}
 
-		fieldNameStr, err := filter.ReadConstantNamedChildString("fieldName")
+		fieldName, err := filter.ReadConstantNamedChildString("fieldName")
 		if err != nil {
 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
 				"Error reading fieldName in filter node: "+err.Error())
-		} else if fieldNameStr == "" {
+		} else if fieldName == "" {
 			return models.AggregateQueryFamily{}, errors.New("Filter fieldName is empty")
 		}
-		fieldName := models.FieldName(fieldNameStr)
 
 		operatorStr, err := filter.ReadConstantNamedChildString("operator")
 		if err != nil {

--- a/usecases/indexes/aggregate_query_test.go
+++ b/usecases/indexes/aggregate_query_test.go
@@ -33,7 +33,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		}
 		aggregateFamily, err := aggregationNodeToQueryFamily(node)
 		asserts.NoError(err)
-		asserts.Equal(models.TableName("table"), aggregateFamily.TableName,
+		asserts.Equal("table", aggregateFamily.TableName,
 			"table name should be input table name")
 	})
 
@@ -77,7 +77,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		}
 		aggregateFamily, err := aggregationNodeToQueryFamily(node)
 		asserts.NoError(err)
-		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
+		asserts.Equal("table", aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
 		asserts.True(aggregateFamily.EqConditions.Contains("field"))
 		asserts.Equal(0, aggregateFamily.IneqConditions.Size())
@@ -116,7 +116,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		}
 		aggregateFamily, err := aggregationNodeToQueryFamily(node)
 		asserts.NoError(err)
-		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
+		asserts.Equal("table", aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
 		asserts.True(aggregateFamily.EqConditions.Contains("field"))
 		asserts.Equal(0, aggregateFamily.IneqConditions.Size())
@@ -155,7 +155,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		}
 		aggregateFamily, err := aggregationNodeToQueryFamily(node)
 		asserts.NoError(err)
-		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
+		asserts.Equal("table", aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
 		asserts.True(aggregateFamily.EqConditions.Contains("field 1"))
 		asserts.Equal(1, aggregateFamily.IneqConditions.Size())
@@ -236,7 +236,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		}
 		aggregateFamily, err := aggregationNodeToQueryFamily(node)
 		asserts.NoError(err)
-		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
+		asserts.Equal("table", aggregateFamily.TableName)
 		asserts.Equal(2, aggregateFamily.EqConditions.Size(),
 			"EqConditions should contain field 1 and field 2")
 		asserts.True(aggregateFamily.EqConditions.Contains("field 1"), "EqConditions should contain field 1")
@@ -307,7 +307,7 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 		asserts.Equal(1, output.Size(), "There should be only 1 query family in the output set")
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)
 		expected.Insert(models.AggregateQueryFamily{
-			TableName:               models.TableName("table"),
+			TableName:               "table",
 			EqConditions:            set.From[string]([]string{"field"}),
 			IneqConditions:          set.New[string](0),
 			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
@@ -393,19 +393,19 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 		asserts.Equal(3, output.Size(), "There should be 2 query families in the output set")
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)
 		expected.Insert(models.AggregateQueryFamily{
-			TableName:               models.TableName("table"),
+			TableName:               "table",
 			EqConditions:            set.From[string]([]string{"field"}),
 			IneqConditions:          set.New[string](0),
 			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
 		})
 		expected.Insert(models.AggregateQueryFamily{
-			TableName:               models.TableName("table"),
+			TableName:               "table",
 			EqConditions:            set.New[string](0),
 			IneqConditions:          set.From[string]([]string{"field"}),
 			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
 		})
 		expected.Insert(models.AggregateQueryFamily{
-			TableName:      models.TableName("table"),
+			TableName:      "table",
 			EqConditions:   set.From[string]([]string{"field 0"}),
 			IneqConditions: set.New[string](0),
 			SelectOrOtherConditions: set.From[string]([]string{
@@ -482,7 +482,7 @@ func Test_indexesToCreateFromScenarioIterations(t *testing.T) {
 		asserts.NoError(err)
 		asserts.Equal(1, len(out), "There should be 1 index to create")
 		asserts.Equal(models.ConcreteIndex{
-			TableName: models.TableName("table"),
+			TableName: "table",
 			Indexed:   []string{"field"},
 			Included:  []string{"field 0"},
 		}, out[0])

--- a/usecases/indexes/aggregate_query_test.go
+++ b/usecases/indexes/aggregate_query_test.go
@@ -79,7 +79,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		asserts.NoError(err)
 		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
-		asserts.True(aggregateFamily.EqConditions.Contains(models.FieldName("field")))
+		asserts.True(aggregateFamily.EqConditions.Contains("field"))
 		asserts.Equal(0, aggregateFamily.IneqConditions.Size())
 		asserts.Equal(1, aggregateFamily.SelectOrOtherConditions.Size(),
 			"SelectOrOtherConditions should contain field 0")
@@ -118,7 +118,7 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		asserts.NoError(err)
 		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
-		asserts.True(aggregateFamily.EqConditions.Contains(models.FieldName("field")))
+		asserts.True(aggregateFamily.EqConditions.Contains("field"))
 		asserts.Equal(0, aggregateFamily.IneqConditions.Size())
 		asserts.Equal(1, aggregateFamily.SelectOrOtherConditions.Size(),
 			"SelectOrOtherConditions should contain field 0")
@@ -157,9 +157,9 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		asserts.NoError(err)
 		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
 		asserts.Equal(1, aggregateFamily.EqConditions.Size())
-		asserts.True(aggregateFamily.EqConditions.Contains(models.FieldName("field 1")))
+		asserts.True(aggregateFamily.EqConditions.Contains("field 1"))
 		asserts.Equal(1, aggregateFamily.IneqConditions.Size())
-		asserts.True(aggregateFamily.IneqConditions.Contains(models.FieldName("field 2")))
+		asserts.True(aggregateFamily.IneqConditions.Contains("field 2"))
 		asserts.Equal(1, aggregateFamily.SelectOrOtherConditions.Size(),
 			"SelectOrOtherConditions should contain field 0")
 	})
@@ -239,16 +239,16 @@ func TestAggregationNodeToQueryFamily(t *testing.T) {
 		asserts.Equal(models.TableName("table"), aggregateFamily.TableName)
 		asserts.Equal(2, aggregateFamily.EqConditions.Size(),
 			"EqConditions should contain field 1 and field 2")
-		asserts.True(aggregateFamily.EqConditions.Contains(models.FieldName("field 1")), "EqConditions should contain field 1")
-		asserts.True(aggregateFamily.EqConditions.Contains(models.FieldName("field 2")), "EqConditions should contain field 2")
+		asserts.True(aggregateFamily.EqConditions.Contains("field 1"), "EqConditions should contain field 1")
+		asserts.True(aggregateFamily.EqConditions.Contains("field 2"), "EqConditions should contain field 2")
 		asserts.Equal(1, aggregateFamily.IneqConditions.Size(),
 			"IneqConditions should contain field 3")
-		asserts.True(aggregateFamily.IneqConditions.Contains(models.FieldName("field 3")),
+		asserts.True(aggregateFamily.IneqConditions.Contains("field 3"),
 			"IneqConditions should contain field 3")
 		asserts.Equal(1, aggregateFamily.SelectOrOtherConditions.Size(),
 			"SelectOrOtherConditions should contain 1 field")
-		asserts.True(aggregateFamily.SelectOrOtherConditions.Contains(
-			models.FieldName("field 0")), "SelectOrOtherConditions should contain field 0")
+		asserts.True(aggregateFamily.SelectOrOtherConditions.Contains("field 0"),
+			"SelectOrOtherConditions should contain field 0")
 	})
 }
 
@@ -308,9 +308,9 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)
 		expected.Insert(models.AggregateQueryFamily{
 			TableName:               models.TableName("table"),
-			EqConditions:            set.From[models.FieldName]([]models.FieldName{"field"}),
-			IneqConditions:          set.New[models.FieldName](0),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{"field 0"}),
+			EqConditions:            set.From[string]([]string{"field"}),
+			IneqConditions:          set.New[string](0),
+			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
 		})
 		asserts.True(output.EqualSet(expected), "The output set should contain the one query family (that was present twice)")
 		fmt.Println(expected)
@@ -394,21 +394,21 @@ func TestAstNodeToQueryFamilies(t *testing.T) {
 		expected := set.NewHashSet[models.AggregateQueryFamily](0)
 		expected.Insert(models.AggregateQueryFamily{
 			TableName:               models.TableName("table"),
-			EqConditions:            set.From[models.FieldName]([]models.FieldName{"field"}),
-			IneqConditions:          set.New[models.FieldName](0),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{"field 0"}),
+			EqConditions:            set.From[string]([]string{"field"}),
+			IneqConditions:          set.New[string](0),
+			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
 		})
 		expected.Insert(models.AggregateQueryFamily{
 			TableName:               models.TableName("table"),
-			EqConditions:            set.New[models.FieldName](0),
-			IneqConditions:          set.From[models.FieldName]([]models.FieldName{"field"}),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{"field 0"}),
+			EqConditions:            set.New[string](0),
+			IneqConditions:          set.From[string]([]string{"field"}),
+			SelectOrOtherConditions: set.From[string]([]string{"field 0"}),
 		})
 		expected.Insert(models.AggregateQueryFamily{
 			TableName:      models.TableName("table"),
-			EqConditions:   set.From[models.FieldName]([]models.FieldName{"field 0"}),
-			IneqConditions: set.New[models.FieldName](0),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{
+			EqConditions:   set.From[string]([]string{"field 0"}),
+			IneqConditions: set.New[string](0),
+			SelectOrOtherConditions: set.From[string]([]string{
 				"field 2", "field 3",
 			}),
 		})
@@ -483,8 +483,8 @@ func Test_indexesToCreateFromScenarioIterations(t *testing.T) {
 		asserts.Equal(1, len(out), "There should be 1 index to create")
 		asserts.Equal(models.ConcreteIndex{
 			TableName: models.TableName("table"),
-			Indexed:   []models.FieldName{"field"},
-			Included:  []models.FieldName{"field 0"},
+			Indexed:   []string{"field"},
+			Included:  []string{"field 0"},
 		}, out[0])
 	})
 

--- a/usecases/indexes/aggregate_query_to_idx_test.go
+++ b/usecases/indexes/aggregate_query_to_idx_test.go
@@ -14,38 +14,26 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts := assert.New(t)
 
 		qFamily := models.AggregateQueryFamily{
-			TableName: "",
-			EqConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("a"), models.FieldName("b"),
-			}),
-			IneqConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("c"), models.FieldName("d"),
-			}),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("e"), models.FieldName("f"),
-			}),
+			TableName:               "",
+			EqConditions:            set.From[string]([]string{"a", "b"}),
+			IneqConditions:          set.From[string]([]string{"c", "d"}),
+			SelectOrOtherConditions: set.From[string]([]string{"e", "f"}),
 		}
 
 		idxFamily := qFamily.ToIndexFamilies()
 		asserts.Equal(2, idxFamily.Size(), "Two possible inequality conditions, so 2 families are rendered")
 		expected := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed: []models.FieldName{},
-				Flex:  set.From([]models.FieldName{models.FieldName("a"), models.FieldName("b")}),
-				Last:  models.FieldName("c"),
-				Included: set.From[models.FieldName]([]models.FieldName{
-					models.FieldName("d"),
-					models.FieldName("e"), models.FieldName("f"),
-				}),
+				Fixed:    []string{},
+				Flex:     set.From([]string{"a", "b"}),
+				Last:     "c",
+				Included: set.From[string]([]string{"d", "e", "f"}),
 			},
 			{
-				Fixed: []models.FieldName{},
-				Flex:  set.From([]models.FieldName{models.FieldName("a"), models.FieldName("b")}),
-				Last:  models.FieldName("d"),
-				Included: set.From[models.FieldName]([]models.FieldName{
-					models.FieldName("c"),
-					models.FieldName("e"), models.FieldName("f"),
-				}),
+				Fixed:    []string{},
+				Flex:     set.From([]string{"a", "b"}),
+				Last:     "d",
+				Included: set.From[string]([]string{"c", "e", "f"}),
 			},
 		})
 		asserts.True(expected.Equal(idxFamily), "The index families in the result are the expected ones")
@@ -55,16 +43,10 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts := assert.New(t)
 
 		qFamily := models.AggregateQueryFamily{
-			TableName: "",
-			EqConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("a"), models.FieldName("b"),
-			}),
-			IneqConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("c"),
-			}),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("d"), models.FieldName("e"),
-			}),
+			TableName:               "",
+			EqConditions:            set.From[string]([]string{"a", "b"}),
+			IneqConditions:          set.From[string]([]string{"c"}),
+			SelectOrOtherConditions: set.From[string]([]string{"d", "e"}),
 		}
 
 		idxFamily := qFamily.ToIndexFamilies()
@@ -76,10 +58,10 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts.Equal(1, idxFamily.Size(), "Just one possible inequality condition, so 1 family is rendered")
 		expected := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed:    []models.FieldName{},
-				Flex:     set.From([]models.FieldName{models.FieldName("a"), models.FieldName("b")}),
-				Last:     models.FieldName("c"),
-				Included: set.From[models.FieldName]([]models.FieldName{models.FieldName("d"), models.FieldName("e")}),
+				Fixed:    []string{},
+				Flex:     set.From([]string{"a", "b"}),
+				Last:     "c",
+				Included: set.From[string]([]string{"d", "e"}),
 			},
 		})
 		asserts.True(expected.Equal(idxFamily), "The index families in the result are the expected ones")
@@ -89,14 +71,10 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts := assert.New(t)
 
 		qFamily := models.AggregateQueryFamily{
-			TableName: "",
-			EqConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("a"), models.FieldName("b"),
-			}),
-			IneqConditions: set.New[models.FieldName](0),
-			SelectOrOtherConditions: set.From[models.FieldName]([]models.FieldName{
-				models.FieldName("d"), models.FieldName("e"),
-			}),
+			TableName:               "",
+			EqConditions:            set.From[string]([]string{"a", "b"}),
+			IneqConditions:          set.New[string](0),
+			SelectOrOtherConditions: set.From[string]([]string{"d", "e"}),
 		}
 
 		idxFamily := qFamily.ToIndexFamilies()
@@ -108,10 +86,10 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts.Equal(1, idxFamily.Size(), "No inequality condition, so 1 family is rendered")
 		expected := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed:    []models.FieldName{},
-				Flex:     set.From([]models.FieldName{models.FieldName("a"), models.FieldName("b")}),
-				Last:     models.FieldName(""),
-				Included: set.From[models.FieldName]([]models.FieldName{models.FieldName("d"), models.FieldName("e")}),
+				Fixed:    []string{},
+				Flex:     set.From([]string{"a", "b"}),
+				Last:     "",
+				Included: set.From[string]([]string{"d", "e"}),
 			},
 		})
 		asserts.True(expected.Equal(idxFamily), "The index families in the result are the expected ones")
@@ -121,7 +99,7 @@ func TestAggregateQueryToIndexFamily(t *testing.T) {
 		asserts := assert.New(t)
 
 		qFamily := models.NewAggregateQueryFamily("")
-		qFamily.SelectOrOtherConditions = set.From([]models.FieldName{"a", "b", "c"})
+		qFamily.SelectOrOtherConditions = set.From([]string{"a", "b", "c"})
 
 		idxFamily := qFamily.ToIndexFamilies()
 		asserts.Equal(0, idxFamily.Size(), "No indexable condition, so no family is rendered")

--- a/usecases/indexes/index_editor_test.go
+++ b/usecases/indexes/index_editor_test.go
@@ -126,8 +126,8 @@ func (suite *ClientDbIndexEditorTestSuite) SetupTest() {
 	suite.scenarioAndIterationWithQuery.Iteration.TriggerConditionAstExpression = &astNode
 	suite.existingIndexes = []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 
@@ -248,8 +248,8 @@ func (suite *ClientDbIndexEditorTestSuite) Test_GetIndexesToCreate_fetch_error()
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_nominal() {
 	indexes := []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
@@ -266,8 +266,8 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_nominal() {
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_security_error() {
 	indexes := []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(suite.securityError)
@@ -282,8 +282,8 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_security_erro
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_error() {
 	indexes := []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
@@ -300,8 +300,8 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_error() {
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_get_executor_error() {
 	indexes := []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
@@ -318,7 +318,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateIndexesAsync_get_executor_
 func (suite *ClientDbIndexEditorTestSuite) Test_ListAllUniqueIndexes_nominal() {
 	uniqueIndexes := []models.UnicityIndex{
 		{
-			TableName: "table", Fields: []models.FieldName{"a", "b"},
+			TableName: "table", Fields: []string{"a", "b"},
 		},
 	}
 	suite.enforceSecurityDataModel.On("ReadDataModel").Return(nil)
@@ -359,7 +359,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_ListAllUniqueIndexes_repository_
 // CreateUniqueIndexAsync
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_nominal() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(suite.transaction, nil)
@@ -374,7 +374,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_nominal()
 
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_security_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(suite.securityError)
 
@@ -388,7 +388,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_security_
 
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(nil, suite.repositoryError)
@@ -403,7 +403,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndexAsync_error() {
 // CreateUniqueIndex
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_nominal() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(suite.transaction, nil)
@@ -418,7 +418,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_nominal() {
 
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_security_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(suite.securityError)
 
@@ -432,7 +432,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_security_error
 
 func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(suite.transaction, nil)
@@ -448,7 +448,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_CreateUniqueIndex_error() {
 // DeleteUniqueIndex
 func (suite *ClientDbIndexEditorTestSuite) Test_DeleteUniqueIndex_nominal() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(suite.transaction, nil)
@@ -463,7 +463,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_DeleteUniqueIndex_nominal() {
 
 func (suite *ClientDbIndexEditorTestSuite) Test_DeleteUniqueIndex_security_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(suite.securityError)
 
@@ -477,7 +477,7 @@ func (suite *ClientDbIndexEditorTestSuite) Test_DeleteUniqueIndex_security_error
 
 func (suite *ClientDbIndexEditorTestSuite) Test_DeleteUniqueIndex_error() {
 	index := models.UnicityIndex{
-		TableName: "table", Fields: []models.FieldName{"a", "b"},
+		TableName: "table", Fields: []string{"a", "b"},
 	}
 	suite.enforceSecurityDataModel.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.executorFactory.On("NewClientDbExecutor", suite.ctx, suite.organizationId).Return(suite.transaction, nil)

--- a/usecases/indexes/index_family.go
+++ b/usecases/indexes/index_family.go
@@ -138,7 +138,7 @@ func refineIdxFamiliesFirstHasNoFixed(A, B models.IndexFamily) (models.IndexFami
 			out.Fixed = append(out.Fixed, fixAppend...)
 			out.Fixed = append(out.Fixed, B.Last)
 		}
-		out.Flex = A.Flex.Difference(set.From(out.Fixed)).(*set.Set[models.FieldName])
+		out.Flex = A.Flex.Difference(set.From(out.Fixed)).(*set.Set[string])
 		out.SetLast(A.Last)
 		out = out.MergeIncluded(A)
 		return out, true
@@ -217,7 +217,7 @@ func refineIdxFamiliesFirstHasNoFixed(A, B models.IndexFamily) (models.IndexFami
 			// ?? To check TODO
 			if A.Flex.Equal(set.From(B.Fixed[:A.Size()])) {
 				out := B.Copy()
-				out.Flex = B.Flex.Difference(set.From(B.Fixed[:A.Size()])).(*set.Set[models.FieldName])
+				out.Flex = B.Flex.Difference(set.From(B.Fixed[:A.Size()])).(*set.Set[string])
 				out = out.MergeIncluded(A)
 				return out, true
 			}
@@ -260,12 +260,12 @@ func refineIdxFamiliesFirstHasNoFixed(A, B models.IndexFamily) (models.IndexFami
 		return models.IndexFamily{}, false
 	}
 	out := B.Copy()
-	appendToFix := B.Flex.Intersect(A.Flex).(*set.Set[models.FieldName]).Slice()
+	appendToFix := B.Flex.Intersect(A.Flex).(*set.Set[string]).Slice()
 	// arbitrary order here
 	slices.Sort(appendToFix)
 	out.Fixed = append(out.Fixed, appendToFix...)
 	out.Fixed = append(out.Fixed, A.Last)
-	out.Flex = B.Flex.Difference(set.From(out.Fixed)).(*set.Set[models.FieldName])
+	out.Flex = B.Flex.Difference(set.From(out.Fixed)).(*set.Set[string])
 	if out.Flex.Empty() {
 		out.SetLast(B.Last)
 	}

--- a/usecases/indexes/index_family.go
+++ b/usecases/indexes/index_family.go
@@ -50,8 +50,8 @@ func extractMinimalSetOfIdxFamiliesOneTable(idxFamiliesIn set.Collection[models.
 	return set.HashSetFrom(output)
 }
 
-func groupIdxFamiliesByTable(idxFamilies *set.HashSet[models.IndexFamily, string]) map[models.TableName]set.Collection[models.IndexFamily] {
-	out := make(map[models.TableName]set.Collection[models.IndexFamily])
+func groupIdxFamiliesByTable(idxFamilies *set.HashSet[models.IndexFamily, string]) map[string]set.Collection[models.IndexFamily] {
+	out := make(map[string]set.Collection[models.IndexFamily])
 	for _, idxFamily := range idxFamilies.Slice() {
 		if _, ok := out[idxFamily.TableName]; !ok {
 			out[idxFamily.TableName] = set.NewHashSet[models.IndexFamily, string](0)

--- a/usecases/indexes/index_family_test.go
+++ b/usecases/indexes/index_family_test.go
@@ -14,10 +14,10 @@ func TestExtractMinimalSetOfIdxFamilies(t *testing.T) {
 		asserts := assert.New(t)
 		idxFamilies := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed:    []models.FieldName{models.FieldName("a"), models.FieldName("b")},
-				Flex:     set.From[models.FieldName]([]models.FieldName{models.FieldName("c")}),
-				Last:     models.FieldName("d"),
-				Included: set.From[models.FieldName]([]models.FieldName{models.FieldName("e"), models.FieldName("f")}),
+				Fixed:    []string{"a", "b"},
+				Flex:     set.From[string]([]string{"c"}),
+				Last:     "d",
+				Included: set.From[string]([]string{"e", "f"}),
 			},
 		})
 
@@ -31,16 +31,16 @@ func TestExtractMinimalSetOfIdxFamilies(t *testing.T) {
 		asserts := assert.New(t)
 		idxFamilies := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed:    []models.FieldName{},
-				Flex:     set.From[models.FieldName]([]models.FieldName{models.FieldName("a")}),
-				Last:     models.FieldName(""),
-				Included: set.New[models.FieldName](0),
+				Fixed:    []string{},
+				Flex:     set.From[string]([]string{"a"}),
+				Last:     "",
+				Included: set.New[string](0),
 			},
 			{
-				Fixed:    []models.FieldName{},
-				Flex:     set.From[models.FieldName]([]models.FieldName{models.FieldName("b")}),
-				Last:     models.FieldName(""),
-				Included: set.New[models.FieldName](0),
+				Fixed:    []string{},
+				Flex:     set.From[string]([]string{"b"}),
+				Last:     "",
+				Included: set.New[string](0),
 			},
 		})
 
@@ -53,17 +53,17 @@ func TestExtractMinimalSetOfIdxFamilies(t *testing.T) {
 	t.Run("2 overlapping families", func(t *testing.T) {
 		asserts := assert.New(t)
 		expected := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{{
-			Fixed:    []models.FieldName{},
-			Flex:     set.From[models.FieldName]([]models.FieldName{models.FieldName("a"), models.FieldName("b")}),
-			Last:     models.FieldName(""),
-			Included: set.New[models.FieldName](0),
+			Fixed:    []string{},
+			Flex:     set.From[string]([]string{"a", "b"}),
+			Last:     "",
+			Included: set.New[string](0),
 		}})
 		idxFamilies := set.HashSetFrom[models.IndexFamily]([]models.IndexFamily{
 			{
-				Fixed:    []models.FieldName{},
-				Flex:     set.From[models.FieldName]([]models.FieldName{models.FieldName("a")}),
-				Last:     models.FieldName(""),
-				Included: set.New[models.FieldName](0),
+				Fixed:    []string{},
+				Flex:     set.From[string]([]string{"a"}),
+				Last:     "",
+				Included: set.New[string](0),
 			},
 		})
 
@@ -80,8 +80,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("1: not the same columns indexed", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.Insert(models.FieldName("a"))
-		B.Flex.Insert(models.FieldName("b"))
+		A.Flex.Insert("a")
+		B.Flex.Insert("b")
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "No overlap expected")
@@ -90,8 +90,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("2: identical, no \"last\"", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.Insert(models.FieldName("a"))
-		B.Flex.Insert(models.FieldName("a"))
+		A.Flex.Insert("a")
+		B.Flex.Insert("a")
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "Expect identical output")
@@ -101,8 +101,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("3: A is like B without order, no \"last\"", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.Insert(models.FieldName("a"))
-		B.Fixed = []models.FieldName{"a"}
+		A.Flex.Insert("a")
+		B.Fixed = []string{"a"}
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "Expect identical output")
@@ -112,8 +112,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("Simple case 2: simple overlap", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Flex.Insert(models.FieldName("a"))
-		fam2.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		fam1.Flex.Insert("a")
+		fam2.Flex.InsertSlice([]string{"a", "b"})
 
 		output, found := refineIdxFamilies(fam1, fam2)
 		asserts.True(found, "Expect identical output")
@@ -123,8 +123,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("Simple case 2: simple overlap 3", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Flex.InsertSlice([]models.FieldName{"a", "c"})
-		fam2.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		fam1.Flex.InsertSlice([]string{"a", "c"})
+		fam2.Flex.InsertSlice([]string{"a", "b", "c"})
 
 		output, found := refineIdxFamilies(fam1, fam2)
 		asserts.True(found, "Expect identical output")
@@ -134,8 +134,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("Disjoint: no way to combine flex that are disjoint", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Flex.InsertSlice([]models.FieldName{"a", "c"})
-		fam2.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		fam1.Flex.InsertSlice([]string{"a", "c"})
+		fam2.Flex.InsertSlice([]string{"a", "b"})
 
 		_, found := refineIdxFamilies(fam1, fam2)
 		asserts.False(found, "No solution to merge them")
@@ -144,10 +144,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("With fixed: 1", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Fixed = []models.FieldName{"a", "b"}
-		fam1.Flex.InsertSlice([]models.FieldName{"c", "d"})
+		fam1.Fixed = []string{"a", "b"}
+		fam1.Flex.InsertSlice([]string{"c", "d"})
 		fam1.SetLast("e")
-		fam2.Fixed = []models.FieldName{"a", "b"}
+		fam2.Fixed = []string{"a", "b"}
 
 		output, found := refineIdxFamilies(fam1, fam2)
 		asserts.True(found, "There is a trivial solution to merge them")
@@ -157,17 +157,17 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("With fixed: 2", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Fixed = []models.FieldName{"a", "b"}
-		fam1.Flex.InsertSlice([]models.FieldName{"c", "d"})
+		fam1.Fixed = []string{"a", "b"}
+		fam1.Flex.InsertSlice([]string{"c", "d"})
 		fam1.SetLast("e")
-		fam2.Fixed = []models.FieldName{"a", "b"}
+		fam2.Fixed = []string{"a", "b"}
 		fam2.SetLast("c")
 
 		output, found := refineIdxFamilies(fam1, fam2)
 		asserts.True(found, "There is a solution to merge them")
 		expected := models.NewIndexFamily()
-		expected.Fixed = []models.FieldName{"a", "b", "c"}
-		expected.Flex.InsertSlice([]models.FieldName{"d"})
+		expected.Fixed = []string{"a", "b", "c"}
+		expected.Flex.InsertSlice([]string{"d"})
 		expected.SetLast("e")
 		asserts.True(output.Equal(expected), "Expect to keep the first one")
 	})
@@ -175,10 +175,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("With fixed incompatible", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Fixed = []models.FieldName{"a", "b"}
-		fam1.Flex.InsertSlice([]models.FieldName{"c", "d"})
+		fam1.Fixed = []string{"a", "b"}
+		fam1.Flex.InsertSlice([]string{"c", "d"})
 		fam1.SetLast("e")
-		fam2.Fixed = []models.FieldName{"a", "c"}
+		fam2.Fixed = []string{"a", "c"}
 		fam2.SetLast("c")
 
 		_, found := refineIdxFamilies(fam1, fam2)
@@ -188,10 +188,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("With fixed incompatible", func(t *testing.T) {
 		fam1 := models.NewIndexFamily()
 		fam2 := models.NewIndexFamily()
-		fam1.Fixed = []models.FieldName{"a", "b"}
-		fam1.Flex.InsertSlice([]models.FieldName{"c", "d"})
+		fam1.Fixed = []string{"a", "b"}
+		fam1.Flex.InsertSlice([]string{"c", "d"})
 		fam1.SetLast("e")
-		fam2.Fixed = []models.FieldName{"a", "c"}
+		fam2.Fixed = []string{"a", "c"}
 		fam2.SetLast("c")
 
 		_, found := refineIdxFamilies(fam1, fam2)
@@ -201,10 +201,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("1", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Fixed = []models.FieldName{"a", "b"}
-		A.Flex.InsertSlice([]models.FieldName{"c", "d"})
+		A.Fixed = []string{"a", "b"}
+		A.Flex.InsertSlice([]string{"c", "d"})
 		A.SetLast("e")
-		B.Flex.InsertSlice([]models.FieldName{"a", "c", "f"})
+		B.Flex.InsertSlice([]string{"a", "c", "f"})
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "No solution to merge them")
@@ -213,9 +213,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("2", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c", "d"})
+		A.Flex.InsertSlice([]string{"a", "b", "c", "d"})
 		A.SetLast("e")
-		B.Flex.InsertSlice([]models.FieldName{"a", "c", "f"})
+		B.Flex.InsertSlice([]string{"a", "c", "f"})
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "No solution to merge them")
@@ -224,15 +224,15 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("3", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c", "d"})
+		A.Flex.InsertSlice([]string{"a", "b", "c", "d"})
 		A.SetLast("e")
-		B.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		B.Flex.InsertSlice([]string{"a", "b", "c"})
 		B.SetLast("d")
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them")
 		expected := models.NewIndexFamily()
-		expected.Fixed = []models.FieldName{"a", "b", "c", "d"}
+		expected.Fixed = []string{"a", "b", "c", "d"}
 		expected.SetLast("e")
 		asserts.True(output.Equal(expected), "Expect to keep the first one")
 	})
@@ -240,9 +240,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("4", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Flex.InsertSlice([]models.FieldName{"a", "c"})
+		B.Flex.InsertSlice([]string{"a", "c"})
 		B.SetLast("b")
 
 		_, found := refineIdxFamilies(A, B)
@@ -252,9 +252,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("5", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		B.Flex.InsertSlice([]string{"a", "b"})
 		B.SetLast("c")
 
 		output, found := refineIdxFamilies(A, B)
@@ -265,9 +265,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("6", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		B.Flex.InsertSlice([]string{"a", "b", "c"})
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them (identical)")
@@ -277,9 +277,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("7", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Fixed = []models.FieldName{"a", "b", "c"}
+		B.Fixed = []string{"a", "b", "c"}
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them (identical)")
@@ -289,9 +289,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("8", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Fixed = []models.FieldName{"a", "c", "b"}
+		B.Fixed = []string{"a", "c", "b"}
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "There no solution to merge them")
@@ -300,10 +300,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("9", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"b", "c"})
+		A.Flex.InsertSlice([]string{"b", "c"})
 		A.SetLast("a")
-		B.Fixed = []models.FieldName{"a"}
-		B.Flex.InsertSlice([]models.FieldName{"b", "c"})
+		B.Fixed = []string{"a"}
+		B.Flex.InsertSlice([]string{"b", "c"})
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "There no solution to merge them")
@@ -312,8 +312,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("10", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
-		B.Fixed = []models.FieldName{"a", "b", "c"}
+		A.Flex.InsertSlice([]string{"a", "b"})
+		B.Fixed = []string{"a", "b", "c"}
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them")
@@ -323,8 +323,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("11", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "d"})
-		B.Fixed = []models.FieldName{"a", "b", "c"}
+		A.Flex.InsertSlice([]string{"a", "d"})
+		B.Fixed = []string{"a", "b", "c"}
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "There is no solution to merge them")
@@ -333,9 +333,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("12", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a"})
+		A.Flex.InsertSlice([]string{"a"})
 		A.SetLast("d")
-		B.Fixed = []models.FieldName{"a", "b", "c"}
+		B.Fixed = []string{"a", "b", "c"}
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "There is no solution to merge them")
@@ -344,10 +344,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("13", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
 		A.SetLast("d")
-		B.Fixed = []models.FieldName{"a", "b"}
-		B.Flex.InsertSlice([]models.FieldName{"c", "e", "f", "g"})
+		B.Fixed = []string{"a", "b"}
+		B.Flex.InsertSlice([]string{"c", "e", "f", "g"})
 
 		_, found := refineIdxFamilies(A, B)
 		asserts.False(found, "There is no solution to merge them")
@@ -356,60 +356,60 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("14", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
 		A.SetLast("d")
-		B.Fixed = []models.FieldName{"a", "b"}
-		B.Flex.InsertSlice([]models.FieldName{"c", "d", "e", "f", "g"})
+		B.Fixed = []string{"a", "b"}
+		B.Flex.InsertSlice([]string{"c", "d", "e", "f", "g"})
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them")
 		expected := models.NewIndexFamily()
-		expected.Fixed = []models.FieldName{"a", "b", "c", "d"}
-		expected.Flex.InsertSlice([]models.FieldName{"e", "f", "g"})
+		expected.Fixed = []string{"a", "b", "c", "d"}
+		expected.Flex.InsertSlice([]string{"e", "f", "g"})
 		asserts.True(output.Equal(expected), "Expected value")
 	})
 
 	t.Run("15", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
 		A.SetLast("d")
-		B.Fixed = []models.FieldName{"a", "b", "c", "d", "e"}
-		B.Flex.InsertSlice([]models.FieldName{"f", "g"})
+		B.Fixed = []string{"a", "b", "c", "d", "e"}
+		B.Flex.InsertSlice([]string{"f", "g"})
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them")
 		expected := models.NewIndexFamily()
-		expected.Fixed = []models.FieldName{"a", "b", "c", "d", "e"}
-		expected.Flex.InsertSlice([]models.FieldName{"f", "g"})
+		expected.Fixed = []string{"a", "b", "c", "d", "e"}
+		expected.Flex.InsertSlice([]string{"f", "g"})
 		asserts.True(output.Equal(expected), "Expected value")
 	})
 
 	t.Run("16", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
 		A.SetLast("d")
-		A.Included.InsertSlice([]models.FieldName{"x", "y", "e"})
-		B.Fixed = []models.FieldName{"a", "b", "c", "d", "e"}
-		B.Flex.InsertSlice([]models.FieldName{"f", "g"})
-		B.Included.InsertSlice([]models.FieldName{"x", "z"})
+		A.Included.InsertSlice([]string{"x", "y", "e"})
+		B.Fixed = []string{"a", "b", "c", "d", "e"}
+		B.Flex.InsertSlice([]string{"f", "g"})
+		B.Included.InsertSlice([]string{"x", "z"})
 
 		output, found := refineIdxFamilies(A, B)
 		asserts.True(found, "There is a solution to merge them")
 		expected := models.NewIndexFamily()
-		expected.Fixed = []models.FieldName{"a", "b", "c", "d", "e"}
-		expected.Flex.InsertSlice([]models.FieldName{"f", "g"})
-		expected.Included.InsertSlice([]models.FieldName{"x", "y", "z"})
+		expected.Fixed = []string{"a", "b", "c", "d", "e"}
+		expected.Flex.InsertSlice([]string{"f", "g"})
+		expected.Included.InsertSlice([]string{"x", "y", "z"})
 		asserts.True(output.Equal(expected), "Expected value")
 	})
 
 	t.Run("17", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.SetLast("c")
-		B.Flex.InsertSlice([]models.FieldName{"a", "b", "d"})
+		B.Flex.InsertSlice([]string{"a", "b", "d"})
 		B.SetLast("c")
 
 		output, found := refineIdxFamilies(B, A)
@@ -420,10 +420,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("18", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a"})
-		A.Fixed = []models.FieldName{"e"}
+		A.Flex.InsertSlice([]string{"a"})
+		A.Fixed = []string{"e"}
 		A.SetLast("c")
-		B.Flex.InsertSlice([]models.FieldName{"a", "b", "d"})
+		B.Flex.InsertSlice([]string{"a", "b", "d"})
 		B.SetLast("c")
 
 		output, found := refineIdxFamilies(B, A)
@@ -434,10 +434,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("19", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c", "d", "e"})
+		A.Flex.InsertSlice([]string{"a", "b", "c", "d", "e"})
 		// A.SetLast("c")
-		B.Fixed = []models.FieldName{"a"}
-		B.Flex.InsertSlice([]models.FieldName{"b", "c"})
+		B.Fixed = []string{"a"}
+		B.Flex.InsertSlice([]string{"b", "c"})
 		B.SetLast("d")
 
 		output, found := refineIdxFamilies(A, B)
@@ -448,10 +448,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("20", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c", "d"})
+		A.Flex.InsertSlice([]string{"a", "b", "c", "d"})
 		A.SetLast("e")
-		B.Fixed = []models.FieldName{"a"}
-		B.Flex.InsertSlice([]models.FieldName{"b", "c"})
+		B.Fixed = []string{"a"}
+		B.Flex.InsertSlice([]string{"b", "c"})
 		B.SetLast("e")
 
 		output, found := refineIdxFamilies(A, B)
@@ -462,10 +462,10 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("21", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
 		A.SetLast("d")
-		B.Fixed = []models.FieldName{"a"}
-		B.Flex.InsertSlice([]models.FieldName{"b", "c", "d"})
+		B.Fixed = []string{"a"}
+		B.Flex.InsertSlice([]string{"b", "c", "d"})
 
 		output, found := refineIdxFamilies(A, B)
 		fmt.Println(output)
@@ -475,8 +475,8 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("22", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
-		B.Fixed = []models.FieldName{"a", "b", "d", "c"}
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
+		B.Fixed = []string{"a", "b", "d", "c"}
 
 		output, found := refineIdxFamilies(A, B)
 		fmt.Println(output)
@@ -486,9 +486,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("23", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b"})
+		A.Flex.InsertSlice([]string{"a", "b"})
 		A.Last = "c"
-		B.Fixed = []models.FieldName{"a", "b", "d", "c"}
+		B.Fixed = []string{"a", "b", "d", "c"}
 
 		output, found := refineIdxFamilies(A, B)
 		fmt.Println(output)
@@ -498,9 +498,9 @@ func TestRefineIdxFamiliesShortHasNoFixed(t *testing.T) {
 	t.Run("24", func(t *testing.T) {
 		A := models.NewIndexFamily()
 		B := models.NewIndexFamily()
-		A.Flex.InsertSlice([]models.FieldName{"a", "b", "c"})
-		B.Fixed = []models.FieldName{"a", "g"}
-		B.Flex.InsertSlice([]models.FieldName{"b", "c", "d", "e", "f", "g", "h"})
+		A.Flex.InsertSlice([]string{"a", "b", "c"})
+		B.Fixed = []string{"a", "g"}
+		B.Flex.InsertSlice([]string{"b", "c", "d", "e", "f", "g", "h"})
 
 		output, found := refineIdxFamilies(A, B)
 		fmt.Println(output)

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -345,7 +345,7 @@ func parseStringValuesToMap(headers []string, values []string, table models.Tabl
 
 	for i, value := range values {
 		fieldName := headers[i]
-		field, ok := table.Fields[models.FieldName(fieldName)]
+		field, ok := table.Fields[fieldName]
 		if !ok {
 			return nil, fmt.Errorf("field %s not found in table %s", fieldName, table.Name)
 		}

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -79,7 +79,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 		return models.UploadLog{}, err
 	}
 
-	table, ok := dataModel.Tables[models.TableName(objectType)]
+	table, ok := dataModel.Tables[objectType]
 	if !ok {
 		return models.UploadLog{}, fmt.Errorf("table %s not found on data model", objectType)
 	}
@@ -249,7 +249,7 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context, file
 		return err
 	}
 
-	table, ok := dataModel.Tables[models.TableName(tableName)]
+	table, ok := dataModel.Tables[tableName]
 	if !ok {
 		return fmt.Errorf("table %s not found in data model for organization %s", tableName, organizationId)
 	}

--- a/usecases/ingestion_usecase_test.go
+++ b/usecases/ingestion_usecase_test.go
@@ -9,7 +9,7 @@ import (
 func TestParseStringValuesToMap(t *testing.T) {
 	table := models.Table{
 		Name: "transactions",
-		Fields: map[models.FieldName]models.Field{
+		Fields: map[string]models.Field{
 			"object_id": {
 				DataType: models.String, Nullable: false,
 			},

--- a/usecases/payload_parser/payload.go
+++ b/usecases/payload_parser/payload.go
@@ -27,12 +27,12 @@ var (
 	errIsInvalidDataType  = fmt.Errorf("invalid type")
 )
 
-func (p *Parser) ParsePayload(table models.Table, json []byte) (models.ClientObject, map[models.FieldName]string, error) {
+func (p *Parser) ParsePayload(table models.Table, json []byte) (models.ClientObject, map[string]string, error) {
 	if !gjson.ValidBytes(json) {
 		return models.ClientObject{}, nil, errIsInvalidJSON
 	}
 
-	errors := make(map[models.FieldName]string)
+	errors := make(map[string]string)
 	out := make(map[string]any)
 	result := gjson.ParseBytes(json)
 
@@ -40,10 +40,10 @@ func (p *Parser) ParsePayload(table models.Table, json []byte) (models.ClientObj
 	for _, name := range []string{"object_id", "updated_at"} {
 		value := result.Get(name)
 		if !value.Exists() || value.Type == gjson.Null {
-			errors[models.FieldName(name)] = errIsNotNullable.Error()
+			errors[name] = errIsNotNullable.Error()
 		}
 		if name == "object_id" && result.String() == "" {
-			errors[models.FieldName(name)] = errIsNotNullable.Error()
+			errors[name] = errIsNotNullable.Error()
 		}
 	}
 

--- a/usecases/payload_parser/payload_test.go
+++ b/usecases/payload_parser/payload_test.go
@@ -13,7 +13,7 @@ func TestParser_ParsePayload(t *testing.T) {
 	table := models.Table{
 		Name:        "transactions",
 		Description: "description",
-		Fields: map[models.FieldName]models.Field{
+		Fields: map[string]models.Field{
 			"object_id": {
 				DataType: models.String,
 			},
@@ -42,7 +42,7 @@ func TestParser_ParsePayload(t *testing.T) {
 		name       string
 		table      models.Table
 		input      []byte
-		wantErrors map[models.FieldName]string
+		wantErrors map[string]string
 		want       models.ClientObject
 		err        error
 	}{
@@ -75,7 +75,7 @@ func TestParser_ParsePayload(t *testing.T) {
 			name:  "empty json",
 			table: table,
 			input: []byte(`{}`),
-			wantErrors: map[models.FieldName]string{
+			wantErrors: map[string]string{
 				"string":     errIsNotNullable.Error(),
 				"integer":    errIsNotNullable.Error(),
 				"float":      errIsNotNullable.Error(),
@@ -100,7 +100,7 @@ func TestParser_ParsePayload(t *testing.T) {
 				"timestamp": "not a timestamp",
 				"boolean": "true"
 			}`),
-			wantErrors: map[models.FieldName]string{
+			wantErrors: map[string]string{
 				"string":     errIsInvalidString.Error(),
 				"integer":    "is not a valid integer: expected an integer, got \"string\"",
 				"float":      "is not a valid float: expected a float, got \"string\"",
@@ -115,7 +115,7 @@ func TestParser_ParsePayload(t *testing.T) {
 			table: models.Table{
 				Name:        "transactions",
 				Description: "description",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"unknown": {
 						DataType: models.UnknownDataType,
 						Nullable: true,
@@ -129,7 +129,7 @@ func TestParser_ParsePayload(t *testing.T) {
 			name: "nullable fields without object_id and updated_at",
 			table: models.Table{
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"nullable": {
 						DataType: models.String,
 						Nullable: true,
@@ -143,7 +143,7 @@ func TestParser_ParsePayload(t *testing.T) {
 					"nullable": nil,
 				},
 			},
-			wantErrors: map[models.FieldName]string{
+			wantErrors: map[string]string{
 				"object_id":  errIsNotNullable.Error(),
 				"updated_at": errIsNotNullable.Error(),
 			},
@@ -152,7 +152,7 @@ func TestParser_ParsePayload(t *testing.T) {
 			name: "nullable fields with object_id and updated_at",
 			table: models.Table{
 				Name: "transactions",
-				Fields: map[models.FieldName]models.Field{
+				Fields: map[string]models.Field{
 					"nullable": {
 						DataType: models.String,
 						Nullable: true,

--- a/usecases/scenario_publication_usecase_test.go
+++ b/usecases/scenario_publication_usecase_test.go
@@ -131,8 +131,8 @@ func (suite *ScenarioPublicationUsecaseTestSuite) SetupTest() {
 	suite.scenarioAndIterationWithQuery.Iteration.TriggerConditionAstExpression = &astNode
 	suite.existingIndexes = []models.ConcreteIndex{
 		{
-			TableName: "table", Indexed: []models.FieldName{"a", "b"},
-			Included: []models.FieldName{"c", "d"},
+			TableName: "table", Indexed: []string{"a", "b"},
+			Included: []string{"c", "d"},
 		},
 	}
 
@@ -373,7 +373,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_GetPublicationPreparation
 	// another prepration is running
 	suite.clientDbIndexEditor.On("GetIndexesToCreate", suite.ctx, suite.iterationId).Return([]models.ConcreteIndex{}, 1, nil)
 
-	// {Indexed: []models.FieldName{"a", "b"}, Included: []models.FieldName{"c", "d"}},
+	// {Indexed: []string{"a", "b"}, Included: []string{"c", "d"}},
 	status, err := suite.makeUsecase().GetPublicationPreparationStatus(suite.ctx, suite.iterationId)
 
 	suite.NoError(err)
@@ -388,7 +388,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_GetPublicationPreparation
 func (suite *ScenarioPublicationUsecaseTestSuite) Test_GetPublicationPreparationStatus_nominal_3() {
 	// One index to create
 	suite.clientDbIndexEditor.On("GetIndexesToCreate", suite.ctx, suite.iterationId).Return([]models.ConcreteIndex{
-		{Indexed: []models.FieldName{"a", "b"}, Included: []models.FieldName{"c", "d"}},
+		{Indexed: []string{"a", "b"}, Included: []string{"c", "d"}},
 	}, 0, nil)
 
 	status, err := suite.makeUsecase().GetPublicationPreparationStatus(suite.ctx, suite.iterationId)
@@ -426,7 +426,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_StartPublicationPreparati
 
 func (suite *ScenarioPublicationUsecaseTestSuite) Test_StartPublicationPreparation_preparation_already_in_progress() {
 	suite.clientDbIndexEditor.On("GetIndexesToCreate", suite.ctx, suite.iterationId).Return([]models.ConcreteIndex{
-		{Indexed: []models.FieldName{"a", "b"}, Included: []models.FieldName{"c", "d"}},
+		{Indexed: []string{"a", "b"}, Included: []string{"c", "d"}},
 	}, 1, nil)
 
 	err := suite.makeUsecase().StartPublicationPreparation(suite.ctx, suite.iterationId)
@@ -438,12 +438,12 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_StartPublicationPreparati
 
 func (suite *ScenarioPublicationUsecaseTestSuite) Test_StartPublicationPreparation_preparation_nominal() {
 	suite.clientDbIndexEditor.On("GetIndexesToCreate", suite.ctx, suite.iterationId).Return([]models.ConcreteIndex{
-		{Indexed: []models.FieldName{"a", "b"}, Included: []models.FieldName{"c", "d"}},
+		{Indexed: []string{"a", "b"}, Included: []string{"c", "d"}},
 	}, 0, nil)
 	suite.clientDbIndexEditor.On("CreateIndexesAsync",
 		suite.ctx,
 		[]models.ConcreteIndex{
-			{Indexed: []models.FieldName{"a", "b"}, Included: []models.FieldName{"c", "d"}},
+			{Indexed: []string{"a", "b"}, Included: []string{"c", "d"}},
 		}).Return(nil)
 
 	err := suite.makeUsecase().StartPublicationPreparation(suite.ctx, suite.iterationId)

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -128,7 +128,7 @@ func (validator *ValidateScenarioIterationImpl) makeDryRunEnvironment(ctx contex
 		}
 	}
 
-	table, ok := dataModel.Tables[models.TableName(si.Scenario.TriggerObjectType)]
+	table, ok := dataModel.Tables[si.Scenario.TriggerObjectType]
 	if !ok {
 		return ast_eval.AstEvaluationEnvironment{}, &models.ScenarioValidationError{
 			Error: errors.Wrap(models.NotFoundError,

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -78,7 +78,7 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 			Tables: map[models.TableName]models.Table{
 				"object_type": {
 					Name: "object_type",
-					Fields: map[models.FieldName]models.Field{
+					Fields: map[string]models.Field{
 						"id": {
 							DataType: models.Int,
 						},

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -75,7 +75,7 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 	mdmr.On("GetDataModel", ctx, exec, scenario.OrganizationId, false).
 		Return(models.DataModel{
 			Version: "version",
-			Tables: map[models.TableName]models.Table{
+			Tables: map[string]models.Table{
 				"object_type": {
 					Name: "object_type",
 					Fields: map[string]models.Field{

--- a/usecases/scheduledexecution/run_scheduled_execution.go
+++ b/usecases/scheduledexecution/run_scheduled_execution.go
@@ -254,7 +254,7 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 		return 0, err
 	}
 	tables := dataModel.Tables
-	table, ok := tables[models.TableName(scenario.TriggerObjectType)]
+	table, ok := tables[scenario.TriggerObjectType]
 	if !ok {
 		return 0, fmt.Errorf("trigger object type %s not found in data model: %w",
 			scenario.TriggerObjectType, models.NotFoundError)

--- a/utils/dummy_datamodel.go
+++ b/utils/dummy_datamodel.go
@@ -40,16 +40,16 @@ func GetDummyDataModel() models.DataModel {
 		Nullable: false,
 	}
 
-	dummyFirstLinkToSingle := map[models.LinkName]models.LinkToSingle{
-		models.LinkName(DummyTableNameSecond): {
+	dummyFirstLinkToSingle := map[string]models.LinkToSingle{
+		string(DummyTableNameSecond): {
 			LinkedTableName: DummyTableNameSecond,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,
 		},
 	}
 
-	dummySecondLinkToSingle := map[models.LinkName]models.LinkToSingle{
-		models.LinkName(DummyTableNameThird): {
+	dummySecondLinkToSingle := map[string]models.LinkToSingle{
+		string(DummyTableNameThird): {
 			LinkedTableName: DummyTableNameThird,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,

--- a/utils/dummy_datamodel.go
+++ b/utils/dummy_datamodel.go
@@ -9,11 +9,11 @@ const (
 )
 
 const (
-	DummyFieldNameId           models.FieldName = "id"
-	DummyFieldNameForBool      models.FieldName = "bool_var"
-	DummyFieldNameForInt       models.FieldName = "int_var"
-	DummyFieldNameForFloat     models.FieldName = "float_var"
-	DummyFieldNameForTimestamp models.FieldName = "time_var"
+	DummyFieldNameId           = "id"
+	DummyFieldNameForBool      = "bool_var"
+	DummyFieldNameForInt       = "int_var"
+	DummyFieldNameForFloat     = "float_var"
+	DummyFieldNameForTimestamp = "time_var"
 )
 
 func GetDummyDataModel() models.DataModel {
@@ -56,11 +56,11 @@ func GetDummyDataModel() models.DataModel {
 		},
 	}
 
-	dummyFieldsIdOnly := map[models.FieldName]models.Field{
+	dummyFieldsIdOnly := map[string]models.Field{
 		DummyFieldNameId: dummyFieldString,
 	}
 
-	dummyAllFields := map[models.FieldName]models.Field{
+	dummyAllFields := map[string]models.Field{
 		DummyFieldNameId:           dummyFieldString,
 		DummyFieldNameForInt:       dummyFieldInt,
 		DummyFieldNameForFloat:     dummyFieldFloat,

--- a/utils/dummy_datamodel.go
+++ b/utils/dummy_datamodel.go
@@ -3,9 +3,9 @@ package utils
 import "github.com/checkmarble/marble-backend/models"
 
 const (
-	DummyTableNameFirst  models.TableName = "first"
-	DummyTableNameSecond models.TableName = "second"
-	DummyTableNameThird  models.TableName = "third"
+	DummyTableNameFirst  = "first"
+	DummyTableNameSecond = "second"
+	DummyTableNameThird  = "third"
 )
 
 const (
@@ -87,7 +87,7 @@ func GetDummyDataModel() models.DataModel {
 
 	return models.DataModel{
 		Version: "1",
-		Tables: map[models.TableName]models.Table{
+		Tables: map[string]models.Table{
 			DummyTableNameFirst:  dummyDataModelFirstTable,
 			DummyTableNameSecond: dummyDataModelSecondTable,
 			DummyTableNameThird:  dummyDataModelThirdTable,


### PR DESCRIPTION
Seemed like a good idea at first, actually it just cluttered the whole codebase with casting from string to custom string types or vice versa.