### PR TITLE
linting with golanci-lint

### DIFF
--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -14,6 +14,11 @@ jobs:
         with:
           go-version-file: ./go.mod
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.60
+
       - name: Build
         run: go build -v ./...
 

--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -5,7 +5,7 @@ on: [workflow_call]
 permissions:
   contents: read
   pull-requests: read
-  check: write
+  checks: write
 
 jobs:
   test_backend:

--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -2,6 +2,11 @@ name: Test back-end
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+  pull-requests: read
+  check: write
+
 jobs:
   test_backend:
     name: Test back-end

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,12 @@
 linters:
   enable:
-    - revive
+    - errorlint
+    - loggercheck
+    - durationcheck
+    - sloglint
+    - unconvert
+
+issues:
+  exclude-rules:
+    - path: repository/ingested_data_indexes_repository.go
+      text: "should be called, not discarded, to avoid a context leak"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
       "go.toolsEnvVars": {
             "GOFUMPT_SPLIT_LONG_LINES": "on"
       },
+      "go.lintTool": "golangci-lint",
+      
       "search.exclude": {
             "go.sum": true,
             "tempFiles/*": true,

--- a/api/handle_scenario_iterations.go
+++ b/api/handle_scenario_iterations.go
@@ -151,7 +151,7 @@ type PostScenarioValidationInputBody struct {
 func (api *API) ValidateScenarioIteration(c *gin.Context) {
 	var input PostScenarioValidationInputBody
 	err := c.ShouldBindJSON(&input)
-	if err != nil && err != io.EOF { //nolint:errorlint
+	if err != nil && err != io.EOF {
 		c.Status(http.StatusBadRequest)
 		return
 	}

--- a/api/handle_scenario_iterations.go
+++ b/api/handle_scenario_iterations.go
@@ -151,7 +151,7 @@ type PostScenarioValidationInputBody struct {
 func (api *API) ValidateScenarioIteration(c *gin.Context) {
 	var input PostScenarioValidationInputBody
 	err := c.ShouldBindJSON(&input)
-	if err != nil && err != io.EOF {
+	if err != nil && err != io.EOF { //nolint:errorlint
 		c.Status(http.StatusBadRequest)
 		return
 	}

--- a/dto/custom_list_dto.go
+++ b/dto/custom_list_dto.go
@@ -17,7 +17,7 @@ type CustomList struct {
 
 func AdaptCustomListDto(list models.CustomList) CustomList {
 	return CustomList{
-		Id:          string(list.Id),
+		Id:          list.Id,
 		Name:        list.Name,
 		Description: list.Description,
 		CreatedAt:   list.CreatedAt,
@@ -41,7 +41,7 @@ type CustomListValue struct {
 
 func AdaptCustomListWithValuesDto(list models.CustomList, values []models.CustomListValue) CustomListWithValues {
 	return CustomListWithValues{
-		Id:          string(list.Id),
+		Id:          list.Id,
 		Name:        list.Name,
 		Description: list.Description,
 		CreatedAt:   list.CreatedAt,
@@ -52,7 +52,7 @@ func AdaptCustomListWithValuesDto(list models.CustomList, values []models.Custom
 
 func AdaptCustomListValueDto(listValue models.CustomListValue) CustomListValue {
 	return CustomListValue{
-		Id:    string(listValue.Id),
+		Id:    listValue.Id,
 		Value: listValue.Value,
 	}
 }

--- a/dto/pagination.go
+++ b/dto/pagination.go
@@ -30,7 +30,7 @@ type PaginationDefaults struct {
 
 func WithPaginationDefaults(pagination PaginationAndSortingInput, defaults PaginationDefaults) PaginationAndSortingInput {
 	if pagination.Sorting == "" {
-		pagination.Sorting = models.SortingField(defaults.SortBy)
+		pagination.Sorting = defaults.SortBy
 	}
 
 	if pagination.Order == "" {

--- a/infra/metabase.go
+++ b/infra/metabase.go
@@ -40,7 +40,7 @@ func (metabase Metabase) GenerateSignedEmbeddingURL(analyticsCustomClaims models
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	signedToken, err := token.SignedString([]byte(metabase.config.JwtSigningKey))
+	signedToken, err := token.SignedString(metabase.config.JwtSigningKey)
 	if err != nil {
 		return "", err
 	}

--- a/infra/tracing.go
+++ b/infra/tracing.go
@@ -41,7 +41,7 @@ func InitTelemetry(configuration TelemetryConfiguration) (TelemetryRessources, e
 		texporter.WithTraceClientOptions([]option.ClientOption{option.WithTelemetryDisabled()}),
 	)
 	if err != nil {
-		return TelemetryRessources{}, fmt.Errorf("texporter.New error: %v", err)
+		return TelemetryRessources{}, fmt.Errorf("texporter.New error: %w", err)
 	}
 
 	res, err := resource.New(context.Background(),

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -66,7 +66,10 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not start resource: %s", err)
 	}
 
-	resource.Expire(testDbLifetime) // Tell docker to hard kill the container in testDbLifetime seconds
+	err = resource.Expire(testDbLifetime) // Tell docker to hard kill the container in testDbLifetime seconds
+	if err != nil {
+		log.Fatalf("Could not set container lifetime: %s", err)
+	}
 
 	pool.MaxWait = testDbLifetime * time.Second
 

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -2,6 +2,8 @@ package ast
 
 import (
 	"fmt"
+
+	"github.com/cockroachdb/errors"
 )
 
 type Function int
@@ -225,7 +227,7 @@ func (f Function) Attributes() (FuncAttributes, error) {
 	return FuncAttributes{
 		DebugName: unknown,
 		AstName:   unknown,
-	}, fmt.Errorf(unknown)
+	}, errors.New(unknown)
 }
 
 func (f Function) DebugString() string {

--- a/pure_utils/clean_bom.go
+++ b/pure_utils/clean_bom.go
@@ -19,7 +19,7 @@ func NewReaderWithoutBom(r io.Reader) io.Reader {
 		return buf
 	}
 	if b[0] == bom0 && b[1] == bom1 && b[2] == bom2 {
-		buf.Discard(3)
+		_, _ = buf.Discard(3)
 	}
 	return buf
 }

--- a/repositories/dbmodels/db_webhook_events.go
+++ b/repositories/dbmodels/db_webhook_events.go
@@ -31,7 +31,7 @@ func AdaptWebhookEvent(db DBWebhookEvent) (models.WebhookEvent, error) {
 	eventData := make(map[string]any)
 	err := json.Unmarshal(db.EventData, &eventData)
 	if err != nil {
-		return models.WebhookEvent{}, fmt.Errorf("can't decode %s webhook's event data: %v", db.Id, err)
+		return models.WebhookEvent{}, fmt.Errorf("can't decode %s webhook's event data: %w", db.Id, err)
 	}
 
 	return models.WebhookEvent{

--- a/repositories/gcs_repository.go
+++ b/repositories/gcs_repository.go
@@ -61,16 +61,16 @@ func (repository *GcsRepositoryImpl) ListFiles(ctx context.Context, bucketName, 
 	it := bucket.Objects(ctx, query)
 	for {
 		attrs, err := it.Next()
-		if err == iterator.Done {
+		if err == iterator.Done { //nolint:errorlint
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to list GCS objects from bucket %s/%s: %v", bucketName, prefix, err)
+			return nil, fmt.Errorf("failed to list GCS objects from bucket %s/%s: %w", bucketName, prefix, err)
 		}
 
 		r, err := bucket.Object(attrs.Name).NewReader(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read GCS object %s/%s: %v", bucketName, attrs.Name, err)
+			return nil, fmt.Errorf("failed to read GCS object %s/%s: %w", bucketName, attrs.Name, err)
 		}
 
 		output = append(output, models.GCSFile{
@@ -112,7 +112,7 @@ func (repository *GcsRepositoryImpl) GetFile(ctx context.Context, bucketName, fi
 	defer span.End()
 	reader, err := bucket.Object(fileName).NewReader(ctx)
 	if err != nil {
-		return models.GCSFile{}, fmt.Errorf("failed to read GCS object %s/%s: %v", bucketName, fileName, err)
+		return models.GCSFile{}, fmt.Errorf("failed to read GCS object %s/%s: %w", bucketName, fileName, err)
 	}
 
 	return models.GCSFile{

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var INDEX_CREATION_TIMEOUT time.Duration = 60 * 4 // 4 hours
+var INDEX_CREATION_TIMEOUT time.Duration = 60 * 4 * time.Minute // 4 hours
 
 func (repo *ClientDbRepository) ListAllValidIndexes(
 	ctx context.Context,
@@ -165,7 +165,7 @@ func asynchronouslyCreateIndexes(
 	indexes []models.ConcreteIndex,
 ) {
 	ctx = context.WithoutCancel(ctx)
-	ctx, _ = context.WithTimeout(ctx, INDEX_CREATION_TIMEOUT*time.Minute)
+	ctx, _ = context.WithTimeout(ctx, INDEX_CREATION_TIMEOUT) //nolint:govet
 	// The function is meant to be executed asynchronously and return way after the request was finished,
 	// so we don't return any error
 	// However the indexes are created one after the other to avoid a (probably) deadlock situation
@@ -174,7 +174,7 @@ func asynchronouslyCreateIndexes(
 		// in particular, if it just finishes.
 		// We still put a high timeout on it to protect agains an index creation that takes probihitively long
 		// An error log is sent from within createIndexSQL and should be monitored
-		createIndexSQL(ctx, exec, index)
+		_ = createIndexSQL(ctx, exec, index)
 	}
 }
 
@@ -252,9 +252,9 @@ func (repo *ClientDbRepository) CreateUniqueIndexAsync(ctx context.Context, exec
 	}
 
 	ctx = context.WithoutCancel(ctx)
-	ctx, _ = context.WithTimeout(ctx, INDEX_CREATION_TIMEOUT*time.Minute)
+	ctx, _ = context.WithTimeout(ctx, INDEX_CREATION_TIMEOUT) //nolint:govet
 
-	go createUniqueIndex(ctx, exec, index, true)
+	go createUniqueIndex(ctx, exec, index, true) //nolint:errcheck
 	// The function is meant to be executed asynchronously and return way after the request was finished,
 	// so we don't return any error
 	return nil

--- a/repositories/transfercheck_enrichment.go
+++ b/repositories/transfercheck_enrichment.go
@@ -82,7 +82,7 @@ func (r *TransferCheckEnrichmentRepository) setupIpCountryRanges(ctx context.Con
 		})
 		record, err = fileReader.Read()
 	}
-	if err != io.EOF {
+	if err != io.EOF { //nolint:errorlint
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Contex
 		})
 		record, err = fileReader.Read()
 	}
-	if err != io.EOF {
+	if err != io.EOF { //nolint:errorlint
 		return errors.Wrap(err, "failed to read VPN IP file")
 	}
 
@@ -233,7 +233,7 @@ func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Contex
 		})
 		record, err = fileReader.Read()
 	}
-	if err != io.EOF {
+	if err != io.EOF { //nolint:errorlint
 		return errors.Wrap(err, "failed to read TOR IP file")
 	}
 

--- a/repositories/user_repository_postgresql.go
+++ b/repositories/user_repository_postgresql.go
@@ -109,7 +109,7 @@ func (repo *UserRepositoryPostgresql) DeleteUsersOfOrganization(ctx context.Cont
 	err := ExecBuilder(
 		ctx,
 		exec,
-		NewQueryBuilder().Delete(dbmodels.TABLE_USERS).Where("organization_id = ?", string(organizationId)),
+		NewQueryBuilder().Delete(dbmodels.TABLE_USERS).Where("organization_id = ?", organizationId),
 	)
 	return err
 }

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -159,7 +159,7 @@ func EvalScenario(
 	}
 
 	// Compute outcome from score
-	outcome := models.None
+	var outcome models.Outcome
 
 	if score < publishedVersion.Body.ScoreReviewThreshold {
 		outcome = models.Approve

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -157,7 +157,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 		// line number starts at 1, and we already read the first line as headers
 		lineNumber := processedLinesCount + 2
 		row, err := fileReader.Read()
-		if err == io.EOF {
+		if err == io.EOF { //nolint:errorlint
 			break
 		}
 		if err != nil {
@@ -338,7 +338,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(ctx context.Context, organ
 		for ; windowStart < windowEnd; windowStart++ {
 			logger.InfoContext(ctx, fmt.Sprintf("Start reading line %v", windowStart))
 			record, err := r.Read()
-			if err == io.EOF {
+			if err == io.EOF { //nolint:errorlint
 				total = windowStart
 				keepParsingFile = false
 				break

--- a/usecases/organization/organization_creator.go
+++ b/usecases/organization/organization_creator.go
@@ -69,11 +69,11 @@ func (creator *OrganizationCreator) seedDefaultList(ctx context.Context, organiz
 		CustomListId: newCustomListId,
 		Value:        "Welcome",
 	}
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
+	_ = creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 	addCustomListValueInput.Value = "to"
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
+	_ = creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 	addCustomListValueInput.Value = "marble"
-	creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
+	_ = creator.CustomListRepository.AddCustomListValue(ctx, exec, addCustomListValueInput, uuid.NewString(), nil)
 
 	logger.InfoContext(ctx, "Finish to create the default custom list for the organization")
 	return nil

--- a/usecases/scenario_usecase_test.go
+++ b/usecases/scenario_usecase_test.go
@@ -189,9 +189,6 @@ func (suite *ScenarioUsecaseTestSuite) TestUpdateScenario_with_workflow_error() 
 	scenario.DecisionToCaseInboxId = utils.Ptr("inbox_id")
 	scenario.DecisionToCaseOutcomes = []models.Outcome{models.Reject}
 
-	updatedScenario := scenario
-	updatedScenario.DecisionToCaseInboxId = utils.Ptr("inbox_id_2")
-
 	suite.transactionFactory.On("Transaction", suite.ctx, mock.Anything).Return(nil)
 	suite.scenarioRepository.On("GetScenarioById", suite.transaction, suite.scenarioId).Return(scenario, nil).Once()
 	suite.enforceSecurity.On("UpdateScenario", scenario).Return(nil)

--- a/usecases/scenarios/scenario_publisher.go
+++ b/usecases/scenarios/scenario_publisher.go
@@ -92,7 +92,7 @@ func (publisher ScenarioPublisher) PublishOrUnpublishIteration(
 	default:
 		return nil, errors.Wrap(
 			models.BadParameterError,
-			"unknown publication action: "+string(publicationAction.String()),
+			"unknown publication action: "+publicationAction.String(),
 		)
 	}
 

--- a/usecases/security/enforce_security_inboxes.go
+++ b/usecases/security/enforce_security_inboxes.go
@@ -50,7 +50,7 @@ func (e EnforceSecurityInboxes) ReadInboxUser(inboxUser models.InboxUser, actorI
 func (e EnforceSecurityInboxes) CreateInboxUser(
 	i models.CreateInboxUserInput, actorInboxUsers []models.InboxUser, targetInbox models.Inbox, targetUser models.User,
 ) error {
-	organizationId := string(e.Credentials.OrganizationId)
+	organizationId := e.Credentials.OrganizationId
 	if targetUser.OrganizationId != organizationId {
 		return errors.Wrap(models.ForbiddenError, "Target user does not belong to the right organization")
 	}

--- a/usecases/seed_usecase.go
+++ b/usecases/seed_usecase.go
@@ -73,9 +73,7 @@ func (usecase *SeedUseCase) CreateOrgAndUser(ctx context.Context, input models.I
 
 	if targetOrg.Id == "" {
 		targetOrg, err = usecase.organizationCreator.CreateOrganization(ctx, input.OrgName)
-		if repositories.IsUniqueViolationError(err) {
-			err = nil
-		} else if err != nil {
+		if err != nil && !repositories.IsUniqueViolationError(err) {
 			return err
 		}
 		logger.InfoContext(

--- a/usecases/tracking/track.go
+++ b/usecases/tracking/track.go
@@ -19,12 +19,15 @@ func TrackEvent(ctx context.Context, event models.AnalyticsEvent, properties map
 	for k, v := range properties {
 		segmentProperties.Set(k, v)
 	}
-
-	segmentClient.Enqueue(analytics.Track{
+	err := segmentClient.Enqueue(analytics.Track{
 		Event:      string(event),
 		UserId:     string(credentials.ActorIdentity.UserId),
 		Properties: segmentProperties,
 	})
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.ErrorContext(ctx, "Failed to track event", "error", err.Error())
+	}
 }
 
 func TrackEventWithUserId(ctx context.Context, event models.AnalyticsEvent, userId models.UserId, properties map[string]interface{}) {
@@ -38,11 +41,15 @@ func TrackEventWithUserId(ctx context.Context, event models.AnalyticsEvent, user
 		segmentProperties.Set(k, v)
 	}
 
-	segmentClient.Enqueue(analytics.Track{
+	err := segmentClient.Enqueue(analytics.Track{
 		Event:      string(event),
 		UserId:     string(userId),
 		Properties: segmentProperties,
 	})
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.ErrorContext(ctx, "Failed to track event", "error", err.Error())
+	}
 }
 
 func Identify(ctx context.Context, userId models.UserId, traits map[string]interface{}) {
@@ -58,10 +65,14 @@ func Identify(ctx context.Context, userId models.UserId, traits map[string]inter
 		segmentTraits.Set(k, v)
 	}
 
-	segmentClient.Enqueue(analytics.Identify{
+	err := segmentClient.Enqueue(analytics.Identify{
 		UserId: string(userId),
 		Traits: segmentTraits,
 	})
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.ErrorContext(ctx, "Failed to track event", "error", err.Error())
+	}
 }
 
 func Group(ctx context.Context, userId models.UserId, organizationId string, traits map[string]interface{}) {
@@ -77,11 +88,15 @@ func Group(ctx context.Context, userId models.UserId, organizationId string, tra
 		segmentTraits.Set(k, v)
 	}
 
-	segmentClient.Enqueue(analytics.Group{
+	err := segmentClient.Enqueue(analytics.Group{
 		UserId:  string(userId),
 		GroupId: organizationId,
 		Traits:  segmentTraits,
 	})
+	if err != nil {
+		logger := utils.LoggerFromContext(ctx)
+		logger.ErrorContext(ctx, "Failed to track event", "error", err.Error())
+	}
 }
 
 func getCredentialsAndAnalyticsClientFromContext(ctx context.Context) (models.Credentials, analytics.Client, bool) {


### PR DESCRIPTION
Uses golangci-lint https://github.com/golangci/golangci-lint/tree/master?tab=readme-ov-file
Getting started: https://golangci-lint.run/welcome/quick-start/

List of linters used can be expanded later (some other interesting options but would require some work to harmonize code first).

----

Example run with a lint error: 
<img width="1744" alt="Capture d’écran 2024-08-26 à 17 29 11" src="https://github.com/user-attachments/assets/e80560d8-cee7-4c12-90d9-c3cc9dd75d41">
