### PR TITLE
first define the API surface and models

### DIFF
--- a/api/handle_datamodel_pivot.go
+++ b/api/handle_datamodel_pivot.go
@@ -22,7 +22,10 @@ func (api *API) createDataModelPivot(c *gin.Context) {
 	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewDataModelUseCase()
-	pivot, err := usecase.CreatePivot(c.Request.Context(), organizationID, dto.AdaptCreatePivotInput(input))
+	pivot, err := usecase.CreatePivot(
+		c.Request.Context(),
+		dto.AdaptCreatePivotInput(input, organizationID),
+	)
 	if presentError(c, err) {
 		return
 	}

--- a/api/handle_datamodel_pivot.go
+++ b/api/handle_datamodel_pivot.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/gin-gonic/gin"
+)
+
+func (api *API) createDataModelPivot(c *gin.Context) {
+	organizationID, err := utils.OrganizationIdFromRequest(c.Request)
+	if presentError(c, err) {
+		return
+	}
+
+	var input dto.CreatePivotInput
+	if err := c.ShouldBind(&input); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	usecase := api.UsecasesWithCreds(c.Request).NewDataModelUseCase()
+	pivot, err := usecase.CreatePivot(c.Request.Context(), organizationID, dto.AdaptCreatePivotInput(input))
+	if presentError(c, err) {
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"pivot": dto.AdaptPivotDto(pivot),
+	})
+}
+
+func (api *API) listDataModelPivots(c *gin.Context) {
+	organizationID, err := utils.OrganizationIdFromRequest(c.Request)
+	if presentError(c, err) {
+		return
+	}
+
+	var filters struct {
+		TableId *string `form:"table_id"`
+	}
+	if err := c.ShouldBind(&filters); err != nil {
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	usecase := api.UsecasesWithCreds(c.Request).NewDataModelUseCase()
+	pivots, err := usecase.ListPivots(c.Request.Context(), organizationID, filters.TableId)
+	if presentError(c, err) {
+		return
+	}
+
+	pivotsDto := pure_utils.Map(pivots, dto.AdaptPivotDto)
+	c.JSON(http.StatusOK, gin.H{
+		"pivots": pivotsDto,
+	})
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -144,6 +144,8 @@ func (api *API) routes(auth *Authentication, tokenHandler *TokenHandler) {
 	router.PATCH("/data-model/fields/:fieldID", api.UpdateDataModelField)
 	router.DELETE("/data-model", api.DeleteDataModel)
 	router.GET("/data-model/openapi", api.OpenAPI)
+	router.POST("data-model/pivots", api.createDataModelPivot)
+	router.GET("data-model/pivots", api.listDataModelPivots)
 
 	router.POST("/transfers", api.handleCreateTransfer)
 	router.GET("/transfers", api.handleQueryTransfers)

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -75,7 +75,7 @@ type PostToggleIsEnum struct {
 
 func AdaptTableDto(table models.Table) Table {
 	return Table{
-		Name: string(table.Name),
+		Name: table.Name,
 		ID:   table.ID,
 		Fields: pure_utils.MapValues(table.Fields, func(field models.Field) Field {
 			return Field{

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -92,7 +92,7 @@ func AdaptTableDto(table models.Table) Table {
 			linkToSingle models.LinkToSingle,
 		) LinkToSingle {
 			return LinkToSingle{
-				LinkedTableName: linkToSingle.LinkedTableName,
+				LinkedTableName: linkToSingle.ParentTableName,
 				ParentFieldName: linkToSingle.ParentFieldName,
 				ChildFieldName:  linkToSingle.ChildFieldName,
 			}

--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -6,9 +6,15 @@ import (
 )
 
 type LinkToSingle struct {
-	LinkedTableName string `json:"linked_table_name"`
-	ParentFieldName string `json:"parent_field_name"`
-	ChildFieldName  string `json:"child_field_name"`
+	ParentTableName_deprec string `json:"linked_table_name"` // left for compatibility
+	ParentTableName        string `json:"parent_table_name"`
+	ParentTableId          string `json:"parent_table_id"`
+	ParentFieldName        string `json:"parent_field_name"`
+	ParentFieldId          string `json:"parent_field_id"`
+	ChildTableName         string `json:"child_table_name"`
+	ChildTableId           string `json:"child_table_id"`
+	ChildFieldName         string `json:"child_field_name"`
+	ChildFieldId           string `json:"child_field_id"`
 }
 
 type Field struct {
@@ -16,7 +22,9 @@ type Field struct {
 	DataType          string `json:"data_type"`
 	Description       string `json:"description"`
 	IsEnum            bool   `json:"is_enum"`
+	Name              string `json:"name"`
 	Nullable          bool   `json:"nullable"`
+	TableId           string `json:"table_id"`
 	Values            []any  `json:"values,omitempty"`
 	UnicityConstraint string `json:"unicity_constraint"`
 }
@@ -30,8 +38,7 @@ type Table struct {
 }
 
 type DataModel struct {
-	Version string           `json:"version"`
-	Tables  map[string]Table `json:"tables"`
+	Tables map[string]Table `json:"tables"`
 }
 
 type PostDataModel struct {
@@ -75,35 +82,44 @@ type PostToggleIsEnum struct {
 
 func AdaptTableDto(table models.Table) Table {
 	return Table{
-		Name: table.Name,
-		ID:   table.ID,
-		Fields: pure_utils.MapValues(table.Fields, func(field models.Field) Field {
-			return Field{
-				ID:                field.ID,
-				DataType:          field.DataType.String(),
-				Description:       field.Description,
-				IsEnum:            field.IsEnum,
-				Nullable:          field.Nullable,
-				Values:            field.Values,
-				UnicityConstraint: field.UnicityConstraint.String(),
-			}
-		}),
-		LinksToSingle: pure_utils.MapValues(table.LinksToSingle, func(
-			linkToSingle models.LinkToSingle,
-		) LinkToSingle {
-			return LinkToSingle{
-				LinkedTableName: linkToSingle.ParentTableName,
-				ParentFieldName: linkToSingle.ParentFieldName,
-				ChildFieldName:  linkToSingle.ChildFieldName,
-			}
-		}),
-		Description: table.Description,
+		Name:          table.Name,
+		ID:            table.ID,
+		Fields:        pure_utils.MapValues(table.Fields, adaptDataModelField),
+		LinksToSingle: pure_utils.MapValues(table.LinksToSingle, adaptDataModelLink),
+		Description:   table.Description,
+	}
+}
+
+func adaptDataModelField(field models.Field) Field {
+	return Field{
+		ID:                field.ID,
+		DataType:          field.DataType.String(),
+		Description:       field.Description,
+		IsEnum:            field.IsEnum,
+		Name:              field.Name,
+		Nullable:          field.Nullable,
+		TableId:           field.TableId,
+		Values:            field.Values,
+		UnicityConstraint: field.UnicityConstraint.String(),
+	}
+}
+
+func adaptDataModelLink(linkToSingle models.LinkToSingle) LinkToSingle {
+	return LinkToSingle{
+		ParentTableName_deprec: linkToSingle.ParentTableName,
+		ParentTableName:        linkToSingle.ParentTableName,
+		ParentTableId:          linkToSingle.ParentTableId,
+		ParentFieldName:        linkToSingle.ParentFieldName,
+		ParentFieldId:          linkToSingle.ParentFieldId,
+		ChildTableName:         linkToSingle.ChildTableName,
+		ChildTableId:           linkToSingle.ChildTableId,
+		ChildFieldName:         linkToSingle.ChildFieldName,
+		ChildFieldId:           linkToSingle.ChildFieldId,
 	}
 }
 
 func AdaptDataModelDto(dataModel models.DataModel) DataModel {
 	return DataModel{
-		Version: dataModel.Version,
-		Tables:  pure_utils.MapValues(dataModel.Tables, AdaptTableDto),
+		Tables: pure_utils.MapValues(dataModel.Tables, AdaptTableDto),
 	}
 }

--- a/dto/data_model_pivot.go
+++ b/dto/data_model_pivot.go
@@ -10,8 +10,10 @@ type Pivot struct {
 	Id        string    `json:"id"`
 	CreatedAt time.Time `json:"created_at"`
 
-	BaseTable   string `json:"base_table"`
-	BaseTableId string `json:"base_table_id"`
+	BaseTable    string `json:"base_table"`
+	BaseTableId  string `json:"base_table_id"`
+	PivotTable   string `json:"pivot_table"`
+	PivotTableId string `json:"pivot_table_id"`
 
 	Field   string `json:"field"`
 	FieldId string `json:"field_id"`
@@ -25,8 +27,10 @@ func AdaptPivotDto(pivot models.Pivot) Pivot {
 		Id:        pivot.Id,
 		CreatedAt: pivot.CreatedAt,
 
-		BaseTable:   pivot.BaseTable,
-		BaseTableId: pivot.BaseTableId,
+		BaseTable:    pivot.BaseTable,
+		BaseTableId:  pivot.BaseTableId,
+		PivotTable:   pivot.PivotTable,
+		PivotTableId: pivot.PivotTableId,
 
 		Field:   pivot.Field,
 		FieldId: pivot.FieldId,

--- a/dto/data_model_pivot.go
+++ b/dto/data_model_pivot.go
@@ -1,0 +1,54 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/guregu/null/v5"
+)
+
+type Pivot struct {
+	Id string `json:"id"`
+
+	BaseTable   string `json:"base_table"`
+	BaseTableId string `json:"base_table_id"`
+
+	CreatedAt time.Time `json:"created_at"`
+
+	BaseField   null.String `json:"base_field"`
+	BaseFieldId null.String `json:"base_field_id"`
+
+	Links   []string `json:"links"`
+	LinkIds []string `json:"link_ids"`
+}
+
+func AdaptPivotDto(pivot models.Pivot) Pivot {
+	return Pivot{
+		Id: pivot.Id,
+
+		BaseTable:   pivot.BaseTable,
+		BaseTableId: pivot.BaseTableId,
+
+		CreatedAt: pivot.CreatedAt,
+
+		BaseField:   null.StringFromPtr(pivot.BaseField),
+		BaseFieldId: null.StringFromPtr(pivot.BaseFieldId),
+
+		Links:   pivot.Links,
+		LinkIds: pivot.LinkIds,
+	}
+}
+
+type CreatePivotInput struct {
+	BaseTableId string   `json:"base_table_id" binding:"required"`
+	BaseFieldId *string  `json:"base_field_id"`
+	LinkIds     []string `json:"link_ids"`
+}
+
+func AdaptCreatePivotInput(input CreatePivotInput) models.CreatePivotInput {
+	return models.CreatePivotInput{
+		BaseTableId: input.BaseTableId,
+		BaseFieldId: input.BaseFieldId,
+		LinkIds:     input.LinkIds,
+	}
+}

--- a/dto/data_model_pivot.go
+++ b/dto/data_model_pivot.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/guregu/null/v5"
 )
 
 type Pivot struct {
@@ -14,8 +13,8 @@ type Pivot struct {
 	BaseTable   string `json:"base_table"`
 	BaseTableId string `json:"base_table_id"`
 
-	Field   null.String `json:"field"`
-	FieldId null.String `json:"field_id"`
+	Field   string `json:"field"`
+	FieldId string `json:"field_id"`
 
 	PathLinks   []string `json:"path_links"`
 	PathLinkIds []string `json:"path_link_ids"`
@@ -29,8 +28,8 @@ func AdaptPivotDto(pivot models.Pivot) Pivot {
 		BaseTable:   pivot.BaseTable,
 		BaseTableId: pivot.BaseTableId,
 
-		Field:   null.StringFromPtr(pivot.Field),
-		FieldId: null.StringFromPtr(pivot.FieldId),
+		Field:   pivot.Field,
+		FieldId: pivot.FieldId,
 
 		PathLinks:   make([]string, 0, len(pivot.PathLinks)),
 		PathLinkIds: make([]string, 0, len(pivot.PathLinks)),
@@ -45,6 +44,7 @@ func AdaptPivotDto(pivot models.Pivot) Pivot {
 	return out
 }
 
+// pass either FieldId or PathLinkIds (not both). If PathLinkIds is passed, FieldId will be calculated in the returned object
 type CreatePivotInput struct {
 	BaseTableId string   `json:"base_table_id" binding:"required"`
 	FieldId     *string  `json:"field_id"`

--- a/dto/data_model_pivot.go
+++ b/dto/data_model_pivot.go
@@ -8,47 +8,54 @@ import (
 )
 
 type Pivot struct {
-	Id string `json:"id"`
+	Id        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
 
 	BaseTable   string `json:"base_table"`
 	BaseTableId string `json:"base_table_id"`
 
-	CreatedAt time.Time `json:"created_at"`
+	Field   null.String `json:"field"`
+	FieldId null.String `json:"field_id"`
 
-	BaseField   null.String `json:"base_field"`
-	BaseFieldId null.String `json:"base_field_id"`
-
-	Links   []string `json:"links"`
-	LinkIds []string `json:"link_ids"`
+	PathLinks   []string `json:"path_links"`
+	PathLinkIds []string `json:"path_link_ids"`
 }
 
 func AdaptPivotDto(pivot models.Pivot) Pivot {
-	return Pivot{
-		Id: pivot.Id,
+	out := Pivot{
+		Id:        pivot.Id,
+		CreatedAt: pivot.CreatedAt,
 
 		BaseTable:   pivot.BaseTable,
 		BaseTableId: pivot.BaseTableId,
 
-		CreatedAt: pivot.CreatedAt,
+		Field:   null.StringFromPtr(pivot.Field),
+		FieldId: null.StringFromPtr(pivot.FieldId),
 
-		BaseField:   null.StringFromPtr(pivot.BaseField),
-		BaseFieldId: null.StringFromPtr(pivot.BaseFieldId),
-
-		Links:   pivot.Links,
-		LinkIds: pivot.LinkIds,
+		PathLinks:   make([]string, 0, len(pivot.PathLinks)),
+		PathLinkIds: make([]string, 0, len(pivot.PathLinks)),
 	}
+	if pivot.PathLinks != nil {
+		out.PathLinks = pivot.PathLinks
+	}
+	if pivot.PathLinkIds != nil {
+		out.PathLinkIds = pivot.PathLinkIds
+	}
+
+	return out
 }
 
 type CreatePivotInput struct {
 	BaseTableId string   `json:"base_table_id" binding:"required"`
-	BaseFieldId *string  `json:"base_field_id"`
-	LinkIds     []string `json:"link_ids"`
+	FieldId     *string  `json:"field_id"`
+	PathLinkIds []string `json:"path_link_ids"`
 }
 
-func AdaptCreatePivotInput(input CreatePivotInput) models.CreatePivotInput {
+func AdaptCreatePivotInput(input CreatePivotInput, organizationId string) models.CreatePivotInput {
 	return models.CreatePivotInput{
-		BaseTableId: input.BaseTableId,
-		BaseFieldId: input.BaseFieldId,
-		LinkIds:     input.LinkIds,
+		OrganizationId: organizationId,
+		BaseTableId:    input.BaseTableId,
+		FieldId:        input.FieldId,
+		PathLinkIds:    input.PathLinkIds,
 	}
 }

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -85,7 +85,7 @@ func NewAPIDecision(decision models.Decision, marbleAppHost string) APIDecision 
 		Id:                decision.DecisionId,
 		AppLink:           toDecisionUrl(marbleAppHost, decision.DecisionId),
 		CreatedAt:         decision.CreatedAt,
-		TriggerObjectType: string(decision.ClientObject.TableName),
+		TriggerObjectType: decision.ClientObject.TableName,
 		TriggerObject:     decision.ClientObject.Data,
 		Outcome:           decision.Outcome.String(),
 		Scenario: APIDecisionScenario{

--- a/dto/openapi.go
+++ b/dto/openapi.go
@@ -265,16 +265,16 @@ func OpenAPIFromDataModel(dataModel models.DataModel) Reference {
 		properties := make(map[string]Property)
 		for name, field := range table.Fields {
 			description := field.Description
-			properties[string(name)] = Property{
+			properties[name] = Property{
 				Description: &description,
 				Type:        toSwaggerType(field.DataType),
 			}
 			if !field.Nullable {
-				required = append(required, string(name))
+				required = append(required, name)
 			}
 		}
 
-		ref.Components.Schemas[string(table.Name)] = ComponentsSchema{
+		ref.Components.Schemas[table.Name] = ComponentsSchema{
 			Required:   required,
 			Type:       "object",
 			Properties: properties,
@@ -293,7 +293,7 @@ func OpenAPIFromDataModel(dataModel models.DataModel) Reference {
 					Content: Content{
 						ApplicationJSON: ApplicationJSON{
 							Schema: Schema{
-								Ref: fmt.Sprintf("#/components/schemas/%s", string(table.Name)),
+								Ref: fmt.Sprintf("#/components/schemas/%s", table.Name),
 							},
 						},
 					},
@@ -315,7 +315,7 @@ func OpenAPIFromDataModel(dataModel models.DataModel) Reference {
 	var triggerObjects []map[string]string
 	for _, table := range dataModel.Tables {
 		ref := map[string]string{
-			"$ref": fmt.Sprintf("#/components/schemas/%s", string(table.Name)),
+			"$ref": fmt.Sprintf("#/components/schemas/%s", table.Name),
 		}
 		triggerObjects = append(triggerObjects, ref)
 	}

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -555,7 +555,7 @@ func createAndTestDecision(
 			ScenarioId:         scenarioId,
 			ClientObject:       &transactionPayload,
 			OrganizationId:     organizationId,
-			TriggerObjectTable: string(table.Name),
+			TriggerObjectTable: table.Name,
 		},
 		false,
 	)

--- a/mocks/data_model_repository.go
+++ b/mocks/data_model_repository.go
@@ -48,6 +48,11 @@ func (d *DataModelRepository) CreateDataModelField(
 	return args.Error(0)
 }
 
+func (d *DataModelRepository) GetLinks(ctx context.Context, exec repositories.Executor, organizationID string) ([]models.LinkToSingle, error) {
+	args := d.Called(ctx, exec, organizationID)
+	return args.Get(0).([]models.LinkToSingle), args.Error(1)
+}
+
 func (d *DataModelRepository) GetDataModelTable(ctx context.Context, exec repositories.Executor, tableID string) (models.TableMetadata, error) {
 	args := d.Called(ctx, exec, tableID)
 	return args.Get(0).(models.TableMetadata), args.Error(1)
@@ -68,4 +73,21 @@ func (d *DataModelRepository) UpdateDataModelField(ctx context.Context, exec rep
 func (repo *DataModelRepository) GetDataModelField(ctx context.Context, exec repositories.Executor, fieldId string) (models.FieldMetadata, error) {
 	args := repo.Called(ctx, exec, fieldId)
 	return args.Get(0).(models.FieldMetadata), args.Error(1)
+}
+
+func (d *DataModelRepository) CreatePivot(ctx context.Context, exec repositories.Executor, id string, pivot models.CreatePivotInput) error {
+	args := d.Called(ctx, exec, id, pivot)
+	return args.Error(0)
+}
+
+func (d *DataModelRepository) ListPivots(ctx context.Context, exec repositories.Executor,
+	organization_id string, tableId *string,
+) ([]models.PivotMetadata, error) {
+	args := d.Called(ctx, exec, organization_id, tableId)
+	return args.Get(0).([]models.PivotMetadata), args.Error(1)
+}
+
+func (d *DataModelRepository) GetPivot(ctx context.Context, exec repositories.Executor, pivotId string) (models.PivotMetadata, error) {
+	args := d.Called(ctx, exec, pivotId)
+	return args.Get(0).(models.PivotMetadata), args.Error(1)
 }

--- a/models/concrete_index.go
+++ b/models/concrete_index.go
@@ -33,15 +33,15 @@ func (i ConcreteIndex) Covers(f IndexFamily) bool {
 	// far as identifiers are concerned (unless quoted)
 	// and as such will return names will all lower case
 	f = f.Copy()
-	f.TableName = strings.ToUpper(string(f.TableName))
-	f.Last = fieldNameToUpper(f.Last)
-	f.Fixed = pure_utils.Map(f.Fixed, fieldNameToUpper)
-	f.Flex = set.From(pure_utils.Map(f.Flex.Slice(), fieldNameToUpper))
-	f.Included = set.From(pure_utils.Map(f.Included.Slice(), fieldNameToUpper))
+	f.TableName = strings.ToUpper(f.TableName)
+	f.Last = strings.ToUpper(f.Last)
+	f.Fixed = pure_utils.Map(f.Fixed, strings.ToUpper)
+	f.Flex = set.From(pure_utils.Map(f.Flex.Slice(), strings.ToUpper))
+	f.Included = set.From(pure_utils.Map(f.Included.Slice(), strings.ToUpper))
 	i = ConcreteIndex{
-		TableName: strings.ToUpper(string(i.TableName)),
-		Indexed:   pure_utils.Map(i.Indexed, fieldNameToUpper),
-		Included:  pure_utils.Map(i.Included, fieldNameToUpper),
+		TableName: strings.ToUpper(i.TableName),
+		Indexed:   pure_utils.Map(i.Indexed, strings.ToUpper),
+		Included:  pure_utils.Map(i.Included, strings.ToUpper),
 	}
 
 	if i.TableName != f.TableName {
@@ -102,8 +102,4 @@ func (i ConcreteIndex) Covers(f IndexFamily) bool {
 	}
 
 	return true
-}
-
-func fieldNameToUpper(f string) string {
-	return string(strings.ToUpper(string(f)))
 }

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -219,10 +219,14 @@ type LinkToSingle struct {
 	Id              string
 	OrganizationId  string
 	Name            string
-	LinkedTableName string
+	ParentTableName string
+	ParentTableId   string
 	ParentFieldName string
+	ParentFieldId   string
 	ChildTableName  string
+	ChildTableId    string
 	ChildFieldName  string
+	ChildFieldId    string
 }
 
 type DataModelLinkCreateInput struct {

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -132,7 +132,7 @@ func ColumnNames(table Table) []string {
 	columnNames := make([]string, len(table.Fields))
 	i := 0
 	for fieldName := range table.Fields {
-		columnNames[i] = string(fieldName)
+		columnNames[i] = fieldName
 		i++
 	}
 	return columnNames

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -66,6 +66,34 @@ func (dm DataModel) Copy() DataModel {
 	}
 }
 
+func (dm DataModel) AllLinksAsMap() map[string]LinkToSingle {
+	links := make(map[string]LinkToSingle, 100)
+	for _, table := range dm.Tables {
+		for _, link := range table.LinksToSingle {
+			links[link.Id] = link
+		}
+	}
+	return links
+}
+
+func (dm DataModel) AllTablesAsMap() map[string]Table {
+	tables := make(map[string]Table, 100)
+	for _, table := range dm.Tables {
+		tables[table.ID] = table
+	}
+	return tables
+}
+
+func (dm DataModel) AllFieldsAsMap() map[string]Field {
+	fields := make(map[string]Field, 100)
+	for _, table := range dm.Tables {
+		for _, field := range table.Fields {
+			fields[field.ID] = field
+		}
+	}
+	return fields
+}
+
 // ///////////////////////////////
 // Data Model table
 // ///////////////////////////////
@@ -188,6 +216,8 @@ type UpdateFieldInput struct {
 // Data Model Link
 // ///////////////////////////////
 type LinkToSingle struct {
+	Id              string
+	OrganizationId  string
 	Name            string
 	LinkedTableName string
 	ParentFieldName string

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+type Pivot struct {
+	Id string
+
+	BaseTable   string
+	BaseTableId string
+
+	CreatedAt time.Time
+
+	BaseField   *string
+	BaseFieldId *string
+
+	Links   []string
+	LinkIds []string
+}
+
+type CreatePivotInput struct {
+	BaseTableId string
+	BaseFieldId *string
+	LinkIds     []string
+}

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -77,7 +77,7 @@ func FieldFromPath(dm DataModel, pathLinkIds []string, baseTableName string) (Fi
 	linksMap := dm.AllLinksAsMap()
 	// check that the first link is from the base table
 	firstLink := linksMap[pathLinkIds[0]]
-	if string(firstLink.ChildTableName) != baseTableName {
+	if firstLink.ChildTableName != baseTableName {
 		return Field{}, errors.Wrap(
 			BadParameterError,
 			fmt.Sprintf(`first link's (%s) child table must be the base table "%s" (is "%s" instead)`,

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -17,6 +17,23 @@ type PivotMetadata struct {
 	PathLinkIds []string
 }
 
+type Pivot struct {
+	Id             string
+	CreatedAt      time.Time
+	OrganizationId string
+
+	BaseTable    string
+	BaseTableId  string
+	PivotTable   string
+	PivotTableId string
+
+	Field   string
+	FieldId string
+
+	PathLinks   []string
+	PathLinkIds []string
+}
+
 func AdaptPivot(pivotMeta PivotMetadata, dataModel DataModel) Pivot {
 	pivot := Pivot{
 		Id:             pivotMeta.Id,
@@ -34,10 +51,16 @@ func AdaptPivot(pivotMeta PivotMetadata, dataModel DataModel) Pivot {
 		field := dataModel.AllFieldsAsMap()[*pivotMeta.FieldId]
 		pivot.Field = field.Name
 		pivot.FieldId = field.ID
+		// in this case, the pivot table is the base table
+		pivot.PivotTable = baseTable.Name
+		pivot.PivotTableId = baseTable.ID
 	} else {
 		field, _ := FieldFromPath(dataModel, pivot.PathLinkIds, pivot.BaseTable)
 		pivot.Field = field.Name
 		pivot.FieldId = field.ID
+		// in this case, the pivot table is the last table in the path
+		pivot.PivotTable = dataModel.AllTablesAsMap()[field.TableId].Name
+		pivot.PivotTableId = field.TableId
 	}
 
 	pivot.PathLinks = make([]string, 0, len(pivot.PathLinkIds))
@@ -48,21 +71,6 @@ func AdaptPivot(pivotMeta PivotMetadata, dataModel DataModel) Pivot {
 	}
 
 	return pivot
-}
-
-type Pivot struct {
-	Id             string
-	CreatedAt      time.Time
-	OrganizationId string
-
-	BaseTable   string
-	BaseTableId string
-
-	Field   string
-	FieldId string
-
-	PathLinks   []string
-	PathLinkIds []string
 }
 
 func FieldFromPath(dm DataModel, pathLinkIds []string, baseTableName string) (Field, error) {

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -2,23 +2,63 @@ package models
 
 import "time"
 
+type PivotMetadata struct {
+	Id             string
+	CreatedAt      time.Time
+	OrganizationId string
+
+	BaseTableId string
+	FieldId     *string
+	PathLinkIds []string
+}
+
+func AdaptPivot(pivotMeta PivotMetadata, dataModel DataModel) Pivot {
+	pivot := Pivot{
+		Id:             pivotMeta.Id,
+		CreatedAt:      pivotMeta.CreatedAt,
+		OrganizationId: pivotMeta.OrganizationId,
+
+		BaseTableId: pivotMeta.BaseTableId,
+		FieldId:     pivotMeta.FieldId,
+		PathLinkIds: pivotMeta.PathLinkIds,
+	}
+
+	baseTable := dataModel.AllTablesAsMap()[pivotMeta.BaseTableId]
+	pivot.BaseTable = baseTable.Name
+
+	if pivot.FieldId != nil {
+		field := dataModel.AllFieldsAsMap()[*pivot.FieldId]
+		pivot.Field = &field.Name
+	}
+
+	pivot.PathLinks = make([]string, 0, len(pivot.PathLinkIds))
+	allLinks := dataModel.AllLinksAsMap()
+	for _, linkId := range pivot.PathLinkIds {
+		link := allLinks[linkId]
+		pivot.PathLinks = append(pivot.PathLinks, link.Name)
+	}
+
+	return pivot
+}
+
 type Pivot struct {
-	Id string
+	Id             string
+	CreatedAt      time.Time
+	OrganizationId string
 
 	BaseTable   string
 	BaseTableId string
 
-	CreatedAt time.Time
+	Field   *string
+	FieldId *string
 
-	BaseField   *string
-	BaseFieldId *string
-
-	Links   []string
-	LinkIds []string
+	PathLinks   []string
+	PathLinkIds []string
 }
 
 type CreatePivotInput struct {
-	BaseTableId string
-	BaseFieldId *string
-	LinkIds     []string
+	BaseTableId    string
+	OrganizationId string
+	FieldId        *string
+	PathLinkIds    []string
 }

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -293,9 +293,13 @@ func (repo *DataModelRepositoryPostgresql) GetLinks(ctx context.Context, exec Ex
 		links.organization_id,
 		links.name,
 		parent_table.name,
+		parent_table.id,
 		parent_field.name,
+		parent_field.id,
 		child_table.name,
-		child_field.name
+		child_table.id,
+		child_field.name,
+		child_field.id
 	FROM data_model_links AS links
     	JOIN data_model_tables AS parent_table ON (links.parent_table_id = parent_table.id)
     	JOIN data_model_fields AS parent_field ON (links.parent_field_id = parent_field.id)
@@ -314,10 +318,14 @@ func (repo *DataModelRepositoryPostgresql) GetLinks(ctx context.Context, exec Ex
 			&dbLinks.Id,
 			&dbLinks.OrganizationId,
 			&dbLinks.Name,
-			&dbLinks.ParentTable,
-			&dbLinks.ParentField,
-			&dbLinks.ChildTable,
-			&dbLinks.ChildField,
+			&dbLinks.ParentTableName,
+			&dbLinks.ParentTableId,
+			&dbLinks.ParentFieldName,
+			&dbLinks.ParentFieldId,
+			&dbLinks.ChildTableName,
+			&dbLinks.ChildTableId,
+			&dbLinks.ChildFieldName,
+			&dbLinks.ChildFieldId,
 		); err != nil {
 			return models.LinkToSingle{}, err
 		}

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -166,7 +166,7 @@ func (repo *DataModelRepositoryPostgresql) CreateDataModelField(
 		query,
 		fieldId,
 		field.TableId,
-		strings.ToLower(string(field.Name)),
+		strings.ToLower(field.Name),
 		field.DataType.String(),
 		field.Nullable,
 		field.Description,
@@ -226,7 +226,7 @@ func (repo *DataModelRepositoryPostgresql) CreateDataModelLink(ctx context.Conte
 			).
 			Values(
 				link.OrganizationID,
-				strings.ToLower(string(link.Name)),
+				strings.ToLower(link.Name),
 				link.ParentTableID,
 				link.ParentFieldID,
 				link.ChildTableID,

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -82,11 +82,12 @@ func (repo *DataModelRepositoryPostgresql) GetDataModel(
 		}
 		dataModel.Tables[field.TableName].Fields[field.FieldName] = models.Field{
 			ID:          field.FieldID,
-			Description: field.FieldDescription,
 			DataType:    models.DataTypeFrom(field.FieldType),
+			Description: field.FieldDescription,
 			Name:        field.FieldName,
 			Nullable:    field.FieldNullable,
 			IsEnum:      field.FieldIsEnum,
+			TableId:     field.TableID,
 			Values:      values,
 		}
 

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -437,6 +437,12 @@ func (repo *DataModelRepositoryPostgresql) CreatePivot(
 			Values(id, pivot.OrganizationId, pivot.BaseTableId, pivot.FieldId, pivot.PathLinkIds),
 	)
 
+	if IsUniqueViolationError(err) {
+		return errors.Wrap(
+			models.ConflictError,
+			fmt.Sprintf("Conflict on creating pivot for table %s in repository CreatePivot", pivot.BaseTableId),
+		)
+	}
 	return err
 }
 

--- a/repositories/dbmodels/db_data_model.go
+++ b/repositories/dbmodels/db_data_model.go
@@ -74,15 +74,19 @@ type DbDataModelTableJoinField struct {
 var SelectDataModelTableJoinFieldColumns = utils.ColumnList[DbDataModelTableJoinField]()
 
 type DbDataModelLink struct {
-	Name        string
-	ParentTable string
-	ParentField string
-	ChildTable  string
-	ChildField  string
+	Id             string
+	OrganizationId string
+	Name           string
+	ParentTable    string
+	ParentField    string
+	ChildTable     string
+	ChildField     string
 }
 
 func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
 	return models.LinkToSingle{
+		Id:              dbDataModelLink.Id,
+		OrganizationId:  dbDataModelLink.OrganizationId,
 		Name:            dbDataModelLink.Name,
 		LinkedTableName: dbDataModelLink.ParentTable,
 		ParentFieldName: dbDataModelLink.ParentField,

--- a/repositories/dbmodels/db_data_model.go
+++ b/repositories/dbmodels/db_data_model.go
@@ -74,13 +74,17 @@ type DbDataModelTableJoinField struct {
 var SelectDataModelTableJoinFieldColumns = utils.ColumnList[DbDataModelTableJoinField]()
 
 type DbDataModelLink struct {
-	Id             string
-	OrganizationId string
-	Name           string
-	ParentTable    string
-	ParentField    string
-	ChildTable     string
-	ChildField     string
+	Id              string
+	OrganizationId  string
+	Name            string
+	ParentTableName string
+	ParentTableId   string
+	ParentFieldName string
+	ParentFieldId   string
+	ChildTableName  string
+	ChildTableId    string
+	ChildFieldName  string
+	ChildFieldId    string
 }
 
 func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
@@ -88,9 +92,13 @@ func AdaptLinkToSingle(dbDataModelLink DbDataModelLink) models.LinkToSingle {
 		Id:              dbDataModelLink.Id,
 		OrganizationId:  dbDataModelLink.OrganizationId,
 		Name:            dbDataModelLink.Name,
-		LinkedTableName: dbDataModelLink.ParentTable,
-		ParentFieldName: dbDataModelLink.ParentField,
-		ChildTableName:  dbDataModelLink.ChildTable,
-		ChildFieldName:  dbDataModelLink.ChildField,
+		ParentTableName: dbDataModelLink.ParentTableName,
+		ParentTableId:   dbDataModelLink.ParentTableId,
+		ParentFieldName: dbDataModelLink.ParentFieldName,
+		ParentFieldId:   dbDataModelLink.ParentFieldId,
+		ChildTableName:  dbDataModelLink.ChildTableName,
+		ChildTableId:    dbDataModelLink.ChildTableId,
+		ChildFieldName:  dbDataModelLink.ChildFieldName,
+		ChildFieldId:    dbDataModelLink.ChildFieldId,
 	}
 }

--- a/repositories/dbmodels/db_data_model_pivot.go
+++ b/repositories/dbmodels/db_data_model_pivot.go
@@ -1,0 +1,38 @@
+package dbmodels
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type DbPivot struct {
+	Id             string      `db:"id"`
+	BaseTableId    string      `db:"base_table_id"`
+	CreatedAt      time.Time   `db:"created_at"`
+	FieldId        pgtype.Text `db:"field_id"`
+	OrganizationId string      `db:"organization_id"`
+	PathLinkIds    []string    `db:"path_link_ids"`
+}
+
+const TABLE_DATA_MODEL_PIVOTS = "data_model_pivots"
+
+var SelectPivotColumns = utils.ColumnList[DbPivot]()
+
+func AdaptPivotMetadata(dbPivot DbPivot) (models.PivotMetadata, error) {
+	pivot := models.PivotMetadata{
+		Id:             dbPivot.Id,
+		OrganizationId: dbPivot.OrganizationId,
+		CreatedAt:      dbPivot.CreatedAt,
+
+		BaseTableId: dbPivot.BaseTableId,
+		PathLinkIds: dbPivot.PathLinkIds,
+	}
+	if dbPivot.FieldId.Valid {
+		pivot.FieldId = &dbPivot.FieldId.String
+	}
+
+	return pivot, nil
+}

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -90,10 +90,10 @@ func createQueryDbForField(exec Executor, readParams models.DbFieldReadParams) (
 	}
 
 	// "first table" is the first table reached starting from the trigger table and following the path
-	firstTable, ok := readParams.DataModel.Tables[link.LinkedTableName]
+	firstTable, ok := readParams.DataModel.Tables[link.ParentTableName]
 	if !ok {
 		return squirrel.SelectBuilder{}, fmt.Errorf("no table with name %s: %w",
-			link.LinkedTableName, models.NotFoundError)
+			link.ParentTableName, models.NotFoundError)
 	}
 	// "last table" is the last table reached starting from the trigger table and following the path, from which the field is selected
 	lastTable, err := getLastTableFromPath(readParams, firstTable)
@@ -137,10 +137,10 @@ func getLastTableFromPath(params models.DbFieldReadParams, firstTable models.Tab
 		if !ok {
 			return models.Table{}, fmt.Errorf("no link with name %s: %w", linkName, models.NotFoundError)
 		}
-		nextTable, ok := params.DataModel.Tables[link.LinkedTableName]
+		nextTable, ok := params.DataModel.Tables[link.ParentTableName]
 		if !ok {
 			return models.Table{}, fmt.Errorf("no table with name %s: %w",
-				link.LinkedTableName, models.NotFoundError)
+				link.ParentTableName, models.NotFoundError)
 		}
 
 		currentTable = nextTable
@@ -162,10 +162,10 @@ func addJoinsOnIntermediateTables(
 			return squirrel.SelectBuilder{}, fmt.Errorf(
 				"no link with name %s on table %s: %w", linkName, currentTable.Name, models.NotFoundError)
 		}
-		nextTable, ok := readParams.DataModel.Tables[link.LinkedTableName]
+		nextTable, ok := readParams.DataModel.Tables[link.ParentTableName]
 		if !ok {
 			return squirrel.SelectBuilder{}, fmt.Errorf("no table with name %s: %w",
-				link.LinkedTableName, models.NotFoundError)
+				link.ParentTableName, models.NotFoundError)
 		}
 
 		currentTableName := tableNameWithSchema(exec, currentTable.Name)

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -115,7 +115,7 @@ func createQueryDbForField(exec Executor, readParams models.DbFieldReadParams) (
 }
 
 func getParentTableJoinField(payload models.ClientObject, fieldName string) (string, error) {
-	parentFieldItf := payload.Data[string(fieldName)]
+	parentFieldItf := payload.Data[fieldName]
 	if parentFieldItf == nil {
 		return "", errors.Wrap(
 			ast.ErrNullFieldRead,

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -52,7 +52,7 @@ func (tx TransactionTest) Exec(ctx context.Context, query string, args ...interf
 }
 
 func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
-	path := []string{string(utils.DummyTableNameSecond)}
+	path := []string{utils.DummyTableNameSecond}
 
 	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
 		TriggerTableName: utils.DummyTableNameFirst,
@@ -61,14 +61,14 @@ func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 		DataModel:        utils.GetDummyDataModel(),
 		ClientObject: models.ClientObject{
 			TableName: utils.DummyTableNameFirst,
-			Data:      map[string]any{string(utils.DummyFieldNameId): string(utils.DummyFieldNameId)},
+			Data:      map[string]any{utils.DummyFieldNameId: utils.DummyFieldNameId},
 		},
 	})
 	assert.Empty(t, err)
 	sql, args, err := query.ToSql()
 	assert.Empty(t, err)
 	if assert.Len(t, args, 2) {
-		assert.Equal(t, args[0], string(utils.DummyFieldNameId))
+		assert.Equal(t, args[0], utils.DummyFieldNameId)
 		assert.Equal(t, args[1], "Infinity")
 	}
 	assert.Equal(t, strings.ReplaceAll(sql, "\"", ""), expectedQueryDbFieldExpectedWithoutJoin)
@@ -76,8 +76,8 @@ func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 
 func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {
 	path := []string{
-		string(utils.DummyTableNameSecond),
-		string(utils.DummyTableNameThird),
+		utils.DummyTableNameSecond,
+		utils.DummyTableNameThird,
 	}
 
 	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
@@ -87,14 +87,14 @@ func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {
 		DataModel:        utils.GetDummyDataModel(),
 		ClientObject: models.ClientObject{
 			TableName: utils.DummyTableNameFirst,
-			Data:      map[string]any{string(utils.DummyFieldNameId): string(utils.DummyFieldNameId)},
+			Data:      map[string]any{utils.DummyFieldNameId: utils.DummyFieldNameId},
 		},
 	})
 	assert.Empty(t, err)
 	sql, args, err := query.ToSql()
 	assert.Empty(t, err)
 	if assert.Len(t, args, 3) {
-		assert.Equal(t, args[0], string(utils.DummyFieldNameId))
+		assert.Equal(t, args[0], utils.DummyFieldNameId)
 		assert.Equal(t, args[1], "Infinity")
 		assert.Equal(t, args[2], "Infinity")
 	}
@@ -128,14 +128,14 @@ func TestIngestedDataQueryCountWithoutFilter(t *testing.T) {
 func TestIngestedDataQueryAggregatedValueWithFilter(t *testing.T) {
 	filters := []ast.Filter{
 		{
-			TableName: string(utils.DummyTableNameFirst),
-			FieldName: string(utils.DummyFieldNameForInt),
+			TableName: utils.DummyTableNameFirst,
+			FieldName: utils.DummyFieldNameForInt,
 			Operator:  ast.FILTER_EQUAL,
 			Value:     1,
 		},
 		{
-			TableName: string(utils.DummyTableNameFirst),
-			FieldName: string(utils.DummyFieldNameForBool),
+			TableName: utils.DummyTableNameFirst,
+			FieldName: utils.DummyFieldNameForBool,
 			Operator:  ast.FILTER_NOT_EQUAL,
 			Value:     true,
 		},

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -198,7 +198,7 @@ func (repo *IngestionRepositoryImpl) buildEnumValuesWithEnumFields(table models.
 	for fieldName := range table.Fields {
 		dataType := table.Fields[fieldName].DataType
 		if table.Fields[fieldName].IsEnum && (dataType == models.String || dataType == models.Float) {
-			enumValues[string(fieldName)] = make(map[any]bool)
+			enumValues[fieldName] = make(map[any]bool)
 		}
 	}
 	return enumValues
@@ -209,7 +209,7 @@ func (repo *IngestionRepositoryImpl) generateInsertValues(payload models.ClientO
 	i := 0
 	for _, columnName := range columnNames {
 		fieldName := columnName
-		insertValues[i] = payload.Data[string(fieldName)]
+		insertValues[i] = payload.Data[fieldName]
 		i++
 	}
 	return insertValues, nil

--- a/repositories/migrations/20240419115400_data_model_pivot.sql
+++ b/repositories/migrations/20240419115400_data_model_pivot.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS
             created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
             field_id uuid REFERENCES data_model_fields (id) ON DELETE CASCADE,
             organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
-            path_link_ids uuid[] default array[]::uuid[]
+            path_link_ids uuid[] NOT NULL DEFAULT ARRAY[]::uuid[]
       );
 
 CREATE UNIQUE INDEX data_model_pivots_base_table_id_idx ON data_model_pivots (organization_id, base_table_id);

--- a/repositories/migrations/20240419115400_data_model_pivot.sql
+++ b/repositories/migrations/20240419115400_data_model_pivot.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE IF NOT EXISTS
+      data_model_pivots (
+            id uuid DEFAULT uuid_generate_v4 () PRIMARY KEY,
+            base_table_id uuid NOT NULL REFERENCES data_model_tables (id) ON DELETE CASCADE,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+            field_id uuid REFERENCES data_model_fields (id) ON DELETE CASCADE,
+            organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+            path_link_ids uuid[] default array[]::uuid[]
+      );
+
+CREATE INDEX data_model_pivots_base_table_id_idx ON data_model_pivots (organization_id, base_table_id);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE data_model_pivots;
+
+-- +goose StatementEnd

--- a/repositories/migrations/20240419115400_data_model_pivot.sql
+++ b/repositories/migrations/20240419115400_data_model_pivot.sql
@@ -10,11 +10,13 @@ CREATE TABLE IF NOT EXISTS
             path_link_ids uuid[] default array[]::uuid[]
       );
 
-CREATE INDEX data_model_pivots_base_table_id_idx ON data_model_pivots (organization_id, base_table_id);
+CREATE UNIQUE INDEX data_model_pivots_base_table_id_idx ON data_model_pivots (organization_id, base_table_id);
 
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
+DROP INDEX data_model_pivots_base_table_id_idx;
+
 DROP TABLE data_model_pivots;
 
 -- +goose StatementEnd

--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -33,7 +33,7 @@ func DryRunGetDbField(dataModel models.DataModel, triggerTableName string, path 
 			return nil, errors.New(fmt.Sprintf("link %s not found in table %s", linkName, table.Name))
 		}
 
-		table, ok = dataModel.Tables[link.LinkedTableName]
+		table, ok = dataModel.Tables[link.ParentTableName]
 		if !ok {
 			return nil, errors.New(fmt.Sprintf("table %s not found in data model", triggerTableName))
 		}

--- a/usecases/ast_eval/evaluate/dry_run_fake_value.go
+++ b/usecases/ast_eval/evaluate/dry_run_fake_value.go
@@ -15,7 +15,7 @@ func DryRunPayload(table models.Table) map[string]any {
 	result := make(map[string]any)
 	for fieldName, field := range table.Fields {
 		fullFieldName := fmt.Sprintf("%s.%s", table.Name, fieldName)
-		result[string(fieldName)] = DryRunValue("Payload", fullFieldName, field)
+		result[fieldName] = DryRunValue("Payload", fullFieldName, field)
 	}
 
 	return result

--- a/usecases/ast_eval/evaluate/evaluate_database_access_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access_test.go
@@ -28,8 +28,8 @@ func TestDatabaseAccessValuesDryRun(t *testing.T) {
 		ReturnFakeValue: true,
 	}
 	testDatabaseAccessNamedArgs := map[string]any{
-		"tableName": string(utils.DummyTableNameFirst),
-		"fieldName": string(utils.DummyFieldNameId),
+		"tableName": utils.DummyTableNameFirst,
+		"fieldName": utils.DummyFieldNameId,
 		"path":      []any{},
 	}
 
@@ -40,29 +40,29 @@ func TestDatabaseAccessValuesDryRun(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("fake value for DbAccess:%s..%s",
 		testDatabaseAccessNamedArgs["tableName"], testDatabaseAccessNamedArgs["fieldName"]), value)
 
-	testDatabaseAccessNamedArgs["fieldName"] = string(utils.DummyFieldNameForBool)
-	testDatabaseAccessNamedArgs["path"] = []any{string(utils.DummyTableNameSecond)}
+	testDatabaseAccessNamedArgs["fieldName"] = utils.DummyFieldNameForBool
+	testDatabaseAccessNamedArgs["path"] = []any{utils.DummyTableNameSecond}
 	value, errs = databaseAccessEval.Evaluate(context.TODO(), ast.Arguments{
 		NamedArgs: testDatabaseAccessNamedArgs,
 	})
 	assert.Len(t, errs, 0)
 	assert.Equal(t, true, value)
 
-	testDatabaseAccessNamedArgs["fieldName"] = string(utils.DummyFieldNameForInt)
+	testDatabaseAccessNamedArgs["fieldName"] = utils.DummyFieldNameForInt
 	value, errs = databaseAccessEval.Evaluate(context.TODO(), ast.Arguments{
 		NamedArgs: testDatabaseAccessNamedArgs,
 	})
 	assert.Len(t, errs, 0)
 	assert.Equal(t, 1, value)
 
-	testDatabaseAccessNamedArgs["fieldName"] = string(utils.DummyFieldNameForFloat)
+	testDatabaseAccessNamedArgs["fieldName"] = utils.DummyFieldNameForFloat
 	value, errs = databaseAccessEval.Evaluate(context.TODO(), ast.Arguments{
 		NamedArgs: testDatabaseAccessNamedArgs,
 	})
 	assert.Len(t, errs, 0)
 	assert.Equal(t, 1.0, value)
 
-	testDatabaseAccessNamedArgs["fieldName"] = string(utils.DummyFieldNameForTimestamp)
+	testDatabaseAccessNamedArgs["fieldName"] = utils.DummyFieldNameForTimestamp
 	timestamp := time.Now()
 	value, errs = databaseAccessEval.Evaluate(context.TODO(), ast.Arguments{
 		NamedArgs: testDatabaseAccessNamedArgs,

--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -44,7 +44,7 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 	var visited []string
 	recursiveDatabaseAccessor = func(path []string, links map[string]models.LinkToSingle) error {
 		for linkName, link := range links {
-			table, found := dataModel.Tables[link.LinkedTableName]
+			table, found := dataModel.Tables[link.ParentTableName]
 			if !found {
 				return fmt.Errorf("table %s not found in data model", scenario.TriggerObjectType)
 			}

--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -55,13 +55,13 @@ func (usecase *AstExpressionUsecase) getLinkedDatabaseIdentifiers(scenario model
 				continue
 			}
 			visited = append(visited, relation)
-			pathForLink := append(path, string(linkName))
+			pathForLink := append(path, linkName)
 
 			for fieldName := range table.Fields {
 				dataAccessors = append(dataAccessors,
 					ast.NewNodeDatabaseAccess(
 						scenario.TriggerObjectType,
-						string(fieldName),
+						fieldName,
 						pathForLink,
 					),
 				)

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -23,7 +23,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 				},
 				LinksToSingle: map[string]models.LinkToSingle{
 					"last_transactions": {
-						LinkedTableName: "transactions",
+						ParentTableName: "transactions",
 						ParentFieldName: "id",
 						ChildFieldName:  "last_transaction",
 					},
@@ -37,7 +37,7 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 				},
 				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
-						LinkedTableName: "accounts",
+						ParentTableName: "accounts",
 						ParentFieldName: "id",
 						ChildFieldName:  "account_id",
 					},

--- a/usecases/data_model_helpers_test.go
+++ b/usecases/data_model_helpers_test.go
@@ -48,7 +48,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
-						LinkedTableName: "accounts",
+						ParentTableName: "accounts",
 						ParentFieldName: "object_id",
 						ChildFieldName:  "account_id",
 					},
@@ -116,7 +116,7 @@ func getTestDataModel() (models.DataModel, models.DataModel) {
 				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
-						LinkedTableName: "accounts",
+						ParentTableName: "accounts",
 						ParentFieldName: "object_id",
 						ChildFieldName:  "account_id",
 					},
@@ -153,7 +153,7 @@ func TestFindLinksToField(t *testing.T) {
 		links := findLinksToField(dataModel, "accounts", "object_id")
 		assert.Equal([]models.LinkToSingle{{
 			Name:            "account",
-			LinkedTableName: "accounts",
+			ParentTableName: "accounts",
 			ParentFieldName: "object_id",
 			ChildTableName:  "",
 			ChildFieldName:  "account_id",

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -456,38 +456,8 @@ func validatePivotCreateInput(input models.CreatePivotInput, dm models.DataModel
 
 	// verify that the links are chained consistently
 	if hasPath {
-		if err := validatePath(dm, input.PathLinkIds, table.Name); err != nil {
+		if _, err := models.FieldFromPath(dm, input.PathLinkIds, table.Name); err != nil {
 			return err
-		}
-	}
-
-	return nil
-}
-
-func validatePath(dm models.DataModel, pathLinkIds []string, baseTableName string) error {
-	linksMap := dm.AllLinksAsMap()
-	// check that the first link is from the base table
-	firstLink := linksMap[pathLinkIds[0]]
-	if string(firstLink.ChildTableName) != baseTableName {
-		return errors.Wrap(
-			models.BadParameterError,
-			fmt.Sprintf(`first link's (%s) child table must be the base table "%s" (is "%s" instead)`,
-				firstLink.Id, baseTableName, firstLink.ChildTableName,
-			),
-		)
-	}
-
-	// check that the links are chained consistently
-	for i := 1; i < len(pathLinkIds); i++ {
-		previousLink := linksMap[pathLinkIds[i-1]]
-		currentLink := linksMap[pathLinkIds[i]]
-		if previousLink.LinkedTableName != currentLink.ChildTableName {
-			return errors.Wrap(
-				models.BadParameterError,
-				fmt.Sprintf(`link %s (parent table "%s") is not a child of link %s (child table "%s")`,
-					previousLink.Id, previousLink.LinkedTableName, currentLink.Id, currentLink.ChildTableName,
-				),
-			)
 		}
 	}
 

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -314,7 +314,7 @@ func findLinksToField(dataModel models.DataModel, tableName string, fieldName st
 	var links []models.LinkToSingle
 	for _, table := range dataModel.Tables {
 		for _, link := range table.LinksToSingle {
-			if string(link.LinkedTableName) == tableName &&
+			if string(link.ParentTableName) == tableName &&
 				string(link.ParentFieldName) == fieldName {
 				links = append(links, link)
 			}

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -314,8 +314,8 @@ func findLinksToField(dataModel models.DataModel, tableName string, fieldName st
 	var links []models.LinkToSingle
 	for _, table := range dataModel.Tables {
 		for _, link := range table.LinksToSingle {
-			if string(link.ParentTableName) == tableName &&
-				string(link.ParentFieldName) == fieldName {
+			if link.ParentTableName == tableName &&
+				link.ParentFieldName == fieldName {
 				links = append(links, link)
 			}
 		}

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
@@ -378,4 +379,40 @@ func (usecase *DataModelUseCase) DeleteDataModel(ctx context.Context, organizati
 			return usecase.organizationSchemaRepository.DeleteSchema(ctx, orgTx)
 		})
 	})
+}
+
+func (usecase *DataModelUseCase) CreatePivot(ctx context.Context, organizationID string, input models.CreatePivotInput) (models.Pivot, error) {
+	if err := usecase.enforceSecurity.WriteDataModel(organizationID); err != nil {
+		return models.Pivot{}, err
+	}
+
+	// return  dummy pivot for now
+	return models.Pivot{
+		Id:        uuid.New().String(),
+		CreatedAt: time.Now(),
+
+		BaseTableId: input.BaseTableId,
+		BaseTable:   "dummy_table",
+		Links:       []string{},
+		LinkIds:     input.LinkIds,
+	}, nil
+}
+
+func (usecase *DataModelUseCase) ListPivots(ctx context.Context, organizationID string, tableID *string) ([]models.Pivot, error) {
+	if err := usecase.enforceSecurity.ReadDataModel(); err != nil {
+		return nil, err
+	}
+
+	// return dummy pivots for now
+	return []models.Pivot{
+		{
+			Id:        uuid.New().String(),
+			CreatedAt: time.Now(),
+
+			BaseTableId: *tableID,
+			BaseTable:   "dummy_table",
+			Links:       []string{},
+			LinkIds:     []string{"dummy_link_id"},
+		},
+	}, nil
 }

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -441,6 +441,12 @@ func validatePivotCreateInput(input models.CreatePivotInput, dm models.DataModel
 			fmt.Sprintf("base table %s not found", input.BaseTableId),
 		)
 	}
+	if hasField && table.Fields[*input.FieldId].DataType != models.String {
+		return errors.Wrap(
+			models.BadParameterError,
+			"pivot field must be of type string",
+		)
+	}
 
 	// check existence of links
 	linksMap := dm.AllLinksAsMap()
@@ -456,8 +462,15 @@ func validatePivotCreateInput(input models.CreatePivotInput, dm models.DataModel
 
 	// verify that the links are chained consistently
 	if hasPath {
-		if _, err := models.FieldFromPath(dm, input.PathLinkIds, table.Name); err != nil {
+		lastTable, err := models.FieldFromPath(dm, input.PathLinkIds, table.Name)
+		if err != nil {
 			return err
+		}
+		if lastTable.DataType != models.String {
+			return errors.Wrap(
+				models.BadParameterError,
+				"pivot field must be of type string",
+			)
 		}
 	}
 

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -78,7 +78,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
-						LinkedTableName: "accounts",
+						ParentTableName: "accounts",
 						ParentFieldName: "object_id",
 						ChildFieldName:  "account_id",
 					},
@@ -142,7 +142,7 @@ func (suite *DatamodelUsecaseTestSuite) SetupTest() {
 				LinksToSingle: map[string]models.LinkToSingle{
 					"account": {
 						Name:            "account",
-						LinkedTableName: "accounts",
+						ParentTableName: "accounts",
 						ParentFieldName: "object_id",
 						ChildFieldName:  "account_id",
 					},

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -88,7 +88,7 @@ func EvalScenario(
 	}
 
 	// Check the scenario & trigger_object's types
-	if params.Scenario.TriggerObjectType != string(params.ClientObject.TableName) {
+	if params.Scenario.TriggerObjectType != params.ClientObject.TableName {
 		return models.ScenarioExecution{}, models.ErrScenarioTriggerTypeAndTiggerObjectTypeMismatch
 	}
 

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -89,13 +89,13 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 		return models.UploadLog{}, fmt.Errorf("error reading first row of CSV (%w)", err)
 	}
 
-	fileName := computeFileName(organizationId, string(table.Name))
+	fileName := computeFileName(organizationId, table.Name)
 	writer := usecase.gcsRepository.OpenStream(ctx, usecase.GcsIngestionBucket, fileName)
 	csvWriter := csv.NewWriter(writer)
 
 	for name, field := range table.Fields {
 		if !field.Nullable {
-			if !containsString(headers, string(name)) {
+			if !containsString(headers, name) {
 				return models.UploadLog{}, fmt.Errorf("missing required field %s in CSV (%w)", name, models.BadParameterError)
 			}
 		}
@@ -274,7 +274,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(ctx context.Context, organ
 	// first, check presence of all required fields in the csv
 	for name, field := range table.Fields {
 		if !field.Nullable {
-			if !containsString(firstRow, string(name)) {
+			if !containsString(firstRow, name) {
 				return fmt.Errorf("missing required field %s in CSV", name)
 			}
 		}

--- a/usecases/payload_parser/payload.go
+++ b/usecases/payload_parser/payload.go
@@ -48,12 +48,12 @@ func (p *Parser) ParsePayload(table models.Table, json []byte) (models.ClientObj
 	}
 
 	for name, field := range table.Fields {
-		value := result.Get(string(name))
+		value := result.Get(name)
 		if !value.Exists() || value.Type == gjson.Null {
 			if !field.Nullable {
 				errors[name] = errIsNotNullable.Error()
 			}
-			out[string(name)] = nil
+			out[name] = nil
 			continue
 		}
 
@@ -65,7 +65,7 @@ func (p *Parser) ParsePayload(table models.Table, json []byte) (models.ClientObj
 		if val, err := parseField(value); err != nil {
 			errors[name] = err.Error()
 		} else {
-			out[string(name)] = val
+			out[name] = val
 		}
 	}
 	if len(errors) > 0 {

--- a/utils/dummy_datamodel.go
+++ b/utils/dummy_datamodel.go
@@ -42,7 +42,7 @@ func GetDummyDataModel() models.DataModel {
 
 	dummyFirstLinkToSingle := map[string]models.LinkToSingle{
 		string(DummyTableNameSecond): {
-			LinkedTableName: DummyTableNameSecond,
+			ParentTableName: DummyTableNameSecond,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,
 		},
@@ -50,7 +50,7 @@ func GetDummyDataModel() models.DataModel {
 
 	dummySecondLinkToSingle := map[string]models.LinkToSingle{
 		string(DummyTableNameThird): {
-			LinkedTableName: DummyTableNameThird,
+			ParentTableName: DummyTableNameThird,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,
 		},

--- a/utils/dummy_datamodel.go
+++ b/utils/dummy_datamodel.go
@@ -41,7 +41,7 @@ func GetDummyDataModel() models.DataModel {
 	}
 
 	dummyFirstLinkToSingle := map[string]models.LinkToSingle{
-		string(DummyTableNameSecond): {
+		DummyTableNameSecond: {
 			ParentTableName: DummyTableNameSecond,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,
@@ -49,7 +49,7 @@ func GetDummyDataModel() models.DataModel {
 	}
 
 	dummySecondLinkToSingle := map[string]models.LinkToSingle{
-		string(DummyTableNameThird): {
+		DummyTableNameThird: {
 			ParentTableName: DummyTableNameThird,
 			ParentFieldName: DummyFieldNameId,
 			ChildFieldName:  DummyFieldNameId,


### PR DESCRIPTION
Cf note on https://www.notion.so/checkmarble/Defining-a-pivot-67cf95c5a94249fa95ba8c183e54751b (doc update following the implementation).

We're keeping open the option to select a field on the last table of the path as the pivot, for now it's only possible to select a field if the pivot is on the base table.

---- 

E.g. 
`POST /data-model/pivots`
```
{
    "base_table_id": "2c8215d6-418a-47c3-a46e-7f95c67dab38",
    "path_link_ids": ["c6cbc438-f3c5-4c0c-9200-cc7553bf1be6","07dfde2b-ee9b-4936-9b05-9a524ec0f306"]
}
```
=> return
```
{
    "pivot": 
        {
            "id": "70f88448-439a-460f-ba26-0de41f159824",
            "created_at": "2024-04-22T16:55:57.26021+02:00",
            "base_table": "transactions",
            "base_table_id": "2c8215d6-418a-47c3-a46e-7f95c67dab38",
            "pivot_table": "new_table",
            "pivot_table_id": "bff3c3a0-1105-42cb-8fab-03ad876c8ed2",
            "field": "object_id",
            "field_id": "cd0aeeb9-defc-488f-9df4-8fe533e4cc67",
            "path_links": [
                "after_migration",
                "test_pivot_link"
            ],
            "path_link_ids": [
                "c6cbc438-f3c5-4c0c-9200-cc7553bf1be6",
                "07dfde2b-ee9b-4936-9b05-9a524ec0f306"
            ]
        }
}
```