### PR TITLE
bump go version to 1.23.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,9 +6,6 @@
       "go.toolsEnvVars": {
             "GOFUMPT_SPLIT_LONG_LINES": "on"
       },
-      "go.delveConfig": {
-            "debugAdapter": "legacy"
-      },
       "go.lintTool": "golangci-lint",
       "go.lintOnSave": "package",
       "search.exclude": {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as build
+FROM golang:1.23 as build
 
 WORKDIR /go/src/app
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/checkmarble/marble-backend
 
-go 1.22.0
+go 1.23.1
 
 require (
 	cloud.google.com/go/storage v1.42.0


### PR DESCRIPTION
I think I managed to fix the dlv-dap timeout issue when launching code in VSCode. See my answer on SO: https://stackoverflow.com/questions/68753251/couldnt-start-dlv-dap/78967126#78967126

I also ended up bumping my version of go in the process => this PR.