### PR TITLE
Pascal/fix ast formula validation

### DIFF
--- a/models/scenario_validation.go
+++ b/models/scenario_validation.go
@@ -12,6 +12,8 @@ const (
 	TriggerConditionRequired
 	// Rule
 	RuleFormulaRequired
+	// Ast output
+	FormulaMustReturnBoolean
 	// Decision
 	ScoreReviewThresholdRequired
 	ScoreRejectThresholdRequired
@@ -29,6 +31,8 @@ func (e ScenarioValidationErrorCode) String() string {
 		return "TRIGGER_CONDITION_REQUIRED"
 	case RuleFormulaRequired:
 		return "RULE_FORMULA_REQUIRED"
+	case FormulaMustReturnBoolean:
+		return "FORMULA_MUST_RETURN_BOOLEAN"
 	case ScoreReviewThresholdRequired:
 		return "SCORE_REVIEW_THRESHOLD_REQUIRED"
 	case ScoreRejectThresholdRequired:

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -94,6 +94,13 @@ func (validator *ValidateScenarioIterationImpl) Validate(ctx context.Context, si
 		})
 	} else {
 		result.Trigger.TriggerEvaluation, _ = ast_eval.EvaluateAst(ctx, dryRunEnvironment, *trigger)
+		if _, ok := result.Trigger.TriggerEvaluation.ReturnValue.(bool); !ok {
+			result.Trigger.Errors = append(result.Trigger.Errors, models.ScenarioValidationError{
+				Error: errors.Wrap(models.BadParameterError,
+					"scenario iteration trigger condition does not return a boolean"),
+				Code: models.FormulaMustReturnBoolean,
+			})
+		}
 	}
 
 	// validate each rule
@@ -108,6 +115,13 @@ func (validator *ValidateScenarioIterationImpl) Validate(ctx context.Context, si
 			result.Rules.Rules[rule.Id] = ruleValidation
 		} else {
 			ruleValidation.RuleEvaluation, _ = ast_eval.EvaluateAst(ctx, dryRunEnvironment, *formula)
+			if _, ok := ruleValidation.RuleEvaluation.ReturnValue.(bool); !ok {
+				ruleValidation.Errors = append(ruleValidation.Errors, models.ScenarioValidationError{
+					Error: errors.Wrap(models.BadParameterError,
+						"rule formula does not return a boolean"),
+					Code: models.FormulaMustReturnBoolean,
+				})
+			}
 			result.Rules.Rules[rule.Id] = ruleValidation
 		}
 	}

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -36,7 +36,7 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
 		TriggerConditionAstExpression: utils.Ptr(ast.Node{
-			Constant: utils.Ptr(100),
+			Constant: true,
 		}),
 		Rules: []models.Rule{
 			{
@@ -101,4 +101,92 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 		Iteration: scenarioIteration,
 	})
 	assert.Empty(t, ScenarioValidationToError(result))
+}
+
+func TestValidateScenarioIterationImpl_Validate_notBool(t *testing.T) {
+	ctx := utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
+	scenario := models.Scenario{
+		Id:                uuid.New().String(),
+		OrganizationId:    uuid.New().String(),
+		Name:              "scenario_name",
+		Description:       "description",
+		TriggerObjectType: "object_type",
+		CreatedAt:         time.Now(),
+		LiveVersionID:     utils.Ptr(uuid.New().String()),
+	}
+
+	scenarioIterationID := uuid.New().String()
+	scenarioIteration := models.ScenarioIteration{
+		Id:             scenarioIterationID,
+		OrganizationId: scenario.OrganizationId,
+		ScenarioId:     scenario.Id,
+		Version:        utils.Ptr(1),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+		TriggerConditionAstExpression: utils.Ptr(ast.Node{
+			Constant: 100, // should be a boolean, resulting in an error
+		}),
+		Rules: []models.Rule{
+			{
+				Id:                  "rule",
+				ScenarioIterationId: scenarioIterationID,
+				OrganizationId:      scenario.OrganizationId,
+				DisplayOrder:        0,
+				Name:                "rule",
+				Description:         "description",
+				FormulaAstExpression: utils.Ptr(ast.Node{
+					Function: ast.FUNC_GREATER,
+					Constant: nil,
+					Children: []ast.Node{
+						{
+							Constant: 10,
+						},
+						{
+							Constant: 100,
+						},
+					},
+				}),
+				ScoreModifier: 10,
+				CreatedAt:     time.Now(),
+			},
+		},
+		ScoreReviewThreshold: utils.Ptr(100),
+		ScoreRejectThreshold: utils.Ptr(1000),
+		BatchTriggerSQL:      "trigger",
+		Schedule:             "schedule",
+	}
+
+	exec := new(mocks.Executor)
+	executorFactory := new(mocks.ExecutorFactory)
+	executorFactory.On("NewExecutor").Once().Return(exec)
+	mdmr := new(mocks.DataModelRepository)
+	mdmr.On("GetDataModel", ctx, exec, scenario.OrganizationId, false).
+		Return(models.DataModel{
+			Version: "version",
+			Tables: map[string]models.Table{
+				"object_type": {
+					Name: "object_type",
+					Fields: map[string]models.Field{
+						"id": {
+							DataType: models.Int,
+						},
+					},
+					LinksToSingle: nil,
+				},
+			},
+		}, nil)
+
+	validator := ValidateScenarioIterationImpl{
+		DataModelRepository: mdmr,
+		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
+			return ast_eval.NewAstEvaluationEnvironment()
+		},
+		ExecutorFactory: executorFactory,
+	}
+
+	result := validator.Validate(ctx, models.ScenarioAndIteration{
+		Scenario:  scenario,
+		Iteration: scenarioIteration,
+	})
+	assert.NotEmpty(t, ScenarioValidationToError(result))
 }


### PR DESCRIPTION
Found this bug while working on https://github.com/checkmarble/marble-backend/pull/655. Rules that do not return a boolean (including, rules that return a nil, for instance because of an empty AND operator) passed the scenario validation on commit and caused errors at runtime.

I need a re-read on this because I'm not sure of the implications for the front (though presumably the front interface is guided enough that you can't end up in this state).