### PR TITLE
create indexes for better perf on org deletion

### DIFF
--- a/repositories/migrations/20240910221600_decision_rules_org_id_idx.sql
+++ b/repositories/migrations/20240910221600_decision_rules_org_id_idx.sql
@@ -1,0 +1,13 @@
+-- +goose NO TRANSACTION
+-- +goose Up 
+CREATE INDEX CONCURRENTLY IF NOT EXISTS decision_rules_org_id_idx ON decision_rules (org_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS decision_pivot_id_idx ON decisions (pivot_id);
+
+-- +goose Down
+DROP INDEX decision_rules_org_id_idx;
+
+DROP INDEX decision_pivot_id_idx;
+
+-- +goose StatementBegin
+-- +goose StatementEnd


### PR DESCRIPTION
Options to explore in the longer term for more efficient org deletion even if there are many decisions: use SET NULL instead of DELETE on CASCADE.
But for now this should do.
_Pour la forme_, I'll add a notice in the release note to run the migration manually before upgrading to the new version of marble, as it can be a slow one to run if there are many decision_rules.