### PR TITLE
fix: proper CI/CD on webhooks retry job, so that that image is proper…

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -91,3 +91,10 @@ jobs:
             --quiet \
             --image=${{ env.IMAGE }} \
             --region="europe-west1" \
+
+      - name: Deploy webhook retry
+        run: |
+          gcloud beta run jobs deploy retry-webhooks \
+            --quiet \
+            --image=${{ env.IMAGE }} \
+            --region="europe-west1" \


### PR DESCRIPTION
…ly updated with future releases (must be done after having deployed with terraform)

For now, I will manually update the docker tag of the image currently used by the job (which is incorrect, so it tries to launch the server, but fails because it does not have the right env variables set), as well as temporarily deactivate it on scheduler (as discussed this afternoon).

(Turns out I made a mistake, because the docker tag is present in terraform -> 0.0.44) but not updated because the CI is doing that. I should have updated it to the latest version when deploying a new job)