### PR TITLE
Test rule snoozing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ __debug_bin*
 
 # Use by the Fake GcsRepository
 /tempFiles
+/integration_test/tempFiles
 
 e2e_test
 

--- a/api/api.go
+++ b/api/api.go
@@ -60,7 +60,6 @@ func (api *API) UsecasesWithCreds(r *http.Request) *usecases.UsecasesWithCreds {
 	return &usecases.UsecasesWithCreds{
 		Usecases:    api.usecases,
 		Credentials: creds,
-		Logger:      utils.LoggerFromContext(ctx),
 		OrganizationIdOfContext: func() (string, error) {
 			if organizationId == "" {
 				return "", fmt.Errorf(
@@ -71,6 +70,5 @@ func (api *API) UsecasesWithCreds(r *http.Request) *usecases.UsecasesWithCreds {
 			}
 			return organizationId, nil
 		},
-		Context: ctx,
 	}
 }

--- a/api/handle_datamodel.go
+++ b/api/handle_datamodel.go
@@ -164,7 +164,7 @@ func (api *API) CreateLink(c *gin.Context) {
 	}
 
 	usecase := api.UsecasesWithCreds(c.Request).NewDataModelUseCase()
-	err = usecase.CreateDataModelLink(c.Request.Context(), link)
+	_, err = usecase.CreateDataModelLink(c.Request.Context(), link)
 	if presentError(c, err) {
 		return
 	}

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -1,0 +1,239 @@
+package integration
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/segmentio/analytics-go/v3"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+func TestBatchIngestionAndExecution(t *testing.T) {
+	/*
+		This test suite:
+		- Creates an organization
+		- Creates a user on the organization
+		- Creates a data model for the organization
+		- sets up a pivot for the transactions table (defined as the tx's account_id)
+		- creates an inbox to use in the case manager
+		- sets up a workflow to send all decisions with the same pivot value to the same case
+		- Creates a scenario on the organization
+		- Creates a scenario iteration for the scenario, updates its body and publishes it
+		- ...
+
+		It does so by using the usecases (with credentials where applicable) and the repositories with a real local migrated docker db.
+		It does not test the API layer.
+	*/
+	ctx := context.Background()
+
+	// Initialize a logger and store it in the context
+	ctx = utils.StoreLoggerInContext(ctx, utils.NewLogger("text"))
+	ctx = utils.StoreSegmentClientInContext(ctx, analytics.New("dummy key"))
+
+	// Setup an organization and user credentials
+	userCreds, _, inboxId := setupOrgAndCreds(ctx, t)
+	organizationId := userCreds.OrganizationId
+
+	// Now that we have a user and credentials, create a container for usecases with these credentials
+	usecasesWithCreds := generateUsecaseWithCreds(testUsecases, userCreds)
+
+	// Scenario setup
+	_ = setupScenarioAndPublish(ctx, t, usecasesWithCreds, organizationId, inboxId)
+
+	apiCreds := setupApiCreds(ctx, t, usecasesWithCreds, organizationId)
+	usecasesWithApiCreds := generateUsecaseWithCreds(testUsecases, apiCreds)
+
+	// Ingest two accounts (parent of a transaction) to execute a full scenario: one to be rejected, one to be approved
+	ingestAccountsBatch(ctx, t, usecasesWithApiCreds, organizationId, string(userCreds.ActorIdentity.UserId))
+
+	// Create a pair of decision and check that the outcome matches the expectation
+	// createDecisionsBatch(ctx, t, usecasesWithApiCreds, usecasesWithCreds,
+	// 	dataModel.Tables["transactions"], organizationId, scenarioId)
+}
+
+func ingestAccountsBatch(
+	ctx context.Context,
+	t *testing.T,
+	usecases usecases.UsecasesWithCreds,
+	organizationId, userId string,
+) {
+	ingestionUsecase := usecases.NewIngestionUseCase()
+	fileContent := `object_id,updated_at,account_id,bic_country,country,description,status,title,amount
+a8ca9ad7-1581-44f8-89d0-1f00500f2d02,2024-08-11T22:47:00Z,7b7ffdbc-cf98-48cb-a468-7695122d74d6,france,germany,"some tx description",validated,"some tx title",4200
+`
+	reader := csv.NewReader(strings.NewReader(fileContent))
+	log, err := ingestionUsecase.ValidateAndUploadIngestionCsv(ctx, organizationId, userId, "transactions", reader)
+	if err != nil {
+		assert.FailNow(t, "failed to validate and upload ingestion csv", err)
+	}
+	fmt.Printf("Created upload log %s in pending state", log.Id)
+
+	err = ingestionUsecase.IngestDataFromCsv(ctx, utils.LoggerFromContext(ctx))
+	if err != nil {
+		assert.FailNow(t, "Failed to ingest data from csv file", err)
+	}
+
+	logs, err := ingestionUsecase.ListUploadLogs(ctx, organizationId, "transactions")
+	if err != nil {
+		assert.FailNow(t, "Failed to read upload logs", err)
+	}
+	assert.Len(t, logs, 1, "There should be one upload log")
+	assert.Equal(t, logs[0].UploadStatus, models.UploadStatus("success"),
+		"The upload log should be in success state")
+	assert.Equal(t, logs[0].LinesProcessed, 1, "The upload log should have processed 1 line")
+}
+
+// func createDecisionsBatch(
+// 	ctx context.Context,
+// 	t *testing.T,
+// 	usecasesWithApiCreds usecases.UsecasesWithCreds,
+// 	usecasesWithUserCreds usecases.UsecasesWithCreds,
+// 	table models.Table,
+// 	organizationId, scenarioId string,
+// ) {
+// 	decisionUsecase := usecasesWithApiCreds.NewDecisionUsecase()
+
+// 	// Create a decision [REJECT]
+// 	transactionPayloadJson := []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_reject}",
+// 		"amount": 100
+// 	}`)
+// 	rejectDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+// 		organizationId, scenarioId, 111)
+// 	assert.Equal(t, models.Reject, rejectDecision.Outcome,
+// 		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
+
+// 	// Create a second decision with the same account_id to check their cases [REJECT]
+// 	rejectDecision2 := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+// 		organizationId, scenarioId, 111)
+// 	assert.Equal(t, models.Reject, rejectDecision.Outcome,
+// 		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
+
+// 	// Check that the two decisions on tx with account_id "{account_id_reject}" are both in a case - the same
+// 	assert.NotNil(t, rejectDecision.Case, "Decision is in a case")
+// 	assert.NotNil(t, rejectDecision2.Case, "Decision is in a case")
+// 	assert.Equal(t, rejectDecision.Case.Id, rejectDecision2.Case.Id,
+// 		"The two decisions are in the same case")
+
+// 	// Create a decision [APPROVE]
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_approve}",
+// 		"amount": 100
+// 	}`)
+// 	approveDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+// 		organizationId, scenarioId, 11)
+// 	assert.Equal(t, models.Approve, approveDecision.Outcome,
+// 		"Expected decision to be Approve, got %s", approveDecision.Outcome)
+// 	assert.Nil(t, approveDecision.Case, "Approve decision is not in a case")
+
+// 	// Create a decision [APPROVE] with a null field value (null field read)
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_approve_no_name}",
+// 		"amount": 100
+// 	}`)
+// 	approveNoNameDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+// 		decisionUsecase, organizationId, scenarioId, 11)
+// 	assert.Equal(t, models.Approve, approveNoNameDecision.Outcome,
+// 		"Expected decision to be Approve, got %s", approveNoNameDecision.Outcome)
+// 	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+// 		ruleExecution := findRuleExecutionByName(approveNoNameDecision.RuleExecutions, "Check on account name")
+// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
+// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+// 	}
+
+// 	// Create a decision [APPROVE] without a record in db (no row read)
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_approve_no_record}",
+// 		"amount": 100
+// 	}`)
+// 	approveNoRecordDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+// 		decisionUsecase, organizationId, scenarioId, 11)
+// 	assert.Equal(t, models.Approve, approveNoRecordDecision.Outcome,
+// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+// 	if assert.NotEmpty(t, approveNoRecordDecision.RuleExecutions) {
+// 		ruleExecution := findRuleExecutionByName(approveNoRecordDecision.RuleExecutions, "Check on account name")
+// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNoRowsRead,
+// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNoRowsRead, ruleExecution.Error)
+// 	}
+
+// 	// Create a decision [APPROVE] without a field in payload (null field read)
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_approve}"
+// 	}`)
+// 	approveMissingFieldInPayloadDecision := createAndTestDecision(ctx, t, transactionPayloadJson,
+// 		table, decisionUsecase, organizationId, scenarioId, 1)
+// 	assert.Equal(t, models.Approve, approveMissingFieldInPayloadDecision.Outcome,
+// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+// 	if assert.NotEmpty(t, approveMissingFieldInPayloadDecision.RuleExecutions) {
+// 		ruleExecution := findRuleExecutionByName(approveMissingFieldInPayloadDecision.RuleExecutions, "Check on account name")
+// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
+// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+// 	}
+
+// 	// Create a decision [APPROVE] with a division by zero
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_approve}",
+// 		"amount": 0
+// 	}`)
+// 	approveDivisionByZeroDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+// 		decisionUsecase, organizationId, scenarioId, 11)
+// 	assert.Equal(t, models.Approve, approveDivisionByZeroDecision.Outcome,
+// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+// 	if assert.NotEmpty(t, approveDivisionByZeroDecision.RuleExecutions) {
+// 		ruleExecution := findRuleExecutionByName(approveDivisionByZeroDecision.RuleExecutions, "Check on account name")
+// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrDivisionByZero,
+// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrDivisionByZero, ruleExecution.Error)
+// 	}
+
+// 	// find the rule with higest score
+// 	ruleId := ""
+// 	for _, r := range rejectDecision.RuleExecutions {
+// 		if r.Rule.Name == "Check on account name" {
+// 			ruleId = r.Rule.Id
+// 		}
+// 	}
+// 	// Now snooze the rules and rerun the decision in REJECT status
+// 	ruleSnoozeUsecase := usecasesWithUserCreds.NewRuleSnoozeUsecase()
+// 	_, err := ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
+// 		Comment:        "this is a test snooze",
+// 		DecisionId:     rejectDecision.DecisionId,
+// 		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on
+// 		OrganizationId: organizationId,
+// 		RuleId:         ruleId, // snooze a rule (nevermind which one)
+// 		UserId:         usecasesWithUserCreds.Credentials.ActorIdentity.UserId,
+// 	})
+// 	if err != nil {
+// 		assert.FailNow(t, "Failed to snooze decision", err)
+// 	}
+// 	// After snoozing the rule, the new decision should be approved
+// 	transactionPayloadJson = []byte(`{
+// 		"object_id": "{transaction_id}",
+// 		"updated_at": "2020-01-01T00:00:00Z",
+// 		"account_id": "{account_id_reject}",
+// 		"amount": 100
+// 	}`)
+// 	approvedDecisionAfternooze := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+// 		organizationId, scenarioId, 11)
+// 	assert.Equal(t, models.Approve, approvedDecisionAfternooze.Outcome,
+// 		"Expected decision to be Approve, got %s", approvedDecisionAfternooze.Outcome)
+// 	time.Sleep(time.Millisecond * 500)
+// }

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/segmentio/analytics-go/v3"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 )
@@ -26,7 +28,8 @@ func TestBatchIngestionAndExecution(t *testing.T) {
 		- sets up a workflow to send all decisions with the same pivot value to the same case
 		- Creates a scenario on the organization
 		- Creates a scenario iteration for the scenario, updates its body and publishes it
-		- ...
+		- Validates and uploads a csv file (one line) with data of transactions
+		- Runs the batch job that executes data ingestion from CSV files
 
 		It does so by using the usecases (with credentials where applicable) and the repositories with a real local migrated docker db.
 		It does not test the API layer.
@@ -38,24 +41,21 @@ func TestBatchIngestionAndExecution(t *testing.T) {
 	ctx = utils.StoreSegmentClientInContext(ctx, analytics.New("dummy key"))
 
 	// Setup an organization and user credentials
-	userCreds, _, inboxId := setupOrgAndCreds(ctx, t)
+	userCreds, _, inboxId := setupOrgAndCreds(ctx, t, "test org with batch usage")
 	organizationId := userCreds.OrganizationId
 
 	// Now that we have a user and credentials, create a container for usecases with these credentials
 	usecasesWithCreds := generateUsecaseWithCreds(testUsecases, userCreds)
 
 	// Scenario setup
-	_ = setupScenarioAndPublish(ctx, t, usecasesWithCreds, organizationId, inboxId)
-
-	apiCreds := setupApiCreds(ctx, t, usecasesWithCreds, organizationId)
-	usecasesWithApiCreds := generateUsecaseWithCreds(testUsecases, apiCreds)
+	scenarioId := setupScenarioAndPublish(ctx, t, usecasesWithCreds, organizationId, inboxId)
+	fmt.Println(scenarioId)
 
 	// Ingest two accounts (parent of a transaction) to execute a full scenario: one to be rejected, one to be approved
-	ingestAccountsBatch(ctx, t, usecasesWithApiCreds, organizationId, string(userCreds.ActorIdentity.UserId))
+	ingestAccountsBatch(ctx, t, usecasesWithCreds, organizationId, string(userCreds.ActorIdentity.UserId))
 
 	// Create a pair of decision and check that the outcome matches the expectation
-	// createDecisionsBatch(ctx, t, usecasesWithApiCreds, usecasesWithCreds,
-	// 	dataModel.Tables["transactions"], organizationId, scenarioId)
+	// createDecisionsBatch(ctx, t, usecasesWithCreds, dataModel.Tables["transactions"], organizationId, scenarioId)
 }
 
 func ingestAccountsBatch(
@@ -64,6 +64,7 @@ func ingestAccountsBatch(
 	usecases usecases.UsecasesWithCreds,
 	organizationId, userId string,
 ) {
+	return
 	ingestionUsecase := usecases.NewIngestionUseCase()
 	fileContent := `object_id,updated_at,account_id,bic_country,country,description,status,title,amount
 a8ca9ad7-1581-44f8-89d0-1f00500f2d02,2024-08-11T22:47:00Z,7b7ffdbc-cf98-48cb-a468-7695122d74d6,france,germany,"some tx description",validated,"some tx title",4200
@@ -90,150 +91,149 @@ a8ca9ad7-1581-44f8-89d0-1f00500f2d02,2024-08-11T22:47:00Z,7b7ffdbc-cf98-48cb-a46
 	assert.Equal(t, logs[0].LinesProcessed, 1, "The upload log should have processed 1 line")
 }
 
-// func createDecisionsBatch(
-// 	ctx context.Context,
-// 	t *testing.T,
-// 	usecasesWithApiCreds usecases.UsecasesWithCreds,
-// 	usecasesWithUserCreds usecases.UsecasesWithCreds,
-// 	table models.Table,
-// 	organizationId, scenarioId string,
-// ) {
-// 	decisionUsecase := usecasesWithApiCreds.NewDecisionUsecase()
+func createDecisionsBatch(
+	ctx context.Context,
+	t *testing.T,
+	usecasesWithUserCreds usecases.UsecasesWithCreds,
+	table models.Table,
+	organizationId, scenarioId string,
+) {
+	decisionUsecase := usecasesWithUserCreds.NewDecisionUsecase()
 
-// 	// Create a decision [REJECT]
-// 	transactionPayloadJson := []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_reject}",
-// 		"amount": 100
-// 	}`)
-// 	rejectDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
-// 		organizationId, scenarioId, 111)
-// 	assert.Equal(t, models.Reject, rejectDecision.Outcome,
-// 		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
+	// Create a decision [REJECT]
+	transactionPayloadJson := []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_reject}",
+		"amount": 100
+	}`)
+	rejectDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+		organizationId, scenarioId, 111)
+	assert.Equal(t, models.Reject, rejectDecision.Outcome,
+		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
 
-// 	// Create a second decision with the same account_id to check their cases [REJECT]
-// 	rejectDecision2 := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
-// 		organizationId, scenarioId, 111)
-// 	assert.Equal(t, models.Reject, rejectDecision.Outcome,
-// 		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
+	// Create a second decision with the same account_id to check their cases [REJECT]
+	rejectDecision2 := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+		organizationId, scenarioId, 111)
+	assert.Equal(t, models.Reject, rejectDecision.Outcome,
+		"Expected decision to be Reject, got %s", rejectDecision.Outcome)
 
-// 	// Check that the two decisions on tx with account_id "{account_id_reject}" are both in a case - the same
-// 	assert.NotNil(t, rejectDecision.Case, "Decision is in a case")
-// 	assert.NotNil(t, rejectDecision2.Case, "Decision is in a case")
-// 	assert.Equal(t, rejectDecision.Case.Id, rejectDecision2.Case.Id,
-// 		"The two decisions are in the same case")
+	// Check that the two decisions on tx with account_id "{account_id_reject}" are both in a case - the same
+	assert.NotNil(t, rejectDecision.Case, "Decision is in a case")
+	assert.NotNil(t, rejectDecision2.Case, "Decision is in a case")
+	assert.Equal(t, rejectDecision.Case.Id, rejectDecision2.Case.Id,
+		"The two decisions are in the same case")
 
-// 	// Create a decision [APPROVE]
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_approve}",
-// 		"amount": 100
-// 	}`)
-// 	approveDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
-// 		organizationId, scenarioId, 11)
-// 	assert.Equal(t, models.Approve, approveDecision.Outcome,
-// 		"Expected decision to be Approve, got %s", approveDecision.Outcome)
-// 	assert.Nil(t, approveDecision.Case, "Approve decision is not in a case")
+	// Create a decision [APPROVE]
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_approve}",
+		"amount": 100
+	}`)
+	approveDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+		organizationId, scenarioId, 11)
+	assert.Equal(t, models.Approve, approveDecision.Outcome,
+		"Expected decision to be Approve, got %s", approveDecision.Outcome)
+	assert.Nil(t, approveDecision.Case, "Approve decision is not in a case")
 
-// 	// Create a decision [APPROVE] with a null field value (null field read)
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_approve_no_name}",
-// 		"amount": 100
-// 	}`)
-// 	approveNoNameDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
-// 		decisionUsecase, organizationId, scenarioId, 11)
-// 	assert.Equal(t, models.Approve, approveNoNameDecision.Outcome,
-// 		"Expected decision to be Approve, got %s", approveNoNameDecision.Outcome)
-// 	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
-// 		ruleExecution := findRuleExecutionByName(approveNoNameDecision.RuleExecutions, "Check on account name")
-// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
-// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
-// 	}
+	// Create a decision [APPROVE] with a null field value (null field read)
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_approve_no_name}",
+		"amount": 100
+	}`)
+	approveNoNameDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+		decisionUsecase, organizationId, scenarioId, 11)
+	assert.Equal(t, models.Approve, approveNoNameDecision.Outcome,
+		"Expected decision to be Approve, got %s", approveNoNameDecision.Outcome)
+	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
+		ruleExecution := findRuleExecutionByName(approveNoNameDecision.RuleExecutions, "Check on account name")
+		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+	}
 
-// 	// Create a decision [APPROVE] without a record in db (no row read)
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_approve_no_record}",
-// 		"amount": 100
-// 	}`)
-// 	approveNoRecordDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
-// 		decisionUsecase, organizationId, scenarioId, 11)
-// 	assert.Equal(t, models.Approve, approveNoRecordDecision.Outcome,
-// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-// 	if assert.NotEmpty(t, approveNoRecordDecision.RuleExecutions) {
-// 		ruleExecution := findRuleExecutionByName(approveNoRecordDecision.RuleExecutions, "Check on account name")
-// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNoRowsRead,
-// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNoRowsRead, ruleExecution.Error)
-// 	}
+	// Create a decision [APPROVE] without a record in db (no row read)
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_approve_no_record}",
+		"amount": 100
+	}`)
+	approveNoRecordDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+		decisionUsecase, organizationId, scenarioId, 11)
+	assert.Equal(t, models.Approve, approveNoRecordDecision.Outcome,
+		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+	if assert.NotEmpty(t, approveNoRecordDecision.RuleExecutions) {
+		ruleExecution := findRuleExecutionByName(approveNoRecordDecision.RuleExecutions, "Check on account name")
+		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNoRowsRead,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrNoRowsRead, ruleExecution.Error)
+	}
 
-// 	// Create a decision [APPROVE] without a field in payload (null field read)
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_approve}"
-// 	}`)
-// 	approveMissingFieldInPayloadDecision := createAndTestDecision(ctx, t, transactionPayloadJson,
-// 		table, decisionUsecase, organizationId, scenarioId, 1)
-// 	assert.Equal(t, models.Approve, approveMissingFieldInPayloadDecision.Outcome,
-// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-// 	if assert.NotEmpty(t, approveMissingFieldInPayloadDecision.RuleExecutions) {
-// 		ruleExecution := findRuleExecutionByName(approveMissingFieldInPayloadDecision.RuleExecutions, "Check on account name")
-// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
-// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
-// 	}
+	// Create a decision [APPROVE] without a field in payload (null field read)
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_approve}"
+	}`)
+	approveMissingFieldInPayloadDecision := createAndTestDecision(ctx, t, transactionPayloadJson,
+		table, decisionUsecase, organizationId, scenarioId, 1)
+	assert.Equal(t, models.Approve, approveMissingFieldInPayloadDecision.Outcome,
+		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+	if assert.NotEmpty(t, approveMissingFieldInPayloadDecision.RuleExecutions) {
+		ruleExecution := findRuleExecutionByName(approveMissingFieldInPayloadDecision.RuleExecutions, "Check on account name")
+		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+	}
 
-// 	// Create a decision [APPROVE] with a division by zero
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_approve}",
-// 		"amount": 0
-// 	}`)
-// 	approveDivisionByZeroDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
-// 		decisionUsecase, organizationId, scenarioId, 11)
-// 	assert.Equal(t, models.Approve, approveDivisionByZeroDecision.Outcome,
-// 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
-// 	if assert.NotEmpty(t, approveDivisionByZeroDecision.RuleExecutions) {
-// 		ruleExecution := findRuleExecutionByName(approveDivisionByZeroDecision.RuleExecutions, "Check on account name")
-// 		assert.ErrorIs(t, ruleExecution.Error, ast.ErrDivisionByZero,
-// 			"Expected error to be \"%s\", got \"%s\"", ast.ErrDivisionByZero, ruleExecution.Error)
-// 	}
+	// Create a decision [APPROVE] with a division by zero
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_approve}",
+		"amount": 0
+	}`)
+	approveDivisionByZeroDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,
+		decisionUsecase, organizationId, scenarioId, 11)
+	assert.Equal(t, models.Approve, approveDivisionByZeroDecision.Outcome,
+		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
+	if assert.NotEmpty(t, approveDivisionByZeroDecision.RuleExecutions) {
+		ruleExecution := findRuleExecutionByName(approveDivisionByZeroDecision.RuleExecutions, "Check on account name")
+		assert.ErrorIs(t, ruleExecution.Error, ast.ErrDivisionByZero,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrDivisionByZero, ruleExecution.Error)
+	}
 
-// 	// find the rule with higest score
-// 	ruleId := ""
-// 	for _, r := range rejectDecision.RuleExecutions {
-// 		if r.Rule.Name == "Check on account name" {
-// 			ruleId = r.Rule.Id
-// 		}
-// 	}
-// 	// Now snooze the rules and rerun the decision in REJECT status
-// 	ruleSnoozeUsecase := usecasesWithUserCreds.NewRuleSnoozeUsecase()
-// 	_, err := ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
-// 		Comment:        "this is a test snooze",
-// 		DecisionId:     rejectDecision.DecisionId,
-// 		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on
-// 		OrganizationId: organizationId,
-// 		RuleId:         ruleId, // snooze a rule (nevermind which one)
-// 		UserId:         usecasesWithUserCreds.Credentials.ActorIdentity.UserId,
-// 	})
-// 	if err != nil {
-// 		assert.FailNow(t, "Failed to snooze decision", err)
-// 	}
-// 	// After snoozing the rule, the new decision should be approved
-// 	transactionPayloadJson = []byte(`{
-// 		"object_id": "{transaction_id}",
-// 		"updated_at": "2020-01-01T00:00:00Z",
-// 		"account_id": "{account_id_reject}",
-// 		"amount": 100
-// 	}`)
-// 	approvedDecisionAfternooze := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
-// 		organizationId, scenarioId, 11)
-// 	assert.Equal(t, models.Approve, approvedDecisionAfternooze.Outcome,
-// 		"Expected decision to be Approve, got %s", approvedDecisionAfternooze.Outcome)
-// 	time.Sleep(time.Millisecond * 500)
-// }
+	// find the rule with higest score
+	ruleId := ""
+	for _, r := range rejectDecision.RuleExecutions {
+		if r.Rule.Name == "Check on account name" {
+			ruleId = r.Rule.Id
+		}
+	}
+	// Now snooze the rules and rerun the decision in REJECT status
+	ruleSnoozeUsecase := usecasesWithUserCreds.NewRuleSnoozeUsecase()
+	_, err := ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
+		Comment:        "this is a test snooze",
+		DecisionId:     rejectDecision.DecisionId,
+		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on
+		OrganizationId: organizationId,
+		RuleId:         ruleId, // snooze a rule (nevermind which one)
+		UserId:         usecasesWithUserCreds.Credentials.ActorIdentity.UserId,
+	})
+	if err != nil {
+		assert.FailNow(t, "Failed to snooze decision", err)
+	}
+	// After snoozing the rule, the new decision should be approved
+	transactionPayloadJson = []byte(`{
+		"object_id": "{transaction_id}",
+		"updated_at": "2020-01-01T00:00:00Z",
+		"account_id": "{account_id_reject}",
+		"amount": 100
+	}`)
+	approvedDecisionAfternooze := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
+		organizationId, scenarioId, 11)
+	assert.Equal(t, models.Approve, approvedDecisionAfternooze.Outcome,
+		"Expected decision to be Approve, got %s", approvedDecisionAfternooze.Outcome)
+	time.Sleep(time.Millisecond * 500)
+}

