### PR TITLE
refactor(dto): change created_from_rule_id to be non-optionnal

### DIFF
--- a/dto/rule_snoozes.go
+++ b/dto/rule_snoozes.go
@@ -13,7 +13,7 @@ type RuleSnooze struct {
 	ExpiresAt             time.Time `json:"ends_at"`
 	CreatedByUser         string    `json:"created_by_user"`
 	CreatedFromDecisionId *string   `json:"created_from_decision_id"`
-	CreatedFromRuleId     *string   `json:"created_from_rule_id"`
+	CreatedFromRuleId     string    `json:"created_from_rule_id"`
 }
 
 type RuleSnoozeWithRuleId struct {

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -13,7 +13,7 @@ type RuleSnooze struct {
 	OrganizationId        string
 	CreatedByUser         string
 	CreatedFromDecisionId *string
-	CreatedFromRuleId     *string
+	CreatedFromRuleId     string
 	PivotValue            string
 	SnoozeGroupId         string
 	StartsAt              time.Time
@@ -24,7 +24,7 @@ type RuleSnoozeWithRuleId struct {
 	Id                    string
 	CreatedByUser         string
 	CreatedFromDecisionId *string
-	CreatedFromRuleId     *string
+	CreatedFromRuleId     string
 	PivotValue            string
 	RuleId                string
 	SnoozeGroupId         string

--- a/repositories/dbmodels/db_rule_snooze.go
+++ b/repositories/dbmodels/db_rule_snooze.go
@@ -33,7 +33,7 @@ type DBRuleSnooze struct {
 	Id                    string    `db:"id"`
 	CreatedByUser         string    `db:"created_by_user"`
 	CreatedFromDecisionId *string   `db:"created_from_decision_id"`
-	CreatedFromRuleId     *string   `db:"created_from_rule_id"`
+	CreatedFromRuleId     string    `db:"created_from_rule_id"`
 	SnoozeGroupId         string    `db:"snooze_group_id"`
 	PivotValue            string    `db:"pivot_value"`
 	StartsAt              time.Time `db:"starts_at"`


### PR DESCRIPTION
Samll refactoring to enforce `created_from_rule_id` is defined (based on PR discussion #646)

(I'll merge this but to keep you in the loop, I tag your account)