### PR TITLE
small fixes for transfercheck

### DIFF
--- a/models/transfer_check.go
+++ b/models/transfer_check.go
@@ -246,7 +246,12 @@ func (t TransferDataCreateBody) FormatAndValidate() (TransferDataCreateBody, err
 		errs["value"] = "value must be positive"
 	}
 
-	return t, errs
+	// FieldValidationError implements the error interface, but I created a non-nil map to fill it
+	// so we only want to return it if any errors were added
+	if len(errs) > 0 {
+		return t, errs
+	}
+	return t, nil
 }
 
 func formatAndValidateBic(bic string) (string, error) {

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -306,7 +306,8 @@ func createQueryAggregated(exec Executor, tableName string,
 		// values of a field, but all rows in the table that match the filters)
 		selectExpression = "COUNT(*)"
 	} else {
-		selectExpression = fmt.Sprintf("%s(%s)", aggregator, fieldName)
+		// pgx will build a math/big.Int if we sum postgresql "bigint" (int64) values - we'd rather have a float64.
+		selectExpression = fmt.Sprintf("%s(%s)::float8", aggregator, fieldName)
 	}
 
 	qualifiedTableName := tableNameWithSchema(exec, tableName)

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -21,13 +21,13 @@ const expectedQueryDbFieldWithJoin string = "SELECT test_schema.third.int_var " 
 	"FROM test_schema.second JOIN test_schema.third ON test_schema.second.id = test_schema.third.id " +
 	"WHERE test_schema.second.id = $1 AND test_schema.second.valid_until = $2 AND test_schema.third.valid_until = $3"
 
-const expectedQueryAggregatedWithoutFilter string = "SELECT AVG(int_var) FROM test_schema.first " +
+const expectedQueryAggregatedWithoutFilter string = "SELECT AVG(int_var)::float8 FROM test_schema.first " +
 	"WHERE test_schema.first.valid_until = $1"
 
 const expectedQueryCountWithoutFilter string = "SELECT COUNT(*) FROM test_schema.first " +
 	"WHERE test_schema.first.valid_until = $1"
 
-const expectedQueryAggregatedWithFilter string = "SELECT AVG(int_var) FROM test_schema.first " +
+const expectedQueryAggregatedWithFilter string = "SELECT AVG(int_var)::float8 FROM test_schema.first " +
 	"WHERE test_schema.first.valid_until = $1 AND test_schema.first.int_var = $2 AND test_schema.first.bool_var <> $3"
 
 type TransactionTest struct{}


### PR DESCRIPTION
- avoid the issue where if the decision fails, we can't post it to transfercheck again
- cast fo float8 in aggregate query to allow aggregates with integers (esp. for pre-aggregated table for transfercheck)
- fix error condition on transfercheck adapter