### PR TITLE
fix(dto): handle optionnal path_link_ids

### DIFF
--- a/dto/data_model_pivot.go
+++ b/dto/data_model_pivot.go
@@ -56,10 +56,14 @@ type CreatePivotInput struct {
 }
 
 func AdaptCreatePivotInput(input CreatePivotInput, organizationId string) models.CreatePivotInput {
-	return models.CreatePivotInput{
+	out := models.CreatePivotInput{
 		OrganizationId: organizationId,
 		BaseTableId:    input.BaseTableId,
 		FieldId:        input.FieldId,
-		PathLinkIds:    input.PathLinkIds,
+		PathLinkIds:    make([]string, 0),
 	}
+	if input.PathLinkIds != nil {
+		out.PathLinkIds = input.PathLinkIds
+	}
+	return out
 }

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -423,7 +423,7 @@ func validatePivotCreateInput(input models.CreatePivotInput, dm models.DataModel
 	if hasField == hasPath {
 		return errors.Wrap(
 			models.BadParameterError,
-			"either field or path must be provided",
+			"either field_id or path_link_ids must be provided",
 		)
 	}
 


### PR DESCRIPTION
**The issue :**

When sending this HTTP request, an internal error is raised
```
POST /data-model/pivots

{
    "base_table_id": "476e49fe-8d08-4c35-9dd5-6abd6a028527",
    "field_id": "74114c55-7fb7-43e6-9867-34162b72827a"
}
```

Before the fix, it was required to always send `path_link_ids` in the payload, even for "field" pivot (= no need for links)