### PR TITLE
refactor(webhooks): refactor webhook dtos

### DIFF
--- a/api/handle_webhooks.go
+++ b/api/handle_webhooks.go
@@ -47,7 +47,7 @@ func (api *API) handleRegisterWebhook(c *gin.Context) {
 
 	usecase := api.UsecasesWithCreds(c.Request).NewWebhooksUsecase()
 
-	err := usecase.RegisterWebhook(c.Request.Context(),
+	webhook, err := usecase.RegisterWebhook(c.Request.Context(),
 		creds.OrganizationId,
 		null.StringFromPtr(creds.PartnerId),
 		models.WebhookRegister{
@@ -61,7 +61,7 @@ func (api *API) handleRegisterWebhook(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusCreated, gin.H{"webhook": dto.AdaptWebhookWithSecret(webhook)})
 }
 
 func (api *API) handleDeleteWebhook(c *gin.Context) {
@@ -103,7 +103,7 @@ func (api *API) handleUpdateWebhook(c *gin.Context) {
 
 	usecase := api.UsecasesWithCreds(c.Request).NewWebhooksUsecase()
 
-	err := usecase.UpdateWebhook(c.Request.Context(),
+	webhook, err := usecase.UpdateWebhook(c.Request.Context(),
 		creds.OrganizationId,
 		null.StringFromPtr(creds.PartnerId),
 		webhookId,
@@ -118,5 +118,5 @@ func (api *API) handleUpdateWebhook(c *gin.Context) {
 		return
 	}
 
-	c.Status(http.StatusOK)
+	c.JSON(http.StatusOK, gin.H{"webhook": dto.AdaptWebhook(webhook)})
 }

--- a/dto/webhooks.go
+++ b/dto/webhooks.go
@@ -16,11 +16,15 @@ type WebhookRegisterBody struct {
 type Webhook struct {
 	Id                string   `json:"id"`
 	EventTypes        []string `json:"event_types,omitempty"`
-	Secrets           []Secret `json:"secrets"`
 	Url               string   `json:"url"`
 	HttpTimeout       *int     `json:"http_timeout,omitempty"`
 	RateLimit         *int     `json:"rate_limit,omitempty"`
 	RateLimitDuration *int     `json:"rate_limit_duration,omitempty"`
+}
+
+type WebhookWithSecret struct {
+	Webhook
+	Secrets []Secret `json:"secrets,omitempty"`
 }
 
 type Secret struct {
@@ -47,11 +51,17 @@ func AdaptWebhook(webhook models.Webhook) Webhook {
 	return Webhook{
 		Id:                webhook.Id,
 		EventTypes:        webhook.EventTypes,
-		Secrets:           pure_utils.Map(webhook.Secrets, AdaptSecret),
 		Url:               webhook.Url,
 		HttpTimeout:       webhook.HttpTimeout,
 		RateLimit:         webhook.RateLimit,
 		RateLimitDuration: webhook.RateLimitDuration,
+	}
+}
+
+func AdaptWebhookWithSecret(webhook models.Webhook) WebhookWithSecret {
+	return WebhookWithSecret{
+		Webhook: AdaptWebhook(webhook),
+		Secrets: pure_utils.Map(webhook.Secrets, AdaptSecret),
 	}
 }
 


### PR DESCRIPTION
Small refactoring to be closer to other resources exposed on the API :
- POST and PATCH should return data
- Only return webhook secret on POST (closer to what we have on API_KEYS, it will help in case we want to implement finer permission strategy)

NB: currently there is no way to retrive an existing webhook secret but it's possible (the secret is stripped off at the dto adapter layer). I let this work for another iteration, focused on secret management.