### PR TITLE
set TOAST_TUPLE_TARGET for decision_rules + no exec detail on TC

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -108,8 +108,11 @@ func handlePostDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.
 				ScenarioId:         requestData.ScenarioId,
 				TriggerObjectTable: requestData.ObjectType,
 			},
-			false,
-			true,
+			models.CreateDecisionParams{
+				WithScenarioPermissionCheck: true,
+				WithDecisionWebhooks:        true,
+				WithRuleExecutionDetails:    true,
+			},
 		)
 
 		if returnExpectedDecisionError(c, err) || presentError(c, err) {

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -595,8 +595,11 @@ func createAndTestDecision(
 			OrganizationId:     organizationId,
 			TriggerObjectTable: table.Name,
 		},
-		false,
-		false,
+		models.CreateDecisionParams{
+			WithDecisionWebhooks:        false,
+			WithRuleExecutionDetails:    true,
+			WithScenarioPermissionCheck: true,
+		},
 	)
 	if err != nil {
 		assert.FailNow(t, "Could not create decision", err)

--- a/models/decision.go
+++ b/models/decision.go
@@ -120,6 +120,12 @@ type CreateDecisionInput struct {
 	TriggerObjectTable string
 }
 
+type CreateDecisionParams struct {
+	WithDecisionWebhooks        bool
+	WithRuleExecutionDetails    bool
+	WithScenarioPermissionCheck bool
+}
+
 type CreateAllDecisionsInput struct {
 	OrganizationId     string
 	PayloadRaw         json.RawMessage

--- a/models/decision.go
+++ b/models/decision.go
@@ -75,12 +75,12 @@ type ScenarioExecution struct {
 
 type RuleExecution struct {
 	DecisionId          string
-	Outcome             string // enum: hit, no_hit, snoozed, error
-	Rule                Rule
-	Result              bool
-	Evaluation          *ast.NodeEvaluationDto
-	ResultScoreModifier int
 	Error               error
+	Evaluation          *ast.NodeEvaluationDto
+	Outcome             string // enum: hit, no_hit, snoozed, error
+	Result              bool
+	ResultScoreModifier int
+	Rule                Rule
 }
 
 func AdaptScenarExecToDecision(scenarioExecution ScenarioExecution, clientObject ClientObject, scheduledExecutionId *string) DecisionWithRuleExecutions {

--- a/repositories/analytics_views/decision_rules.sql
+++ b/repositories/analytics_views/decision_rules.sql
@@ -8,10 +8,8 @@ SELECT
       id,
       org_id AS organization_id,
       decision_id,
-      deleted_at,
-      description,
       error_code,
-      name,
+      outcome,
       result,
       rule_id,
       score_modifier

--- a/repositories/analytics_views/scenario_iterations.sql
+++ b/repositories/analytics_views/scenario_iterations.sql
@@ -12,6 +12,7 @@ SELECT
       created_at,
       updated_at,
       score_review_threshold,
+      score_block_and_review_threshold,
       score_reject_threshold,
       deleted_at,
       schedule

--- a/repositories/dbmodels/db_decision_rule.go
+++ b/repositories/dbmodels/db_decision_rule.go
@@ -3,29 +3,23 @@ package dbmodels
 import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
-	"github.com/checkmarble/marble-backend/utils"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type DbDecisionRule struct {
-	Id             string             `db:"id"`
-	OrganizationId string             `db:"org_id"`
-	DecisionId     string             `db:"decision_id"`
-	Name           string             `db:"name"`
-	Description    string             `db:"description"`
-	ScoreModifier  int                `db:"score_modifier"`
-	Result         bool               `db:"result"`
-	ErrorCode      ast.ExecutionError `db:"error_code"`
-	DeletedAt      pgtype.Time        `db:"deleted_at"`
-	RuleId         string             `db:"rule_id"`
-	RuleEvaluation []byte             `db:"rule_evaluation"`
-	Outcome        string             `db:"outcome"`
+	Id             string
+	OrganizationId string
+	DecisionId     string
+	Name           string
+	Description    string
+	ScoreModifier  int
+	Result         bool
+	ErrorCode      ast.ExecutionError
+	RuleId         string
+	RuleEvaluation []byte
+	Outcome        string
 }
 
 const TABLE_DECISION_RULES = "decision_rules"
-
-var SelectDecisionRuleColumn = utils.ColumnList[DbDecisionRule]()
 
 func AdaptRuleExecution(db DbDecisionRule) (models.RuleExecution, error) {
 	evaluation, err := DeserializeNodeEvaluationDto(db.RuleEvaluation)
@@ -44,16 +38,16 @@ func AdaptRuleExecution(db DbDecisionRule) (models.RuleExecution, error) {
 		}
 	}
 	return models.RuleExecution{
-		DecisionId: db.DecisionId,
+		DecisionId:          db.DecisionId,
+		Error:               ast.AdaptErrorCodeAsError(db.ErrorCode),
+		Evaluation:          evaluation,
+		Outcome:             outcome,
+		Result:              db.Result,
+		ResultScoreModifier: db.ScoreModifier,
 		Rule: models.Rule{
 			Id:          db.RuleId,
 			Name:        db.Name,
 			Description: db.Description,
 		},
-		Result:              db.Result,
-		ResultScoreModifier: db.ScoreModifier,
-		Error:               ast.AdaptErrorCodeAsError(db.ErrorCode),
-		Evaluation:          evaluation,
-		Outcome:             outcome,
 	}, nil
 }

--- a/repositories/migrations/20240925120000_decision_rules_toast_setting.sql
+++ b/repositories/migrations/20240925120000_decision_rules_toast_setting.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE decision_rules
+SET
+    (TOAST_TUPLE_TARGET = 128);
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE decision_rules
+SET
+    (TOAST_TUPLE_TARGET = 2048);
+
+-- +goose StatementEnd

--- a/repositories/migrations/20240925120000_decision_rules_toast_setting.sql
+++ b/repositories/migrations/20240925120000_decision_rules_toast_setting.sql
@@ -4,11 +4,27 @@ ALTER TABLE decision_rules
 SET
     (TOAST_TUPLE_TARGET = 128);
 
+ALTER TABLE decision_rules
+ALTER COLUMN name
+DROP NOT NULL;
+
+ALTER TABLE decision_rules
+ALTER COLUMN description
+DROP NOT NULL;
+
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE decision_rules
 SET
     (TOAST_TUPLE_TARGET = 2048);
+
+ALTER TABLE decision_rules
+ALTER COLUMN name
+SET NOT NULL;
+
+ALTER TABLE decision_rules
+ALTER COLUMN description
+SET NOT NULL;
 
 -- +goose StatementEnd

--- a/usecases/transfer_check_usecase.go
+++ b/usecases/transfer_check_usecase.go
@@ -209,8 +209,11 @@ func (usecase *TransferCheckUsecase) CreateTransfer(
 			OrganizationId:     organizationId,
 			TriggerObjectTable: models.TransferCheckTable,
 		},
-		true,
-		false,
+		models.CreateDecisionParams{
+			WithDecisionWebhooks:        false,
+			WithRuleExecutionDetails:    false,
+			WithScenarioPermissionCheck: false,
+		},
 	)
 	if err != nil {
 		return models.Transfer{}, errors.Wrapf(
@@ -505,8 +508,11 @@ func (usecase *TransferCheckUsecase) ScoreTransfer(
 			OrganizationId:     organizationId,
 			TriggerObjectTable: models.TransferCheckTable,
 		},
-		true,
-		false,
+		models.CreateDecisionParams{
+			WithDecisionWebhooks:        false,
+			WithRuleExecutionDetails:    false,
+			WithScenarioPermissionCheck: false,
+		},
 	)
 	if err != nil {
 		return models.Transfer{}, errors.Wrapf(


### PR DESCRIPTION
- Better setup of TOAST for decision_rules: storage of decision rule exec detail is dominating and it's bloat (see [postgres doc](https://www.postgresql.org/docs/current/storage-toast.html), [slack discussion](https://checkmarble.slack.com/archives/C04JB5ZADBN/p1727257822435979))
- Do not store the rule execution details for TC scenario executions (in the longer term, move to a blob storage, see [slack discussion](https://checkmarble.slack.com/archives/C04JB5ZADBN/p1727257822435979))
- Normalize decision_rule name & description - we are never filtering by them, they have no business being denormalized
- I also modified the sql questions in Metabase accordingly - though right now they're broken anyway because of the big decision_rules table