### PR TITLE
query decisions by pivot value

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -48,8 +48,12 @@ func (api *API) handleListDecisions(c *gin.Context) {
 	paginationAndSorting = dto.WithPaginationDefaults(paginationAndSorting, decisionPaginationDefaults)
 
 	usecase := api.UsecasesWithCreds(c.Request).NewDecisionUsecase()
-	decisions, err := usecase.ListDecisions(c.Request.Context(), organizationId,
-		dto.AdaptPaginationAndSortingInput(paginationAndSorting), filters)
+	decisions, err := usecase.ListDecisions(
+		c.Request.Context(),
+		organizationId,
+		dto.AdaptPaginationAndSortingInput(paginationAndSorting),
+		filters,
+	)
 	if presentError(c, err) {
 		return
 	}

--- a/api/scheduled_execution.go
+++ b/api/scheduled_execution.go
@@ -30,6 +30,10 @@ func (api *API) handleGetScheduledExecution(c *gin.Context) {
 
 func (api *API) handleGetScheduledExecutionDecisions(c *gin.Context) {
 	scheduledExecutionID := c.Param("execution_id")
+	organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+	if presentError(c, err) {
+		return
+	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewScheduledExecutionUsecase()
 
@@ -45,7 +49,7 @@ func (api *API) handleGetScheduledExecutionDecisions(c *gin.Context) {
 	c.Writer.Header().Set("Content-Type", "application/zip")
 	c.Writer.Header().Set("Content-Disposition", "attachment; filename=\"decisions.ndjson.zip\"")
 	numberOfExportedDecisions, err := usecase.ExportScheduledExecutionDecisions(
-		c.Request.Context(), scheduledExecutionID, fileWriter)
+		c.Request.Context(), organizationId, scheduledExecutionID, fileWriter)
 	if err != nil {
 		// note: un case of security error, the header has not been sent, so we can still send a 401
 		presentError(c, err)

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -112,7 +112,7 @@ func NewAPIDecision(decision models.Decision, marbleAppHost string) APIDecision 
 		apiDecision.Case = &c
 	}
 
-	if decision.PivotId != nil {
+	if decision.PivotValue != nil {
 		apiDecision.PivotValues = append(apiDecision.PivotValues, PivotValueDto{
 			PivotId:    null.StringFromPtr(decision.PivotId),
 			PivotValue: null.StringFromPtr(decision.PivotValue),

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -16,6 +16,7 @@ type DecisionFilters struct {
 	EndDate               time.Time `form:"end_date"`
 	HasCase               *bool     `form:"has_case"`
 	Outcomes              []string  `form:"outcome[]"`
+	PivotValue            *string   `form:"pivot_value"`
 	ScenarioIds           []string  `form:"scenario_id[]"`
 	ScheduledExecutionIds []string  `form:"scheduled_execution_id[]"`
 	StartDate             time.Time `form:"start_date"`

--- a/mocks/export_decisions_mock.go
+++ b/mocks/export_decisions_mock.go
@@ -11,7 +11,7 @@ type ExportDecisionsMock struct {
 	mock.Mock
 }
 
-func (e *ExportDecisionsMock) ExportDecisions(ctx context.Context, scheduledExecutionId string, dest io.Writer) (int, error) {
-	args := e.Called(scheduledExecutionId, dest)
+func (e *ExportDecisionsMock) ExportDecisions(ctx context.Context, organizationId string, scheduledExecutionId string, dest io.Writer) (int, error) {
+	args := e.Called(ctx, organizationId, scheduledExecutionId, dest)
 	return args.Int(0), args.Error(1)
 }

--- a/models/decision.go
+++ b/models/decision.go
@@ -110,14 +110,15 @@ type CreateAllDecisionsInput struct {
 }
 
 type DecisionFilters struct {
-	ScenarioIds           []string
-	StartDate             time.Time
-	EndDate               time.Time
-	Outcomes              []Outcome
-	TriggerObjects        []string
-	HasCase               *bool
 	CaseIds               []string
+	EndDate               time.Time
+	HasCase               *bool
+	Outcomes              []Outcome
+	PivotValue            *string
+	ScenarioIds           []string
 	ScheduledExecutionIds []string
+	StartDate             time.Time
+	TriggerObjects        []string
 }
 
 const (

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -292,6 +292,9 @@ func applyDecisionFilters(query squirrel.SelectBuilder, filters models.DecisionF
 	if len(filters.ScheduledExecutionIds) > 0 {
 		query = query.Where(squirrel.Eq{"scheduled_execution_id": filters.ScheduledExecutionIds})
 	}
+	if filters.PivotValue != nil {
+		query = query.Where(squirrel.Eq{"pivot_value": *filters.PivotValue})
+	}
 	return query
 }
 

--- a/repositories/migrations/20240425140600_decisions_pivot_index.sql
+++ b/repositories/migrations/20240425140600_decisions_pivot_index.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX decisions_pivot_value_index ON decisions (org_id, pivot_value, created_at DESC);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX decisions_pivot_value_index;
+
+-- +goose StatementEnd

--- a/repositories/migrations/20240425161100_rationalize_decisions_indexes.sql
+++ b/repositories/migrations/20240425161100_rationalize_decisions_indexes.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX decisions_by_org_id_index ON decisions (org_id, created_at DESC) INCLUDE (scenario_id, outcome, trigger_object_type, case_id);
+
+CREATE INDEX decisions_scheduled_execution_id_idx_2 ON decisions (org_id, scheduled_execution_id, created_at DESC);
+
+DROP INDEX decisions_org_id_idx;
+
+DROP INDEX decisions_scheduled_execution_id_idx;
+
+DROP INDEX scenario_id_idx;
+
+DROP INDEX outcome_idx;
+
+DROP INDEX trigger_object_type_idx;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+CREATE INDEX trigger_object_type_idx ON decisions (org_id, trigger_object_type, created_at DESC);
+
+CREATE INDEX outcome_idx ON decisions (org_id, outcome, created_at DESC);
+
+CREATE INDEX scenario_id_idx ON decisions (org_id, scenario_id, created_at DESC);
+
+CREATE INDEX decisions_scheduled_execution_id_idx ON decisions (scheduled_execution_id, created_at DESC);
+
+CREATE INDEX decisions_org_id_idx ON decisions (org_id, created_at DESC);
+
+DROP INDEX decisions_pivot_value_index;
+
+DROP INDEX decisions_by_org_id_index;
+
+-- +goose StatementEnd

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -533,7 +533,7 @@ func (usecase *CaseUseCase) getCaseWithDetails(ctx context.Context, exec reposit
 		return models.Case{}, err
 	}
 
-	decisions, err := usecase.decisionRepository.DecisionsByCaseId(ctx, exec, caseId)
+	decisions, err := usecase.decisionRepository.DecisionsByCaseId(ctx, exec, c.OrganizationId, caseId)
 	if err != nil {
 		return models.Case{}, err
 	}

--- a/usecases/scheduled_execution_usecase.go
+++ b/usecases/scheduled_execution_usecase.go
@@ -13,7 +13,7 @@ import (
 )
 
 type ExportDecisions interface {
-	ExportDecisions(ctx context.Context, scheduledExecutionId string, dest io.Writer) (int, error)
+	ExportDecisions(ctx context.Context, organizationId string, scheduledExecutionId string, dest io.Writer) (int, error)
 }
 
 type ScheduledExecutionUsecaseRepository interface {
@@ -55,7 +55,12 @@ func (usecase *ScheduledExecutionUsecase) GetScheduledExecution(ctx context.Cont
 	})
 }
 
-func (usecase *ScheduledExecutionUsecase) ExportScheduledExecutionDecisions(ctx context.Context, scheduledExecutionID string, w io.Writer) (int, error) {
+func (usecase *ScheduledExecutionUsecase) ExportScheduledExecutionDecisions(
+	ctx context.Context,
+	organizationId string,
+	scheduledExecutionID string,
+	w io.Writer,
+) (int, error) {
 	return executor_factory.TransactionReturnValue(ctx, usecase.transactionFactory, func(
 		tx repositories.Executor,
 	) (int, error) {
@@ -67,7 +72,7 @@ func (usecase *ScheduledExecutionUsecase) ExportScheduledExecutionDecisions(ctx 
 			return 0, err
 		}
 
-		return usecase.exportScheduleExecution.ExportDecisions(ctx, execution.Id, w)
+		return usecase.exportScheduleExecution.ExportDecisions(ctx, organizationId, execution.Id, w)
 	})
 }
 


### PR DESCRIPTION
Add a new possibility to filter decisions by pivot_value in the API. Add an index on `decisions(org_id,pivot_value,created_at DESC)`.
Still as discussed here : https://www.notion.so/checkmarble/Defining-a-pivot-67cf95c5a94249fa95ba8c183e54751b.
I propose to wait a bit before we include this in the public API doc, on purpose.

--- 

The last commit is not directly related to this PR's subject, but cleans up indexes on the decisions table:
Before 
```
CREATE INDEX decisions_org_id_idx ON decisions(org_id uuid_ops,created_at DESC);
CREATE INDEX decisions_scheduled_execution_id_idx ON decisions(scheduled_execution_id,created_at DESC);
CREATE INDEX scenario_id_idx ON decisions(org_id,scenario_id,created_at DESC);
CREATE INDEX outcome_idx ON decisions(org_id,outcome,created_at DESC);
CREATE INDEX trigger_object_type_idx ON decisions(org_id,trigger_object_type,created_at DESC);
CREATE INDEX decisions_case_id_idx ON decisions(org_id uuid_ops,case_id);
CREATE INDEX decision_object_id_idx ON decisions(org_id uuid_ops,(trigger_object ->> 'object_id'::text));
CREATE INDEX decisions_pivot_value_index ON decisions(org_id,pivot_value,created_at DESC);
```
After 
```
CREATE INDEX decisions_case_id_idx ON decisions(org_id,case_id);
CREATE INDEX decision_object_id_idx ON decisions(org_id,(trigger_object ->> 'object_id'::text));
CREATE INDEX decisions_pivot_value_index ON decisions(org_id,pivot_value,created_at DESC);
CREATE INDEX decisions_by_org_id_index ON decisions(org_id,created_at DESC) INCLUDE(scenario_id,outcome,trigger_object_type,case_id);
CREATE INDEX decisions_scheduled_execution_id_idx_2 ON decisions(org_id,scheduled_execution_id,created_at DESC);
```

Based on the following guidelines broadly:
- if we want to allow to filter decisions by something very specific (AKA few decisions have this attribute), probably it's worth having its own index (and let the query optimizer do its job): e.g. if we filter by pivot_value, presumably only a handful out of many decisions match a given value, we don't want to do a full index scan. Is the case for:
    - scheduled_execution_id
    - case_id
    - pivot_value
    - trigger_object.object_id
- inversely if it's reasonable to assume that a kinda large % of decisions match a given value, it's reasonable _until performance issues prove otherwise_ to just use one index (on org_id, created_at desc) and include the other tables we want to filter => `CREATE INDEX decisions_by_org_id_index ON decisions(org_id,created_at DESC) INCLUDE(scenario_id,outcome,trigger_object_type,case_id);`