### PR TITLE
try to silence sentry errors when cloud run fails to create unix socket

### DIFF
--- a/jobs/execute_all_scheduled_scenarios.go
+++ b/jobs/execute_all_scheduled_scenarios.go
@@ -2,69 +2,24 @@ package jobs
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/checkmarble/marble-backend/tracing"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/utils"
-	"github.com/getsentry/sentry-go"
 )
 
 // Runs every minute
-func ExecuteAllScheduledScenarios(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) error {
-	telemetryRessources, err := tracing.Init(config)
-	if err != nil {
-		return fmt.Errorf("error initializing tracing: %w", err)
-	}
-	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
-
-	logger := utils.LoggerFromContext(ctx)
-	logger.InfoContext(ctx, "Start pending scheduled executions")
-
-	checkinId := sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			MonitorSlug: "scheduled-execution",
-			Status:      sentry.CheckInStatusInProgress,
+func ExecuteAllScheduledScenarios(ctx context.Context, uc usecases.Usecases, config tracing.Configuration) error {
+	return executeWithMonitoring(
+		ctx,
+		uc,
+		config,
+		"scheduled-execution",
+		func(
+			ctx context.Context, usecases usecases.Usecases,
+		) error {
+			usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
+			runScheduledExecution := usecasesWithCreds.NewRunScheduledExecution()
+			return runScheduledExecution.ExecuteAllScheduledScenarios(ctx)
 		},
-		nil,
 	)
-	fmt.Println("checkinId: ", *checkinId)
-
-	usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
-	runScheduledExecution := usecasesWithCreds.NewRunScheduledExecution()
-	err = runScheduledExecution.ExecuteAllScheduledScenarios(ctx)
-	if err != nil {
-		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
-		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
-			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
-			return nil
-		}
-		sentry.CaptureCheckIn(
-			&sentry.CheckIn{
-				ID:          *checkinId,
-				MonitorSlug: "scheduled-execution",
-				Status:      sentry.CheckInStatusError,
-			},
-			nil,
-		)
-		if hub := sentry.GetHubFromContext(ctx); hub != nil {
-			hub.CaptureException(err)
-		} else {
-			sentry.CaptureException(err)
-		}
-		return fmt.Errorf("error executing scheduled scenarios: %w", err)
-	}
-
-	sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			ID:          *checkinId,
-			MonitorSlug: "scheduled-execution",
-			Status:      sentry.CheckInStatusOK,
-		},
-		nil,
-	)
-
-	logger.InfoContext(ctx, "Done executing all due scenarios")
-	return nil
 }

--- a/jobs/execute_with_monitoring.go
+++ b/jobs/execute_with_monitoring.go
@@ -1,0 +1,72 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/checkmarble/marble-backend/tracing"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/getsentry/sentry-go"
+)
+
+func executeWithMonitoring(
+	ctx context.Context,
+	uc usecases.Usecases,
+	config tracing.Configuration,
+	jobName string,
+	fn func(context.Context, usecases.Usecases) error,
+) error {
+	telemetryRessources, err := tracing.Init(config)
+	if err != nil {
+		return fmt.Errorf("error initializing tracing: %w", err)
+	}
+	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
+
+	logger := utils.LoggerFromContext(ctx)
+	logger.InfoContext(ctx, fmt.Sprintf("Start job %s", jobName))
+
+	checkinId := sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			MonitorSlug: jobName,
+			Status:      sentry.CheckInStatusInProgress,
+		},
+		nil,
+	)
+
+	err = fn(ctx, uc)
+	if err != nil {
+		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
+		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
+			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
+			return nil
+		}
+		sentry.CaptureCheckIn(
+			&sentry.CheckIn{
+				ID:          *checkinId,
+				MonitorSlug: jobName,
+				Status:      sentry.CheckInStatusError,
+			},
+			nil,
+		)
+		if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			hub.CaptureException(err)
+		} else {
+			sentry.CaptureException(err)
+		}
+		return fmt.Errorf("error executing job %s: %w", jobName, err)
+	}
+
+	sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			ID:          *checkinId,
+			MonitorSlug: jobName,
+			Status:      sentry.CheckInStatusOK,
+		},
+		nil,
+	)
+
+	logger.InfoContext(ctx, fmt.Sprintf("Done executing job %s", jobName))
+	return nil
+}

--- a/jobs/ingest_data_from_csv.go
+++ b/jobs/ingest_data_from_csv.go
@@ -2,66 +2,26 @@ package jobs
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/checkmarble/marble-backend/tracing"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
-	"github.com/getsentry/sentry-go"
 )
 
