### PR TITLE
better logging in gcp env: log trace ids & spanid in logs so that we can correlate logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ ENABLE_GCP_TRACING=false
 
 # 'liveness' (only log liveness requests) || 'all' (log all requests) || any other value for no request logs
 REQUEST_LOGGING_LEVEL=all
-# 'json' || 'text'
+# 'json' || 'text' || 'gcp'
 LOGGING_FORMAT=text
 
 # configure the document storage backend with optional fake backends

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.27.0
 	go.opentelemetry.io/otel/trace v1.27.0
 	golang.org/x/net v0.26.0
+	golang.org/x/oauth2 v0.21.0
 	golang.org/x/sync v0.7.0
 	golang.org/x/text v0.16.0
 	google.golang.org/api v0.184.0
@@ -147,7 +148,6 @@ require (
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
-	golang.org/x/oauth2 v0.21.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d // indirect

--- a/utils/context_logging.go
+++ b/utils/context_logging.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/oauth2/google"
 )
 
 func NewLogger(format string) *slog.Logger {
@@ -28,11 +29,11 @@ func NewLogger(format string) *slog.Logger {
 	case "json":
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	case "gcp":
-		projectId := GetEnv("GOOGLE_CLOUD_PROJECT", "")
-		if projectId == "" {
-			fmt.Println("GOOGLE_CLOUD_PROJECT not set, the trace id in logs will not be usable")
+		creds, err := google.FindDefaultCredentials(context.Background())
+		if err != nil || creds.ProjectID == "" {
+			fmt.Printf("failed to find default credentials (%v) or projectId empty: the traceId in logs will not be usable\n", err)
 		}
-		logger = slog.New(NewGcpHandler(projectId))
+		logger = slog.New(NewGcpHandler(creds.ProjectID))
 	}
 	return logger
 }

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -6,52 +6,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
+
+	"go.opentelemetry.io/otel/trace"
 )
 
-func GCPLoggerAttributeReplacer(groups []string, a slog.Attr) slog.Attr {
-	// Rename "msg" to "message" so that stackdriver logging can parse it as the main message
-	if a.Key == "msg" {
-		a.Key = "message"
-		return a
-	}
-
-	// Rename "level" to "severity" and convert the value so that stackdriver can properly parse it to a stackdriver severity
-	if a.Key == slog.LevelKey {
-		a.Key = "severity"
-
-		level := a.Value.Any().(slog.Level)
-
-		const (
-			LevelDebug   = slog.LevelDebug
-			LevelInfo    = slog.LevelInfo
-			LevelWarning = slog.LevelWarn
-			LevelError   = slog.LevelError
-		)
-
-		const (
-			gcpLevelDebug   = "DEBUG"
-			gcpLevelInfo    = "INFO"
-			gcpLevelWarning = "WARNING"
-			gcpLevelError   = "ERROR"
-		)
-
-		switch {
-		case level < LevelInfo:
-			a.Value = slog.StringValue(gcpLevelDebug)
-		case level < LevelWarning:
-			a.Value = slog.StringValue(gcpLevelInfo)
-		case level < LevelError:
-			a.Value = slog.StringValue(gcpLevelWarning)
-		default:
-			a.Value = slog.StringValue(gcpLevelError)
-		}
-	}
-
-	return a
-}
-
+// Log handler for logging to local development, that formats the log message and adds color
 type LocalDevHandler struct {
 	opts            LocalDevHandlerOptions
 	internalHandler slog.Handler
@@ -91,6 +53,12 @@ func (h *LocalDevHandler) Enabled(ctx context.Context, level slog.Level) bool {
 
 func (h *LocalDevHandler) Handle(ctx context.Context, r slog.Record) error {
 	var buf bytes.Buffer
+
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().HasTraceID() {
+		traceId := span.SpanContext().TraceID().String()
+		r.AddAttrs(slog.String("trace", traceId))
+	}
 
 	buf.WriteString(r.Time.Format(time.RFC3339))
 	buf.WriteString(" ")
@@ -165,4 +133,84 @@ func addColorToLevel(level string) string {
 		color = unknownLevelColor
 	}
 	return color.Add(level)
+}
+
+// Log handler for logging to GCP, by replacing relevant attributes and adding trace attributes.
+type GcpHandler struct {
+	projectId       string
+	internalHandler slog.Handler
+}
+
+func (h *GcpHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.internalHandler.Enabled(ctx, level)
+}
+
+func (h *GcpHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h.internalHandler.WithAttrs(attrs)
+}
+
+func (h *GcpHandler) WithGroup(name string) slog.Handler {
+	return h.internalHandler.WithGroup(name)
+}
+
+func (h *GcpHandler) Handle(ctx context.Context, r slog.Record) error {
+	span := trace.SpanFromContext(ctx)
+	if span.SpanContext().HasTraceID() {
+		traceId := span.SpanContext().TraceID().String()
+		r.AddAttrs(slog.String("trace", fmt.Sprintf("projects/%s/traces/%s", h.projectId, traceId)))
+	}
+	if span.SpanContext().HasSpanID() {
+		spanId := span.SpanContext().SpanID().String()
+		r.AddAttrs(slog.String("spanId", spanId))
+	}
+
+	return h.internalHandler.Handle(ctx, r)
+}
+
+func NewGcpHandler(projectId string) *GcpHandler {
+	slogOption := slog.HandlerOptions{ReplaceAttr: GCPLoggerAttributeReplacer}
+	jsonHandler := slog.NewJSONHandler(os.Stdout, &slogOption)
+	return &GcpHandler{projectId: projectId, internalHandler: jsonHandler}
+}
+
+func GCPLoggerAttributeReplacer(groups []string, a slog.Attr) slog.Attr {
+	// Rename "msg" to "message" so that stackdriver logging can parse it as the main message
+	if a.Key == "msg" {
+		a.Key = "message"
+		return a
+	}
+
+	// Rename "level" to "severity" and convert the value so that stackdriver can properly parse it to a stackdriver severity
+	if a.Key == slog.LevelKey {
+		a.Key = "severity"
+
+		level := a.Value.Any().(slog.Level)
+
+		const (
+			LevelDebug   = slog.LevelDebug
+			LevelInfo    = slog.LevelInfo
+			LevelWarning = slog.LevelWarn
+			LevelError   = slog.LevelError
+		)
+
+		const (
+			gcpLevelDebug   = "DEBUG"
+			gcpLevelInfo    = "INFO"
+			gcpLevelWarning = "WARNING"
+			gcpLevelError   = "ERROR"
+		)
+
+		switch {
+		case level < LevelInfo:
+			a.Value = slog.StringValue(gcpLevelDebug)
+		case level < LevelWarning:
+			a.Value = slog.StringValue(gcpLevelInfo)
+		case level < LevelError:
+			a.Value = slog.StringValue(gcpLevelWarning)
+		default:
+			a.Value = slog.StringValue(gcpLevelError)
+		}
+	}
+
+	return a
 }


### PR DESCRIPTION
## Inspiration
 [this](https://github.com/jussi-kalliokoski/slogdriver/blob/main/handler.go)

Also see [this](https://cloud.google.com/trace/docs/trace-log-integration#:~:text=To%20associate%20a%20log%20entry%20with%20a%20trace,project%20ID%20and%20TRACE_ID%20is%20the%20trace%20identifier)

## Requirements
~This means I need to put back the env var in cloud run~ or maybe not, see second commit

Goes with https://github.com/checkmarble/terraform/pull/27