### PR TITLE
refactor: properly do webhooks retry count

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -70,7 +70,6 @@ type WebhookEventCreate struct {
 type WebhookEventUpdate struct {
 	Id             string
 	DeliveryStatus WebhookEventDeliveryStatus
-	RetryCount     int
 }
 
 type WebhookEventFilters struct {

--- a/repositories/convoy_repository.go
+++ b/repositories/convoy_repository.go
@@ -212,9 +212,8 @@ func adaptEventTypes(convoyFilterConfig convoy.DatastoreFilterConfiguration) []s
 	if len(*convoyFilterConfig.EventTypes) == 1 && (*convoyFilterConfig.EventTypes)[0] == "*" {
 		return eventTypes
 	}
-	for _, eventType := range *convoyFilterConfig.EventTypes {
-		eventTypes = append(eventTypes, eventType)
-	}
+	eventTypes = append(eventTypes, *convoyFilterConfig.EventTypes...)
+
 	return eventTypes
 }
 

--- a/repositories/webhook_events_repository.go
+++ b/repositories/webhook_events_repository.go
@@ -93,7 +93,7 @@ func (repo MarbleDbRepository) CreateWebhookEvent(
 	return err
 }
 
-func (repo MarbleDbRepository) UpdateWebhookEvent(
+func (repo MarbleDbRepository) MarkWebhookEventRetried(
 	ctx context.Context,
 	exec Executor,
 	input models.WebhookEventUpdate,
@@ -109,8 +109,9 @@ func (repo MarbleDbRepository) UpdateWebhookEvent(
 			Update(dbmodels.TABLE_WEBHOOK_EVENTS).
 			Set("updated_at", "NOW()").
 			Set("delivery_status", input.DeliveryStatus).
-			Set("retry_count", input.RetryCount).
-			Where(squirrel.Eq{"id": input.Id}),
+			Set("retry_count", squirrel.Expr("retry_count + 1")).
+			Where(squirrel.Eq{"id": input.Id}).
+			Where(squirrel.NotEq{"delivery_status": models.Success}),
 	)
 	return err
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -422,7 +422,6 @@ func (usecases *UsecasesWithCreds) NewWebhookEventsUsecase() WebhookEventsUsecas
 	return NewWebhookEventsUsecase(
 		security.NewEnforceSecurity(usecases.Credentials),
 		usecases.NewExecutorFactory(),
-		usecases.NewTransactionFactory(),
 		usecases.Repositories.ConvoyRepository,
 		usecases.Repositories.MarbleDbRepository,
 		usecases.Usecases.failedWebhooksRetryPageSize,


### PR DESCRIPTION
Do retry count update properly:
- don't lose the number when the webhook finally goes to "success" (was being reset to 0)
- don't use needless DB transaction (instead, do the update in an atomic DB update, that cannot overwrite a row that is already in "success" by design, with a more specialized db update repository method