### PR TITLE
dirty fix: no webhooks for decisions from TC usecase

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -103,6 +103,7 @@ func (api *API) handlePostDecision(c *gin.Context) {
 			TriggerObjectTable: requestData.TriggerObjectType,
 		},
 		false,
+		true,
 	)
 
 	if returnExpectedDecisionError(c, err) || presentError(c, err) {

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -551,6 +551,7 @@ func createAndTestDecision(
 			TriggerObjectTable: table.Name,
 		},
 		false,
+		false,
 	)
 	assert.NoError(t, err, "Could not create decision")
 	assert.Equal(t, expectedScore, decision.Score, "The score should match the expected value")

--- a/usecases/transfer_check_usecase.go
+++ b/usecases/transfer_check_usecase.go
@@ -210,6 +210,7 @@ func (usecase *TransferCheckUsecase) CreateTransfer(
 			TriggerObjectTable: models.TransferCheckTable,
 		},
 		true,
+		false,
 	)
 	if err != nil {
 		return models.Transfer{}, errors.Wrapf(
@@ -505,6 +506,7 @@ func (usecase *TransferCheckUsecase) ScoreTransfer(
 			TriggerObjectTable: models.TransferCheckTable,
 		},
 		true,
+		false,
 	)
 	if err != nil {
 		return models.Transfer{}, errors.Wrapf(


### PR DESCRIPTION
This is a bit of a dirty fix.
I should probably start to disentangle the decisions usecase from the transfercheck usecase.
I'm creating a task in the linear backlog for this.