### PR TITLE
Pascal/test

### DIFF
--- a/repositories/aws_s3_repository.go
+++ b/repositories/aws_s3_repository.go
@@ -43,6 +43,6 @@ func (repo *AwsS3Repository) StoreInBucket(ctx context.Context, bucketName strin
 		return errors.Errorf("Couldn't upload fileName to %v:%v. Here's why: %v\n", bucketName, key, err)
 	}
 
-	logger.Info(fmt.Sprintf("Successfully uploaded to s3 to %v", location.Location))
+	logger.InfoContext(ctx, fmt.Sprintf("Successfully uploaded to s3 to %v", location.Location))
 	return nil
 }

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -61,7 +61,7 @@ func (repo *IngestionRepositoryImpl) IngestObjects(
 		}
 	}
 
-	logger.Info("Inserted objects in db",
+	logger.InfoContext(ctx, "Inserted objects in db",
 		slog.String("type", tableNameWithSchema(exec, table.Name)),
 		slog.Int("nb_objects", len(payloadsToInsert)))
 

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -161,9 +161,6 @@ func (h *GcpHandler) WithGroup(name string) slog.Handler {
 
 func (h *GcpHandler) Handle(ctx context.Context, r slog.Record) error {
 	span := trace.SpanFromContext(ctx)
-	fmt.Println(span.SpanContext().HasTraceID())
-	fmt.Println(span.SpanContext().HasSpanID())
-	fmt.Println(span.SpanContext().IsValid())
 	if span.SpanContext().HasTraceID() {
 		traceId := span.SpanContext().TraceID().String()
 		r.AddAttrs(slog.String("logging.googleapis.com/trace",


### PR DESCRIPTION
## Object
With this, combined with previous PRs:
- We get the possibility to see all logs related to a trace (could even be across services in the future) :
<img width="606" alt="Capture d’écran 2024-06-27 à 11 07 11" src="https://github.com/checkmarble/marble-backend/assets/128643171/ecc1966e-7e60-403a-b9c3-03a11849b8e8">
<img width="1571" alt="Capture d’écran 2024-06-27 à 11 07 04" src="https://github.com/checkmarble/marble-backend/assets/128643171/0e49f660-9f68-4c7d-9abc-8434ee27a8fb">

In particular, it's now possible to see all logs from the service related to a given request, as see in the request logger (native to cloud run)

- in the trace explorer, we can see events (shown as "dots") which can in particular be logs:
<img width="1869" alt="Capture d’écran 2024-06-27 à 11 08 28" src="https://github.com/checkmarble/marble-backend/assets/128643171/71125e58-892e-4708-9cd4-0801b7c14d6e">

--- 

## Full PR history
The changes needed to implement this are the combination of:
https://github.com/checkmarble/marble-backend/pull/604
https://github.com/checkmarble/marble-backend/pull/606
https://github.com/checkmarble/marble-backend/pull/607
and https://github.com/checkmarble/marble-backend/pull/609 (this PR)