### PR TITLE
refactor(repositories): add options pattern to NewRepositories

### DIFF
--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -65,7 +65,9 @@ func RunBatchIngestion() error {
 		return err
 	}
 
-	repositories := repositories.NewRepositories(nil, pool, nil, "")
+	repositories := repositories.NewRepositories(pool,
+		repositories.WithFakeGcsRepository(gcpConfig.FakeGcsRepository),
+	)
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithGcsIngestionBucket(gcpConfig.GcsIngestionBucket),
 		usecases.WithFakeGcsRepository(gcpConfig.FakeGcsRepository),

--- a/cmd/run_job_scheduler.go
+++ b/cmd/run_job_scheduler.go
@@ -66,7 +66,9 @@ func RunJobScheduler() error {
 		return err
 	}
 
-	repositories := repositories.NewRepositories(nil, pool, nil, "")
+	repositories := repositories.NewRepositories(pool,
+		repositories.WithFakeGcsRepository(gcpConfig.FakeGcsRepository),
+	)
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithGcsIngestionBucket(gcpConfig.GcsIngestionBucket),
 		usecases.WithFakeAwsS3Repository(jobConfig.fakeAwsS3Repository),

--- a/cmd/schedule_scenarios.go
+++ b/cmd/schedule_scenarios.go
@@ -63,7 +63,7 @@ func RunScheduleScenarios() error {
 		return err
 	}
 
-	repositories := repositories.NewRepositories(nil, pool, nil, "")
+	repositories := repositories.NewRepositories(pool)
 	uc := usecases.NewUsecases(repositories)
 
 	err = jobs.ScheduleDueScenarios(ctx, uc)

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -65,7 +65,7 @@ func RunScheduledExecuter() error {
 		return err
 	}
 
-	repositories := repositories.NewRepositories(nil, pool, nil, "")
+	repositories := repositories.NewRepositories(pool)
 
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithFakeAwsS3Repository(jobConfig.fakeAwsS3Repository))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -55,6 +55,7 @@ func RunServer() error {
 			models.GlobalDashboard: utils.GetEnv("METABASE_GLOBAL_DASHBOARD_ID", 0),
 		},
 	}
+
 	seedOrgConfig := models.SeedOrgConfiguration{
 		CreateGlobalAdminEmail: utils.GetEnv("CREATE_GLOBAL_ADMIN_EMAIL", ""),
 		CreateOrgName:          utils.GetEnv("CREATE_ORG_NAME", ""),
@@ -92,11 +93,11 @@ func RunServer() error {
 		utils.LogAndReportSentryError(ctx, err)
 	}
 
-	repositories := repositories.NewRepositories(
-		infra.InitializeFirebase(ctx),
-		pool,
-		infra.InitializeMetabase(metabaseConfig),
-		gcpConfig.GcsTransferCheckEnrichmentBucket,
+	repositories := repositories.NewRepositories(pool,
+		repositories.WithFirebaseClient(infra.InitializeFirebase(ctx)),
+		repositories.WithMetabase(infra.InitializeMetabase(metabaseConfig)),
+		repositories.WithTransferCheckEnrichmentBucket(gcpConfig.GcsTransferCheckEnrichmentBucket),
+		repositories.WithFakeGcsRepository(gcpConfig.FakeGcsRepository),
 	)
 
 	uc := usecases.NewUsecases(repositories,

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -105,12 +105,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Could not create private key: %s", err)
 	}
-	repos := repositories.NewRepositories(
-		nil,
-		dbPool,
-		nil,
-		"",
-	)
+	repos := repositories.NewRepositories(dbPool)
 
 	jwtRepository := repositories.NewJWTRepository(privateKey)
 	database := postgres.New(dbPool)


### PR DESCRIPTION
In this PR, a refac to fix the issue with local use of fake GCS repository :
- need to handle fake GCS repository in `NewRepositories`
- refactor interface to use the `With*` options pattern, so we no longer need to explicitly assign "null" values for non used options in init phase