### PR TITLE
WIP: implement data enrichment for ip addresses on transfercheck

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,7 @@ LOGGING_FORMAT=text
 # configure the document storage backend with optional fake backends
 GCS_INGESTION_BUCKET="data-ingestion-bucket"
 GCS_CASE_MANAGER_BUCKET="case-manager-bucket"
+GCS_TRANSFER_CHECK_ENRICHMENT_BUCKET="transfercheck-bucket"
 FAKE_GCS=true
 
 # Configure the AWS S3 backend for sending decision files

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,7 +7,6 @@
             "GOFUMPT_SPLIT_LONG_LINES": "on"
       },
       "search.exclude": {
-            "go.mod": true,
             "go.sum": true,
             "tempFiles/*": true,
             "**/*.ndjson": true,

--- a/dto/transfer_check.go
+++ b/dto/transfer_check.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"net/netip"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -24,22 +25,22 @@ func AdaptTransferCheckResultDto(result models.Transfer) Transfer {
 }
 
 type TransferData struct {
-	BeneficiaryBic      string    `json:"beneficiary_bic"`
-	BeneficiaryIban     string    `json:"beneficiary_iban"`
-	BeneficiaryName     string    `json:"beneficiary_name"`
-	CreatedAt           time.Time `json:"created_at"`
-	Currency            string    `json:"currency"`
-	Label               string    `json:"label"`
-	SenderAccountId     string    `json:"sender_account_id"`
-	SenderBic           string    `json:"sender_bic"`
-	SenderDevice        string    `json:"sender_device"`
-	SenderIP            string    `json:"sender_ip"`
-	Status              string    `json:"status"`
-	Timezone            string    `json:"timezone"`
-	TransferId          string    `json:"transfer_id"`
-	TransferRequestedAt time.Time `json:"transfer_requested_at"`
-	UpdatedAt           time.Time `json:"updated_at"`
-	Value               int64     `json:"value"`
+	BeneficiaryBic      string     `json:"beneficiary_bic"`
+	BeneficiaryIban     string     `json:"beneficiary_iban"`
+	BeneficiaryName     string     `json:"beneficiary_name"`
+	CreatedAt           time.Time  `json:"created_at"`
+	Currency            string     `json:"currency"`
+	Label               string     `json:"label"`
+	SenderAccountId     string     `json:"sender_account_id"`
+	SenderBic           string     `json:"sender_bic"`
+	SenderDevice        string     `json:"sender_device"`
+	SenderIP            netip.Addr `json:"sender_ip"`
+	Status              string     `json:"status"`
+	Timezone            string     `json:"timezone"`
+	TransferId          string     `json:"transfer_id"`
+	TransferRequestedAt time.Time  `json:"transfer_requested_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	Value               int64      `json:"value"`
 }
 
 func AdaptTransferDataDto(transfer models.TransferData) TransferData {

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -112,6 +112,7 @@ func TestMain(m *testing.M) {
 		nil,
 		dbPool,
 		nil,
+		"",
 	)
 	if err != nil {
 		panic(err)

--- a/main.go
+++ b/main.go
@@ -158,17 +158,16 @@ func main() {
 			User:                utils.GetRequiredEnv[string]("PG_USER"),
 		},
 		config: models.GlobalConfiguration{
-			TokenLifetimeMinute:  utils.GetEnv("TOKEN_LIFETIME_MINUTE", 60*2),
-			FakeAwsS3Repository:  utils.GetEnv("FAKE_AWS_S3", false),
-			FakeGcsRepository:    utils.GetEnv("FAKE_GCS", false),
-			GcsIngestionBucket:   utils.GetRequiredEnv[string]("GCS_INGESTION_BUCKET"),
-			GcsCaseManagerBucket: utils.GetRequiredEnv[string]("GCS_CASE_MANAGER_BUCKET"),
-			GcsTransferCheckEnrichmentBucket: utils.GetEnv("GCS_TRANSFER_CHECK_ENRICHMENT_BUCKET",
-				"case-manager-tokyo-country-381508"), // TODO: fixme hard coded placeholder
-			MarbleAppHost:        utils.GetEnv("MARBLE_APP_HOST", ""),
-			MarbleBackofficeHost: utils.GetEnv("MARBLE_BACKOFFICE_HOST", ""),
-			SegmentWriteKey:      utils.GetRequiredEnv[string]("SEGMENT_WRITE_KEY"),
-			JwtSigningKey:        utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),
+			TokenLifetimeMinute:              utils.GetEnv("TOKEN_LIFETIME_MINUTE", 60*2),
+			FakeAwsS3Repository:              utils.GetEnv("FAKE_AWS_S3", false),
+			FakeGcsRepository:                utils.GetEnv("FAKE_GCS", false),
+			GcsIngestionBucket:               utils.GetRequiredEnv[string]("GCS_INGESTION_BUCKET"),
+			GcsCaseManagerBucket:             utils.GetRequiredEnv[string]("GCS_CASE_MANAGER_BUCKET"),
+			GcsTransferCheckEnrichmentBucket: utils.GetEnv("GCS_TRANSFER_CHECK_ENRICHMENT_BUCKET", ""), // required for transfercheck
+			MarbleAppHost:                    utils.GetEnv("MARBLE_APP_HOST", ""),
+			MarbleBackofficeHost:             utils.GetEnv("MARBLE_BACKOFFICE_HOST", ""),
+			SegmentWriteKey:                  utils.GetRequiredEnv[string]("SEGMENT_WRITE_KEY"),
+			JwtSigningKey:                    utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),
 		},
 		sentryDsn: utils.GetEnv("SENTRY_DSN", ""),
 		metabase: models.MetabaseConfiguration{

--- a/main.go
+++ b/main.go
@@ -163,6 +163,8 @@ func main() {
 			FakeGcsRepository:    utils.GetEnv("FAKE_GCS", false),
 			GcsIngestionBucket:   utils.GetRequiredEnv[string]("GCS_INGESTION_BUCKET"),
 			GcsCaseManagerBucket: utils.GetRequiredEnv[string]("GCS_CASE_MANAGER_BUCKET"),
+			GcsTransferCheckEnrichmentBucket: utils.GetEnv("GCS_TRANSFER_CHECK_ENRICHMENT_BUCKET",
+				"case-manager-tokyo-country-381508"), // TODO: fixme hard coded placeholder
 			MarbleAppHost:        utils.GetEnv("MARBLE_APP_HOST", ""),
 			MarbleBackofficeHost: utils.GetEnv("MARBLE_BACKOFFICE_HOST", ""),
 			SegmentWriteKey:      utils.GetRequiredEnv[string]("SEGMENT_WRITE_KEY"),

--- a/main.go
+++ b/main.go
@@ -277,6 +277,7 @@ func NewUseCases(ctx context.Context, appConfiguration AppConfiguration, marbleJ
 		infra.InitializeFirebase(ctx),
 		marbleConnectionPool,
 		infra.InitializeMetabase(appConfiguration.metabase),
+		appConfiguration.config.GcsTransferCheckEnrichmentBucket,
 	)
 	if err != nil {
 		slog.Error("repositories.NewRepositories failed", slog.String("error", err.Error()))

--- a/models/global_configuration.go
+++ b/models/global_configuration.go
@@ -1,13 +1,14 @@
 package models
 
 type GlobalConfiguration struct {
-	FakeAwsS3Repository  bool
-	FakeGcsRepository    bool
-	GcsIngestionBucket   string
-	GcsCaseManagerBucket string
-	JwtSigningKey        string
-	MarbleAppHost        string
-	MarbleBackofficeHost string
-	SegmentWriteKey      string
-	TokenLifetimeMinute  int
+	FakeAwsS3Repository              bool
+	FakeGcsRepository                bool
+	GcsIngestionBucket               string
+	GcsCaseManagerBucket             string
+	GcsTransferCheckEnrichmentBucket string
+	JwtSigningKey                    string
+	MarbleAppHost                    string
+	MarbleBackofficeHost             string
+	SegmentWriteKey                  string
+	TokenLifetimeMinute              int
 }

--- a/repositories/repositories.go
+++ b/repositories/repositories.go
@@ -10,24 +10,25 @@ import (
 )
 
 type Repositories struct {
-	ExecutorGetter                ExecutorGetter
-	FirebaseTokenRepository       FireBaseTokenRepository
-	MarbleJwtRepository           func() MarbleJwtRepository
-	UserRepository                UserRepository
-	OrganizationRepository        OrganizationRepository
-	IngestionRepository           IngestionRepository
-	DataModelRepository           DataModelRepository
-	IngestedDataReadRepository    IngestedDataReadRepository
-	DecisionRepository            DecisionRepository
-	MarbleDbRepository            MarbleDbRepository
-	ClientDbRepository            ClientDbRepository
-	ScenarioPublicationRepository ScenarioPublicationRepository
-	OrganizationSchemaRepository  OrganizationSchemaRepository
-	AwsS3Repository               AwsS3Repository
-	GcsRepository                 GcsRepository
-	CustomListRepository          CustomListRepository
-	UploadLogRepository           UploadLogRepository
-	MarbleAnalyticsRepository     MarbleAnalyticsRepository
+	ExecutorGetter                    ExecutorGetter
+	FirebaseTokenRepository           FireBaseTokenRepository
+	MarbleJwtRepository               func() MarbleJwtRepository
+	UserRepository                    UserRepository
+	OrganizationRepository            OrganizationRepository
+	IngestionRepository               IngestionRepository
+	DataModelRepository               DataModelRepository
+	IngestedDataReadRepository        IngestedDataReadRepository
+	DecisionRepository                DecisionRepository
+	MarbleDbRepository                MarbleDbRepository
+	ClientDbRepository                ClientDbRepository
+	ScenarioPublicationRepository     ScenarioPublicationRepository
+	OrganizationSchemaRepository      OrganizationSchemaRepository
+	AwsS3Repository                   AwsS3Repository
+	GcsRepository                     GcsRepository
+	CustomListRepository              CustomListRepository
+	UploadLogRepository               UploadLogRepository
+	MarbleAnalyticsRepository         MarbleAnalyticsRepository
+	TransferCheckEnrichmentRepository *TransferCheckEnrichmentRepository
 }
 
 func NewQueryBuilder() squirrel.StatementBuilderType {
@@ -39,9 +40,11 @@ func NewRepositories(
 	firebaseClient *auth.Client,
 	marbleConnectionPool *pgxpool.Pool,
 	metabase Metabase,
+	tranfsercheckEnrichmentBucket string,
 ) (*Repositories, error) {
 	executorGetter := NewExecutorGetter(marbleConnectionPool)
 
+	gcsRepository := GcsRepositoryImpl{}
 	return &Repositories{
 		ExecutorGetter:          executorGetter,
 		FirebaseTokenRepository: firebase.New(firebaseClient),
@@ -66,9 +69,13 @@ func NewRepositories(
 		CustomListRepository:          &CustomListRepositoryPostgresql{},
 		UploadLogRepository:           &UploadLogRepositoryImpl{},
 		AwsS3Repository:               AwsS3Repository{s3Client: NewS3Client()},
-		GcsRepository:                 &GcsRepositoryImpl{},
+		GcsRepository:                 &gcsRepository,
 		MarbleAnalyticsRepository: MarbleAnalyticsRepository{
 			metabase: metabase,
 		},
+		TransferCheckEnrichmentRepository: NewTransferCheckEnrichmentRepository(
+			&gcsRepository,
+			tranfsercheckEnrichmentBucket,
+		),
 	}, nil
 }

--- a/repositories/transfercheck_enrichment.go
+++ b/repositories/transfercheck_enrichment.go
@@ -9,19 +9,32 @@ import (
 	"sync"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/pkg/errors"
 )
 
-const IP_COUNTRY_RANGE_FILE = "ip_country_ranges.csv"
+const (
+	IP_COUNTRY_RANGE_FILE = "ip_country_ranges.csv"
+	IP_VPN_RANGE_FILE     = "ip_vpn_ranges.csv"
+	IP_TOR_RANGE_FILE     = "ip_tor_ranges.csv"
+)
 
 type ipCountryRange struct {
 	ipRange netip.Prefix
 	country string // ISO 3166-1 alpha-3
 }
+
+type ipTypeRange struct {
+	ipRange netip.Prefix
+	ipType  string
+}
+
 type TransferCheckEnrichmentRepository struct {
 	gcsRepository   GcsRepository
 	bucket          string
 	ipCountryRanges []ipCountryRange
-	mu              sync.Mutex
+	ipTypeRanges    []ipTypeRange
+	muCountries     sync.Mutex
+	muIpTypes       sync.Mutex
 }
 
 func NewTransferCheckEnrichmentRepository(gcsrepository GcsRepository, bucket string) *TransferCheckEnrichmentRepository {
@@ -33,8 +46,8 @@ func NewTransferCheckEnrichmentRepository(gcsrepository GcsRepository, bucket st
 
 // Expects a CSV file with two columns: IP range and country code (ISO 3166-1 alpha-3) containing both ipv4 and ipv6 ranges.
 func (r *TransferCheckEnrichmentRepository) setupIpCountryRanges(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.muCountries.Lock()
+	defer r.muCountries.Unlock()
 	file, err := r.gcsRepository.GetFile(ctx, r.bucket, IP_COUNTRY_RANGE_FILE)
 	if err != nil {
 		return err
@@ -102,7 +115,106 @@ func (r *TransferCheckEnrichmentRepository) findCountryDichotomy(ip netip.Addr) 
 }
 
 func (r *TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip netip.Addr) (string, error) {
+	// TODO later: add an expiry mechanism for the ipTypeRanges so that the csv file is polled again every X hours/days
+	if len(r.ipTypeRanges) == 0 {
+		if err := r.setupIpTypeRanges(ctx); err != nil {
+			return "", err
+		}
+	}
+
+	ipType := r.findIpTypeDichotomy(ip)
+	if ipType != "" {
+		return ipType, nil
+	}
+
 	return models.RegularIP, nil
+}
+
+func (r *TransferCheckEnrichmentRepository) findIpTypeDichotomy(ip netip.Addr) string {
+	left := 0
+	right := len(r.ipTypeRanges) - 1
+
+	for right >= left {
+		mid := left + (right-left)/2
+
+		ipRange := r.ipTypeRanges[mid].ipRange
+		if ipRange.Contains(ip) {
+			return r.ipTypeRanges[mid].ipType
+		} else if ip.Less(ipRange.Addr()) {
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+	}
+
+	return ""
+}
+
+// Expects two CSV files:
+// one with one column (CIDR IP range) containing both ipv4 and ipv6 ranges with VPN address ranges
+// one with one column (IP addresses) containing  both ipv4 and ipv6 with TOR exit nodes
+// The ips & ranges between the two files may overlap.
+func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Context) error {
+	r.muIpTypes.Lock()
+	defer r.muIpTypes.Unlock()
+	file, err := r.gcsRepository.GetFile(ctx, r.bucket, IP_VPN_RANGE_FILE)
+	if err != nil {
+		return errors.Wrap(err, "failed to get VPN IP file")
+	}
+	defer file.Reader.Close()
+	fileReader := csv.NewReader(file.Reader)
+	record, err := fileReader.Read()
+	var ipRange netip.Prefix
+	for err == nil {
+		ipRange, err = netip.ParsePrefix(record[0])
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse VPN IP range %s", record[0])
+		}
+		r.ipTypeRanges = append(r.ipTypeRanges, ipTypeRange{
+			ipRange: ipRange,
+			ipType:  models.VpnIP,
+		})
+		record, err = fileReader.Read()
+	}
+	if err != io.EOF {
+		return errors.Wrap(err, "failed to read VPN IP file")
+	}
+
+	file, err = r.gcsRepository.GetFile(ctx, r.bucket, IP_TOR_RANGE_FILE)
+	if err != nil {
+		return errors.Wrap(err, "failed to get TOR IP file")
+	}
+	defer file.Reader.Close()
+	fileReader = csv.NewReader(file.Reader)
+	record, err = fileReader.Read()
+	var ip netip.Addr
+	for err == nil {
+		ip, err = netip.ParseAddr(record[0])
+		if err != nil {
+			return errors.Wrapf(err, "failed to parse TOR IP address %s", record[0])
+		}
+		r.ipTypeRanges = append(r.ipTypeRanges, ipTypeRange{
+			ipRange: netip.PrefixFrom(ip, ip.BitLen()),
+			ipType:  models.TorIP,
+		})
+		record, err = fileReader.Read()
+	}
+	if err != io.EOF {
+		return errors.Wrap(err, "failed to read TOR IP file")
+	}
+
+	// at the end, sort the full slice of ip ranges
+	slices.SortFunc(r.ipTypeRanges, func(range1, range2 ipTypeRange) int {
+		// multiple ip ranges may have the same start address, but we don't care about how there ordered between them
+		if range1.ipRange == range2.ipRange {
+			return 0
+		} else if range1.ipRange.Addr().Less(range2.ipRange.Addr()) {
+			return -1
+		}
+		return 1
+	})
+
+	return nil
 }
 
 func (r *TransferCheckEnrichmentRepository) GetSenderBicRiskLevel(ctx context.Context, bic string) (string, error) {

--- a/repositories/transfercheck_enrichment.go
+++ b/repositories/transfercheck_enrichment.go
@@ -2,24 +2,109 @@ package repositories
 
 import (
 	"context"
+	"encoding/csv"
+	"io"
+	"net/netip"
+	"slices"
+	"sync"
 
 	"github.com/checkmarble/marble-backend/models"
 )
 
-type TransferCheckEnrichmentRepository struct{}
+const IP_COUNTRY_RANGE_FILE = "ip_country_ranges.csv"
 
-func NewTransferCheckEnrichmentRepository() TransferCheckEnrichmentRepository {
-	return TransferCheckEnrichmentRepository{}
+type ipCountryRange struct {
+	ipRange netip.Prefix
+	country string // ISO 3166-1 alpha-3
+}
+type TransferCheckEnrichmentRepository struct {
+	gcsRepository   GcsRepository
+	bucket          string
+	ipCountryRanges []ipCountryRange
+	mu              sync.Mutex
 }
 
-func (r TransferCheckEnrichmentRepository) GetIPCountry(ctx context.Context, ip string) (string, error) {
-	return "FR", nil
+func NewTransferCheckEnrichmentRepository(gcsrepository GcsRepository, bucket string) *TransferCheckEnrichmentRepository {
+	return &TransferCheckEnrichmentRepository{
+		gcsRepository: gcsrepository,
+		bucket:        bucket,
+	}
 }
 
-func (r TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip string) (string, error) {
+// Expects a CSV file with two columns: IP range and country code (ISO 3166-1 alpha-3) containing both ipv4 and ipv6 ranges.
+func (r *TransferCheckEnrichmentRepository) setupIpCountryRanges(ctx context.Context) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	file, err := r.gcsRepository.GetFile(ctx, r.bucket, IP_COUNTRY_RANGE_FILE)
+	if err != nil {
+		return err
+	}
+	defer file.Reader.Close()
+	fileReader := csv.NewReader(file.Reader)
+	record, err := fileReader.Read()
+	var ipRange netip.Prefix
+	for err == nil {
+		ipRange, err = netip.ParsePrefix(record[0])
+		if err != nil {
+			return err
+		}
+		r.ipCountryRanges = append(r.ipCountryRanges, ipCountryRange{
+			ipRange: ipRange,
+			country: record[1],
+		})
+		record, err = fileReader.Read()
+	}
+	if err != io.EOF {
+		return err
+	}
+
+	slices.SortFunc(r.ipCountryRanges, func(range1, range2 ipCountryRange) int {
+		if range1.ipRange == range2.ipRange {
+			return 0
+		} else if range1.ipRange.Addr().Less(range2.ipRange.Addr()) {
+			return -1
+		}
+		return 1
+	})
+
+	return nil
+}
+
+func (r *TransferCheckEnrichmentRepository) GetIPCountry(ctx context.Context, ip netip.Addr) (string, error) {
+	// TODO later: add an expiry mechanism for the ipCountryRanges so that the csv file is polled again every X hours/days
+	if len(r.ipCountryRanges) == 0 {
+		if err := r.setupIpCountryRanges(ctx); err != nil {
+			return "", err
+		}
+	}
+
+	return r.findCountryDichotomy(ip), nil
+}
+
+func (r *TransferCheckEnrichmentRepository) findCountryDichotomy(ip netip.Addr) string {
+	left := 0
+	right := len(r.ipCountryRanges) - 1
+
+	for right >= left {
+		mid := left + (right-left)/2
+
+		ipRange := r.ipCountryRanges[mid].ipRange
+		if ipRange.Contains(ip) {
+			return r.ipCountryRanges[mid].country
+		} else if ip.Less(ipRange.Addr()) {
+			right = mid - 1
+		} else {
+			left = mid + 1
+		}
+	}
+
+	return ""
+}
+
+func (r *TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip netip.Addr) (string, error) {
 	return models.RegularIP, nil
 }
 
-func (r TransferCheckEnrichmentRepository) GetSenderBicRiskLevel(ctx context.Context, bic string) (string, error) {
+func (r *TransferCheckEnrichmentRepository) GetSenderBicRiskLevel(ctx context.Context, bic string) (string, error) {
 	return models.RegularSender, nil
 }

--- a/usecases/transfer_check_usecase.go
+++ b/usecases/transfer_check_usecase.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"slices"
 	"time"
 
@@ -35,8 +36,8 @@ type transferMappingsRepository interface {
 }
 
 type transferCheckEnrichmentRepository interface {
-	GetIPCountry(ctx context.Context, ip string) (string, error)
-	GetIPType(ctx context.Context, ip string) (string, error)
+	GetIPCountry(ctx context.Context, ip netip.Addr) (string, error)
+	GetIPType(ctx context.Context, ip netip.Addr) (string, error)
 	GetSenderBicRiskLevel(ctx context.Context, bic string) (string, error)
 }
 
@@ -224,7 +225,7 @@ func (usecase *TransferCheckUsecase) enrichTransfer(
 	ctx context.Context,
 	transfer models.TransferData,
 ) (models.TransferData, error) {
-	if transfer.SenderIP != "" {
+	if !transfer.SenderIP.IsUnspecified() {
 		country, err := usecase.transferCheckEnrichmentRepository.GetIPCountry(ctx, transfer.SenderIP)
 		if err != nil {
 			return models.TransferData{}, err

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -358,20 +358,17 @@ func (usecases *UsecasesWithCreds) NewAnalyticsUseCase() AnalyticsUseCase {
 
 func (usecases *UsecasesWithCreds) NewTransferCheckUsecase() TransferCheckUsecase {
 	return TransferCheckUsecase{
-		dataModelRepository:        usecases.Repositories.DataModelRepository,
-		decisionUseCase:            usecases.NewDecisionUsecase(),
-		decisionRepository:         usecases.Repositories.DecisionRepository,
-		enforceSecurity:            security.NewEnforceSecurity(usecases.Credentials),
-		executorFactory:            usecases.NewExecutorFactory(),
-		ingestedDataReadRepository: usecases.Repositories.IngestedDataReadRepository,
-		ingestionRepository:        usecases.Repositories.IngestionRepository,
-		organizationRepository:     usecases.Repositories.OrganizationRepository,
-		transactionFactory:         usecases.NewTransactionFactory(),
-		transferMappingsRepository: &usecases.Repositories.MarbleDbRepository,
-		transferCheckEnrichmentRepository: repositories.NewTransferCheckEnrichmentRepository(
-			usecases.Repositories.GcsRepository,
-			usecases.Configuration.GcsTransferCheckEnrichmentBucket,
-		),
+		dataModelRepository:               usecases.Repositories.DataModelRepository,
+		decisionUseCase:                   usecases.NewDecisionUsecase(),
+		decisionRepository:                usecases.Repositories.DecisionRepository,
+		enforceSecurity:                   security.NewEnforceSecurity(usecases.Credentials),
+		executorFactory:                   usecases.NewExecutorFactory(),
+		ingestedDataReadRepository:        usecases.Repositories.IngestedDataReadRepository,
+		ingestionRepository:               usecases.Repositories.IngestionRepository,
+		organizationRepository:            usecases.Repositories.OrganizationRepository,
+		transactionFactory:                usecases.NewTransactionFactory(),
+		transferMappingsRepository:        &usecases.Repositories.MarbleDbRepository,
+		transferCheckEnrichmentRepository: usecases.Repositories.TransferCheckEnrichmentRepository,
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -358,17 +358,20 @@ func (usecases *UsecasesWithCreds) NewAnalyticsUseCase() AnalyticsUseCase {
 
 func (usecases *UsecasesWithCreds) NewTransferCheckUsecase() TransferCheckUsecase {
 	return TransferCheckUsecase{
-		dataModelRepository:               usecases.Repositories.DataModelRepository,
-		decisionUseCase:                   usecases.NewDecisionUsecase(),
-		decisionRepository:                usecases.Repositories.DecisionRepository,
-		enforceSecurity:                   security.NewEnforceSecurity(usecases.Credentials),
-		executorFactory:                   usecases.NewExecutorFactory(),
-		ingestedDataReadRepository:        usecases.Repositories.IngestedDataReadRepository,
-		ingestionRepository:               usecases.Repositories.IngestionRepository,
-		organizationRepository:            usecases.Repositories.OrganizationRepository,
-		transactionFactory:                usecases.NewTransactionFactory(),
-		transferMappingsRepository:        &usecases.Repositories.MarbleDbRepository,
-		transferCheckEnrichmentRepository: repositories.NewTransferCheckEnrichmentRepository(),
+		dataModelRepository:        usecases.Repositories.DataModelRepository,
+		decisionUseCase:            usecases.NewDecisionUsecase(),
+		decisionRepository:         usecases.Repositories.DecisionRepository,
+		enforceSecurity:            security.NewEnforceSecurity(usecases.Credentials),
+		executorFactory:            usecases.NewExecutorFactory(),
+		ingestedDataReadRepository: usecases.Repositories.IngestedDataReadRepository,
+		ingestionRepository:        usecases.Repositories.IngestionRepository,
+		organizationRepository:     usecases.Repositories.OrganizationRepository,
+		transactionFactory:         usecases.NewTransactionFactory(),
+		transferMappingsRepository: &usecases.Repositories.MarbleDbRepository,
+		transferCheckEnrichmentRepository: repositories.NewTransferCheckEnrichmentRepository(
+			usecases.Repositories.GcsRepository,
+			usecases.Configuration.GcsTransferCheckEnrichmentBucket,
+		),
 	}
 }
 


### PR DESCRIPTION
## Recap
Overall I'm satisfied with this PR as it is.
It expects to find a set of csv files in the transfercheck bucket on GCS, containing ip ranges. At the first transfercheck request received by the instance, they are read and put in memory. For an incoming sender ip address, we do a dichotomy search on the known ip ranges to find if it matches a given country/vpn/tor address range.

Because the GCS files are downloaded at the first request, that means we have a bit of a cold start (e.g. ~1sec on the first request) on the instance for transfercheck routes. But so be it, the possible workarounds are just too cumbersome compared to what we lose, for now anyway.

## To do:
- implement an expiry date on the data held in memory, preparing for...
- ... refresh the files on GCS on a schedule (daily at least?) with a script (I'll see where I put it, I kind of don't want to pollute the marble OS codebase with background scripts for transfercheck...)

## Prerequisite
 https://github.com/checkmarble/terraform/pull/21

## Examples of csv files with the right format
[ip_tor_ranges.csv](https://github.com/user-attachments/files/15592486/ip_tor_ranges.csv)
[ip_vpn_ranges.csv](https://github.com/user-attachments/files/15592487/ip_vpn_ranges.csv)
[ip_country_ranges.csv](https://github.com/user-attachments/files/15592488/ip_country_ranges.csv)
<img width="462" alt="Capture d’écran 2024-06-05 à 16 50 56" src="https://github.com/checkmarble/marble-backend/assets/128643171/5f16ec8c-9582-423e-b9e5-160d1d604ea2">
