### PR TITLE
fix: sort columns when reading data model columns, for consistent ingestion queries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   db:
     container_name: postgres
     image: europe-west1-docker.pkg.dev/marble-infra/marble/postgresql-db:latest # custom image of postgres 15 with pg_cron extension added
+    shm_size: 1g
     restart: always
     environment:
       POSTGRES_USER: postgres

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -1,5 +1,7 @@
 package models
 
+import "slices"
+
 // ///////////////////////////////
 // Data Type
 // ///////////////////////////////
@@ -135,6 +137,7 @@ func ColumnNames(table Table) []string {
 		columnNames[i] = fieldName
 		i++
 	}
+	slices.Sort(columnNames)
 	return columnNames
 }
 


### PR DESCRIPTION
Currently we end up with this in the query insights
<img width="2474" alt="Capture d’écran 2024-05-06 à 16 47 58" src="https://github.com/checkmarble/marble-backend/assets/128643171/ec038247-b893-48b2-b9f0-bb5d64ad0800">
we may still have duplicates corresponding to different numbers of rows to ingest, but it should be a lot better