-func IngestDataFromCsv(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) error {
-	telemetryRessources, err := tracing.Init(config)
-	if err != nil {
-		return fmt.Errorf("error initializing tracing: %w", err)
-	}
-	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
-
-	checkinId := sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			MonitorSlug: "batch-ingestion",
-			Status:      sentry.CheckInStatusInProgress,
+func IngestDataFromCsv(ctx context.Context, uc usecases.Usecases, config tracing.Configuration) error {
+	return executeWithMonitoring(
+		ctx,
+		uc,
+		config,
+		"batch-ingestion",
+		func(
+			ctx context.Context, usecases usecases.Usecases,
+		) error {
+			usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
+			usecase := usecasesWithCreds.NewIngestionUseCase()
+			logger := utils.LoggerFromContext(ctx)
+			logger.InfoContext(ctx, "Start ingesting data from upload logs")
+			return usecase.IngestDataFromCsv(ctx, logger)
 		},
-		nil,
 	)
-
-	usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
-	usecase := usecasesWithCreds.NewIngestionUseCase()
-	logger := utils.LoggerFromContext(ctx)
-	logger.InfoContext(ctx, "Start ingesting data from upload logs")
-
-	err = usecase.IngestDataFromCsv(ctx, logger)
-	if err != nil {
-		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
-		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
-			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
-			return nil
-		}
-		sentry.CaptureCheckIn(
-			&sentry.CheckIn{
-				ID:          *checkinId,
-				MonitorSlug: "batch-ingestion",
-				Status:      sentry.CheckInStatusError,
-			},
-			nil,
-		)
-		if hub := sentry.GetHubFromContext(ctx); hub != nil {
-			hub.CaptureException(err)
-		} else {
-			sentry.CaptureException(err)
-		}
-		return fmt.Errorf("failed to ingest data from upload logs: %w", err)
-	}
-	logger.InfoContext(ctx, "Completed ingesting data from upload logs")
-	sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			ID:          *checkinId,
-			MonitorSlug: "batch-ingestion",
-			Status:      sentry.CheckInStatusOK,
-		},
-		nil,
-	)
-
-	return nil
 }

--- a/jobs/ingest_data_from_csv.go
+++ b/jobs/ingest_data_from_csv.go
@@ -3,21 +3,65 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/checkmarble/marble-backend/tracing"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/getsentry/sentry-go"
 )
 
-func IngestDataFromCsv(ctx context.Context, usecases usecases.Usecases) error {
+func IngestDataFromCsv(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) error {
+	telemetryRessources, err := tracing.Init(config)
+	if err != nil {
+		return fmt.Errorf("error initializing tracing: %w", err)
+	}
+	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
+
+	checkinId := sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			MonitorSlug: "batch-ingestion",
+			Status:      sentry.CheckInStatusInProgress,
+		},
+		nil,
+	)
+
 	usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
 	usecase := usecasesWithCreds.NewIngestionUseCase()
 	logger := utils.LoggerFromContext(ctx)
 	logger.InfoContext(ctx, "Start ingesting data from upload logs")
 
-	err := usecase.IngestDataFromCsv(ctx, logger)
+	err = usecase.IngestDataFromCsv(ctx, logger)
 	if err != nil {
+		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
+		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
+			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
+			return nil
+		}
+		sentry.CaptureCheckIn(
+			&sentry.CheckIn{
+				ID:          *checkinId,
+				MonitorSlug: "batch-ingestion",
+				Status:      sentry.CheckInStatusError,
+			},
+			nil,
+		)
+		if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			hub.CaptureException(err)
+		} else {
+			sentry.CaptureException(err)
+		}
 		return fmt.Errorf("failed to ingest data from upload logs: %w", err)
 	}
 	logger.InfoContext(ctx, "Completed ingesting data from upload logs")
+	sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			ID:          *checkinId,
+			MonitorSlug: "batch-ingestion",
+			Status:      sentry.CheckInStatusOK,
+		},
+		nil,
+	)
+
 	return nil
 }

--- a/jobs/schedule_due_scenarios.go
+++ b/jobs/schedule_due_scenarios.go
@@ -4,20 +4,72 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/cockroachdb/errors"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/tracing"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 )
 
 // Runs every hour at past 10min
-func ScheduleDueScenarios(ctx context.Context, usecases usecases.Usecases) error {
+func ScheduleDueScenarios(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) error {
 	logger := utils.LoggerFromContext(ctx)
+	telemetryRessources, err := tracing.Init(config)
+	if err != nil {
+		return fmt.Errorf("error initializing tracing: %w", err)
+	}
+	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
+
+	checkinId := sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			MonitorSlug: "scenario-scheduler",
+			Status:      sentry.CheckInStatusInProgress,
+		},
+		nil,
+	)
 
 	logger.InfoContext(ctx, "Start scheduling scenarios")
 
