### PR TITLE
fix(api): harmonize custom list return

### DIFF
--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -94,7 +94,7 @@ func (api *API) handlePatchCustomList(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{
-		"lists": dto.AdaptCustomListDto(CustomList),
+		"custom_list": dto.AdaptCustomListDto(CustomList),
 	})
 }
 


### PR DESCRIPTION
Small breaking change to harmonize api return.

NB: I checked the frontend repo, the return type is not used. Indeed, the repository implementation is **wrong** so it would not work if used.