### PR TITLE
set status of batch ingestion job to failed if errors occur (including 1h timeout)

### DIFF
--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -43,7 +43,7 @@ func handleIngestion(uc usecases.Usecases) func(c *gin.Context) {
 	}
 }
 
-func handleCsvIngestion(uc usecases.Usecases) func(c *gin.Context) {
+func handlePostCsvIngestion(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		organizationId, err := utils.OrganizationIdFromRequest(c.Request)

--- a/api/routes.go
+++ b/api/routes.go
@@ -49,7 +49,7 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 	router.POST("/decisions/:decision_id/snooze", handleSnoozeDecision(uc))
 
 	router.POST("/ingestion/:object_type", handleIngestion(uc))
-	router.POST("/ingestion/:object_type/batch", timeoutMiddleware(batchIngestionTimeout), handleCsvIngestion(uc))
+	router.POST("/ingestion/:object_type/batch", timeoutMiddleware(batchIngestionTimeout), handlePostCsvIngestion(uc))
 	router.GET("/ingestion/:object_type/upload-logs", handleListUploadLogs(uc))
 
 	router.GET("/scenarios", listScenarios(uc))

--- a/dto/upload_log_dto.go
+++ b/dto/upload_log_dto.go
@@ -7,17 +7,19 @@ import (
 )
 
 type APIUploadLog struct {
-	Status         string     `json:"status"`
-	StartedAt      time.Time  `json:"started_at"`
-	FinishedAt     *time.Time `json:"finished_at"`
-	LinesProcessed int        `json:"lines_processed"`
+	Status          string     `json:"status"`
+	StartedAt       time.Time  `json:"started_at"`
+	FinishedAt      *time.Time `json:"finished_at"`
+	LinesProcessed  int        `json:"lines_processed"`
+	NumRowsIngested int        `json:"num_rows_ingested"`
 }
 
 func AdaptUploadLogDto(log models.UploadLog) APIUploadLog {
 	return APIUploadLog{
-		Status:         string(log.UploadStatus),
-		StartedAt:      log.StartedAt,
-		FinishedAt:     log.FinishedAt,
-		LinesProcessed: log.LinesProcessed,
+		Status:          string(log.UploadStatus),
+		StartedAt:       log.StartedAt,
+		FinishedAt:      log.FinishedAt,
+		LinesProcessed:  log.LinesProcessed,
+		NumRowsIngested: log.RowsIngested,
 	}
 }

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -77,7 +77,7 @@ a8ca9ad7-1581-44f8-89d0-1f00500f2d02,2024-08-11T22:47:00Z,7b7ffdbc-cf98-48cb-a46
 	}
 	fmt.Printf("Created upload log %s in pending state", log.Id)
 
-	err = ingestionUsecase.IngestDataFromCsv(ctx, utils.LoggerFromContext(ctx))
+	err = ingestionUsecase.IngestDataFromCsv(ctx)
 	if err != nil {
 		assert.FailNow(t, "Failed to ingest data from csv file", err)
 	}

--- a/jobs/ingest_data_from_csv.go
+++ b/jobs/ingest_data_from_csv.go
@@ -2,10 +2,12 @@ package jobs
 
 import (
 	"context"
+	"time"
 
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/utils"
 )
+
+const csvIngestionTimeout = 1 * time.Hour
 
 func IngestDataFromCsv(ctx context.Context, uc usecases.Usecases) error {
 	return executeWithMonitoring(
@@ -17,9 +19,9 @@ func IngestDataFromCsv(ctx context.Context, uc usecases.Usecases) error {
 		) error {
 			usecasesWithCreds := GenerateUsecaseWithCredForMarbleAdmin(ctx, usecases)
 			usecase := usecasesWithCreds.NewIngestionUseCase()
-			logger := utils.LoggerFromContext(ctx)
-			logger.InfoContext(ctx, "Start ingesting data from upload logs")
-			return usecase.IngestDataFromCsv(ctx, logger)
+			ctx, cancel := context.WithTimeout(ctx, csvIngestionTimeout)
+			defer cancel()
+			return usecase.IngestDataFromCsv(ctx)
 		},
 	)
 }

--- a/mocks/upload_log_repository.go
+++ b/mocks/upload_log_repository.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -11,29 +13,31 @@ type UploadLogRepository struct {
 	mock.Mock
 }
 
-func (r *UploadLogRepository) CreateUploadLog(exec repositories.Executor, log models.UploadLog) error {
-	args := r.Called(exec, log)
+func (r *UploadLogRepository) CreateUploadLog(ctx context.Context, exec repositories.Executor, log models.UploadLog) error {
+	args := r.Called(ctx, exec, log)
 	return args.Error(0)
 }
 
-func (r *UploadLogRepository) UpdateUploadLogStatus(exec repositories.Executor, input models.UpdateUploadLogStatusInput) error {
-	args := r.Called(exec, input)
-	return args.Error(0)
+func (r *UploadLogRepository) UpdateUploadLogStatus(ctx context.Context, exec repositories.Executor, input models.UpdateUploadLogStatusInput) (bool, error) {
+	args := r.Called(ctx, exec, input)
+	return true, args.Error(0)
 }
 
-func (r *UploadLogRepository) UploadLogById(exec repositories.Executor, id string) (models.UploadLog, error) {
-	args := r.Called(exec, id)
+func (r *UploadLogRepository) UploadLogById(ctx context.Context, exec repositories.Executor, id string) (models.UploadLog, error) {
+	args := r.Called(ctx, exec, id)
 	return args.Get(0).(models.UploadLog), args.Error(1)
 }
 
-func (r *UploadLogRepository) AllUploadLogsByStatus(exec repositories.Executor, status models.UploadStatus) ([]models.UploadLog, error) {
-	args := r.Called(exec, status)
+func (r *UploadLogRepository) AllUploadLogsByStatus(ctx context.Context, exec repositories.Executor, status models.UploadStatus) ([]models.UploadLog, error) {
+	args := r.Called(ctx, exec, status)
 	return args.Get(0).([]models.UploadLog), args.Error(1)
 }
 
-func (r *UploadLogRepository) AllUploadLogsByTable(exec repositories.Executor,
+func (r *UploadLogRepository) AllUploadLogsByTable(
+	ctx context.Context,
+	exec repositories.Executor,
 	organizationId, tableName string,
 ) ([]models.UploadLog, error) {
-	args := r.Called(exec, organizationId, tableName)
+	args := r.Called(ctx, exec, organizationId, tableName)
 	return args.Get(0).([]models.UploadLog), args.Error(1)
 }

--- a/mocks/upload_log_repository.go
+++ b/mocks/upload_log_repository.go
@@ -16,7 +16,7 @@ func (r *UploadLogRepository) CreateUploadLog(exec repositories.Executor, log mo
 	return args.Error(0)
 }
 
-func (r *UploadLogRepository) UpdateUploadLog(exec repositories.Executor, input models.UpdateUploadLogInput) error {
+func (r *UploadLogRepository) UpdateUploadLogStatus(exec repositories.Executor, input models.UpdateUploadLogStatusInput) error {
 	args := r.Called(exec, input)
 	return args.Error(0)
 }

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -35,8 +35,9 @@ func UploadStatusFrom(s string) UploadStatus {
 	return UploadPending
 }
 
-type UpdateUploadLogInput struct {
-	Id           string
-	UploadStatus UploadStatus
-	FinishedAt   *time.Time
+type UpdateUploadLogStatusInput struct {
+	Id                           string
+	UploadStatus                 UploadStatus
+	CurrentUploadStatusCondition UploadStatus // for optimistic locking. Only rows matching this current status will be updated
+	FinishedAt                   *time.Time
 }

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -31,6 +31,8 @@ func UploadStatusFrom(s string) UploadStatus {
 		return UploadSuccess
 	case "failure":
 		return UploadFailure
+	case "processing":
+		return UploadProcessing
 	}
 	return UploadPending
 }

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -12,6 +12,7 @@ type UploadLog struct {
 	StartedAt      time.Time
 	FinishedAt     *time.Time
 	LinesProcessed int
+	RowsIngested   int
 }
 
 type UploadStatus string
@@ -42,4 +43,5 @@ type UpdateUploadLogStatusInput struct {
 	UploadStatus                 UploadStatus
 	CurrentUploadStatusCondition UploadStatus // for optimistic locking. Only rows matching this current status will be updated
 	FinishedAt                   *time.Time
+	NumRowsIngested              *int
 }

--- a/repositories/dbmodels/db_upload_logs.go
+++ b/repositories/dbmodels/db_upload_logs.go
@@ -8,15 +8,16 @@ import (
 )
 
 type DBUploadLog struct {
-	Id             string     `db:"id"`
-	OrganizationId string     `db:"org_id"`
-	UserId         string     `db:"user_id"`
-	FileName       string     `db:"file_name"`
-	TableName      string     `db:"table_name"`
-	Status         string     `db:"status"`
-	StartedAt      time.Time  `db:"started_at"`
-	FinishedAt     *time.Time `db:"finished_at"`
-	LinesProcessed int        `db:"lines_processed"`
+	Id              string     `db:"id"`
+	OrganizationId  string     `db:"org_id"`
+	UserId          string     `db:"user_id"`
+	FileName        string     `db:"file_name"`
+	TableName       string     `db:"table_name"`
+	Status          string     `db:"status"`
+	StartedAt       time.Time  `db:"started_at"`
+	FinishedAt      *time.Time `db:"finished_at"`
+	LinesProcessed  int        `db:"lines_processed"`
+	NumRowsIngested int        `db:"num_rows_ingested"`
 }
 
 const TABLE_UPLOAD_LOGS = "upload_logs"
@@ -34,5 +35,6 @@ func AdaptUploadLog(db DBUploadLog) (models.UploadLog, error) {
 		StartedAt:      db.StartedAt,
 		FinishedAt:     db.FinishedAt,
 		LinesProcessed: db.LinesProcessed,
+		RowsIngested:   db.NumRowsIngested,
 	}, nil
 }

--- a/repositories/migrations/20240829121800_upload_log_rows_ingested.sql
+++ b/repositories/migrations/20240829121800_upload_log_rows_ingested.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE upload_logs
+ADD COLUMN num_rows_ingested INTEGER NOT NULL DEFAULT 0;
+
+UPDATE upload_logs
+SET
+    num_rows_ingested = lines_processed
+WHERE
+    status = 'success';
+
+-- +goose StatementEnd
+-- +goose Down
+ALTER TABLE upload_logs
+DROP COLUMN num_rows_ingested;
+
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -11,7 +11,7 @@ import (
 
 type UploadLogRepository interface {
 	CreateUploadLog(ctx context.Context, exec Executor, log models.UploadLog) error
-	UpdateUploadLog(ctx context.Context, exec Executor, input models.UpdateUploadLogInput) error
+	UpdateUploadLogStatus(ctx context.Context, exec Executor, input models.UpdateUploadLogStatusInput) error
 	UploadLogById(ctx context.Context, exec Executor, id string) (models.UploadLog, error)
 	AllUploadLogsByStatus(ctx context.Context, exec Executor, status models.UploadStatus) ([]models.UploadLog, error)
 	AllUploadLogsByTable(ctx context.Context, exec Executor, organizationId, tableName string) ([]models.UploadLog, error)
@@ -54,7 +54,7 @@ func (repo *UploadLogRepositoryImpl) CreateUploadLog(ctx context.Context, exec E
 	return err
 }
 
-func (repo *UploadLogRepositoryImpl) UpdateUploadLog(ctx context.Context, exec Executor, input models.UpdateUploadLogInput) error {
+func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(ctx context.Context, exec Executor, input models.UpdateUploadLogStatusInput) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
 	}
@@ -67,7 +67,9 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLog(ctx context.Context, exec E
 	if input.FinishedAt != nil {
 		updateRequest = updateRequest.Set("finished_at", *input.FinishedAt)
 	}
-	updateRequest = updateRequest.Where("id = ?", input.Id)
+	updateRequest = updateRequest.
+		Where("id = ?", input.Id).
+		Where("status = ?", input.CurrentUploadStatusCondition)
 
 	err := ExecBuilder(ctx, exec, updateRequest)
 	return err

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -85,7 +85,7 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(
 		return false, err
 	}
 
-	tag, err := exec.Exec(ctx, sql, args)
+	tag, err := exec.Exec(ctx, sql, args...)
 	if err != nil {
 		return false, err
 	}

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -67,6 +67,10 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(ctx context.Context, 
 	if input.FinishedAt != nil {
 		updateRequest = updateRequest.Set("finished_at", *input.FinishedAt)
 	}
+	if input.NumRowsIngested != nil {
+		updateRequest = updateRequest.Set("num_rows_ingested", *input.NumRowsIngested)
+	}
+
 	updateRequest = updateRequest.
 		Where("id = ?", input.Id).
 		Where("status = ?", input.CurrentUploadStatusCondition)


### PR DESCRIPTION
Goes with https://github.com/checkmarble/marble-frontend/compare/pascal/mar-621-batch-job-data-ingestion-correctly-sets-status-in-error-case?expand=1

--- 

The motivation is here https://checkmarble.slack.com/archives/C05VAKSTL02/p1724747857435739
I ended up manually correcting upload log statuses in the db when there were errors.

In a next step, we could add mailing or other alerting to the users - but this is a good first improvement.
I'll do something similar for the scheduled execution (or at least make sure it doesn't remain in "processing" when the cloud run job times out).

---
I set a 1h timeout on the ingestion job (the cloud run job itself has a 2h timeout) which should be super sufficient (we'd be limited by the timeout of the file upload well before that).

--- 
I also added a field with the number of rows actually ingested on the upload log. Event if it fails before the end, because rows are ingested by batches of 1000, a part of the rows may have been ingested even if the final status of the job is "failure". See the front PR.