+	err = scheduledScenarios(ctx, usecases)
+	if err != nil {
+		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
+		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
+			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
+			return nil
+		}
+		sentry.CaptureCheckIn(
+			&sentry.CheckIn{
+				ID:          *checkinId,
+				MonitorSlug: "scenario-scheduler",
+				Status:      sentry.CheckInStatusError,
+			},
+			nil,
+		)
+		if hub := sentry.GetHubFromContext(ctx); hub != nil {
+			hub.CaptureException(err)
+		} else {
+			sentry.CaptureException(err)
+		}
+		return fmt.Errorf("failed to schedule due scenarios: %w", err)
+	}
+
+	sentry.CaptureCheckIn(
+		&sentry.CheckIn{
+			ID:          *checkinId,
+			MonitorSlug: "scenario-scheduler",
+			Status:      sentry.CheckInStatusOK,
+		},
+		nil,
+	)
+	return nil
+}
+
+func scheduledScenarios(ctx context.Context, usecases usecases.Usecases) error {
+	logger := utils.LoggerFromContext(ctx)
 	scenarios, err := usecases.Repositories.MarbleDbRepository.ListAllScenarios(
 		ctx,
 		usecases.NewExecutorFactory().NewExecutor(),
@@ -31,17 +83,13 @@ func ScheduleDueScenarios(ctx context.Context, usecases usecases.Usecases) error
 	runScheduledExecution := usecasesWithCreds.NewRunScheduledExecution()
 
 	for _, scenario := range scenarios {
-		logger.DebugContext(ctx, "executing scenario",
+		logger.DebugContext(ctx, "Scheduled scenario scenario",
 			slog.String("scenario", scenario.Id),
 			slog.String("organization", scenario.OrganizationId),
 		)
 		err := runScheduledExecution.ScheduleScenarioIfDue(ctx, scenario.OrganizationId, scenario.Id)
 		if err != nil {
-			logger.ErrorContext(ctx, "error scheduling scenario",
-				slog.String("scenario", scenario.Id),
-				slog.String("organization", scenario.OrganizationId),
-			)
-			logger.ErrorContext(ctx, fmt.Sprintf("error scheduling scenario: %+v", err))
+			return err
 		}
 	}
 	logger.InfoContext(ctx, "Done scheduling all due scenarios")

--- a/jobs/schedule_due_scenarios.go
+++ b/jobs/schedule_due_scenarios.go
@@ -2,12 +2,9 @@ package jobs
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/cockroachdb/errors"
-	"github.com/getsentry/sentry-go"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/tracing"
@@ -16,56 +13,18 @@ import (
 )
 
 // Runs every hour at past 10min
-func ScheduleDueScenarios(ctx context.Context, usecases usecases.Usecases, config tracing.Configuration) error {
-	logger := utils.LoggerFromContext(ctx)
-	telemetryRessources, err := tracing.Init(config)
-	if err != nil {
-		return fmt.Errorf("error initializing tracing: %w", err)
-	}
-	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
-
-	checkinId := sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			MonitorSlug: "scenario-scheduler",
-			Status:      sentry.CheckInStatusInProgress,
+func ScheduleDueScenarios(ctx context.Context, uc usecases.Usecases, config tracing.Configuration) error {
+	return executeWithMonitoring(
+		ctx,
+		uc,
+		config,
+		"scenario-scheduler",
+		func(
+			ctx context.Context, usecases usecases.Usecases,
+		) error {
+			return scheduledScenarios(ctx, usecases)
 		},
-		nil,
 	)
-
-	logger.InfoContext(ctx, "Start scheduling scenarios")
-
-	err = scheduledScenarios(ctx, usecases)
-	if err != nil {
-		// Known issue where Cloud Run will sometimes fail to create the unix socket to connect to CloudSQL. In this case, we don't log the error in Sentry.
-		if strings.Contains(err.Error(), "failed to connect to `host=/cloudsql/") {
-			logger.WarnContext(ctx, "Failed to create unix socket to connect to CloudSQL. Wait for the next execution of the job.")
-			return nil
-		}
-		sentry.CaptureCheckIn(
-			&sentry.CheckIn{
-				ID:          *checkinId,
-				MonitorSlug: "scenario-scheduler",
-				Status:      sentry.CheckInStatusError,
-			},
-			nil,
-		)
-		if hub := sentry.GetHubFromContext(ctx); hub != nil {
-			hub.CaptureException(err)
-		} else {
-			sentry.CaptureException(err)
-		}
-		return fmt.Errorf("failed to schedule due scenarios: %w", err)
-	}
-
-	sentry.CaptureCheckIn(
-		&sentry.CheckIn{
-			ID:          *checkinId,
-			MonitorSlug: "scenario-scheduler",
-			Status:      sentry.CheckInStatusOK,
-		},
-		nil,
-	)
-	return nil
 }
 
 func scheduledScenarios(ctx context.Context, usecases usecases.Usecases) error {
@@ -83,7 +42,7 @@ func scheduledScenarios(ctx context.Context, usecases usecases.Usecases) error {
 	runScheduledExecution := usecasesWithCreds.NewRunScheduledExecution()
 
 	for _, scenario := range scenarios {
-		logger.DebugContext(ctx, "Scheduled scenario scenario",
+		logger.DebugContext(ctx, "Scheduled scenario",
 			slog.String("scenario", scenario.Id),
 			slog.String("organization", scenario.OrganizationId),
 		)

--- a/jobs/scheduler.go
+++ b/jobs/scheduler.go
@@ -26,7 +26,7 @@ func RunScheduler(ctx context.Context, usecases usecases.Usecases, config tracin
 	taskr.Task("* * * * *", func(ctx context.Context) (int, error) {
 		logger := utils.LoggerFromContext(ctx).With("job", "schedule_due_scenarios")
 		ctx = utils.StoreLoggerInContext(ctx, logger)
-		err := ScheduleDueScenarios(ctx, usecases)
+		err := ScheduleDueScenarios(ctx, usecases, config)
 		return errToReturnCode(err), err
 	}, notConcurrent)
 
@@ -40,7 +40,7 @@ func RunScheduler(ctx context.Context, usecases usecases.Usecases, config tracin
 	taskr.Task("* * * * *", func(ctx context.Context) (int, error) {
 		logger := utils.LoggerFromContext(ctx).With("job", "ingest_data_from_csv")
 		ctx = utils.StoreLoggerInContext(ctx, logger)
-		err := IngestDataFromCsv(ctx, usecases)
+		err := IngestDataFromCsv(ctx, usecases, config)
 		return errToReturnCode(err), err
 	})
 

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func main() {
 
 	if *shouldRunScheduleScenarios {
 		usecases := NewUseCases(appContext, appConfig, nil)
-		err := jobs.ScheduleDueScenarios(appContext, usecases)
+		err := jobs.ScheduleDueScenarios(appContext, usecases, tracingConfig)
 		if err != nil {
 			logger.ErrorContext(appContext, "jobs.ScheduleDueScenarios failed", slog.String("error", err.Error()))
 			os.Exit(1)
@@ -251,7 +251,7 @@ func main() {
 
 	if *shouldRunDataIngestion {
 		usecases := NewUseCases(appContext, appConfig, nil)
-		err := jobs.IngestDataFromCsv(appContext, usecases)
+		err := jobs.IngestDataFromCsv(appContext, usecases, tracingConfig)
 		if err != nil {
 			logger.ErrorContext(appContext, "jobs.IngestDataFromCsv failed", slog.String("error", err.Error()))
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func main() {
 		usecases := NewUseCases(appContext, appConfig, nil)
 		err := jobs.ScheduleDueScenarios(appContext, usecases)
 		if err != nil {
-			slog.Error("jobs.ScheduleDueScenarios failed", slog.String("error", err.Error()))
+			logger.ErrorContext(appContext, "jobs.ScheduleDueScenarios failed", slog.String("error", err.Error()))
 			os.Exit(1)
 			return
 		}
@@ -243,7 +243,7 @@ func main() {
 		usecases := NewUseCases(appContext, appConfig, nil)
 		err := jobs.ExecuteAllScheduledScenarios(appContext, usecases, tracingConfig)
 		if err != nil {
-			slog.Error("jobs.ExecuteAllScheduledScenarios failed", slog.String("error", err.Error()))
+			logger.ErrorContext(appContext, "jobs.ExecuteAllScheduledScenarios failed", slog.String("error", err.Error()))
 			os.Exit(1)
 			return
 		}
@@ -253,7 +253,7 @@ func main() {
 		usecases := NewUseCases(appContext, appConfig, nil)
 		err := jobs.IngestDataFromCsv(appContext, usecases)
 		if err != nil {
-			slog.Error("jobs.IngestDataFromCsv failed", slog.String("error", err.Error()))
+			logger.ErrorContext(appContext, "jobs.IngestDataFromCsv failed", slog.String("error", err.Error()))
 			os.Exit(1)
 			return
 		}


### PR DESCRIPTION
I spent some time trying to find exactly what kind of error this should be. After failing, I went for stupid string matching 🤷 

Edit 24/05: Ok while I was at it I also took the opportunity to add sentry monitoring and tracing to the other jobs, with a helper function to avoid repeating all the code