### PR TITLE
tracing: inject dependencies instead of using otel globals

### DIFF
--- a/jobs/scheduler.go
+++ b/jobs/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/adhocore/gronx/pkg/tasker"
+	"github.com/checkmarble/marble-backend/tracing"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 )
@@ -15,7 +16,7 @@ func errToReturnCode(err error) int {
 	return 0
 }
 
-func RunScheduler(ctx context.Context, usecases usecases.Usecases) {
+func RunScheduler(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) {
 	taskr := tasker.New(tasker.Option{
 		Verbose: true,
 		Tz:      "Europe/Paris",
@@ -32,7 +33,7 @@ func RunScheduler(ctx context.Context, usecases usecases.Usecases) {
 	taskr.Task("* * * * *", func(ctx context.Context) (int, error) {
 		logger := utils.LoggerFromContext(ctx).With("job", "execute_all_scheduled_scenarios")
 		ctx = utils.StoreLoggerInContext(ctx, logger)
-		err := ExecuteAllScheduledScenarios(ctx, usecases)
+		err := ExecuteAllScheduledScenarios(ctx, usecases, config)
 		return errToReturnCode(err), err
 	})
 

--- a/router.go
+++ b/router.go
@@ -56,10 +56,14 @@ func initRouter(ctx context.Context, conf AppConfiguration, deps dependencies) *
 	r.Use(sentrygin.New(sentrygin.Options{Repanic: true}))
 	r.Use(cors.New(corsOption(conf)))
 	r.Use(middleware.NewLogging(logger, conf.requestLoggingLevel))
-	r.Use(otelgin.Middleware("marble-backend"))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))
 	r.Use(utils.StoreSegmentClientInContextMiddleware(deps.SegmentClient))
-	r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(deps.OpenTelemetryTracer))
+	r.Use(otelgin.Middleware(
+		conf.appName,
+		otelgin.WithTracerProvider(deps.TelemetryRessources.TracerProvider),
+		otelgin.WithPropagators(deps.TelemetryRessources.TextMapPropagator),
+	))
+	r.Use(utils.StoreOpenTelemetryTracerInContextMiddleware(deps.TelemetryRessources.Tracer))
 
 	return r
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -29,13 +29,17 @@ type TelemetryRessources struct {
 	TextMapPropagator propagation.TextMapPropagator
 }
 
+func NoopTelemetry() TelemetryRessources {
+	return TelemetryRessources{
+		TracerProvider:    noop.NewTracerProvider(),
+		Tracer:            &noop.Tracer{},
+		TextMapPropagator: nil,
+	}
+}
+
 func Init(configuration Configuration) (TelemetryRessources, error) {
 	if !configuration.Enabled {
-		return TelemetryRessources{
-			TracerProvider:    noop.NewTracerProvider(),
-			Tracer:            &noop.Tracer{},
-			TextMapPropagator: nil,
-		}, nil
+		return NoopTelemetry(), nil
 	}
 
 	exporter, err := texporter.New(texporter.WithProjectID(configuration.ProjectID))

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -8,6 +8,7 @@ import (
 	gcppropagator "github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator"
 
 	"go.opentelemetry.io/contrib/detectors/gcp"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -57,6 +58,14 @@ func Init(configuration Configuration) (TelemetryRessources, error) {
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
 	)
+	otel.SetTextMapPropagator(
+		propagation.NewCompositeTextMapPropagator(
+			gcppropagator.CloudTraceFormatPropagator{},
+			propagation.TraceContext{},
+			propagation.Baggage{},
+		),
+	)
+	otel.SetTracerProvider(tp)
 
 	tracer := tp.Tracer(configuration.ApplicationName)
 	return TelemetryRessources{


### PR DESCRIPTION
This PR adds tracing to scenario execution done in batch (rather than on API requests).
I had to reshuffle how we setup the tracer a bit, though some more work remains for another day (see comment below). 
Let's put this in staging and see how it behaves.