### PR TITLE
remove go-fuzzywuzzy dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.48.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/adhocore/gronx v1.8.1
+	github.com/adrg/strutil v0.3.1
 	github.com/avast/retry-go/v4 v4.6.0
 	github.com/aws/aws-sdk-go-v2 v1.28.0
 	github.com/aws/aws-sdk-go-v2/config v1.27.19
@@ -30,7 +31,6 @@ require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.3.0
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/ory/dockertest/v3 v3.10.0
-	github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e
 	github.com/pkg/errors v0.9.1
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/segmentio/analytics-go/v3 v3.3.0

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/adhocore/gronx v1.8.1 h1:F2mLTG5sB11z7vplwD4iydz3YCEjstSfYmCrdSm3t6A=
 github.com/adhocore/gronx v1.8.1/go.mod h1:7oUY1WAU8rEJWmAxXR2DN0JaO4gi9khSgKjiRypqteg=
+github.com/adrg/strutil v0.3.1 h1:OLvSS7CSJO8lBii4YmBt8jiK9QOtB9CzCzwl4Ic/Fz4=
+github.com/adrg/strutil v0.3.1/go.mod h1:8h90y18QLrs11IBffcGX3NW/GFBXCMcNg4M7H6MspPA=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=
@@ -321,8 +323,6 @@ github.com/opencontainers/runc v1.1.12 h1:BOIssBaW1La0/qbNZHXOOa71dZfZEQOzW7dqQf
 github.com/opencontainers/runc v1.1.12/go.mod h1:S+lQwSfncpBha7XTy/5lBwWgm5+y5Ma/O44Ekby9FK8=
 github.com/ory/dockertest/v3 v3.10.0 h1:4K3z2VMe8Woe++invjaTB7VRyQXQy5UY+loujO4aNE4=
 github.com/ory/dockertest/v3 v3.10.0/go.mod h1:nr57ZbRWMqfsdGdFNLHz5jjNdDb7VVFnzAeW1n5N1Lg=
-github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e h1:UMX/0xkc/jcivgGjoBumSA1YwxT3eq6rYeWOOEuPU38=
-github.com/paul-mannino/go-fuzzywuzzy v0.0.0-20200127021948-54652b135d0e/go.mod h1:AMWhKRluACdXhJMWJiVOuqwmZvJOcdmjgbla/9zOKzE=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pelletier/go-toml/v2 v2.2.2 h1:aYUidT7k73Pcl9nb2gScu7NSrKCSHIDE89b3+6Wq+LM=
 github.com/pelletier/go-toml/v2 v2.2.2/go.mod h1:1t835xjRzz80PqgE6HHgN2JOsmgYu/h4qDAS4n929Rs=

--- a/pure_utils/strings.go
+++ b/pure_utils/strings.go
@@ -1,27 +1,23 @@
 package pure_utils
 
 import (
+	"math"
+	"sort"
 	"strings"
 	"unicode"
 
-	fuzzy "github.com/paul-mannino/go-fuzzywuzzy"
+	"github.com/adrg/strutil/metrics"
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 )
-
-func Capitalize(str string) string {
-	runes := []rune(str)
-	runes[0] = unicode.ToUpper(runes[0])
-	return string(runes)
-}
 
 func Normalize(s string) string {
 	result, _, _ := transform.String(norm.NFC, s)
 	return result
 }
 
