### PR TITLE
Pascal/refactor org id injection

### DIFF
--- a/api/handle_analytics.go
+++ b/api/handle_analytics.go
@@ -8,12 +8,18 @@ import (
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 func handleListAnalytics(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		usecase := usecasesWithCreds(c.Request, uc).NewAnalyticsUseCase()
-		analytics, err := usecase.ListAnalytics(c.Request.Context())
+		analytics, err := usecase.ListAnalytics(c.Request.Context(), organizationId)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_apikey.go
+++ b/api/handle_apikey.go
@@ -14,8 +14,13 @@ import (
 
 func handleListApiKeys(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		usecase := usecasesWithCreds(c.Request, uc).NewApiKeyUseCase()
-		apiKeys, err := usecase.ListApiKeys(c.Request.Context())
+		apiKeys, err := usecase.ListApiKeys(c.Request.Context(), organizationId)
 		if presentError(c, err) {
 			return
 		}
@@ -28,7 +33,7 @@ func handleListApiKeys(uc usecases.Usecases) func(c *gin.Context) {
 
 func handlePostApiKey(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -23,7 +23,7 @@ var casesPaginationDefaults = dto.PaginationDefaults{
 
 func handleListCases(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -104,7 +104,7 @@ func handlePostCase(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewCaseUseCase()
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -109,12 +109,16 @@ func handlePostCase(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		inboxCase, err := usecase.CreateCaseAsUser(c.Request.Context(), userId, models.CreateCaseAttributes{
-			DecisionIds:    data.DecisionIds,
-			InboxId:        data.InboxId,
-			Name:           data.Name,
-			OrganizationId: organizationId,
-		})
+		inboxCase, err := usecase.CreateCaseAsUser(
+			c.Request.Context(),
+			organizationId,
+			userId,
+			models.CreateCaseAttributes{
+				DecisionIds:    data.DecisionIds,
+				InboxId:        data.InboxId,
+				Name:           data.Name,
+				OrganizationId: organizationId,
+			})
 
 		if presentError(c, err) {
 			return

--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -16,8 +16,13 @@ import (
 
 func handleGetAllCustomLists(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		usecase := usecasesWithCreds(c.Request, uc).NewCustomListUseCase()
-		lists, err := usecase.GetCustomLists(c.Request.Context())
+		lists, err := usecase.GetCustomLists(c.Request.Context(), organizationId)
 		if presentError(c, err) {
 			return
 		}
@@ -29,6 +34,11 @@ func handleGetAllCustomLists(uc usecases.Usecases) func(c *gin.Context) {
 
 func handlePostCustomList(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		var data dto.CreateCustomListBodyDto
 		if err := c.ShouldBindJSON(&data); err != nil {
 			c.Status(http.StatusBadRequest)
@@ -37,8 +47,9 @@ func handlePostCustomList(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(c.Request, uc).NewCustomListUseCase()
 		customList, err := usecase.CreateCustomList(c.Request.Context(), models.CreateCustomListInput{
-			Name:        data.Name,
-			Description: data.Description,
+			Name:           data.Name,
+			Description:    data.Description,
+			OrganizationId: organizationId,
 		})
 		if presentError(c, err) {
 			return

--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -77,7 +77,7 @@ func handlePatchCustomList(uc usecases.Usecases) func(c *gin.Context) {
 		ctx := c.Request.Context()
 		logger := utils.LoggerFromContext(ctx)
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -112,7 +112,7 @@ func handleDeleteCustomList(uc usecases.Usecases) func(c *gin.Context) {
 		ctx := c.Request.Context()
 		logger := utils.LoggerFromContext(ctx)
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -133,7 +133,7 @@ func handlePostCustomListValue(uc usecases.Usecases) func(c *gin.Context) {
 		ctx := c.Request.Context()
 		logger := utils.LoggerFromContext(ctx)
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -166,7 +166,7 @@ func handleDeleteCustomListValue(uc usecases.Usecases) func(c *gin.Context) {
 		ctx := c.Request.Context()
 		logger := utils.LoggerFromContext(ctx)
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -35,7 +35,7 @@ func handleGetDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.C
 
 func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -87,7 +87,7 @@ func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin
 
 func handlePostDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -138,7 +138,7 @@ func returnExpectedDecisionError(c *gin.Context, err error) bool {
 
 func handlePostAllDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_inboxes.go
+++ b/api/handle_inboxes.go
@@ -62,7 +62,7 @@ type CreateInboxInput struct {
 
 func handlePostInbox(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_inboxes.go
+++ b/api/handle_inboxes.go
@@ -38,6 +38,11 @@ func handleGetInboxById(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleListInboxes(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		withCaseCountFilter := struct {
 			WithCaseCount bool `form:"withCaseCount"`
 		}{}
@@ -47,7 +52,7 @@ func handleListInboxes(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewInboxUsecase()
-		inboxes, err := usecase.ListInboxes(c.Request.Context(), withCaseCountFilter.WithCaseCount)
+		inboxes, err := usecase.ListInboxes(c.Request.Context(), organizationId, withCaseCountFilter.WithCaseCount)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -18,7 +18,7 @@ import (
 
 func handleIngestion(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_rules.go
+++ b/api/handle_rules.go
@@ -35,7 +35,7 @@ func handleListRules(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleCreateRule(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_scenario_iterations.go
+++ b/api/handle_scenario_iterations.go
@@ -18,9 +18,15 @@ import (
 func handleListScenarioIterations(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		scenarioID := c.Query("scenarioId")
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioIterationUsecase()
-		scenarioIterations, err := usecase.ListScenarioIterations(c.Request.Context(),
+		scenarioIterations, err := usecase.ListScenarioIterations(
+			c.Request.Context(),
+			organizationId,
 			models.GetScenarioIterationFilters{
 				ScenarioId: utils.PtrTo(scenarioID, &utils.PtrToOptions{OmitZero: true}),
 			})

--- a/api/handle_scenario_iterations.go
+++ b/api/handle_scenario_iterations.go
@@ -45,7 +45,7 @@ func handleCreateScenarioIteration(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -79,7 +79,7 @@ func handleCreateDraftFromIteration(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_scenario_publications.go
+++ b/api/handle_scenario_publications.go
@@ -37,12 +37,18 @@ func NewAPIScenarioPublication(sp models.ScenarioPublication) APIScenarioPublica
 
 func handleListScenarioPublications(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		scenarioID := c.Query("scenarioID")
 		scenarioIterationID := c.Query("scenarioIterationID")
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioPublicationUsecase()
 		scenarioPublications, err := usecase.ListScenarioPublications(
 			c.Request.Context(),
+			organizationId,
 			models.ListScenarioPublicationsFilters{
 				ScenarioId:          utils.PtrTo(scenarioID, &utils.PtrToOptions{OmitZero: true}),
 				ScenarioIterationId: utils.PtrTo(scenarioIterationID, &utils.PtrToOptions{OmitZero: true}),

--- a/api/handle_scenario_publications.go
+++ b/api/handle_scenario_publications.go
@@ -56,6 +56,11 @@ func handleListScenarioPublications(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleCreateScenarioPublication(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		var data dto.CreateScenarioPublicationBody
 		if err := c.ShouldBindJSON(&data); err != nil {
 			c.Status(http.StatusBadRequest)
@@ -65,6 +70,7 @@ func handleCreateScenarioPublication(uc usecases.Usecases) func(c *gin.Context) 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioPublicationUsecase()
 		scenarioPublications, err := usecase.ExecuteScenarioPublicationAction(
 			c.Request.Context(),
+			organizationId,
 			models.PublishScenarioIterationInput{
 				ScenarioIterationId: data.ScenarioIterationId,
 				PublicationAction:   models.PublicationActionFrom(data.PublicationAction),
@@ -91,6 +97,11 @@ func handleGetScenarioPublication(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleGetPublicationPreparationStatus(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		var data struct {
 			ScenarioIterationId string `form:"scenario_iteration_id" binding:"required"`
 		}
@@ -100,7 +111,10 @@ func handleGetPublicationPreparationStatus(uc usecases.Usecases) func(c *gin.Con
 		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioPublicationUsecase()
-		status, err := usecase.GetPublicationPreparationStatus(c.Request.Context(), data.ScenarioIterationId)
+		status, err := usecase.GetPublicationPreparationStatus(
+			c.Request.Context(),
+			organizationId,
+			data.ScenarioIterationId)
 		if presentError(c, err) {
 			return
 		}
@@ -110,6 +124,11 @@ func handleGetPublicationPreparationStatus(uc usecases.Usecases) func(c *gin.Con
 
 func handleStartPublicationPreparation(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		var data struct {
 			ScenarioIterationId string `json:"scenario_iteration_id" binding:"required"`
 		}
@@ -119,7 +138,7 @@ func handleStartPublicationPreparation(uc usecases.Usecases) func(c *gin.Context
 		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioPublicationUsecase()
-		err := usecase.StartPublicationPreparation(c.Request.Context(), data.ScenarioIterationId)
+		err = usecase.StartPublicationPreparation(c.Request.Context(), organizationId, data.ScenarioIterationId)
 		if handleExpectedPublicationError(c, err) || presentError(c, err) {
 			return
 		}

--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -8,12 +8,18 @@ import (
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 func listScenarios(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioUsecase()
-		scenarios, err := usecase.ListScenarios(c.Request.Context())
+		scenarios, err := usecase.ListScenarios(c.Request.Context(), organizationId)
 		if presentError(c, err) {
 			return
 		}
@@ -23,6 +29,11 @@ func listScenarios(uc usecases.Usecases) func(c *gin.Context) {
 
 func createScenario(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
+
 		var input dto.CreateScenarioBody
 		if err := c.ShouldBindJSON(&input); err != nil {
 			c.Status(http.StatusBadRequest)
@@ -30,7 +41,9 @@ func createScenario(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScenarioUsecase()
-		scenario, err := usecase.CreateScenario(c.Request.Context(), dto.AdaptCreateScenarioInput(input))
+		scenario, err := usecase.CreateScenario(
+			c.Request.Context(),
+			dto.AdaptCreateScenarioInput(input, organizationId))
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_scheduled_execution.go
+++ b/api/handle_scheduled_execution.go
@@ -68,10 +68,17 @@ func handleGetScheduledExecutionDecisions(uc usecases.Usecases) func(c *gin.Cont
 
 func handleListScheduledExecution(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		scenarioID := c.Query("scenario_id")
+		scenarioId := c.Query("scenario_id")
+		scenarioIdPtr := utils.PtrTo(scenarioId, &utils.PtrToOptions{OmitZero: true})
+
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(c, err) {
+			return
+		}
 
 		usecase := usecasesWithCreds(c.Request, uc).NewScheduledExecutionUsecase()
-		executions, err := usecase.ListScheduledExecutions(c.Request.Context(), scenarioID)
+
+		executions, err := usecase.ListScheduledExecutions(c.Request.Context(), organizationId, scenarioIdPtr)
 
 		if presentError(c, err) {
 			return

--- a/api/handle_scheduled_execution.go
+++ b/api/handle_scheduled_execution.go
@@ -85,8 +85,7 @@ func handleListScheduledExecution(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleCreateScheduledExecution(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		ctx := c.Request.Context()
-		organizationId, err := utils.OrgIDFromCtx(ctx, c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_snoozes.go
+++ b/api/handle_snoozes.go
@@ -15,7 +15,7 @@ import (
 
 func handleSnoozesOfDecision(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		_, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		_, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -38,7 +38,7 @@ func handleSnoozesOfDecision(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleSnoozeDecision(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -77,7 +77,7 @@ func handleSnoozeDecision(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleSnoozesOfScenarioIteartion(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		_, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		_, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_tags.go
+++ b/api/handle_tags.go
@@ -17,7 +17,7 @@ type InboxIdUriInput struct {
 
 func handleListTags(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -42,7 +42,7 @@ func handleListTags(uc usecases.Usecases) func(c *gin.Context) {
 
 func handlePostTag(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -90,7 +90,7 @@ func handleGetTag(uc usecases.Usecases) func(c *gin.Context) {
 
 func handlePatchTag(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -123,7 +123,7 @@ func handlePatchTag(uc usecases.Usecases) func(c *gin.Context) {
 
 func handleDeleteTag(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/handle_transfer_check.go
+++ b/api/handle_transfer_check.go
@@ -18,7 +18,7 @@ func handleCreateTransfer(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		usecase := usecasesWithCreds(c.Request, uc).NewTransferCheckUsecase()
 
-		orgId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -51,7 +51,7 @@ func handleUpdateTransfer(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(c.Request, uc).NewTransferCheckUsecase()
 
-		orgId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -86,7 +86,7 @@ func handleQueryTransfers(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(c.Request, uc).NewTransferCheckUsecase()
 
-		orgId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -110,7 +110,7 @@ func handleGetTransfer(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		id := c.Param("transfer_id")
 
-		organizationId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}
@@ -131,7 +131,7 @@ func handleScoreTransfer(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(c.Request, uc).NewTransferCheckUsecase()
 
-		orgId, err := utils.OrgIDFromCtx(c.Request.Context(), c.Request)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if presentError(c, err) {
 			return
 		}

--- a/api/usecases_with_context_credentials.go
+++ b/api/usecases_with_context_credentials.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
-	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 )
@@ -17,22 +15,8 @@ func usecasesWithCreds(r *http.Request, uc usecases.Usecases) *usecases.Usecases
 		panic("no credentials in context")
 	}
 
-	// marble admin can specify on which organization to operate
-	// Ignore error, empty organizationId is fine, this is not the place to enforce security
-	organizationId, _ := utils.OrganizationIdFromRequest(r)
-
 	return &usecases.UsecasesWithCreds{
 		Usecases:    uc,
 		Credentials: creds,
-		OrganizationIdOfContext: func() (string, error) {
-			if organizationId == "" {
-				return "", fmt.Errorf(
-					"no OrganizationId for %s in this context. MarbleAdmin can specify one using 'organization-id' query param. %w",
-					creds.ActorIdentityDescription(),
-					models.BadParameterError,
-				)
-			}
-			return organizationId, nil
-		},
 	}
 }

--- a/dto/scenarios.go
+++ b/dto/scenarios.go
@@ -45,11 +45,12 @@ type CreateScenarioBody struct {
 	TriggerObjectType string `json:"triggerObjectType"`
 }
 
-func AdaptCreateScenarioInput(input CreateScenarioBody) models.CreateScenarioInput {
+func AdaptCreateScenarioInput(input CreateScenarioBody, organizationId string) models.CreateScenarioInput {
 	return models.CreateScenarioInput{
 		Name:              input.Name,
 		Description:       input.Description,
 		TriggerObjectType: input.TriggerObjectType,
+		OrganizationId:    organizationId,
 	}
 }
 

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -99,7 +99,7 @@ func createDecisionsBatch(
 	organizationId, scenarioId, scenarioIterationId string,
 ) {
 	scheduledExecUsecase := usecasesWithUserCreds.NewScheduledExecutionUsecase()
-	ses, err := scheduledExecUsecase.ListScheduledExecutions(ctx, scenarioId)
+	ses, err := scheduledExecUsecase.ListScheduledExecutions(ctx, organizationId, &scenarioId)
 	if err != nil {
 		assert.FailNow(t, "Failed to list scheduled executions", err)
 	}
@@ -118,7 +118,7 @@ func createDecisionsBatch(
 		assert.FailNow(t, "Failed to create scheduled executions", err)
 	}
 
-	ses, err = scheduledExecUsecase.ListScheduledExecutions(ctx, scenarioId)
+	ses, err = scheduledExecUsecase.ListScheduledExecutions(ctx, organizationId, &scenarioId)
 	if err != nil {
 		assert.FailNow(t, "Failed to list scheduled executions", err)
 	}

--- a/integration_test/generate_usecases.go
+++ b/integration_test/generate_usecases.go
@@ -11,9 +11,8 @@ func generateUsecaseWithCredForMarbleAdmin(
 ) usecases.UsecasesWithCreds {
 	creds := models.Credentials{Role: models.MARBLE_ADMIN}
 	return usecases.UsecasesWithCreds{
-		Usecases:                testUsecases,
-		Credentials:             creds,
-		OrganizationIdOfContext: func() (string, error) { return organizationId, nil },
+		Usecases:    testUsecases,
+		Credentials: creds,
 	}
 }
 
@@ -22,8 +21,7 @@ func generateUsecaseWithCreds(
 	creds models.Credentials,
 ) usecases.UsecasesWithCreds {
 	return usecases.UsecasesWithCreds{
-		Usecases:                testUsecases,
-		Credentials:             creds,
-		OrganizationIdOfContext: func() (string, error) { return creds.OrganizationId, nil },
+		Usecases:    testUsecases,
+		Credentials: creds,
 	}
 }

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -337,16 +337,19 @@ func setupScenarioAndPublish(
 	if err != nil {
 		assert.FailNow(t, "Could not commit scenario iteration", err)
 	}
-	err = scenarioPublicationUsecase.StartPublicationPreparation(ctx, scenarioIterationId)
+	err = scenarioPublicationUsecase.StartPublicationPreparation(ctx, organizationId, scenarioIterationId)
 	if err != nil {
 		assert.FailNow(t, "Could not start publication preparation", err)
 	}
 	time.Sleep(50 * time.Millisecond)
 	scenarioPublications, err := scenarioPublicationUsecase.ExecuteScenarioPublicationAction(
-		ctx, models.PublishScenarioIterationInput{
+		ctx,
+		organizationId,
+		models.PublishScenarioIterationInput{
 			ScenarioIterationId: scenarioIterationId,
 			PublicationAction:   models.Publish,
-		})
+		},
+	)
 	if err != nil {
 		assert.FailNow(t, "Could not publish scenario iteration", err)
 	}

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -268,6 +268,7 @@ func setupScenarioAndPublish(
 		Name:              "Test scenario",
 		Description:       "Test scenario description",
 		TriggerObjectType: "transactions",
+		OrganizationId:    organizationId,
 	})
 	if err != nil {
 		assert.FailNow(t, "Could not create scenario", err)

--- a/jobs/generate_usecases_with_creds.go
+++ b/jobs/generate_usecases_with_creds.go
@@ -13,8 +13,7 @@ func GenerateUsecaseWithCredForMarbleAdmin(ctx context.Context, jobUsecases usec
 		OrganizationId: "",
 	}
 	return usecases.UsecasesWithCreds{
-		Usecases:                jobUsecases,
-		Credentials:             creds,
-		OrganizationIdOfContext: func() (string, error) { return "", nil },
+		Usecases:    jobUsecases,
+		Credentials: creds,
 	}
 }

--- a/mocks/client_db_index_editor.go
+++ b/mocks/client_db_index_editor.go
@@ -14,40 +14,43 @@ type ClientDbIndexEditor struct {
 
 func (editor *ClientDbIndexEditor) GetIndexesToCreate(
 	ctx context.Context,
+	organizationId string,
 	scenarioIterationId string,
 ) (toCreate []models.ConcreteIndex, numPending int, err error) {
-	args := editor.Called(ctx, scenarioIterationId)
+	args := editor.Called(ctx, organizationId, scenarioIterationId)
 	return args.Get(0).([]models.ConcreteIndex), args.Int(1), args.Error(2)
 }
 
 func (editor *ClientDbIndexEditor) CreateIndexesAsync(
 	ctx context.Context,
+	organizationId string,
 	indexes []models.ConcreteIndex,
 ) error {
-	args := editor.Called(ctx, indexes)
+	args := editor.Called(ctx, organizationId, indexes)
 	return args.Error(0)
 }
 
-func (editor *ClientDbIndexEditor) ListAllUniqueIndexes(ctx context.Context) ([]models.UnicityIndex, error) {
-	args := editor.Called(ctx)
+func (editor *ClientDbIndexEditor) ListAllUniqueIndexes(ctx context.Context, organizationId string) ([]models.UnicityIndex, error) {
+	args := editor.Called(ctx, organizationId)
 	return args.Get(0).([]models.UnicityIndex), args.Error(1)
 }
 
 func (editor *ClientDbIndexEditor) CreateUniqueIndex(
 	ctx context.Context,
 	exec repositories.Executor,
+	organizationId string,
 	index models.UnicityIndex,
 ) error {
-	args := editor.Called(ctx, exec, index)
+	args := editor.Called(ctx, exec, organizationId, index)
 	return args.Error(0)
 }
 
-func (editor *ClientDbIndexEditor) CreateUniqueIndexAsync(ctx context.Context, index models.UnicityIndex) error {
-	args := editor.Called(ctx, index)
+func (editor *ClientDbIndexEditor) CreateUniqueIndexAsync(ctx context.Context, organizationId string, index models.UnicityIndex) error {
+	args := editor.Called(ctx, organizationId, index)
 	return args.Error(0)
 }
 
-func (editor *ClientDbIndexEditor) DeleteUniqueIndex(ctx context.Context, index models.UnicityIndex) error {
-	args := editor.Called(ctx, index)
+func (editor *ClientDbIndexEditor) DeleteUniqueIndex(ctx context.Context, organizationId string, index models.UnicityIndex) error {
+	args := editor.Called(ctx, organizationId, index)
 	return args.Error(0)
 }

--- a/mocks/custom_list_repository.go
+++ b/mocks/custom_list_repository.go
@@ -38,9 +38,9 @@ func (cl *CustomListRepository) GetCustomListValueById(ctx context.Context,
 }
 
 func (cl *CustomListRepository) CreateCustomList(ctx context.Context, exec repositories.Executor,
-	createCustomList models.CreateCustomListInput, organizationId string, newCustomListId string,
+	createCustomList models.CreateCustomListInput, newCustomListId string,
 ) error {
-	args := cl.Called(exec, createCustomList)
+	args := cl.Called(ctx, exec, createCustomList, newCustomListId)
 	return args.Error(0)
 }
 

--- a/models/custom_list.go
+++ b/models/custom_list.go
@@ -21,8 +21,9 @@ type CustomListValue struct {
 }
 
 type CreateCustomListInput struct {
-	Name        string
-	Description string
+	Name           string
+	Description    string
+	OrganizationId string
 }
 
 type UpdateCustomListInput struct {

--- a/models/scenarios.go
+++ b/models/scenarios.go
@@ -37,6 +37,7 @@ type CreateScenarioInput struct {
 	Description       string
 	Name              string
 	TriggerObjectType string
+	OrganizationId    string
 }
 
 type UpdateScenarioInput struct {

--- a/repositories/custom_list_repository.go
+++ b/repositories/custom_list_repository.go
@@ -14,8 +14,7 @@ type CustomListRepository interface {
 	GetCustomListById(ctx context.Context, exec Executor, id string) (models.CustomList, error)
 	GetCustomListValues(ctx context.Context, exec Executor, getCustomList models.GetCustomListValuesInput) ([]models.CustomListValue, error)
 	GetCustomListValueById(ctx context.Context, exec Executor, id string) (models.CustomListValue, error)
-	CreateCustomList(ctx context.Context, exec Executor, createCustomList models.CreateCustomListInput,
-		organizationId string, newCustomListId string) error
+	CreateCustomList(ctx context.Context, exec Executor, createCustomList models.CreateCustomListInput, newCustomListId string) error
 	UpdateCustomList(ctx context.Context, exec Executor, updateCustomList models.UpdateCustomListInput) error
 	SoftDeleteCustomList(ctx context.Context, exec Executor, listId string) error
 	AddCustomListValue(
@@ -106,7 +105,6 @@ func (repo *CustomListRepositoryPostgresql) CreateCustomList(
 	ctx context.Context,
 	exec Executor,
 	createCustomList models.CreateCustomListInput,
-	organizationId string,
 	newCustomListId string,
 ) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
@@ -125,7 +123,7 @@ func (repo *CustomListRepositoryPostgresql) CreateCustomList(
 			).
 			Values(
 				newCustomListId,
-				organizationId,
+				createCustomList.OrganizationId,
 				createCustomList.Name,
 				createCustomList.Description,
 			),

--- a/usecases/analytics_usecase.go
+++ b/usecases/analytics_usecase.go
@@ -15,17 +15,11 @@ type EnforceSecurityAnalytics interface {
 }
 
 type AnalyticsUseCase struct {
-	organizationIdOfContext func() (string, error)
-	enforceSecurity         EnforceSecurityAnalytics
-	analyticsRepository     AnalyticsRepository
+	enforceSecurity     EnforceSecurityAnalytics
+	analyticsRepository AnalyticsRepository
 }
 
-func (usecase *AnalyticsUseCase) ListAnalytics(ctx context.Context) ([]models.Analytics, error) {
-	organizationId, err := usecase.organizationIdOfContext()
-	if err != nil {
-		return []models.Analytics{}, err
-	}
-
+func (usecase *AnalyticsUseCase) ListAnalytics(ctx context.Context, organizationId string) ([]models.Analytics, error) {
 	analyticsList, err := usecase.analyticsRepository.ListAnalytics(ctx, organizationId)
 	if err != nil {
 		return []models.Analytics{}, err

--- a/usecases/api_key_usecase.go
+++ b/usecases/api_key_usecase.go
@@ -29,18 +29,12 @@ type EnforceSecurityApiKey interface {
 }
 
 type ApiKeyUseCase struct {
-	executorFactory         executor_factory.ExecutorFactory
-	organizationIdOfContext func() (string, error)
-	enforceSecurity         EnforceSecurityApiKey
-	apiKeyRepository        ApiKeyRepository
+	executorFactory  executor_factory.ExecutorFactory
+	enforceSecurity  EnforceSecurityApiKey
+	apiKeyRepository ApiKeyRepository
 }
 
-func (usecase *ApiKeyUseCase) ListApiKeys(ctx context.Context) ([]models.ApiKey, error) {
-	organizationId, err := usecase.organizationIdOfContext()
-	if err != nil {
-		return []models.ApiKey{}, err
-	}
-
+func (usecase *ApiKeyUseCase) ListApiKeys(ctx context.Context, organizationId string) ([]models.ApiKey, error) {
 	apiKeys, err := usecase.apiKeyRepository.ListApiKeys(ctx,
 		usecase.executorFactory.NewExecutor(), organizationId)
 	if err != nil {

--- a/usecases/api_key_usecase_test.go
+++ b/usecases/api_key_usecase_test.go
@@ -42,9 +42,6 @@ func (suite *ApiKeyUsecaseTestSuite) makeUsecase() *ApiKeyUseCase {
 		apiKeyRepository: suite.apiKeyRepository,
 		enforceSecurity:  suite.enforceSecurity,
 		executorFactory:  suite.executorFactory,
-		organizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
 	}
 }
 

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -222,7 +222,7 @@ func (suite *DatamodelUsecaseTestSuite) TestGetDataModel_nominal_no_unique() {
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return([]models.UnicityIndex{}, nil)
 
 	dataModel, err := usecase.GetDataModel(suite.ctx, suite.organizationId)
@@ -239,7 +239,7 @@ func (suite *DatamodelUsecaseTestSuite) TestGetDataModel_nominal_with_unique() {
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 
 	dataModel, err := usecase.GetDataModel(suite.ctx, suite.organizationId)
@@ -298,7 +298,10 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelTable_nominal() {
 	suite.organizationSchemaRepository.On("CreateTable", suite.ctx, suite.transaction, tableName).
 		Return(nil)
 	suite.clientDbIndexEditor.On("CreateUniqueIndex",
-		suite.ctx, suite.transaction, models.UnicityIndex{
+		suite.ctx,
+		suite.transaction,
+		suite.organizationId,
+		models.UnicityIndex{
 			TableName: tableName,
 			Fields:    []string{"object_id"},
 			Included:  []string{"updated_at", "id"},
@@ -490,7 +493,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelField_nominal_unique(
 	suite.transactionFactory.On("TransactionInOrgSchema", suite.ctx, suite.organizationId, mock.Anything).Return(nil)
 	suite.organizationSchemaRepository.On("CreateField", suite.ctx, suite.transaction, table.Name, field).
 		Return(nil)
-	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
+	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, suite.organizationId, models.UnicityIndex{
 		TableName: table.Name,
 		Fields:    []string{field.Name},
 	}).Return(nil)
@@ -679,7 +682,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_nominal() {
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 
 	_, err := usecase.CreateDataModelLink(suite.ctx, link)
@@ -716,7 +719,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelLink_parent_field_not
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return([]models.UnicityIndex{}, nil)
 
 	_, err := usecase.CreateDataModelLink(suite.ctx, link)
@@ -779,7 +782,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
@@ -811,7 +814,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
@@ -850,11 +853,11 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
-	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, models.UnicityIndex{
+	suite.clientDbIndexEditor.On("CreateUniqueIndexAsync", suite.ctx, suite.organizationId, models.UnicityIndex{
 		TableName: "transactions",
 		Fields:    []string{"not_yet_unique_id"},
 	}).Return(nil)
@@ -887,7 +890,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.enforceSecurity.On("WriteDataModel", suite.organizationId).Return(nil)
 	suite.dataModelRepository.On("UpdateDataModelField", suite.ctx, suite.transaction, fieldId, input).
 		Return(nil)
-	suite.clientDbIndexEditor.On("DeleteUniqueIndex", suite.ctx, models.UnicityIndex{
+	suite.clientDbIndexEditor.On("DeleteUniqueIndex", suite.ctx, suite.organizationId, models.UnicityIndex{
 		TableName: "transactions",
 		Fields:    []string{"unique_id"},
 	}).Return(nil)
@@ -897,7 +900,7 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_nominal_update_
 	suite.dataModelRepository.On("GetDataModel",
 		suite.ctx, suite.transaction, suite.organizationId, true).
 		Return(suite.dataModel, nil)
-	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx).
+	suite.clientDbIndexEditor.On("ListAllUniqueIndexes", suite.ctx, suite.organizationId).
 		Return(suite.uniqueIndexes, nil)
 
 	err := usecase.UpdateDataModelField(suite.ctx, fieldId, input)

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -63,7 +63,6 @@ type DecisionUsecase struct {
 	repository                 DecisionUsecaseRepository
 	evaluateAstExpression      ast_eval.EvaluateAstExpression
 	decisionWorkflows          decisionWorkflowsUsecase
-	organizationIdOfContext    func() (string, error)
 	webhookEventsSender        webhookEventsUsecase
 	snoozesReader              snoozesForDecisionReader
 }

--- a/usecases/inboxes/inboxes_test.go
+++ b/usecases/inboxes/inboxes_test.go
@@ -73,9 +73,6 @@ func (suite *InboxReaderTestSuite) SetupTest() {
 
 func (suite *InboxReaderTestSuite) makeUsecase() *InboxReader {
 	return &InboxReader{
-		OrganizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
 		EnforceSecurity: suite.enforceSecurity,
 		InboxRepository: suite.inboxRepository,
 		Credentials:     suite.credentials,
@@ -85,9 +82,6 @@ func (suite *InboxReaderTestSuite) makeUsecase() *InboxReader {
 
 func (suite *InboxReaderTestSuite) makeUsecaseAdmin() *InboxReader {
 	return &InboxReader{
-		OrganizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
 		EnforceSecurity: suite.enforceSecurity,
 		InboxRepository: suite.inboxRepository,
 		Credentials:     suite.adminCredentials,
@@ -147,7 +141,7 @@ func (suite *InboxReaderTestSuite) Test_ListInboxes_nominal_admin() {
 		mock.MatchedBy(func(s []string) bool { return s == nil })).Return([]models.Inbox{suite.inbox}, nil)
 	suite.enforceSecurity.On("ReadInbox", suite.inbox).Return(nil)
 
-	result, err := suite.makeUsecaseAdmin().ListInboxes(suite.ctx, suite.transaction, false)
+	result, err := suite.makeUsecaseAdmin().ListInboxes(suite.ctx, suite.transaction, suite.organizationId, false)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -166,7 +160,7 @@ func (suite *InboxReaderTestSuite) Test_ListInboxes_nominal_non_admin() {
 	}).Return([]models.Inbox{suite.inbox}, nil)
 	suite.enforceSecurity.On("ReadInbox", suite.inbox).Return(nil)
 
-	result, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, false)
+	result, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, suite.organizationId, false)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -181,7 +175,7 @@ func (suite *InboxReaderTestSuite) Test_ListInboxes_nominal_no_inboxes() {
 		UserId: suite.nonAdminUserId,
 	}).Return([]models.InboxUser{}, nil)
 
-	result, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, false)
+	result, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, suite.organizationId, false)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -199,7 +193,7 @@ func (suite *InboxReaderTestSuite) Test_ListInboxes_repository_error() {
 		suite.inboxId,
 	}).Return([]models.Inbox{}, suite.repositoryError)
 
-	_, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, false)
+	_, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, suite.organizationId, false)
 
 	t := suite.T()
 	assert.ErrorIs(t, err, suite.repositoryError)
@@ -217,7 +211,7 @@ func (suite *InboxReaderTestSuite) Test_ListInboxes_security_error() {
 	}).Return([]models.Inbox{suite.inbox}, nil)
 	suite.enforceSecurity.On("ReadInbox", suite.inbox).Return(suite.securityError)
 
-	_, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, false)
+	_, err := suite.makeUsecase().ListInboxes(suite.ctx, suite.transaction, suite.organizationId, false)
 
 	t := suite.T()
 	assert.ErrorIs(t, err, suite.securityError)

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -31,23 +31,22 @@ type EnforceSecurityInboxes interface {
 }
 
 type InboxUsecase struct {
-	transactionFactory      executor_factory.TransactionFactory
-	executorFactory         executor_factory.ExecutorFactory
-	enforceSecurity         EnforceSecurityInboxes
-	organizationIdOfContext func() (string, error)
-	inboxRepository         InboxRepository
-	userRepository          repositories.UserRepository
-	credentials             models.Credentials
-	inboxReader             inboxes.InboxReader
-	inboxUsers              inboxes.InboxUsers
+	transactionFactory executor_factory.TransactionFactory
+	executorFactory    executor_factory.ExecutorFactory
+	enforceSecurity    EnforceSecurityInboxes
+	inboxRepository    InboxRepository
+	userRepository     repositories.UserRepository
+	credentials        models.Credentials
+	inboxReader        inboxes.InboxReader
+	inboxUsers         inboxes.InboxUsers
 }
 
 func (usecase *InboxUsecase) GetInboxById(ctx context.Context, inboxId string) (models.Inbox, error) {
 	return usecase.inboxReader.GetInboxById(ctx, inboxId)
 }
 
-func (usecase *InboxUsecase) ListInboxes(ctx context.Context, withCaseCount bool) ([]models.Inbox, error) {
-	return usecase.inboxReader.ListInboxes(ctx, usecase.executorFactory.NewExecutor(), withCaseCount)
+func (usecase *InboxUsecase) ListInboxes(ctx context.Context, organizationId string, withCaseCount bool) ([]models.Inbox, error) {
+	return usecase.inboxReader.ListInboxes(ctx, usecase.executorFactory.NewExecutor(), organizationId, withCaseCount)
 }
 
 func (usecase *InboxUsecase) CreateInbox(ctx context.Context, input models.CreateInboxInput) (models.Inbox, error) {

--- a/usecases/inboxes_usecase_test.go
+++ b/usecases/inboxes_usecase_test.go
@@ -73,9 +73,6 @@ func (suite *InboxUsecaseTestSuite) SetupTest() {
 
 func (suite *InboxUsecaseTestSuite) makeUsecase() *InboxUsecase {
 	return &InboxUsecase{
-		organizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
 		enforceSecurity:    suite.enforceSecurity,
 		inboxRepository:    suite.inboxRepository,
 		userRepository:     suite.userRepository,
@@ -95,9 +92,6 @@ func (suite *InboxUsecaseTestSuite) makeUsecase() *InboxUsecase {
 
 func (suite *InboxUsecaseTestSuite) makeUsecaseAdmin() *InboxUsecase {
 	return &InboxUsecase{
-		organizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
 		enforceSecurity:    suite.enforceSecurity,
 		inboxRepository:    suite.inboxRepository,
 		userRepository:     suite.userRepository,

--- a/usecases/organization/organization_creator.go
+++ b/usecases/organization/organization_creator.go
@@ -58,9 +58,10 @@ func (creator *OrganizationCreator) seedDefaultList(ctx context.Context, organiz
 	newCustomListId := uuid.NewString()
 
 	err := creator.CustomListRepository.CreateCustomList(ctx, exec, models.CreateCustomListInput{
-		Name:        "Welcome to Marble",
-		Description: "Need a whitelist or blacklist ? The list is your friend :)",
-	}, organizationId, newCustomListId)
+		Name:           "Welcome to Marble",
+		Description:    "Need a whitelist or blacklist ? The list is your friend :)",
+		OrganizationId: organizationId,
+	}, newCustomListId)
 	if err != nil {
 		return err
 	}

--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -55,7 +55,6 @@ type IterationUsecaseRepository interface {
 
 type ScenarioIterationUsecase struct {
 	repository                IterationUsecaseRepository
-	organizationIdOfContext   func() (string, error)
 	enforceSecurity           security.EnforceSecurityScenario
 	scenarioFetcher           scenarios.ScenarioFetcher
 	validateScenarioIteration scenarios.ValidateScenarioIteration
@@ -63,13 +62,11 @@ type ScenarioIterationUsecase struct {
 	transactionFactory        executor_factory.TransactionFactory
 }
 
-func (usecase *ScenarioIterationUsecase) ListScenarioIterations(ctx context.Context,
+func (usecase *ScenarioIterationUsecase) ListScenarioIterations(
+	ctx context.Context,
+	organizationId string,
 	filters models.GetScenarioIterationFilters,
 ) ([]models.ScenarioIteration, error) {
-	organizationId, err := usecase.organizationIdOfContext()
-	if err != nil {
-		return nil, err
-	}
 	scenarioIterations, err := usecase.repository.ListScenarioIterations(ctx,
 		usecase.executorFactory.NewExecutor(), organizationId, filters)
 	if err != nil {

--- a/usecases/scenario_publication_usecase_test.go
+++ b/usecases/scenario_publication_usecase_test.go
@@ -143,11 +143,8 @@ func (suite *ScenarioPublicationUsecaseTestSuite) SetupTest() {
 
 func (suite *ScenarioPublicationUsecaseTestSuite) makeUsecase() *ScenarioPublicationUsecase {
 	return &ScenarioPublicationUsecase{
-		enforceSecurity: suite.enforceSecurity,
-		executorFactory: suite.executorFactory,
-		OrganizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
+		enforceSecurity:                suite.enforceSecurity,
+		executorFactory:                suite.executorFactory,
 		scenarioFetcher:                suite.scenarioFetcher,
 		scenarioPublicationsRepository: suite.scenarioPublicationsRepository,
 		scenarioPublisher:              suite.scenarioPublisher,
@@ -234,7 +231,9 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_ListScenarioPublications_
 		models.ListScenarioPublicationsFilters{},
 	).Return([]models.ScenarioPublication{suite.scenarioPublication}, nil)
 
-	publications, err := suite.makeUsecase().ListScenarioPublications(suite.ctx,
+	publications, err := suite.makeUsecase().ListScenarioPublications(
+		suite.ctx,
+		suite.organizationId,
 		models.ListScenarioPublicationsFilters{})
 
 	suite.NoError(err)
@@ -247,7 +246,9 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_ListScenarioPublications_
 func (suite *ScenarioPublicationUsecaseTestSuite) Test_ListScenarioPublications_security_error() {
 	suite.enforceSecurity.On("ListScenarios", suite.organizationId).Return(suite.securityError)
 
-	publications, err := suite.makeUsecase().ListScenarioPublications(suite.ctx,
+	publications, err := suite.makeUsecase().ListScenarioPublications(
+		suite.ctx,
+		suite.organizationId,
 		models.ListScenarioPublicationsFilters{})
 
 	suite.Equal(suite.securityError, err)
@@ -267,7 +268,9 @@ func (suite *ScenarioPublicationUsecaseTestSuite) Test_ListScenarioPublications_
 		models.ListScenarioPublicationsFilters{},
 	).Return([]models.ScenarioPublication{}, suite.repositoryError)
 
-	publications, err := suite.makeUsecase().ListScenarioPublications(suite.ctx,
+	publications, err := suite.makeUsecase().ListScenarioPublications(
+		suite.ctx,
+		suite.organizationId,
 		models.ListScenarioPublicationsFilters{})
 
 	suite.Equal(suite.repositoryError, err)

--- a/usecases/scenario_publications_usecase.go
+++ b/usecases/scenario_publications_usecase.go
@@ -44,7 +44,6 @@ type ScenarioPublicationUsecase struct {
 	transactionFactory             executor_factory.TransactionFactory
 	executorFactory                executor_factory.ExecutorFactory
 	scenarioPublicationsRepository repositories.ScenarioPublicationRepository
-	OrganizationIdOfContext        func() (string, error)
 	enforceSecurity                security.EnforceSecurityScenario
 	scenarioFetcher                ScenarioFetcher
 	scenarioPublisher              ScenarioPublisher
@@ -70,13 +69,9 @@ func (usecase *ScenarioPublicationUsecase) GetScenarioPublication(
 
 func (usecase *ScenarioPublicationUsecase) ListScenarioPublications(
 	ctx context.Context,
+	organizationId string,
 	filters models.ListScenarioPublicationsFilters,
 ) ([]models.ScenarioPublication, error) {
-	organizationId, err := usecase.OrganizationIdOfContext()
-	if err != nil {
-		return nil, err
-	}
-
 	// Enforce permissions
 	if err := usecase.enforceSecurity.ListScenarios(organizationId); err != nil {
 		return nil, err

--- a/usecases/scenario_usecase_test.go
+++ b/usecases/scenario_usecase_test.go
@@ -52,11 +52,8 @@ func (suite *ScenarioUsecaseTestSuite) makeUsecase() *ScenarioUsecase {
 	return &ScenarioUsecase{
 		transactionFactory: suite.transactionFactory,
 		executorFactory:    suite.executorFactory,
-		organizationIdOfContext: func() (string, error) {
-			return suite.organizationId, nil
-		},
-		enforceSecurity: suite.enforceSecurity,
-		repository:      suite.scenarioRepository,
+		enforceSecurity:    suite.enforceSecurity,
+		repository:         suite.scenarioRepository,
 	}
 }
 
@@ -75,7 +72,7 @@ func (suite *ScenarioUsecaseTestSuite) TestListScenarios() {
 		suite.organizationId).Return(expected, nil)
 	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(nil)
 
-	result, err := suite.makeUsecase().ListScenarios(suite.ctx)
+	result, err := suite.makeUsecase().ListScenarios(suite.ctx, suite.organizationId)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -90,7 +87,7 @@ func (suite *ScenarioUsecaseTestSuite) TestListScenarios_security() {
 		suite.organizationId).Return([]models.Scenario{suite.scenario}, nil)
 	suite.enforceSecurity.On("ReadScenario", suite.scenario).Return(suite.securityError)
 
-	_, err := suite.makeUsecase().ListScenarios(suite.ctx)
+	_, err := suite.makeUsecase().ListScenarios(suite.ctx, suite.organizationId)
 
 	assert.ErrorIs(suite.T(), err, suite.securityError)
 	suite.AssertExpectations()
@@ -219,7 +216,8 @@ func (suite *ScenarioUsecaseTestSuite) TestUpdateScenario_security() {
 
 func (suite *ScenarioUsecaseTestSuite) TestCreateScenario() {
 	createScenarioInput := models.CreateScenarioInput{
-		Name: "new scenario",
+		Name:           "new scenario",
+		OrganizationId: suite.organizationId,
 	}
 
 	suite.enforceSecurity.On("CreateScenario", suite.organizationId).Return(nil)
@@ -241,7 +239,9 @@ func (suite *ScenarioUsecaseTestSuite) TestCreateScenario() {
 func (suite *ScenarioUsecaseTestSuite) TestCreateScenario_security() {
 	suite.enforceSecurity.On("CreateScenario", suite.organizationId).Return(suite.securityError)
 
-	_, err := suite.makeUsecase().CreateScenario(context.Background(), models.CreateScenarioInput{})
+	_, err := suite.makeUsecase().CreateScenario(context.Background(), models.CreateScenarioInput{
+		OrganizationId: suite.organizationId,
+	})
 	assert.ErrorIs(suite.T(), err, suite.securityError)
 
 	suite.AssertExpectations()

--- a/usecases/scheduled_execution_usecase_test.go
+++ b/usecases/scheduled_execution_usecase_test.go
@@ -21,6 +21,7 @@ type ScheduledExecutionsTestSuite struct {
 	repository              *mocks.ScheduledExecutionUsecaseRepository
 	exportScheduleExecution *mocks.ExportDecisionsMock
 
+	organizationId      string
 	scenarioId          string
 	scheduledExecutions []models.ScheduledExecution
 }
@@ -32,6 +33,7 @@ func (suite *ScheduledExecutionsTestSuite) SetupTest() {
 	suite.repository = new(mocks.ScheduledExecutionUsecaseRepository)
 	suite.exportScheduleExecution = new(mocks.ExportDecisionsMock)
 
+	suite.organizationId = "some org id"
 	suite.scenarioId = "some scenario id"
 	suite.scheduledExecutions = []models.ScheduledExecution{
 		{
@@ -46,9 +48,6 @@ func (suite *ScheduledExecutionsTestSuite) makeUsecase() *ScheduledExecutionUsec
 		transactionFactory:      suite.transactionFactory,
 		repository:              suite.repository,
 		exportScheduleExecution: suite.exportScheduleExecution,
-		organizationIdOfContext: func() (string, error) {
-			return "some org id", nil
-		},
 	}
 }
 
@@ -69,7 +68,7 @@ func (suite *ScheduledExecutionsTestSuite) TestListScheduledExecutions_with_Orga
 	}).Return(suite.scheduledExecutions, nil)
 	suite.enforceSecurity.On("ReadScheduledExecution", suite.scheduledExecutions[0]).Return(nil)
 
-	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, "")
+	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, suite.organizationId, nil)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -86,7 +85,7 @@ func (suite *ScheduledExecutionsTestSuite) TestListScheduledExecutions_with_Scen
 	}).Return(suite.scheduledExecutions, nil)
 	suite.enforceSecurity.On("ReadScheduledExecution", suite.scheduledExecutions[0]).Return(nil)
 
-	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, suite.scenarioId)
+	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, suite.organizationId, &suite.scenarioId)
 
 	t := suite.T()
 	assert.NoError(t, err)
@@ -105,7 +104,7 @@ func (suite *ScheduledExecutionsTestSuite) TestListScheduledExecutions_security(
 	}).Return(suite.scheduledExecutions, nil)
 	suite.enforceSecurity.On("ReadScheduledExecution", suite.scheduledExecutions[0]).Return(securityError)
 
-	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, suite.scenarioId)
+	result, err := suite.makeUsecase().ListScheduledExecutions(ctx, suite.organizationId, &suite.scenarioId)
 
 	t := suite.T()
 	assert.ErrorIs(t, err, securityError)

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -99,11 +99,10 @@ func (usecases *UsecasesWithCreds) NewDecisionWorkflows() decision_workflows.Dec
 
 func (usecases *UsecasesWithCreds) NewScenarioUsecase() ScenarioUsecase {
 	return ScenarioUsecase{
-		transactionFactory:      usecases.NewTransactionFactory(),
-		executorFactory:         usecases.NewExecutorFactory(),
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
-		enforceSecurity:         usecases.NewEnforceScenarioSecurity(),
-		repository:              &usecases.Repositories.MarbleDbRepository,
+		transactionFactory: usecases.NewTransactionFactory(),
+		executorFactory:    usecases.NewExecutorFactory(),
+		enforceSecurity:    usecases.NewEnforceScenarioSecurity(),
+		repository:         &usecases.Repositories.MarbleDbRepository,
 	}
 }
 
@@ -140,11 +139,10 @@ func (usecases *UsecasesWithCreds) AstExpressionUsecase() AstExpressionUsecase {
 
 func (usecases *UsecasesWithCreds) NewCustomListUseCase() CustomListUseCase {
 	return CustomListUseCase{
-		enforceSecurity:         usecases.NewEnforceCustomListSecurity(),
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
-		transactionFactory:      usecases.NewTransactionFactory(),
-		executorFactory:         usecases.NewExecutorFactory(),
-		CustomListRepository:    usecases.Repositories.CustomListRepository,
+		enforceSecurity:      usecases.NewEnforceCustomListSecurity(),
+		transactionFactory:   usecases.NewTransactionFactory(),
+		executorFactory:      usecases.NewExecutorFactory(),
+		CustomListRepository: usecases.Repositories.CustomListRepository,
 	}
 }
 
@@ -153,7 +151,6 @@ func (usecases *UsecasesWithCreds) NewScenarioPublicationUsecase() ScenarioPubli
 		transactionFactory:             usecases.NewTransactionFactory(),
 		executorFactory:                usecases.NewExecutorFactory(),
 		scenarioPublicationsRepository: usecases.Repositories.ScenarioPublicationRepository,
-		OrganizationIdOfContext:        usecases.OrganizationIdOfContext,
 		enforceSecurity:                usecases.NewEnforceScenarioSecurity(),
 		scenarioFetcher:                usecases.NewScenarioFetcher(),
 		scenarioPublisher:              usecases.NewScenarioPublisher(),
@@ -269,11 +266,10 @@ func (usecases *UsecasesWithCreds) NewCaseUseCase() *CaseUseCase {
 		repository:         &usecases.Repositories.MarbleDbRepository,
 		decisionRepository: usecases.Repositories.DecisionRepository,
 		inboxReader: inboxes.InboxReader{
-			EnforceSecurity:         sec,
-			OrganizationIdOfContext: usecases.OrganizationIdOfContext,
-			InboxRepository:         &usecases.Repositories.MarbleDbRepository,
-			Credentials:             usecases.Credentials,
-			ExecutorFactory:         usecases.NewExecutorFactory(),
+			EnforceSecurity: sec,
+			InboxRepository: &usecases.Repositories.MarbleDbRepository,
+			Credentials:     usecases.Credentials,
+			ExecutorFactory: usecases.NewExecutorFactory(),
 		},
 		gcsCaseManagerBucket: usecases.gcsCaseManagerBucket,
 		gcsRepository:        gcsRepository,
@@ -288,19 +284,17 @@ func (usecases *UsecasesWithCreds) NewInboxUsecase() InboxUsecase {
 	}
 	executorFactory := usecases.NewExecutorFactory()
 	return InboxUsecase{
-		enforceSecurity:         sec,
-		inboxRepository:         &usecases.Repositories.MarbleDbRepository,
-		userRepository:          usecases.Repositories.UserRepository,
-		credentials:             usecases.Credentials,
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
-		transactionFactory:      usecases.NewTransactionFactory(),
-		executorFactory:         executorFactory,
+		enforceSecurity:    sec,
+		inboxRepository:    &usecases.Repositories.MarbleDbRepository,
+		userRepository:     usecases.Repositories.UserRepository,
+		credentials:        usecases.Credentials,
+		transactionFactory: usecases.NewTransactionFactory(),
+		executorFactory:    executorFactory,
 		inboxReader: inboxes.InboxReader{
-			EnforceSecurity:         sec,
-			OrganizationIdOfContext: usecases.OrganizationIdOfContext,
-			InboxRepository:         &usecases.Repositories.MarbleDbRepository,
-			Credentials:             usecases.Credentials,
-			ExecutorFactory:         executorFactory,
+			EnforceSecurity: sec,
+			InboxRepository: &usecases.Repositories.MarbleDbRepository,
+			Credentials:     usecases.Credentials,
+			ExecutorFactory: executorFactory,
 		},
 		inboxUsers: inboxes.InboxUsers{
 			EnforceSecurity:     sec,
@@ -324,11 +318,10 @@ func (usecases *UsecasesWithCreds) NewTagUseCase() TagUseCase {
 		executorFactory:    usecases.NewExecutorFactory(),
 		repository:         &usecases.Repositories.MarbleDbRepository,
 		inboxReader: inboxes.InboxReader{
-			EnforceSecurity:         sec,
-			OrganizationIdOfContext: usecases.OrganizationIdOfContext,
-			InboxRepository:         &usecases.Repositories.MarbleDbRepository,
-			Credentials:             usecases.Credentials,
-			ExecutorFactory:         usecases.NewExecutorFactory(),
+			EnforceSecurity: sec,
+			InboxRepository: &usecases.Repositories.MarbleDbRepository,
+			Credentials:     usecases.Credentials,
+			ExecutorFactory: usecases.NewExecutorFactory(),
 		},
 	}
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -83,7 +83,6 @@ func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 		dataModelRepository:        usecases.Repositories.DataModelRepository,
 		repository:                 &usecases.Repositories.MarbleDbRepository,
 		evaluateAstExpression:      usecases.NewEvaluateAstExpression(),
-		organizationIdOfContext:    usecases.OrganizationIdOfContext,
 		decisionWorkflows:          usecases.NewDecisionWorkflows(),
 		webhookEventsSender:        usecases.NewWebhookEventsUsecase(),
 		snoozesReader:              &usecases.Repositories.MarbleDbRepository,
@@ -169,7 +168,6 @@ func (usecases *UsecasesWithCreds) NewClientDbIndexEditor() clientDbIndexEditor 
 		&usecases.Repositories.ClientDbRepository,
 		usecases.NewEnforceScenarioSecurity(),
 		usecases.NewEnforceOrganizationSecurity(),
-		usecases.OrganizationIdOfContext,
 	)
 }
 
@@ -337,8 +335,7 @@ func (usecases *UsecasesWithCreds) NewTagUseCase() TagUseCase {
 
 func (usecases *UsecasesWithCreds) NewApiKeyUseCase() ApiKeyUseCase {
 	return ApiKeyUseCase{
-		executorFactory:         usecases.NewExecutorFactory(),
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
+		executorFactory: usecases.NewExecutorFactory(),
 		enforceSecurity: &security.EnforceSecurityApiKeyImpl{
 			EnforceSecurity: usecases.NewEnforceSecurity(),
 			Credentials:     usecases.Credentials,
@@ -349,7 +346,6 @@ func (usecases *UsecasesWithCreds) NewApiKeyUseCase() ApiKeyUseCase {
 
 func (usecases *UsecasesWithCreds) NewAnalyticsUseCase() AnalyticsUseCase {
 	return AnalyticsUseCase{
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
 		enforceSecurity: &security.EnforceSecurityAnalyticsImpl{
 			EnforceSecurity: usecases.NewEnforceSecurity(),
 			Credentials:     usecases.Credentials,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -13,8 +13,7 @@ import (
 
 type UsecasesWithCreds struct {
 	Usecases
-	Credentials             models.Credentials
-	OrganizationIdOfContext func() (string, error)
+	Credentials models.Credentials
 }
 
 func (usecases *UsecasesWithCreds) NewEnforceSecurity() security.EnforceSecurity {
@@ -109,7 +108,6 @@ func (usecases *UsecasesWithCreds) NewScenarioUsecase() ScenarioUsecase {
 func (usecases *UsecasesWithCreds) NewScenarioIterationUsecase() ScenarioIterationUsecase {
 	return ScenarioIterationUsecase{
 		repository:                &usecases.Repositories.MarbleDbRepository,
-		organizationIdOfContext:   usecases.OrganizationIdOfContext,
 		enforceSecurity:           usecases.NewEnforceScenarioSecurity(),
 		scenarioFetcher:           usecases.NewScenarioFetcher(),
 		validateScenarioIteration: usecases.NewValidateScenarioIteration(),
@@ -120,11 +118,10 @@ func (usecases *UsecasesWithCreds) NewScenarioIterationUsecase() ScenarioIterati
 
 func (usecases *UsecasesWithCreds) NewRuleUsecase() RuleUsecase {
 	return RuleUsecase{
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
-		enforceSecurity:         usecases.NewEnforceScenarioSecurity(),
-		repository:              &usecases.Repositories.MarbleDbRepository,
-		scenarioFetcher:         usecases.NewScenarioFetcher(),
-		transactionFactory:      usecases.NewTransactionFactory(),
+		enforceSecurity:    usecases.NewEnforceScenarioSecurity(),
+		repository:         &usecases.Repositories.MarbleDbRepository,
+		scenarioFetcher:    usecases.NewScenarioFetcher(),
+		transactionFactory: usecases.NewTransactionFactory(),
 	}
 }
 
@@ -236,7 +233,6 @@ func (usecases *UsecasesWithCreds) NewScheduledExecutionUsecase() ScheduledExecu
 		executorFactory:         usecases.NewExecutorFactory(),
 		repository:              &usecases.Repositories.MarbleDbRepository,
 		exportScheduleExecution: usecases.NewExportScheduleExecution(),
-		organizationIdOfContext: usecases.OrganizationIdOfContext,
 	}
 }
 

--- a/utils/context_credentials.go
+++ b/utils/context_credentials.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/cockroachdb/errors"
 )
 
 func CredentialsFromCtx(ctx context.Context) (models.Credentials, bool) {
@@ -14,41 +15,43 @@ func CredentialsFromCtx(ctx context.Context) (models.Credentials, bool) {
 }
 
 func OrganizationIdFromRequest(request *http.Request) (organizationId string, err error) {
+	if request == nil {
+		return "", fmt.Errorf("no request passed to OrganizationIdFromRequest: %w", models.ForbiddenError)
+	}
+
 	creds, found := CredentialsFromCtx(request.Context())
 	if !found {
 		return "", fmt.Errorf("no credentials in context: %w", models.ForbiddenError)
 	}
 
 	var requestOrganizationId string
-	if request != nil {
-		requestOrganizationId = request.URL.Query().Get("organization-id")
-		if requestOrganizationId != "" {
-			if err := ValidateUuid(requestOrganizationId); err != nil {
-				return "", err
-			}
-		}
-	}
 
 	// allow organizationId to be passed in query param
+	requestOrganizationId = request.URL.Query().Get("organization-id")
 	if requestOrganizationId != "" {
+		if err := ValidateUuid(requestOrganizationId); err != nil {
+			return "", err
+		}
+
+		// technically, any user can pass an org id in query params, but it can be different from the credentials org id
+		// only for a marble admin user
 		if err := EnforceOrganizationAccess(creds, requestOrganizationId); err != nil {
 			return "", err
 		}
 		return requestOrganizationId, nil
 	}
 
+	if creds.OrganizationId == "" && creds.Role == models.MARBLE_ADMIN {
+		return "", errors.Wrap(
+			models.ForbiddenError,
+			"An organizationId must be passed in the request query params for MARBLE_ADMIN to use this endpoint")
+	}
+
 	if creds.OrganizationId == "" {
-		noMarbleAdmin := ""
-		if creds.Role == models.MARBLE_ADMIN {
-			noMarbleAdmin = "this Api is not supposed to be called with marble admin creds "
-		}
-		return "", fmt.Errorf("no organizationId in context. %s: %w", noMarbleAdmin, models.ForbiddenError)
+		return "", errors.Wrap(
+			models.ForbiddenError,
+			"Unexpected error: credentials does not grant access to any organization")
 	}
 
 	return creds.OrganizationId, nil
-}
-
-// TODO: replace me with OrganizationIdFromContext
-func OrgIDFromCtx(ctx context.Context, request *http.Request) (organizationId string, err error) {
-	return OrganizationIdFromRequest(request)
 }

--- a/utils/context_credentials.go
+++ b/utils/context_credentials.go
@@ -24,10 +24,8 @@ func OrganizationIdFromRequest(request *http.Request) (organizationId string, er
 		return "", fmt.Errorf("no credentials in context: %w", models.ForbiddenError)
 	}
 
-	var requestOrganizationId string
-
 	// allow organizationId to be passed in query param
-	requestOrganizationId = request.URL.Query().Get("organization-id")
+	requestOrganizationId := request.URL.Query().Get("organization-id")
 	if requestOrganizationId != "" {
 		if err := ValidateUuid(requestOrganizationId); err != nil {
 			return "", err


### PR DESCRIPTION
Retrospectively this was more painful than I hoped for...
Anyway: the way dependencies, in particular trivial ones like the org id, are injected as a helper function into the usecases was a pain in the ass, I wanted to get rid of it for a while.