### PR TITLE
case event: rule snooze created

### DIFF
--- a/api/handle_snoozes.go
+++ b/api/handle_snoozes.go
@@ -56,6 +56,7 @@ func (api *API) handleSnoozeDecision(c *gin.Context) {
 
 	ruleSnoozeUsecase := api.UsecasesWithCreds(c.Request).NewRuleSnoozeUsecase()
 	snoozes, err := ruleSnoozeUsecase.SnoozeDecision(c.Request.Context(), models.SnoozeDecisionInput{
+		Comment:        input.Comment,
 		DecisionId:     decisionId,
 		Duration:       input.Duration,
 		OrganizationId: organizationId,

--- a/api/handle_snoozes.go
+++ b/api/handle_snoozes.go
@@ -91,3 +91,21 @@ func (api *API) handleSnoozesOfScenarioIteartion(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"snoozes": dto.AdaptSnoozesOfIteration(snoozes)})
 }
+
+func (api *API) handleGetSnoozesById(c *gin.Context) {
+	ruleSnoozeId := c.Param("rule_snooze_id")
+	_, err := uuid.Parse(ruleSnoozeId)
+	if err != nil {
+		presentError(c, errors.Wrap(models.BadParameterError,
+			"rule_snooze_id must be a valid uuid"))
+		return
+	}
+
+	ruleSnoozeUsecase := api.UsecasesWithCreds(c.Request).NewRuleSnoozeUsecase()
+	snooze, err := ruleSnoozeUsecase.GetRuleSnoozeById(c.Request.Context(), ruleSnoozeId)
+	if presentError(c, err) {
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"snooze": dto.AdaptRuleSnoose(snooze)})
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -180,4 +180,6 @@ func (api *API) routes(auth Authentication, tokenHandler TokenHandler) {
 	router.GET("/webhooks/:webhook_id", api.handleGetWebhook)
 	router.PATCH("/webhooks/:webhook_id", api.handleUpdateWebhook)
 	router.DELETE("/webhooks/:webhook_id", api.handleDeleteWebhook)
+
+	router.GET("/rule-snoozes/:rule_snooze_id", api.handleGetSnoozesById)
 }

--- a/dto/case_event_dto.go
+++ b/dto/case_event_dto.go
@@ -15,6 +15,8 @@ type APICaseEvent struct {
 	EventType      string      `json:"event_type"`
 	AdditionalNote string      `json:"additional_note"`
 	NewValue       string      `json:"new_value"`
+	ResourceType   string      `json:"resource_type"`
+	ResourceId     string      `json:"resource_id"`
 }
 
 func NewAPICaseEvent(caseEvent models.CaseEvent) APICaseEvent {
@@ -26,5 +28,7 @@ func NewAPICaseEvent(caseEvent models.CaseEvent) APICaseEvent {
 		EventType:      string(caseEvent.EventType),
 		AdditionalNote: caseEvent.AdditionalNote,
 		NewValue:       caseEvent.NewValue,
+		ResourceType:   string(caseEvent.ResourceType),
+		ResourceId:     caseEvent.ResourceId,
 	}
 }

--- a/dto/rule_snoozes.go
+++ b/dto/rule_snoozes.go
@@ -69,4 +69,5 @@ func AdaptSnoozesOfIteration(s models.SnoozesOfIteration) SnoozesOfIteration {
 type SnoozeDecisionInput struct {
 	RuleId   string `json:"rule_id"`
 	Duration string `json:"duration"`
+	Comment  string `json:"comment"`
 }

--- a/dto/rule_snoozes.go
+++ b/dto/rule_snoozes.go
@@ -7,12 +7,13 @@ import (
 )
 
 type RuleSnooze struct {
-	Id            string    `json:"id"`
-	RuleId        string    `json:"rule_id"`
-	PivotValue    string    `json:"pivot_value"`
-	StartsAt      time.Time `json:"starts_at"`
-	ExpiresAt     time.Time `json:"ends_at"`
-	CreatedByUser string    `json:"created_by_user"`
+	Id                    string    `json:"id"`
+	RuleId                string    `json:"rule_id"`
+	PivotValue            string    `json:"pivot_value"`
+	StartsAt              time.Time `json:"starts_at"`
+	ExpiresAt             time.Time `json:"ends_at"`
+	CreatedByUser         string    `json:"created_by_user"`
+	CreatedFromDecisionId *string   `json:"created_from_decision_id"`
 }
 
 type SnoozesOfDecision struct {
@@ -24,12 +25,13 @@ func AdaptSnoozesOfDecision(s models.SnoozesOfDecision) SnoozesOfDecision {
 	snoozes := make([]RuleSnooze, 0, len(s.RuleSnoozes))
 	for _, s := range s.RuleSnoozes {
 		snoozes = append(snoozes, RuleSnooze{
-			Id:            s.Id,
-			RuleId:        s.RuleId,
-			PivotValue:    s.PivotValue,
-			StartsAt:      s.StartsAt,
-			ExpiresAt:     s.ExpiresAt,
-			CreatedByUser: s.CreatedByUser,
+			Id:                    s.Id,
+			RuleId:                s.RuleId,
+			PivotValue:            s.PivotValue,
+			StartsAt:              s.StartsAt,
+			ExpiresAt:             s.ExpiresAt,
+			CreatedByUser:         s.CreatedByUser,
+			CreatedFromDecisionId: s.CreatedFromDecisionId,
 		})
 	}
 

--- a/dto/rule_snoozes.go
+++ b/dto/rule_snoozes.go
@@ -8,7 +8,6 @@ import (
 
 type RuleSnooze struct {
 	Id                    string    `json:"id"`
-	RuleId                string    `json:"rule_id"`
 	PivotValue            string    `json:"pivot_value"`
 	StartsAt              time.Time `json:"starts_at"`
 	ExpiresAt             time.Time `json:"ends_at"`
@@ -16,22 +15,40 @@ type RuleSnooze struct {
 	CreatedFromDecisionId *string   `json:"created_from_decision_id"`
 }
 
+type RuleSnoozeWithRuleId struct {
+	RuleSnooze
+	RuleId string `json:"rule_id"`
+}
+
+func AdaptRuleSnoose(r models.RuleSnooze) RuleSnooze {
+	return RuleSnooze{
+		Id:                    r.Id,
+		PivotValue:            r.PivotValue,
+		StartsAt:              r.StartsAt,
+		ExpiresAt:             r.ExpiresAt,
+		CreatedByUser:         r.CreatedByUser,
+		CreatedFromDecisionId: r.CreatedFromDecisionId,
+	}
+}
+
 type SnoozesOfDecision struct {
-	DecisionId  string       `json:"decision_id"`
-	RuleSnoozes []RuleSnooze `json:"rule_snoozes"`
+	DecisionId  string                 `json:"decision_id"`
+	RuleSnoozes []RuleSnoozeWithRuleId `json:"rule_snoozes"`
 }
 
 func AdaptSnoozesOfDecision(s models.SnoozesOfDecision) SnoozesOfDecision {
-	snoozes := make([]RuleSnooze, 0, len(s.RuleSnoozes))
+	snoozes := make([]RuleSnoozeWithRuleId, 0, len(s.RuleSnoozes))
 	for _, s := range s.RuleSnoozes {
-		snoozes = append(snoozes, RuleSnooze{
-			Id:                    s.Id,
-			RuleId:                s.RuleId,
-			PivotValue:            s.PivotValue,
-			StartsAt:              s.StartsAt,
-			ExpiresAt:             s.ExpiresAt,
-			CreatedByUser:         s.CreatedByUser,
-			CreatedFromDecisionId: s.CreatedFromDecisionId,
+		snoozes = append(snoozes, RuleSnoozeWithRuleId{
+			RuleSnooze: RuleSnooze{
+				Id:                    s.Id,
+				PivotValue:            s.PivotValue,
+				StartsAt:              s.StartsAt,
+				ExpiresAt:             s.ExpiresAt,
+				CreatedByUser:         s.CreatedByUser,
+				CreatedFromDecisionId: s.CreatedFromDecisionId,
+			},
+			RuleId: s.RuleId,
 		})
 	}
 

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -22,22 +22,24 @@ type CaseEvent struct {
 type CaseEventType string
 
 const (
-	CaseCreated       CaseEventType = "case_created"
-	CaseStatusUpdated CaseEventType = "status_updated"
-	DecisionAdded     CaseEventType = "decision_added"
-	CaseCommentAdded  CaseEventType = "comment_added"
-	CaseNameUpdated   CaseEventType = "name_updated"
-	CaseTagsUpdated   CaseEventType = "tags_updated"
-	CaseFileAdded     CaseEventType = "file_added"
-	CaseInboxChanged  CaseEventType = "inbox_changed"
+	CaseCreated           CaseEventType = "case_created"
+	CaseStatusUpdated     CaseEventType = "status_updated"
+	DecisionAdded         CaseEventType = "decision_added"
+	CaseCommentAdded      CaseEventType = "comment_added"
+	CaseNameUpdated       CaseEventType = "name_updated"
+	CaseTagsUpdated       CaseEventType = "tags_updated"
+	CaseFileAdded         CaseEventType = "file_added"
+	CaseInboxChanged      CaseEventType = "inbox_changed"
+	CaseRuleSnooseCreated CaseEventType = "rule_snooze_created"
 )
 
 type CaseEventResourceType string
 
 const (
-	DecisionResourceType CaseEventResourceType = "decision"
-	CaseTagResourceType  CaseEventResourceType = "case_tag"
-	CaseFileResourceType CaseEventResourceType = "case_file"
+	DecisionResourceType   CaseEventResourceType = "decision"
+	CaseTagResourceType    CaseEventResourceType = "case_tag"
+	CaseFileResourceType   CaseEventResourceType = "case_file"
+	RuleSnoozeResourceType CaseEventResourceType = "rule_snooze"
 )
 
 type CreateCaseEventAttributes struct {

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -81,6 +81,7 @@ type RuleSnoozeInformation struct {
 }
 
 type SnoozeDecisionInput struct {
+	Comment        string
 	DecisionId     string
 	Duration       string
 	OrganizationId string
@@ -90,6 +91,7 @@ type SnoozeDecisionInput struct {
 
 type RuleSnoozeCaseEventInput struct {
 	CaseId         string
+	Comment        string
 	RuleSnoozeId   string
 	UserId         string
 	WebhookEventId string

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -9,22 +9,24 @@ type SnoozeGroup struct {
 }
 
 type RuleSnooze struct {
-	Id            string
-	CreatedByUser string
-	PivotValue    string
-	SnoozeGroupId string
-	StartsAt      time.Time
-	ExpiresAt     time.Time
+	Id                    string
+	CreatedByUser         string
+	CreatedFromDecisionId *string
+	PivotValue            string
+	SnoozeGroupId         string
+	StartsAt              time.Time
+	ExpiresAt             time.Time
 }
 
 type RuleSnoozeWithRuleId struct {
-	Id            string
-	CreatedByUser string
-	PivotValue    string
-	RuleId        string
-	SnoozeGroupId string
-	StartsAt      time.Time
-	ExpiresAt     time.Time
+	Id                    string
+	CreatedByUser         string
+	CreatedFromDecisionId *string
+	PivotValue            string
+	RuleId                string
+	SnoozeGroupId         string
+	StartsAt              time.Time
+	ExpiresAt             time.Time
 }
 
 type SnoozesOfDecision struct {
@@ -41,13 +43,14 @@ func NewSnoozesOfDecision(decisionId string, snoozes []RuleSnooze, iteration Sce
 			if rule.SnoozeGroupId != nil && *rule.SnoozeGroupId == s.SnoozeGroupId {
 				ruleId = rule.Id
 				snoozesWithRuleId = append(snoozesWithRuleId, RuleSnoozeWithRuleId{
-					Id:            s.Id,
-					CreatedByUser: s.CreatedByUser,
-					PivotValue:    s.PivotValue,
-					RuleId:        ruleId,
-					SnoozeGroupId: s.SnoozeGroupId,
-					StartsAt:      s.StartsAt,
-					ExpiresAt:     s.ExpiresAt,
+					Id:                    s.Id,
+					CreatedByUser:         s.CreatedByUser,
+					CreatedFromDecisionId: s.CreatedFromDecisionId,
+					PivotValue:            s.PivotValue,
+					RuleId:                ruleId,
+					SnoozeGroupId:         s.SnoozeGroupId,
+					StartsAt:              s.StartsAt,
+					ExpiresAt:             s.ExpiresAt,
 				})
 				break
 			}
@@ -62,11 +65,12 @@ func NewSnoozesOfDecision(decisionId string, snoozes []RuleSnooze, iteration Sce
 }
 
 type RuleSnoozeCreateInput struct {
-	Id            string
-	SnoozeGroupId string
-	ExpiresAt     time.Time
-	CreatedByUser UserId
-	PivotValue    string
+	Id                    string
+	CreatedByUserId       UserId
+	CreatedFromDecisionId string
+	ExpiresAt             time.Time
+	PivotValue            string
+	SnoozeGroupId         string
 }
 
 type SnoozesOfIteration struct {

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -10,6 +10,7 @@ type SnoozeGroup struct {
 
 type RuleSnooze struct {
 	Id                    string
+	OrganizationId        string
 	CreatedByUser         string
 	CreatedFromDecisionId *string
 	PivotValue            string

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -87,3 +87,10 @@ type SnoozeDecisionInput struct {
 	RuleId         string
 	UserId         UserId
 }
+
+type RuleSnoozeCaseEventInput struct {
+	CaseId         string
+	RuleSnoozeId   string
+	UserId         string
+	WebhookEventId string
+}

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -23,14 +23,15 @@ const (
 type WebhookEventType string
 
 const (
-	WebhookEventType_CaseUpdated          WebhookEventType = "case.updated"
-	WebhookEventType_CaseCreatedManually  WebhookEventType = "case.created_manually"
-	WebhookEventType_CaseCreatedWorkflow  WebhookEventType = "case.created_from_workflow"
-	WebhookEventType_CaseDecisionsUpdated WebhookEventType = "case.decisions_updated"
-	WebhookEventType_CaseTagsUpdated      WebhookEventType = "case.tags_updated"
-	WebhookEventType_CaseCommentCreated   WebhookEventType = "case.comment_created"
-	WebhookEventType_CaseFileCreated      WebhookEventType = "case.file_created"
-	WebhookEventType_DecisionCreated      WebhookEventType = "decision.created"
+	WebhookEventType_CaseUpdated           WebhookEventType = "case.updated"
+	WebhookEventType_CaseCreatedManually   WebhookEventType = "case.created_manually"
+	WebhookEventType_CaseCreatedWorkflow   WebhookEventType = "case.created_from_workflow"
+	WebhookEventType_CaseDecisionsUpdated  WebhookEventType = "case.decisions_updated"
+	WebhookEventType_CaseTagsUpdated       WebhookEventType = "case.tags_updated"
+	WebhookEventType_CaseCommentCreated    WebhookEventType = "case.comment_created"
+	WebhookEventType_CaseFileCreated       WebhookEventType = "case.file_created"
+	WebhookEventType_CaseRuleSnoozeCreated WebhookEventType = "case.rule_snooze_created"
+	WebhookEventType_DecisionCreated       WebhookEventType = "decision.created"
 )
 
 var validWebhookEventTypes = []WebhookEventType{
@@ -171,6 +172,10 @@ func NewWebhookEventCaseCommentCreated(c Case) WebhookEventContent {
 
 func NewWebhookEventCaseFileCreated(c Case) WebhookEventContent {
 	return newWebhookContentCase(WebhookEventType_CaseFileCreated, c.Id)
+}
+
+func NewWebhookEventRuleSnoozeCreated(c Case) WebhookEventContent {
+	return newWebhookContentCase(WebhookEventType_CaseRuleSnoozeCreated, c.Id)
 }
 
 type Webhook struct {

--- a/repositories/dbmodels/db_rule_snooze.go
+++ b/repositories/dbmodels/db_rule_snooze.go
@@ -30,21 +30,23 @@ const TABLE_RULE_SNOOZES = "rule_snoozes"
 var SelectRuleSnoozesColumn = utils.ColumnList[DBRuleSnooze]()
 
 type DBRuleSnooze struct {
-	Id            string    `db:"id"`
-	CreatedByUser string    `db:"created_by_user"`
-	SnoozeGroupId string    `db:"snooze_group_id"`
-	PivotValue    string    `db:"pivot_value"`
-	StartsAt      time.Time `db:"starts_at"`
-	ExpiresAt     time.Time `db:"expires_at"`
+	Id                    string    `db:"id"`
+	CreatedByUser         string    `db:"created_by_user"`
+	CreatedFromDecisionId *string   `db:"created_from_decision_id"`
+	SnoozeGroupId         string    `db:"snooze_group_id"`
+	PivotValue            string    `db:"pivot_value"`
+	StartsAt              time.Time `db:"starts_at"`
+	ExpiresAt             time.Time `db:"expires_at"`
 }
 
 func AdaptRuleSnooze(s DBRuleSnooze) (models.RuleSnooze, error) {
 	return models.RuleSnooze{
-		Id:            s.Id,
-		CreatedByUser: s.CreatedByUser,
-		SnoozeGroupId: s.SnoozeGroupId,
-		PivotValue:    s.PivotValue,
-		StartsAt:      s.StartsAt,
-		ExpiresAt:     s.ExpiresAt,
+		Id:                    s.Id,
+		CreatedByUser:         s.CreatedByUser,
+		CreatedFromDecisionId: s.CreatedFromDecisionId,
+		SnoozeGroupId:         s.SnoozeGroupId,
+		PivotValue:            s.PivotValue,
+		StartsAt:              s.StartsAt,
+		ExpiresAt:             s.ExpiresAt,
 	}, nil
 }

--- a/repositories/migrations/20240808165800_rule_snoozes_store_decision_id.sql
+++ b/repositories/migrations/20240808165800_rule_snoozes_store_decision_id.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE rule_snoozes
+ADD COLUMN created_from_decision_id UUID REFERENCES decisions (id) ON DELETE SET NULL;
+
+-- +goose StatementEnd
+-- +goose Down
+ALTER TABLE rule_snoozes
+DROP COLUMN created_from_decision_id;
+
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/repositories/rule_snoozes.go
+++ b/repositories/rule_snoozes.go
@@ -66,6 +66,7 @@ func (repo *MarbleDbRepository) CreateRuleSnooze(ctx context.Context, exec Execu
 				"id",
 				"created_at",
 				"created_by_user",
+				"created_from_decision_id",
 				"snooze_group_id",
 				"pivot_value",
 				"starts_at",
@@ -74,7 +75,8 @@ func (repo *MarbleDbRepository) CreateRuleSnooze(ctx context.Context, exec Execu
 			Values(
 				input.Id,
 				"NOW()",
-				input.CreatedByUser,
+				input.CreatedByUserId,
+				input.CreatedFromDecisionId,
 				input.SnoozeGroupId,
 				input.PivotValue,
 				"NOW()",

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -891,11 +891,12 @@ func (usecase *CaseUseCase) CreateRuleSnoozeEvent(ctx context.Context, tx reposi
 
 	resourceType := models.RuleSnoozeResourceType
 	err = usecase.repository.CreateCaseEvent(ctx, tx, models.CreateCaseEventAttributes{
-		CaseId:       input.CaseId,
-		UserId:       input.UserId,
-		EventType:    models.CaseRuleSnooseCreated,
-		ResourceType: &resourceType,
-		ResourceId:   &input.RuleSnoozeId,
+		AdditionalNote: &input.Comment,
+		CaseId:         input.CaseId,
+		UserId:         input.UserId,
+		EventType:      models.CaseRuleSnooseCreated,
+		ResourceType:   &resourceType,
+		ResourceId:     &input.RuleSnoozeId,
 	})
 	if err != nil {
 		return err

--- a/usecases/rule_snoozes.go
+++ b/usecases/rule_snoozes.go
@@ -21,6 +21,7 @@ type iterationGetter interface {
 }
 
 type ruleSnoozeRepository interface {
+	GetSnoozeById(ctx context.Context, exec repositories.Executor, ruleSnoozeId string) (models.RuleSnooze, error)
 	CreateSnoozeGroup(ctx context.Context, exec repositories.Executor, id, organizationId string) error
 	ListRuleSnoozesForDecision(
 		ctx context.Context,
@@ -44,6 +45,7 @@ type enforceSecuritySnoozes interface {
 	ReadSnoozesOfDecision(ctx context.Context, decision models.Decision) error
 	CreateSnoozesOnDecision(ctx context.Context, decision models.Decision) error
 	ReadSnoozesOfIteration(ctx context.Context, iteration models.ScenarioIteration) error
+	ReadRuleSnooze(ctx context.Context, snooze models.RuleSnooze) error
 }
 
 type updateRuleRepository interface {
@@ -342,4 +344,14 @@ func (usecase RuleSnoozeUsecase) ActiveSnoozesForScenarioIteration(ctx context.C
 		IterationId: iterationId,
 		RuleSnoozes: snoozes,
 	}, nil
+}
+
+func (usecase RuleSnoozeUsecase) GetRuleSnoozeById(ctx context.Context, ruleSnoozeId string) (models.RuleSnooze, error) {
+	s, err := usecase.ruleSnoozeRepository.GetSnoozeById(
+		ctx, usecase.executorFactory.NewExecutor(), ruleSnoozeId)
+	if err != nil {
+		return models.RuleSnooze{}, err
+	}
+
+	return s, nil
 }

--- a/usecases/rule_snoozes.go
+++ b/usecases/rule_snoozes.go
@@ -263,11 +263,12 @@ func (usecase RuleSnoozeUsecase) SnoozeDecision(
 			}
 			snoozeId := uuid.NewString()
 			err = usecase.ruleSnoozeRepository.CreateRuleSnooze(ctx, tx, models.RuleSnoozeCreateInput{
-				Id:            snoozeId,
-				SnoozeGroupId: *snoozeGroupId,
-				ExpiresAt:     time.Now().Add(duration),
-				CreatedByUser: input.UserId,
-				PivotValue:    *decision.PivotValue,
+				Id:                    snoozeId,
+				CreatedByUserId:       input.UserId,
+				ExpiresAt:             time.Now().Add(duration),
+				CreatedFromDecisionId: input.DecisionId,
+				PivotValue:            *decision.PivotValue,
+				SnoozeGroupId:         *snoozeGroupId,
 			})
 			if err != nil {
 				return nil, err

--- a/usecases/rule_snoozes.go
+++ b/usecases/rule_snoozes.go
@@ -275,6 +275,7 @@ func (usecase RuleSnoozeUsecase) SnoozeDecision(
 
 			err = usecase.caseUsecase.CreateRuleSnoozeEvent(ctx, tx, models.RuleSnoozeCaseEventInput{
 				CaseId:         decision.Case.Id,
+				Comment:        input.Comment,
 				RuleSnoozeId:   snoozeId,
 				UserId:         string(input.UserId),
 				WebhookEventId: webhookEventId,

--- a/usecases/security/enforce_security_snoozes.go
+++ b/usecases/security/enforce_security_snoozes.go
@@ -29,3 +29,10 @@ func (e *EnforceSecurityImpl) ReadSnoozesOfIteration(ctx context.Context, iterat
 		utils.EnforceOrganizationAccess(e.Credentials, iteration.OrganizationId),
 	)
 }
+
+func (e *EnforceSecurityImpl) ReadRuleSnooze(ctx context.Context, snooze models.RuleSnooze) error {
+	return errors.Join(
+		e.Permission(models.READ_SNOOZES),
+		utils.EnforceOrganizationAccess(e.Credentials, snooze.OrganizationId),
+	)
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -450,5 +450,6 @@ func (usecases *UsecasesWithCreds) NewRuleSnoozeUsecase() RuleSnoozeUsecase {
 		&usecases.Repositories.MarbleDbRepository,
 		&usecases.Repositories.MarbleDbRepository,
 		security.NewEnforceSecurity(usecases.Credentials),
+		usecases.NewWebhookEventsUsecase(),
 	)
 }


### PR DESCRIPTION
Comment related to commit [01e9abe](https://github.com/checkmarble/marble-backend/pull/643/commits/01e9abed43b401c790254e9ebca483685f4fa4cf):
The field is nullable, for the odd case where we end up deleting decisions but do not want to delete all the related rule_snoozes. It shouldn't happen too much in theory but I already had the case once or twice with S&P where they wanted some decisions deleted.
I made it “on delete set null" instead.