### PR TITLE
fix: conflict on case contributors insert should not return an error

### DIFF
--- a/repositories/case_contributor_repository.go
+++ b/repositories/case_contributor_repository.go
@@ -39,7 +39,7 @@ func (repo *MarbleDbRepository) CreateCaseContributor(ctx context.Context, exec 
 		Values(
 			caseId,
 			userId,
-		)
+		).Suffix("ON CONFLICT DO NOTHING")
 
 	err := ExecBuilder(ctx, exec, query)
 


### PR DESCRIPTION
This should be sufficient for now.
The implementation is not perfect because it could result in a state where one of the concurrent transactions (the one that had the conflict) commits, the other one (without the conflict) does not, and we are left without the case contributor inserted.
But I think the completeness of case contributors is not the highest level of criticity and it's still really unlikely to happen anyway, so let's go with this for now.

Cf Bard's explanation below (trying to confuse me FFS)
<img width="736" alt="Capture d’écran 2024-06-05 à 09 38 15" src="https://github.com/checkmarble/marble-backend/assets/128643171/0334d499-ed1b-436a-aecd-2bb2c64da418">