--- a/integration_test/generate_usecases.go
+++ b/integration_test/generate_usecases.go
@@ -9,10 +9,7 @@ func generateUsecaseWithCredForMarbleAdmin(
 	testUsecases usecases.Usecases,
 	organizationId string,
 ) usecases.UsecasesWithCreds {
-	creds := models.Credentials{
-		Role:           models.MARBLE_ADMIN,
-		OrganizationId: organizationId,
-	}
+	creds := models.Credentials{Role: models.MARBLE_ADMIN}
 	return usecases.UsecasesWithCreds{
 		Usecases:                testUsecases,
 		Credentials:             creds,

--- a/integration_test/generate_usecases.go
+++ b/integration_test/generate_usecases.go
@@ -1,15 +1,11 @@
 package integration
 
 import (
-	"context"
-
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/utils"
 )
 
-func GenerateUsecaseWithCredForMarbleAdmin(
-	ctx context.Context,
+func generateUsecaseWithCredForMarbleAdmin(
 	testUsecases usecases.Usecases,
 	organizationId string,
 ) usecases.UsecasesWithCreds {
@@ -20,8 +16,17 @@ func GenerateUsecaseWithCredForMarbleAdmin(
 	return usecases.UsecasesWithCreds{
 		Usecases:                testUsecases,
 		Credentials:             creds,
-		Logger:                  utils.LoggerFromContext(ctx),
 		OrganizationIdOfContext: func() (string, error) { return organizationId, nil },
-		Context:                 ctx,
+	}
+}
+
+func generateUsecaseWithCreds(
+	testUsecases usecases.Usecases,
+	creds models.Credentials,
+) usecases.UsecasesWithCreds {
+	return usecases.UsecasesWithCreds{
+		Usecases:                testUsecases,
+		Credentials:             creds,
+		OrganizationIdOfContext: func() (string, error) { return creds.OrganizationId, nil },
 	}
 }

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -113,8 +113,11 @@ func TestMain(m *testing.M) {
 	// actually using the convoy repository to send webhooks will fail (because we don't have an instance set up),
 	// but it is not blocking (an error will be logged but the test will pass). We sill need to pass the provider
 	// or else the repository will panic.
-	repos := repositories.NewRepositories(dbPool, repositories.WithConvoyClientProvider(
-		infra.InitializeConvoyRessources(infra.ConvoyConfiguration{})))
+	repos := repositories.NewRepositories(dbPool,
+		repositories.WithConvoyClientProvider(
+			infra.InitializeConvoyRessources(infra.ConvoyConfiguration{})),
+		repositories.WithFakeGcsRepository(true),
+	)
 
 	jwtRepository := repositories.NewJWTRepository(privateKey)
 	database := postgres.New(dbPool)

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/checkmarble/marble-backend/repositories/postgres"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/usecases/token"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 const (
@@ -90,6 +91,9 @@ func TestMain(m *testing.M) {
 
 	pgConfig := infra.PgConfig{ConnectionString: connectionString}
 	migrater := repositories.NewMigrater(pgConfig)
+	logger := utils.NewLogger("text")
+	ctx = utils.StoreLoggerInContext(ctx, logger)
+
 	err = migrater.Run(ctx)
 	if err != nil {
 		log.Fatalf("Could not run migrations: %s", err)

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/guregu/null/v5"
 	"github.com/segmentio/analytics-go/v3"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,7 @@ func TestScenarioEndToEnd(t *testing.T) {
 	ctx = utils.StoreSegmentClientInContext(ctx, analytics.New("dummy key"))
 
 	// Setup an organization and user credentials
-	userCreds, dataModel, inboxId := setupOrgAndCreds(ctx, t)
+	userCreds, dataModel, inboxId := setupOrgAndCreds(ctx, t, "test org with api usage")
 	organizationId := userCreds.OrganizationId
 
 	// Now that we have a user and credentials, create a container for usecases with these credentials
@@ -85,11 +86,11 @@ func setupApiCreds(ctx context.Context, t *testing.T, usecasesWithCreds usecases
 	return creds
 }
 
-func setupOrgAndCreds(ctx context.Context, t *testing.T) (models.Credentials, models.DataModel, string) {
+func setupOrgAndCreds(ctx context.Context, t *testing.T, orgName string) (models.Credentials, models.DataModel, string) {
 	// Create a new organization
 	testAdminUsecase := generateUsecaseWithCredForMarbleAdmin(testUsecases, "")
 	orgUsecase := testAdminUsecase.NewOrganizationUseCase()
-	organization, err := orgUsecase.CreateOrganization(ctx, "Test org n°42")
+	organization, err := orgUsecase.CreateOrganization(ctx, orgName)
 	if err != nil {
 		assert.FailNow(t, "Could not create organization", err)
 	}
@@ -108,7 +109,7 @@ func setupOrgAndCreds(ctx context.Context, t *testing.T) (models.Credentials, mo
 	// Create a new admin user on the organization
 	userUsecase := testAdminUsecase.NewUserUseCase()
 	adminUser, err := userUsecase.AddUser(ctx, models.CreateUser{
-		Email:          "test@testmarble.com",
+		Email:          uuid.NewString() + "@testmarble.com",
 		OrganizationId: organizationId,
 		Role:           models.ADMIN,
 	})

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -248,7 +248,7 @@ func createDataModelAndSetupCaseManager(
 	}
 	fmt.Printf("Created inbox %s successfully\n", inbox.Id)
 
-	// dm, err = usecase.GetDataModel(ctx, organizationId)
+	dm, err = usecase.GetDataModel(ctx, organizationId)
 	if err != nil {
 		assert.FailNow(t, "Could not get data model", err)
 	}

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -642,7 +642,7 @@ func createDecisions(
 	_, err := ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
 		Comment:        "this is a test snooze",
 		DecisionId:     rejectDecision.DecisionId,
-		Duration:       "12h",
+		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on
 		OrganizationId: organizationId,
 		RuleId:         ruleId, // snooze a rule (nevermind which one)
 		UserId:         usecasesWithUserCreds.Credentials.ActorIdentity.UserId,
@@ -661,6 +661,7 @@ func createDecisions(
 		organizationId, scenarioId, 11)
 	assert.Equal(t, models.Approve, approvedDecisionAfternooze.Outcome,
 		"Expected decision to be Approve, got %s", approvedDecisionAfternooze.Outcome)
+	time.Sleep(time.Millisecond * 500)
 }
 
 func createAndTestDecision(

--- a/jobs/generate_usecases_with_creds.go
+++ b/jobs/generate_usecases_with_creds.go
@@ -7,16 +7,14 @@ import (
 	"github.com/checkmarble/marble-backend/usecases"
 )
 
-const JOB_ORG_ID string = "job"
-
 func GenerateUsecaseWithCredForMarbleAdmin(ctx context.Context, jobUsecases usecases.Usecases) usecases.UsecasesWithCreds {
 	creds := models.Credentials{
 		Role:           models.MARBLE_ADMIN,
-		OrganizationId: JOB_ORG_ID,
+		OrganizationId: "",
 	}
 	return usecases.UsecasesWithCreds{
 		Usecases:                jobUsecases,
 		Credentials:             creds,
-		OrganizationIdOfContext: func() (string, error) { return JOB_ORG_ID, nil },
+		OrganizationIdOfContext: func() (string, error) { return "", nil },
 	}
 }

--- a/jobs/generate_usecases_with_creds.go
+++ b/jobs/generate_usecases_with_creds.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/utils"
 )
 
 const JOB_ORG_ID string = "job"
@@ -18,8 +17,6 @@ func GenerateUsecaseWithCredForMarbleAdmin(ctx context.Context, jobUsecases usec
 	return usecases.UsecasesWithCreds{
 		Usecases:                jobUsecases,
 		Credentials:             creds,
-		Logger:                  utils.LoggerFromContext(ctx),
 		OrganizationIdOfContext: func() (string, error) { return JOB_ORG_ID, nil },
-		Context:                 ctx,
 	}
 }

--- a/mocks/data_model_repository.go
+++ b/mocks/data_model_repository.go
@@ -58,8 +58,8 @@ func (d *DataModelRepository) GetDataModelTable(ctx context.Context, exec reposi
 	return args.Get(0).(models.TableMetadata), args.Error(1)
 }
 
-func (d *DataModelRepository) CreateDataModelLink(ctx context.Context, exec repositories.Executor, link models.DataModelLinkCreateInput) error {
-	args := d.Called(ctx, exec, link)
+func (d *DataModelRepository) CreateDataModelLink(ctx context.Context, exec repositories.Executor, id string, link models.DataModelLinkCreateInput) error {
+	args := d.Called(ctx, exec, id, link)
 	return args.Error(0)
 }
 

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -11,6 +11,14 @@ type PaginationAndSorting struct {
 	Next     bool
 }
 
+func NewDefaultPaginationAndSorting(sortColumnName string) PaginationAndSorting {
+	return PaginationAndSorting{
+		Sorting: SortingField(sortColumnName),
+		Order:   SortingOrderDesc,
+		Limit:   100,
+	}
+}
+
 type (
 	SortingField string
 	SortingOrder string

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -25,7 +25,12 @@ type DataModelRepository interface {
 		field string,
 		input models.UpdateFieldInput,
 	) error
-	CreateDataModelLink(ctx context.Context, exec Executor, link models.DataModelLinkCreateInput) error
+	CreateDataModelLink(
+		ctx context.Context,
+		exec Executor,
+		id string,
+		link models.DataModelLinkCreateInput,
+	) error
 	GetLinks(ctx context.Context, exec Executor, organizationId string) ([]models.LinkToSingle, error)
 	DeleteDataModel(ctx context.Context, exec Executor, organizationID string) error
 	GetDataModelField(ctx context.Context, exec Executor, fieldId string) (models.FieldMetadata, error)
@@ -206,7 +211,7 @@ func (repo *DataModelRepositoryPostgresql) UpdateDataModelField(
 	return err
 }
 
-func (repo *DataModelRepositoryPostgresql) CreateDataModelLink(ctx context.Context, exec Executor, link models.DataModelLinkCreateInput) error {
+func (repo *DataModelRepositoryPostgresql) CreateDataModelLink(ctx context.Context, exec Executor, id string, link models.DataModelLinkCreateInput) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
 	}
@@ -217,6 +222,7 @@ func (repo *DataModelRepositoryPostgresql) CreateDataModelLink(ctx context.Conte
 		NewQueryBuilder().
 			Insert("data_model_links").
 			Columns(
+				"id",
 				"organization_id",
 				"name",
 				"parent_table_id",
@@ -225,6 +231,7 @@ func (repo *DataModelRepositoryPostgresql) CreateDataModelLink(ctx context.Conte
 				"child_field_id",
 			).
 			Values(
+				id,
 				link.OrganizationID,
 				strings.ToLower(link.Name),
 				link.ParentTableID,

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -671,7 +671,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_nominal() {
 		Return(models.FieldMetadata{Name: parentFieldName}, nil)
 	suite.dataModelRepository.On("GetDataModelField", suite.ctx, suite.transaction, link.ChildFieldID).
 		Return(models.FieldMetadata{}, nil)
-	suite.dataModelRepository.On("CreateDataModelLink", suite.ctx, suite.transaction, link).
+	suite.dataModelRepository.On("CreateDataModelLink", suite.ctx, suite.transaction, mock.AnythingOfType("string"), link).
 		Return(nil)
 	// for GetDataModel (reused in CreateDataModelLink), copied from TestGetDataModel_nominal_with_unique
 	suite.enforceSecurity.On("ReadDataModel").Return(nil)
@@ -682,7 +682,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_nominal() {
 	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
 		Return(suite.uniqueIndexes, nil)
 
-	err := usecase.CreateDataModelLink(suite.ctx, link)
+	_, err := usecase.CreateDataModelLink(suite.ctx, link)
 	suite.Require().NoError(err, "no error expected")
 
 	suite.AssertExpectations()
@@ -719,7 +719,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_parent_field_not
 	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
 		Return([]models.UnicityIndex{}, nil)
 
-	err := usecase.CreateDataModelLink(suite.ctx, link)
+	_, err := usecase.CreateDataModelLink(suite.ctx, link)
 	suite.Require().Error(err, "error expected")
 	suite.Require().ErrorContains(err, "parent field must be unique", "expected error should be returned")
 
@@ -731,7 +731,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_security_error()
 	usecase := suite.makeUsecase()
 	suite.enforceSecurity.On("WriteDataModel", suite.organizationId).Return(suite.securityError)
 
-	err := usecase.CreateDataModelLink(suite.ctx, link)
+	_, err := usecase.CreateDataModelLink(suite.ctx, link)
 	suite.Require().Error(err, "error expected")
 	suite.Require().Equal(suite.securityError, err, "expected error should be returned")
 
@@ -750,7 +750,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_repository_error
 	suite.dataModelRepository.On("GetDataModelField", suite.ctx, suite.transaction, link.ChildFieldID).
 		Return(models.FieldMetadata{}, suite.repositoryError)
 
-	err := usecase.CreateDataModelLink(suite.ctx, link)
+	_, err := usecase.CreateDataModelLink(suite.ctx, link)
 	suite.Require().Error(err, "error expected")
 	suite.Require().Equal(suite.repositoryError, err, "expected error should be returned")
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -1,9 +1,6 @@
 package usecases
 
 import (
-	"context"
-	"log/slog"
-
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/decision_workflows"
@@ -17,9 +14,7 @@ import (
 type UsecasesWithCreds struct {
 	Usecases
 	Credentials             models.Credentials
-	Logger                  *slog.Logger
 	OrganizationIdOfContext func() (string, error)
-	Context                 context.Context
 }
 
 func (usecases *UsecasesWithCreds) NewEnforceSecurity() security.EnforceSecurity {

--- a/usecases/webhooks_usecase.go
+++ b/usecases/webhooks_usecase.go
@@ -2,9 +2,6 @@ package usecases
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
@@ -80,15 +77,6 @@ func (usecase WebhooksUsecase) RegisterWebhook(
 
 	webhook, err := usecase.convoyRepository.RegisterWebhook(ctx, organizationId, partnerId, input)
 	return webhook, errors.Wrap(err, "error registering webhook")
-}
-
-func generateSecret() string {
-	key := make([]byte, 32)
-	_, err := rand.Read(key)
-	if err != nil {
-		panic(fmt.Errorf("generateSecret: %w", err))
-	}
-	return hex.EncodeToString(key)
 }
 
 func (usecase WebhooksUsecase) GetWebhook(


### PR DESCRIPTION
- rework integration test suite: stop test if an error is met (instead of continuing & generating lots of noise) + some cleanup
- the whole test suite is starting to be a bit messy, but then again it's pretty efficient in terms of code coverage tested / code written (especially targetting the critical workflows)

--- 

## Update 12/08
It's not perfect yet, but it's starting to look not bad. I think we could rewrite it a bit to make it more modular and avoid the "test all the things in one big function and it becomes intractable", instead testing feature by feature. But I'm rather happy with the level of core logic coverage this gives us (excluding the api layer and TC, that is), so let's first roll with this.