-func NormalizeAndRemoveDiacritics(s string) string {
+func normalizeAndRemoveDiacritics(s string) string {
 	t := transform.Chain(
 		norm.NFD,
 		runes.Remove(runes.In(unicode.Mn)),
@@ -31,11 +27,128 @@ func NormalizeAndRemoveDiacritics(s string) string {
 	return result
 }
 
+func onlyLettersAndNumbers(s string) string {
+	var result strings.Builder
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			result.WriteRune(r)
+		} else {
+			result.WriteRune(' ')
+		}
+	}
+	return result.String()
+}
+
 // - normalize
 // - remove diacritics
 // - set to lower case
-// - keep only letters and numbers
-// - keep non-ASCII characters
-func CleanseString(s string) string {
-	return strings.TrimSpace(fuzzy.Cleanse(NormalizeAndRemoveDiacritics(s), false))
+// - only letters and numbers
+func cleanseString(s string) string {
+	return strings.TrimSpace(strings.ToLower(
+		onlyLettersAndNumbers(normalizeAndRemoveDiacritics(s))))
+}
+
+// Converts a string into a set (map) of unique words.
+func stringToSet(s string) map[string]bool {
+	set := make(map[string]bool)
+	tokens := strings.Fields(s)
+	for _, token := range tokens {
+		set[token] = true
+	}
+	return set
+}
+
+// Calculates the intersection of two sets.
+func intersect(set1, set2 map[string]bool) map[string]bool {
+	intersection := make(map[string]bool)
+	for key := range set1 {
+		if _, exists := set2[key]; exists {
+			intersection[key] = true
+		}
+	}
+	return intersection
+}
+
+// Calculates the difference of two sets (set1 - set2).
+func difference(set1, set2 map[string]bool) map[string]bool {
+	diff := make(map[string]bool)
+	for key := range set1 {
+		if _, exists := set2[key]; !exists {
+			diff[key] = true
+		}
+	}
+	return diff
+}
+
+func setToSlice(set map[string]bool) []string {
+	slice := make([]string, 0, len(set))
+	for key := range set {
+		slice = append(slice, key)
+	}
+	return slice
+}
+
+func similarityRatioFloat(s1, s2 string) float64 {
+	sumOfLen := len(s1) + len(s2)
+	if sumOfLen == 0 {
+		return 1
+	}
+
+	lev := metrics.NewLevenshtein()
+	// There are different flavors of Levenshtein distance. We need a replace cost of 2 if two completely
+	// different strings (no shared letter in same position) of same size are to have a similarity of 0 and not 50%
+	// Not all implementations available in open-source conform with this (or expose the option).
+	lev.InsertCost = 1
+	lev.ReplaceCost = 2
+	lev.DeleteCost = 1
+	editDistance := lev.Distance(s1, s2)
+	return 1 - float64(editDistance)/float64(sumOfLen)
+}
+
+func similarityRatio(s1, s2 string) int {
+	return int(math.Round(similarityRatioFloat(s1, s2) * 100))
+}
+
+func DirectSimilarity(s1, s2 string) int {
+	s1 = cleanseString(s1)
+	s2 = cleanseString(s2)
+	return similarityRatio(s1, s2)
+}
+
+// Calculates the similarity ratio between two strings.
+func BagOfWordsSimilarity(s1, s2 string) int {
+	s1 = cleanseString(s1)
+	s2 = cleanseString(s2)
+
+	set1 := stringToSet(s1)
+	set2 := stringToSet(s2)
+
+	intersection := intersect(set1, set2)
+	diff1to2 := difference(set1, set2)
+	diff2to1 := difference(set2, set1)
+
+	intersectionSlice := setToSlice(intersection)
+	diff1to2Slice := setToSlice(diff1to2)
+	diff2to1Slice := setToSlice(diff2to1)
+
+	sort.Strings(intersectionSlice)
+	sort.Strings(diff1to2Slice)
+	sort.Strings(diff2to1Slice)
+
+	intersectionBag := strings.Join(intersectionSlice, " ")
+	diff1to2Bag := strings.Trim(intersectionBag+" "+strings.Join(diff1to2Slice, " "), " ")
+	diff2to1Bag := strings.Trim(intersectionBag+" "+strings.Join(diff2to1Slice, " "), " ")
+
+	ratio1 := similarityRatio(intersectionBag, diff1to2Bag)
+	ratio2 := similarityRatio(intersectionBag, diff2to1Bag)
+	ratio3 := similarityRatio(diff1to2Bag, diff2to1Bag)
+
+	out := ratio1
+	if ratio2 > out {
+		out = ratio2
+	}
+	if ratio3 > out {
+		out = ratio3
+	}
+	return out
 }

--- a/pure_utils/strings_test.go
+++ b/pure_utils/strings_test.go
@@ -1,0 +1,124 @@
+package pure_utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/adrg/strutil"
+	"github.com/adrg/strutil/metrics"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBagOfWordsSimilarity(t *testing.T) {
+	examples := []struct {
+		s1       string
+		s2       string
+		expected int
+	}{
+		{"", "", 100},
+		{"teatime", "tea time", 93},
+		{"the dog was walking on the sidewalk", "the dog was walking on the side walk", 98},
+		{"the dog was walking on the sidewalk", "the d og as walkin' on the side alk", 72},
+		{"Mr Mrs John Jane OR Doe Smith	", "John Doe", 100},
+		{"ça, c'est une théière", "la theier a une typo", 65},
+	}
+
+	for _, example := range examples {
+		t.Run(example.s1+" vs "+example.s2, func(t *testing.T) {
+			result := BagOfWordsSimilarity(example.s1, example.s2)
+			assert.Equal(t, example.expected, result)
+		})
+	}
+}
+
+func TestCleanseString(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{
+			name: "cleanse string",
+			args: "old mc donald had a farm",
+			want: "old mc donald had a farm",
+		},
+		{
+			name: "cleanse string with special characters",
+			args: "old mc donald had a farm!@#$%^&*()",
+			want: "old mc donald had a farm",
+		},
+		{
+			name: "cleanse string with accents",
+			args: "il était une fois une belle théière à ma sœur et ça c'est beau",
+			want: "il etait une fois une belle theiere a ma sœur et ca c est beau",
+		},
+		{
+			name: "various accents with upper case",
+			args: "AÉÇÀÈÙÎÏ",
+			want: "aecaeuii",
+		},
+		{
+			name: "theiere",
+			args: "ça, c'est une théière",
+			want: "ca  c est une theiere",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, cleanseString(tt.args))
+		})
+	}
+}
+
+func TestSimilarityRatio(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected float64
+	}{
+		{"empty strings", "", "", 100},
+		{"same strings", "hello", "hello", 100},
+		{"completely different strings", "hello", "aaaaa", 0},
+		{
+			"different strings with accents",
+			"the dog was walking on the sidewalk", "the d og as walkin' on the side alk", 91,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := similarityRatio(tt.s1, tt.s2)
+			assert.InDelta(t, tt.expected, result, 0.01)
+		})
+	}
+}
+
+func TestLehvenstein2(t *testing.T) {
+	tests := []struct {
+		name     string
+		s1       string
+		s2       string
+		expected int
+	}{
+		{"different strings", "une c ca est theiere", "une a la theier typo", 14},
+		{"all different strings", "world", "maiji", 10},
+		{"from other test", "old mc donald had a farm", "old mc donald may have had a farm", 9},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lev := metrics.NewLevenshtein()
+			lev.InsertCost = 1
+			lev.ReplaceCost = 2
+			lev.DeleteCost = 1
+
+			similarity := strutil.Similarity("make", "Cake", lev)
+			fmt.Printf("%.2f\n", similarity)
+
+			result := lev.Distance(tt.s1, tt.s2)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/checkmarble/marble-backend/models/ast"
-	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,22 +18,10 @@ func TestFuzzyMatch(t *testing.T) {
 		errors []error
 	}{
 		{
-			name: "partial_token_set_ratio",
+			name: "bag_of_words_similarity",
 			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
-			algo: "partial_token_set_ratio",
+			algo: "bag_of_words_similarity",
 			want: 100,
-		},
-		{
-			name: "token_set_ratio",
-			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
-			algo: "token_set_ratio",
-			want: 100,
-		},
-		{
-			name: "partial_ratio",
-			args: []any{"old mc donald had a farm", "old mc donald may have had a farm"},
-			algo: "partial_ratio",
-			want: 75,
 		},
 		{
 			name:   "error algo",
@@ -45,7 +32,7 @@ func TestFuzzyMatch(t *testing.T) {
 		{
 			name: "with accents",
 			args: []any{"ça, c'est une théière", "la theier a une typo"},
-			algo: "token_set_ratio",
+			algo: "bag_of_words_similarity",
 			want: 65,
 		},
 	}
@@ -74,25 +61,19 @@ func TestFuzzyMatchAnyOf(t *testing.T) {
 		errors []error
 	}{
 		{
-			name: "partial_token_set_ratio",
-			args: []any{"old mc donald had a farm", []string{"old mc donald may have had a farm", "E I E I O"}},
-			algo: "partial_token_set_ratio",
-			want: 100,
-		},
-		{
-			name: "token_set_ratio",
+			name: "bag_of_words_similarity",
 			args: []any{"old mc donald had a farm", []string{"E I E I O"}},
-			algo: "token_set_ratio",
+			algo: "bag_of_words_similarity",
 			want: 21,
 		},
 		{
-			name: "partial_ratio",
+			name: "ratio",
 			args: []any{"old mc donald had a farm", []string{
 				"Lorem ipsum dolor sit amet, consectetur adipiscing elit",
 				"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
 			}},
-			algo: "partial_ratio",
-			want: 46,
+			algo: "ratio",
+			want: 31,
 		},
 		{
 			name:   "error algo",
@@ -113,41 +94,6 @@ func TestFuzzyMatchAnyOf(t *testing.T) {
 				assert.ErrorContains(t, errs[0], tt.errors[0].Error())
 			}
 			assert.Equal(t, tt.want, r)
-		})
-	}
-}
-
-func TestCleanseString(t *testing.T) {
-	tests := []struct {
-		name string
-		args string
-		want string
-	}{
-		{
-			name: "cleanse string",
-			args: "old mc donald had a farm",
-			want: "old mc donald had a farm",
-		},
-		{
-			name: "cleanse string with special characters",
-			args: "old mc donald had a farm!@#$%^&*()",
-			want: "old mc donald had a farm",
-		},
-		{
-			name: "cleanse string with accents",
-			args: "il était une fois une belle théière à ma sœur et ça c'est beau",
-			want: "il etait une fois une belle theiere a ma sœur et ca c est beau",
-		},
-		{
-			name: "various accents with upper case",
-			args: "AÉÇÀÈÙÎÏ",
-			want: "aecaeuii",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, pure_utils.CleanseString(tt.args))
 		})
 	}
 }


### PR DESCRIPTION
Library replaced for licensing reasons. https://github.com/adrg/strutil which comes as a partial replacement (for the edit distance) is under MIT license.

--- 

Last thing to do (but no strong urgency): update the naming of the functions in the front and the doc. I changed "token_set_ratio" it to "bag_of_words_similarity" because it's less library specific and ultimately more self-explanatory, though I kept backwards compatibility of course for old ASTs.


--- 

Making if fully backwards compatible was a bit tricky because of subtle differences in how the Levensthtein distance is defined (and computed), see comment in the strings.go file