### PR TITLE
feat(license): use dev license in dev environment

### DIFF
--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -38,6 +38,7 @@ func RunBatchIngestion() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	jobConfig := struct {
 		env           string

--- a/cmd/run_job_scheduler.go
+++ b/cmd/run_job_scheduler.go
@@ -37,6 +37,7 @@ func RunJobScheduler() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	jobConfig := struct {
 		env                         string

--- a/cmd/schedule_scenarios.go
+++ b/cmd/schedule_scenarios.go
@@ -36,6 +36,7 @@ func RunScheduleScenarios() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	jobConfig := struct {
 		env           string

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -36,6 +36,7 @@ func RunScheduledExecuter() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	jobConfig := struct {
 		env                 string

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -36,6 +36,7 @@ func RunSendPendingWebhookEvents() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	jobConfig := struct {
 		env                         string

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,6 +69,7 @@ func RunServer() error {
 	licenseConfig := models.LicenseConfiguration{
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
+		IsDevEnvironment:       utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", "") != "",
 	}
 	serverConfig := struct {
 		jwtSigningKey string

--- a/infra/verify_license.go
+++ b/infra/verify_license.go
@@ -45,6 +45,9 @@ func VerifyLicense(config models.LicenseConfiguration) models.LicenseValidation 
 		if isWhitelisted {
 			return models.NewFullLicense()
 		}
+		if config.IsDevEnvironment {
+			return models.NewDevLicense()
+		}
 		return models.NewNotFoundLicense()
 	}
 

--- a/models/license.go
+++ b/models/license.go
@@ -80,6 +80,21 @@ func NewFullLicense() LicenseValidation {
 	}
 }
 
+func NewDevLicense() LicenseValidation {
+	return LicenseValidation{
+		LicenseValidationCode: VALID,
+		LicenseEntitlements: LicenseEntitlements{
+			Sso:            true,
+			Workflows:      true,
+			Analytics:      true,
+			DataEnrichment: true,
+			UserRoles:      true,
+			Webhooks:       false,
+			RuleSnoozes:    true,
+		},
+	}
+}
+
 func NewNotFoundLicense() LicenseValidation {
 	return LicenseValidation{
 		LicenseValidationCode: NOT_FOUND,
@@ -125,4 +140,5 @@ func (l *UpdateLicenseInput) Validate() error {
 type LicenseConfiguration struct {
 	LicenseKey             string
 	KillIfReadLicenseError bool
+	IsDevEnvironment       bool
 }


### PR DESCRIPTION
# Issue

Since the backend start to use internally the license to block some premium features, we may need to align the behaviour between frontend and backend to ensure consistency (only divergent for dev mode)

> Note: we still have some divergence for SAAS env. But since whitelisted env and SAAS licenses return the same entitlements, we ensure consistency

# Proposition

I propose to introduce the same specific logic for dev special case (more or less) :

In the frontend, when we detect a "dev env" (= Firebase auth emulator is used, we do not relly on the explicit env var) we bypass the API call to return the hardcoded dev license.

Here, I propose to do the same in the backend. The main difference is :
- `KillIfReadLicenseError` prevent on this conditionnal logic.
- if a license key is provided, use it
- if the projectid is whitelisted, use the full license instead