### PR TITLE
improve query to use index

### DIFF
--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -349,7 +349,7 @@ func selectCasesWithJoinedFields(query squirrel.SelectBuilder, p models.Paginati
 				dbmodels.TABLE_CASE_TAGS,
 			),
 		).
-		Column(fmt.Sprintf("(SELECT count(distinct d.id) FROM %s AS d WHERE d.case_id = c.id) AS decisions_count", dbmodels.TABLE_DECISIONS))
+		Column(fmt.Sprintf("(SELECT count(distinct d.id) FROM %s AS d WHERE d.case_id = c.id AND d.org_id=c.org_id) AS decisions_count", dbmodels.TABLE_DECISIONS))
 	if fromSubquery {
 		q = q.Column("rank_number")
 	}


### PR DESCRIPTION
According to my tests, this should do the job. Postgres was not using the existing secondary index (indeed could not use it) because I was not filtering on decision org_id.