### PR TITLE
API interface to edit scenario workflow

### DIFF
--- a/dto/scenarios.go
+++ b/dto/scenarios.go
@@ -10,21 +10,23 @@ import (
 
 // Read DTO
 type ScenarioDto struct {
-	Id                     string    `json:"id"`
-	CreatedAt              time.Time `json:"createdAt"`
-	DecisionToCaseOutcomes []string  `json:"decision_to_case_outcomes"`
-	DecisionToCaseInboxId  string    `json:"decision_to_case_inbox_id"`
-	Description            string    `json:"description"`
-	LiveVersionID          *string   `json:"liveVersionId,omitempty"`
-	Name                   string    `json:"name"`
-	OrganizationId         string    `json:"organization_id"`
-	TriggerObjectType      string    `json:"triggerObjectType"`
+	Id                         string      `json:"id"`
+	CreatedAt                  time.Time   `json:"createdAt"`
+	DecisionToCaseOutcomes     []string    `json:"decision_to_case_outcomes"`
+	DecisionToCaseInboxId      null.String `json:"decision_to_case_inbox_id"`
+	DecisionToCaseWorkflowType null.String `json:"decision_to_case_workflow_type"`
+	Description                string      `json:"description"`
+	LiveVersionID              *string     `json:"liveVersionId,omitempty"`
+	Name                       string      `json:"name"`
+	OrganizationId             string      `json:"organization_id"`
+	TriggerObjectType          string      `json:"triggerObjectType"`
 }
 
 func AdaptScenarioDto(scenario models.Scenario) ScenarioDto {
 	out := ScenarioDto{
-		Id:        scenario.Id,
-		CreatedAt: scenario.CreatedAt,
+		Id:                    scenario.Id,
+		CreatedAt:             scenario.CreatedAt,
+		DecisionToCaseInboxId: null.StringFromPtr(scenario.DecisionToCaseInboxId),
 		DecisionToCaseOutcomes: pure_utils.Map(scenario.DecisionToCaseOutcomes,
 			func(o models.Outcome) string { return o.String() }),
 		Description:       scenario.Description,
@@ -33,9 +35,11 @@ func AdaptScenarioDto(scenario models.Scenario) ScenarioDto {
 		OrganizationId:    scenario.OrganizationId,
 		TriggerObjectType: scenario.TriggerObjectType,
 	}
-	if scenario.DecisionToCaseInboxId != nil {
-		out.DecisionToCaseInboxId = *scenario.DecisionToCaseInboxId
+	if scenario.DecisionToCaseWorkflowType != nil {
+		out.DecisionToCaseWorkflowType = null.StringFrom(
+			string(*scenario.DecisionToCaseWorkflowType))
 	}
+
 	return out
 }
 
@@ -56,10 +60,11 @@ func AdaptCreateScenarioInput(input CreateScenarioBody) models.CreateScenarioInp
 
 // Update scenario DTO
 type UpdateScenarioBody struct {
-	DecisionToCaseOutcomes []string    `json:"decision_to_case_outcomes"`
-	DecisionToCaseInboxId  null.String `json:"decision_to_case_inbox_id"`
-	Description            *string     `json:"description"`
-	Name                   *string     `json:"name"`
+	DecisionToCaseOutcomes     []string    `json:"decision_to_case_outcomes"`
+	DecisionToCaseInboxId      null.String `json:"decision_to_case_inbox_id"`
+	DecisionToCaseWorkflowType *string     `json:"decision_to_case_workflow_type"`
+	Description                *string     `json:"description"`
+	Name                       *string     `json:"name"`
 }
 
 func AdaptUpdateScenarioInput(scenarioId string, input UpdateScenarioBody) models.UpdateScenarioInput {
@@ -71,6 +76,10 @@ func AdaptUpdateScenarioInput(scenarioId string, input UpdateScenarioBody) model
 	}
 	if input.DecisionToCaseOutcomes != nil {
 		parsedInput.DecisionToCaseOutcomes = pure_utils.Map(input.DecisionToCaseOutcomes, models.OutcomeFrom)
+	}
+	if input.DecisionToCaseWorkflowType != nil {
+		val := models.WorkflowType(*input.DecisionToCaseWorkflowType)
+		parsedInput.DecisionToCaseWorkflowType = &val
 	}
 	return parsedInput
 }

--- a/dto/scenarios.go
+++ b/dto/scenarios.go
@@ -14,7 +14,7 @@ type ScenarioDto struct {
 	CreatedAt                  time.Time   `json:"createdAt"`
 	DecisionToCaseOutcomes     []string    `json:"decision_to_case_outcomes"`
 	DecisionToCaseInboxId      null.String `json:"decision_to_case_inbox_id"`
-	DecisionToCaseWorkflowType null.String `json:"decision_to_case_workflow_type"`
+	DecisionToCaseWorkflowType string      `json:"decision_to_case_workflow_type"`
 	Description                string      `json:"description"`
 	LiveVersionID              *string     `json:"liveVersionId,omitempty"`
 	Name                       string      `json:"name"`
@@ -23,24 +23,19 @@ type ScenarioDto struct {
 }
 
 func AdaptScenarioDto(scenario models.Scenario) ScenarioDto {
-	out := ScenarioDto{
+	return ScenarioDto{
 		Id:                    scenario.Id,
 		CreatedAt:             scenario.CreatedAt,
 		DecisionToCaseInboxId: null.StringFromPtr(scenario.DecisionToCaseInboxId),
 		DecisionToCaseOutcomes: pure_utils.Map(scenario.DecisionToCaseOutcomes,
 			func(o models.Outcome) string { return o.String() }),
-		Description:       scenario.Description,
-		LiveVersionID:     scenario.LiveVersionID,
-		Name:              scenario.Name,
-		OrganizationId:    scenario.OrganizationId,
-		TriggerObjectType: scenario.TriggerObjectType,
+		DecisionToCaseWorkflowType: string(scenario.DecisionToCaseWorkflowType),
+		Description:                scenario.Description,
+		LiveVersionID:              scenario.LiveVersionID,
+		Name:                       scenario.Name,
+		OrganizationId:             scenario.OrganizationId,
+		TriggerObjectType:          scenario.TriggerObjectType,
 	}
-	if scenario.DecisionToCaseWorkflowType != nil {
-		out.DecisionToCaseWorkflowType = null.StringFrom(
-			string(*scenario.DecisionToCaseWorkflowType))
-	}
-
-	return out
 }
 
 // Create scenario DTO

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -9,11 +9,13 @@ import (
 type WorkflowType string
 
 const (
+	WorkflowDisabled            WorkflowType = "DISABLED"
 	WorkflowCreateCase          WorkflowType = "CREATE_CASE"
 	WorkflowAddToCaseIfPossible WorkflowType = "ADD_TO_CASE_IF_POSSIBLE"
 )
 
 var ValidWorkflowTypes = []WorkflowType{
+	WorkflowDisabled,
 	WorkflowCreateCase,
 	WorkflowAddToCaseIfPossible,
 }
@@ -23,7 +25,7 @@ type Scenario struct {
 	CreatedAt                  time.Time
 	DecisionToCaseOutcomes     []Outcome
 	DecisionToCaseInboxId      *string
-	DecisionToCaseWorkflowType *WorkflowType
+	DecisionToCaseWorkflowType WorkflowType
 	Description                string
 	LiveVersionID              *string
 	Name                       string

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -6,16 +6,29 @@ import (
 	"github.com/guregu/null/v5"
 )
 
+type WorkflowType string
+
+const (
+	WorkflowCreateCase          WorkflowType = "CREATE_CASE"
+	WorkflowAddToCaseIfPossible WorkflowType = "ADD_TO_CASE_IF_POSSIBLE"
+)
+
+var ValidWorkflowTypes = []WorkflowType{
+	WorkflowCreateCase,
+	WorkflowAddToCaseIfPossible,
+}
+
 type Scenario struct {
-	Id                     string
-	CreatedAt              time.Time
-	DecisionToCaseOutcomes []Outcome
-	DecisionToCaseInboxId  *string
-	Description            string
-	LiveVersionID          *string
-	Name                   string
-	OrganizationId         string
-	TriggerObjectType      string
+	Id                         string
+	CreatedAt                  time.Time
+	DecisionToCaseOutcomes     []Outcome
+	DecisionToCaseInboxId      *string
+	DecisionToCaseWorkflowType *WorkflowType
+	Description                string
+	LiveVersionID              *string
+	Name                       string
+	OrganizationId             string
+	TriggerObjectType          string
 }
 
 type CreateScenarioInput struct {
@@ -25,11 +38,12 @@ type CreateScenarioInput struct {
 }
 
 type UpdateScenarioInput struct {
-	Id                     string
-	DecisionToCaseOutcomes []Outcome
-	DecisionToCaseInboxId  null.String
-	Description            *string
-	Name                   *string
+	Id                         string
+	DecisionToCaseOutcomes     []Outcome
+	DecisionToCaseInboxId      null.String
+	DecisionToCaseWorkflowType *WorkflowType
+	Description                *string
+	Name                       *string
 }
 
 type ListAllScenariosFilters struct {

--- a/repositories/dbmodels/db_scenario.go
+++ b/repositories/dbmodels/db_scenario.go
@@ -15,7 +15,7 @@ type DBScenario struct {
 	CreatedAt                  time.Time   `db:"created_at"`
 	DecisionToCaseInboxId      pgtype.Text `db:"decision_to_case_inbox_id"`
 	DecisionToCaseOutcomes     []string    `db:"decision_to_case_outcomes"`
-	DecisionToCaseWorkflowType pgtype.Text `db:"decision_to_case_workflow_type"`
+	DecisionToCaseWorkflowType string      `db:"decision_to_case_workflow_type"`
 	DeletedAt                  pgtype.Time `db:"deleted_at"`
 	Description                string      `db:"description"`
 	LiveVersionID              pgtype.Text `db:"live_scenario_iteration_id"`
@@ -34,17 +34,14 @@ func AdaptScenario(dto DBScenario) (models.Scenario, error) {
 		CreatedAt: dto.CreatedAt,
 		DecisionToCaseOutcomes: pure_utils.Map(dto.DecisionToCaseOutcomes,
 			func(s string) models.Outcome { return models.OutcomeFrom(s) }),
-		Description:       dto.Description,
-		Name:              dto.Name,
-		OrganizationId:    dto.OrganizationId,
-		TriggerObjectType: dto.TriggerObjectType,
+		DecisionToCaseWorkflowType: models.WorkflowType(dto.DecisionToCaseWorkflowType),
+		Description:                dto.Description,
+		Name:                       dto.Name,
+		OrganizationId:             dto.OrganizationId,
+		TriggerObjectType:          dto.TriggerObjectType,
 	}
 	if dto.DecisionToCaseInboxId.Valid {
 		scenario.DecisionToCaseInboxId = &dto.DecisionToCaseInboxId.String
-	}
-	if dto.DecisionToCaseWorkflowType.Valid {
-		val := models.WorkflowType(dto.DecisionToCaseWorkflowType.String)
-		scenario.DecisionToCaseWorkflowType = &val
 	}
 	if dto.LiveVersionID.Valid {
 		scenario.LiveVersionID = &dto.LiveVersionID.String

--- a/repositories/dbmodels/db_scenario.go
+++ b/repositories/dbmodels/db_scenario.go
@@ -11,16 +11,17 @@ import (
 )
 
 type DBScenario struct {
-	Id                     string      `db:"id"`
-	CreatedAt              time.Time   `db:"created_at"`
-	DecisionToCaseInboxId  pgtype.Text `db:"decision_to_case_inbox_id"`
-	DecisionToCaseOutcomes []string    `db:"decision_to_case_outcomes"`
-	DeletedAt              pgtype.Time `db:"deleted_at"`
-	Description            string      `db:"description"`
-	LiveVersionID          pgtype.Text `db:"live_scenario_iteration_id"`
-	Name                   string      `db:"name"`
-	OrganizationId         string      `db:"org_id"`
-	TriggerObjectType      string      `db:"trigger_object_type"`
+	Id                         string      `db:"id"`
+	CreatedAt                  time.Time   `db:"created_at"`
+	DecisionToCaseInboxId      pgtype.Text `db:"decision_to_case_inbox_id"`
+	DecisionToCaseOutcomes     []string    `db:"decision_to_case_outcomes"`
+	DecisionToCaseWorkflowType pgtype.Text `db:"decision_to_case_workflow_type"`
+	DeletedAt                  pgtype.Time `db:"deleted_at"`
+	Description                string      `db:"description"`
+	LiveVersionID              pgtype.Text `db:"live_scenario_iteration_id"`
+	Name                       string      `db:"name"`
+	OrganizationId             string      `db:"org_id"`
+	TriggerObjectType          string      `db:"trigger_object_type"`
 }
 
 const TABLE_SCENARIOS = "scenarios"
@@ -40,6 +41,10 @@ func AdaptScenario(dto DBScenario) (models.Scenario, error) {
 	}
 	if dto.DecisionToCaseInboxId.Valid {
 		scenario.DecisionToCaseInboxId = &dto.DecisionToCaseInboxId.String
+	}
+	if dto.DecisionToCaseWorkflowType.Valid {
+		val := models.WorkflowType(dto.DecisionToCaseWorkflowType.String)
+		scenario.DecisionToCaseWorkflowType = &val
 	}
 	if dto.LiveVersionID.Valid {
 		scenario.LiveVersionID = &dto.LiveVersionID.String

--- a/repositories/migrations/20240507140800_scenario_workflow_type.sql
+++ b/repositories/migrations/20240507140800_scenario_workflow_type.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scenarios
+ADD COLUMN decision_to_case_workflow_type VARCHAR(255);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE scenarios
+DROP COLUMN decision_to_case_workflow_type;
+
+-- +goose StatementEnd

--- a/repositories/migrations/20240507140800_scenario_workflow_type.sql
+++ b/repositories/migrations/20240507140800_scenario_workflow_type.sql
@@ -1,7 +1,13 @@
 -- +goose Up
 -- +goose StatementBegin
 ALTER TABLE scenarios
-ADD COLUMN decision_to_case_workflow_type VARCHAR(255);
+ADD COLUMN decision_to_case_workflow_type VARCHAR(255) NOT NULL DEFAULT 'DISABLED';
+
+UPDATE scenarios
+SET
+      decision_to_case_workflow_type = 'CREATE_CASE'
+WHERE
+      decision_to_case_inbox_id IS NOT NULL;
 
 -- +goose StatementEnd
 -- +goose Down

--- a/repositories/scenarios_write.go
+++ b/repositories/scenarios_write.go
@@ -62,6 +62,10 @@ func (repo *MarbleDbRepository) UpdateScenario(ctx context.Context, exec Executo
 		sql = sql.Set("decision_to_case_outcomes", scenario.DecisionToCaseOutcomes)
 		countApply++
 	}
+	if scenario.DecisionToCaseWorkflowType != nil {
+		sql = sql.Set("decision_to_case_workflow_type", scenario.DecisionToCaseWorkflowType)
+		countApply++
+	}
 	if scenario.Description != nil {
 		sql = sql.Set("description", scenario.Description)
 		countApply++

--- a/usecases/scenario_usecase_test.go
+++ b/usecases/scenario_usecase_test.go
@@ -39,8 +39,9 @@ func (suite *ScenarioUsecaseTestSuite) SetupTest() {
 	suite.organizationId = "25ab6323-1657-4a52-923a-ef6983fe4532"
 	suite.scenarioId = "c5968ff7-6142-4623-a6b3-1539f345e5fa"
 	suite.scenario = models.Scenario{
-		Id:             suite.scenarioId,
-		OrganizationId: suite.organizationId,
+		Id:                         suite.scenarioId,
+		OrganizationId:             suite.organizationId,
+		DecisionToCaseWorkflowType: models.WorkflowDisabled,
 	}
 	suite.ctx = context.Background()
 }


### PR DESCRIPTION
- new field `decision_to_case_workflow_type`, not nullable, `"DISABLED"` by default
- can be set to `"CREATE_CASE"` or `"ADD_TO_CASE_IF_POSSIBLE"` to activate the workflows. Doing so requires `decision_to_case_inbox_id` and `decision_to_case_outcomes` to be non null (and non empty in the case of `decision_to_case_outcomes`)