### PR TITLE
fix error on parsing license key url param

### DIFF
--- a/api/handle_license.go
+++ b/api/handle_license.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -75,7 +76,7 @@ func (api *API) handleValidateLicense(c *gin.Context) {
 	licenseKey := c.Param("license_key")
 
 	usecase := api.usecases.NewLicenseUsecase()
-	licenseValidation, err := usecase.ValidateLicense(c.Request.Context(), licenseKey)
+	licenseValidation, err := usecase.ValidateLicense(c.Request.Context(), strings.TrimPrefix(licenseKey, "/"))
 	if presentError(c, err) {
 		return
 	}


### PR DESCRIPTION
It turns out a patter like `foo/*bar` parses the param value `"/bar"` if called with `foo/bar`...
There was an issue but the PR linked never went anywhere because breaking.
I quick fixed it this afternoon by inserting a duplicate of the key with the added slash in the db.