### PR TITLE
Pascal/mar 650 apply initial filter computed from trigger condition ast for

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--server",
         "--migrations"
       ],
-      // "console": "integratedTerminal"
+      "console": "integratedTerminal"
     },
     {
       "name": "Launch scenario scheduling job (.env)",
@@ -27,7 +27,7 @@
       "args": [
         "--scheduler"
       ],
-      // "console": "integratedTerminal"
+      "console": "integratedTerminal"
     },
     {
       "name": "Launch execute scheduled scenario job (.env)",
@@ -39,7 +39,7 @@
       "args": [
         "--scheduled-executer"
       ],
-      // "console": "integratedTerminal"
+      "console": "integratedTerminal"
     },
     {
       "name": "Launch data ingestion job (.env)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--server",
         "--migrations"
       ],
-      "console": "integratedTerminal"
+      // "console": "integratedTerminal"
     },
     {
       "name": "Launch scenario scheduling job (.env)",
@@ -27,7 +27,7 @@
       "args": [
         "--scheduler"
       ],
-      "console": "integratedTerminal"
+      // "console": "integratedTerminal"
     },
     {
       "name": "Launch execute scheduled scenario job (.env)",
@@ -39,7 +39,7 @@
       "args": [
         "--scheduled-executer"
       ],
-      "console": "integratedTerminal"
+      // "console": "integratedTerminal"
     },
     {
       "name": "Launch data ingestion job (.env)",

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -287,8 +287,20 @@ func setupScenarioAndPublish(
 			Body: &models.CreateScenarioIterationBody{
 				Rules: rules,
 				TriggerConditionAstExpression: &ast.Node{
-					Function: ast.FUNC_EQUAL,
-					Children: []ast.Node{{Constant: "transactions"}, {Constant: "transactions"}},
+					Function: ast.FUNC_AND,
+					Children: []ast.Node{
+						{
+							Function: ast.FUNC_EQUAL,
+							Children: []ast.Node{{Constant: "transactions"}, {Constant: "transactions"}},
+						},
+						{
+							Function: ast.FUNC_GREATER_OR_EQUAL,
+							Children: []ast.Node{
+								{Function: ast.FUNC_TIME_NOW},
+								{Function: ast.FUNC_PAYLOAD, Children: []ast.Node{{Constant: "updated_at"}}},
+							},
+						},
+					},
 				},
 				ScoreReviewThreshold:         &threshold,
 				ScoreBlockAndReviewThreshold: &threshold,

--- a/models/scheduled_scenario_execution_test.go
+++ b/models/scheduled_scenario_execution_test.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterToSql(t *testing.T) {
+	type testCase struct {
+		name     string
+		filter   Filter
+		expected string
+		args     []any
+	}
+
+	testCases := []testCase{
+		{
+			name: "simple equal filter",
+			filter: Filter{
+				LeftSql:    "left",
+				Operator:   ast.FUNC_EQUAL,
+				RightValue: 1,
+			},
+			expected: "left = ?",
+			args:     []any{1},
+		},
+		{
+			name: "string in list filter",
+			filter: Filter{
+				LeftValue:  "blabla",
+				Operator:   ast.FUNC_IS_IN_LIST,
+				RightValue: []string{"bla", "and bla"},
+			},
+			expected: "? = ANY(?)",
+			args:     []any{"blabla", []string{"bla", "and bla"}},
+		},
+		{
+			name: "string contains filter",
+			filter: Filter{
+				LeftValue:  "COMMIT",
+				Operator:   ast.FUNC_STRING_CONTAINS,
+				RightValue: "mit",
+			},
+			expected: "? ILIKE CONCAT('%',?,'%')",
+			args:     []any{"COMMIT", "mit"},
+		},
+		{
+			name: "string in list",
+			filter: Filter{
+				LeftValue:  "blabla",
+				Operator:   ast.FUNC_IS_IN_LIST,
+				RightValue: []string{"bla", "and bla"},
+			},
+			expected: "? = ANY(?)",
+			args:     []any{"blabla", []string{"bla", "and bla"}},
+		},
+		{
+			name: "nested math with division",
+			filter: Filter{
+				LeftValue: float64(1),
+				Operator:  ast.FUNC_LESS,
+				RightNestedFilter: &Filter{
+					LeftValue: float64(3),
+					Operator:  ast.FUNC_DIVIDE,
+					RightSql:  "\"schema\".\"table\".\"num\"",
+				},
+			},
+			expected: "? < (? / NULLIF(\"schema\".\"table\".\"num\", 0))",
+			args:     []any{float64(1), float64(3)},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql, args := tc.filter.ToSql()
+			assert.Equal(t, tc.expected, sql, tc.name)
+			assert.Equal(t, tc.args, args, tc.name)
+		})
+	}
+}

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -1,9 +1,8 @@
 package models
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/checkmarble/marble-backend/models/ast"
 )
 
 type ScheduledExecution struct {
@@ -80,9 +79,30 @@ type ListScheduledExecutionsFilters struct {
 type Filter struct {
 	LeftSql    string
 	LeftValue  any
-	Operator   ast.Function
+	Operator   string
 	RightSql   string
 	RightValue any
+}
+
+func (f Filter) ToSql() (string, []any) {
+	var args []any
+	var left string
+	if f.LeftSql != "" {
+		left = f.LeftSql
+	} else {
+		left = "?"
+		args = append(args, f.LeftValue)
+	}
+
+	var right string
+	if f.RightSql != "" {
+		right = f.RightSql
+	} else {
+		right = "?"
+		args = append(args, f.RightValue)
+	}
+
+	return fmt.Sprintf("%s %s %s", left, f.Operator, right), args
 }
 
 type TableIdentifier struct {

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -1,6 +1,10 @@
 package models
 
-import "time"
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
 
 type ScheduledExecution struct {
 	Id                       string
@@ -71,4 +75,10 @@ type ListScheduledExecutionsFilters struct {
 	ScenarioId     string
 	Status         []ScheduledExecutionStatus
 	ExcludeManual  bool
+}
+
+type Filter struct {
+	LeftFieldOrValue  any
+	Operator          ast.Function
+	RightFieldOrValue any
 }

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -78,7 +78,14 @@ type ListScheduledExecutionsFilters struct {
 }
 
 type Filter struct {
-	LeftFieldOrValue  any
-	Operator          ast.Function
-	RightFieldOrValue any
+	LeftSql    string
+	LeftValue  any
+	Operator   ast.Function
+	RightSql   string
+	RightValue any
+}
+
+type TableIdentifier struct {
+	Schema string
+	Table  string
 }

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -251,7 +251,7 @@ func (repo *IngestedDataReadRepositoryImpl) QueryIngestedObject(
 		columnNames,
 		[]models.Filter{{
 			LeftSql:    fmt.Sprintf("%s.object_id", qualifiedTableName),
-			Operator:   ast.FUNC_EQUAL,
+			Operator:   "=",
 			RightValue: objectId,
 		}}...,
 	)
@@ -273,9 +273,10 @@ func queryWithDynamicColumnList(
 		Select(columnNames...).
 		From(qualifiedTableName).
 		Where(rowIsValid(qualifiedTableName))
-	// if objectId != nil {
-	// 	q = q.Where(squirrel.Eq{fmt.Sprintf("%s.object_id", qualifiedTableName): *objectId})
-	// }
+	for _, f := range filters {
+		sql, args := f.ToSql()
+		q = q.Where(sql, args...)
+	}
 
 	sql, args, err := q.ToSql()
 	if err != nil {

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -251,7 +251,7 @@ func (repo *IngestedDataReadRepositoryImpl) QueryIngestedObject(
 		columnNames,
 		[]models.Filter{{
 			LeftSql:    fmt.Sprintf("%s.object_id", qualifiedTableName),
-			Operator:   "=",
+			Operator:   ast.FUNC_EQUAL,
 			RightValue: objectId,
 		}}...,
 	)

--- a/usecases/scheduled_execution/batch_filtering.go
+++ b/usecases/scheduled_execution/batch_filtering.go
@@ -1,0 +1,176 @@
+package scheduled_execution
+
+import (
+	"slices"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+func selectFiltersFromTriggerAstRootAnd(node ast.Node) ([]models.Filter, error) {
+	if node.Function != ast.FUNC_AND {
+		return nil, nil
+	}
+
+	filters := make([]models.Filter, 0, 10)
+	for _, node := range node.Children {
+		filter, valid := astConditionToFilter(node)
+		if valid {
+			filters = append(filters, filter)
+		}
+	}
+	return filters, nil
+}
+
+func astConditionToFilter(node ast.Node) (models.Filter, bool) {
+	switch node.Function {
+	case ast.FUNC_GREATER,
+		ast.FUNC_GREATER_OR_EQUAL,
+		ast.FUNC_LESS,
+		ast.FUNC_LESS_OR_EQUAL,
+		ast.FUNC_EQUAL,
+		ast.FUNC_NOT_EQUAL:
+		return models.Filter{}, false
+	case ast.FUNC_IS_IN_LIST,
+		ast.FUNC_IS_NOT_IN_LIST,
+		ast.FUNC_CONTAINS_ANY,
+		ast.FUNC_CONTAINS_NONE:
+		return models.Filter{}, false
+	case ast.FUNC_STRING_CONTAINS,
+		ast.FUNC_STRING_NOT_CONTAIN:
+		return models.Filter{}, false
+	}
+	return models.Filter{}, false
+}
+
+func filterFromComparisonNode(node ast.Node) (models.Filter, bool) {
+	if !slices.Contains([]ast.Function{
+		ast.FUNC_GREATER,
+		ast.FUNC_GREATER_OR_EQUAL,
+		ast.FUNC_LESS,
+		ast.FUNC_LESS_OR_EQUAL,
+		ast.FUNC_EQUAL,
+		ast.FUNC_NOT_EQUAL,
+	}, node.Function) {
+		return models.Filter{}, false
+	}
+
+	// left options:
+	// - constant (string, number, boolean allowed. String can be timestamp)
+	// - payload (field name)
+	// - time_add operator with something else inside
+	// - "now" operator
+
+	// right options:
+	// same things actually, the comparison is "symmetric"
+
+	// one at least must involve a "payload" field, otherwise nothing to filter on the table
+
+	fieldName, err := node.ReadConstantNamedChildString("fieldName")
+	if err != nil {
+		return models.Filter{}, false
+	}
+
+	value, err := node.ReadConstantNamedChildString("value")
+	if err != nil {
+		return models.Filter{}, false
+	}
+
+	return models.Filter{
+		LeftFieldOrValue:  nil,
+		Operator:          node.Function,
+		RightFieldOrValue: nil,
+	}, true
+}
+
+func comparisonValueFromNode(node ast.Node) (value any, involvesPayload bool, valid bool) {
+	// case 1: payload field
+
+	// case 2: date add operator
+
+	// case 3: now operator
+
+	// case 4: custom list accessor
+
+	// case 5: constant value
+	//   - string
+	//   - number
+	//   - boolean
+	//   - timestamp, but it's a string (we can pass the string to the sql query)
+	//   - list of strings => should not happen here because it's a comparison operator
+
+	return 0, false, false
+}
+
+// func aggregationNodeToQueryFamily(node ast.Node) (models.AggregateQueryFamily, error) {
+// 	if node.Function != ast.FUNC_AGGREGATOR {
+// 		return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST, "Node is not an aggregator")
+// 	}
+
+// 	queryTableName, err := node.ReadConstantNamedChildString("tableName")
+// 	if err != nil {
+// 		return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 			"Error reading tableName in aggregation node: "+err.Error())
+// 	}
+
+// 	aggregatedFieldName, err := node.ReadConstantNamedChildString("fieldName")
+// 	if err != nil {
+// 		return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 			"Error reading fieldName in aggregation node: "+err.Error())
+// 	}
+
+// 	family := models.NewAggregateQueryFamily(queryTableName)
+
+// 	filters, ok := node.NamedChildren["filters"]
+// 	if !ok {
+// 		return family, nil
+// 	}
+// 	for _, filter := range filters.Children {
+// 		if tableNameStr, err := filter.ReadConstantNamedChildString("tableName"); err != nil {
+// 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 				"Error reading tableName in filter node: "+err.Error())
+// 		} else if tableNameStr == "" || tableNameStr != queryTableName {
+// 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 				"Filter tableName empty or is different from parent aggregator node's tableName")
+// 		}
+
+// 		fieldName, err := filter.ReadConstantNamedChildString("fieldName")
+// 		if err != nil {
+// 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 				"Error reading fieldName in filter node: "+err.Error())
+// 		} else if fieldName == "" {
+// 			return models.AggregateQueryFamily{}, errors.New("Filter fieldName is empty")
+// 		}
+
+// 		operatorStr, err := filter.ReadConstantNamedChildString("operator")
+// 		if err != nil {
+// 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 				"Error reading operator in filter node:"+err.Error())
+// 		}
+
+// 		switch ast.FilterOperator(operatorStr) {
+// 		case ast.FILTER_EQUAL:
+// 			family.EqConditions.Insert(fieldName)
+// 		case ast.FILTER_GREATER, ast.FILTER_GREATER_OR_EQUAL, ast.FILTER_LESSER, ast.FILTER_LESSER_OR_EQUAL:
+// 			if !family.EqConditions.Contains(fieldName) {
+// 				family.IneqConditions.Insert(fieldName)
+// 			}
+// 		case ast.FILTER_IS_IN_LIST, ast.FILTER_IS_NOT_IN_LIST, ast.FILTER_NOT_EQUAL:
+// 			if !family.EqConditions.Contains(fieldName) &&
+// 				!family.IneqConditions.Contains(fieldName) {
+// 				family.SelectOrOtherConditions.Insert(fieldName)
+// 			}
+// 		default:
+// 			return models.AggregateQueryFamily{}, errors.Wrap(models.ErrInvalidAST,
+// 				fmt.Sprintf("Filter operator %s is not valid", operatorStr))
+// 		}
+// 	}
+
+// 	// Columns that are used in the index but not in = or <,>,>=,<= filters are added as columns to be "included" in the index
+// 	if !family.EqConditions.Contains(aggregatedFieldName) &&
+// 		!family.IneqConditions.Contains(aggregatedFieldName) {
+// 		family.SelectOrOtherConditions.Insert(aggregatedFieldName)
+// 	}
+
+// 	return family, nil
+// }

--- a/usecases/scheduled_execution/batch_filtering.go
+++ b/usecases/scheduled_execution/batch_filtering.go
@@ -76,10 +76,29 @@ func filterFromComparisonNode(node ast.Node, table models.TableIdentifier) (mode
 	return models.Filter{
 		LeftSql:    leftVal.rawSql,
 		LeftValue:  leftVal.value,
-		Operator:   node.Function,
+		Operator:   comparisonAstNodeToString(node),
 		RightSql:   rightVal.rawSql,
 		RightValue: rightVal.value,
 	}, true
+}
+
+func comparisonAstNodeToString(node ast.Node) string {
+	switch node.Function {
+	case ast.FUNC_GREATER:
+		return ">"
+	case ast.FUNC_GREATER_OR_EQUAL:
+		return ">="
+	case ast.FUNC_LESS:
+		return "<"
+	case ast.FUNC_LESS_OR_EQUAL:
+		return "<="
+	case ast.FUNC_EQUAL:
+		return "="
+	case ast.FUNC_NOT_EQUAL:
+		return "!="
+	default:
+		return ""
+	}
 }
 
 type parsedFilter struct {
@@ -135,7 +154,7 @@ func comparisonValueFromNode(node ast.Node, table models.TableIdentifier) parsed
 		}
 
 		return parsedFilter{
-			rawSql:          fmt.Sprintf("%s %s interval %s", time, sign, durationStr),
+			rawSql:          fmt.Sprintf("%s %s interval '%s'", time, sign, durationStr),
 			involvesPayload: involvesPayload,
 			valid:           true,
 		}

--- a/usecases/scheduled_execution/batch_filtering_test.go
+++ b/usecases/scheduled_execution/batch_filtering_test.go
@@ -28,7 +28,7 @@ func TestFilterFromComparisonNode(t *testing.T) {
 		{
 			name: "timestamp comparison with date shift",
 			ruleJson: `{
-				"name": "\u003c",
+				"name": "<",
 				"children": [
 					{
 					"name": "TimeAdd",
@@ -51,7 +51,7 @@ func TestFilterFromComparisonNode(t *testing.T) {
 		{
 			name: "number comparison with nested division",
 			ruleJson: `{
-				"name": "\u003c",
+				"name": "<",
 				"children": [
 					{ "constant": 1 },
 					{

--- a/usecases/scheduled_execution/batch_filtering_test.go
+++ b/usecases/scheduled_execution/batch_filtering_test.go
@@ -1,0 +1,186 @@
+package scheduled_execution
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterFromComparisonNode(t *testing.T) {
+	table := models.TableIdentifier{
+		Schema: "schema",
+		Table:  "table",
+	}
+
+	type testCase struct {
+		name     string
+		ruleJson string
+		expected models.Filter
+		valid    bool
+	}
+
+	testCases := []testCase{
+		{
+			name: "timestamp comparison with date shift",
+			ruleJson: `{
+				"name": "\u003c",
+				"children": [
+					{
+					"name": "TimeAdd",
+					"named_children": {
+						"duration": { "constant": "PT0S" },
+						"sign": { "constant": "+" },
+						"timestampField": { "name": "TimeNow" }
+					}
+					},
+					{ "name": "Payload", "children": [{ "constant": "updated_at" }] }
+				]
+			}`,
+			expected: models.Filter{
+				LeftSql:  "now() + interval 'PT0S'",
+				Operator: ast.FUNC_LESS,
+				RightSql: "\"schema\".\"table\".\"updated_at\"",
+			},
+			valid: true,
+		},
+		{
+			name: "number comparison with nested division",
+			ruleJson: `{
+				"name": "\u003c",
+				"children": [
+					{ "constant": 1 },
+					{
+					"name": "/",
+					"children": [
+						{ "constant": 3 },
+						{ "name": "Payload", "children": [{ "constant": "num" }] }
+					]
+					}
+				]
+			}`,
+			expected: models.Filter{
+				LeftValue: float64(1),
+				Operator:  ast.FUNC_LESS,
+				RightNestedFilter: &models.Filter{
+					LeftValue: float64(3),
+					Operator:  ast.FUNC_DIVIDE,
+					RightSql:  "\"schema\".\"table\".\"num\"",
+				},
+			},
+			valid: true,
+		},
+		{
+			ruleJson: `{
+				"name": "IsInList",
+				"children": [
+					{ "constant": "blabla" },
+					{ "constant": ["bla", "and bla"] }
+				]
+			}`,
+			expected: models.Filter{
+				LeftValue:  "blabla",
+				Operator:   ast.FUNC_IS_IN_LIST,
+				RightValue: []string{"bla", "and bla"},
+			},
+			valid: true,
+		},
+		{
+			name: "string contains comparison",
+			ruleJson: `{
+				"name": "StringContains",
+				"children": [{ "constant": "COMMIT" }, { "constant": "mit" }]
+			  }`,
+			expected: models.Filter{
+				LeftValue:  "COMMIT",
+				Operator:   ast.FUNC_STRING_CONTAINS,
+				RightValue: "mit",
+			},
+			valid: true,
+		},
+		{
+			name: "db access",
+			ruleJson: `{
+				"name": "≠",
+				"children": [
+					{
+					"name": "DatabaseAccess",
+					"named_children": {
+						"fieldName": { "constant": "new_table_pivot_field" },
+						"path": { "constant": ["test_pivot_link"] },
+						"tableName": { "constant": "Accounts" }
+					}
+					},
+					{ "constant": "qzefzqef" }
+				]
+			}`,
+			valid: false,
+		},
+		{
+			name: "custom list access",
+			ruleJson: `{
+				"name": "IsInList",
+				"children": [
+					{ "name": "Payload", "children": [{ "constant": "account_name" }] },
+					{
+					"name": "CustomListAccess",
+					"named_children": {
+						"customListId": {
+						"constant": "8a02e830-3094-4438-86e1-ab6762e778cf"
+						}
+					}
+					}
+				]
+			}`,
+			valid: false,
+		},
+		{
+			name: "nested bool comparison",
+			ruleJson: `{
+				"name": "=",
+				"children": [
+					{ "name": "Payload", "children": [{ "constant": "after_migration" }] },
+					{
+					"name": "≠",
+					"children": [
+						{ "name": "Payload", "children": [{ "constant": "bool" }] },
+						{ "constant": false }
+					]
+					}
+				]
+			}`,
+			valid: true,
+			expected: models.Filter{
+				LeftSql:  "\"schema\".\"table\".\"after_migration\"",
+				Operator: ast.FUNC_EQUAL,
+				RightNestedFilter: &models.Filter{
+					LeftSql:    "\"schema\".\"table\".\"bool\"",
+					Operator:   ast.FUNC_NOT_EQUAL,
+					RightValue: false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var nodeDto dto.NodeDto
+			err := json.Unmarshal([]byte(tc.ruleJson), &nodeDto)
+			if err != nil {
+				t.Fatal(err, tc.name)
+			}
+			node, err := dto.AdaptASTNode(nodeDto)
+			if err != nil {
+				t.Fatal(err, tc.name)
+			}
+
+			filter, valid := filterFromComparisonNode(node, table, 0)
+			assert.Equal(t, tc.valid, valid, tc.name)
+			assert.Equal(t, tc.expected, filter, tc.name)
+		})
+	}
+}

--- a/usecases/scheduled_execution/export_schedule_execution.go
+++ b/usecases/scheduled_execution/export_schedule_execution.go
@@ -1,4 +1,4 @@
-package scheduledexecution
+package scheduled_execution
 
 import (
 	"context"

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -1,4 +1,4 @@
-package scheduledexecution
+package scheduled_execution
 
 import (
 	"context"

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -9,7 +9,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/organization"
 	"github.com/checkmarble/marble-backend/usecases/scenarios"
-	"github.com/checkmarble/marble-backend/usecases/scheduledexecution"
+	"github.com/checkmarble/marble-backend/usecases/scheduled_execution"
 	"github.com/checkmarble/marble-backend/usecases/security"
 )
 
@@ -106,8 +106,8 @@ func (usecases *Usecases) NewOrganizationCreator() organization.OrganizationCrea
 	}
 }
 
-func (usecases *Usecases) NewExportScheduleExecution() *scheduledexecution.ExportScheduleExecution {
-	return &scheduledexecution.ExportScheduleExecution{
+func (usecases *Usecases) NewExportScheduleExecution() *scheduled_execution.ExportScheduleExecution {
+	return &scheduled_execution.ExportScheduleExecution{
 		DecisionRepository:     usecases.Repositories.DecisionRepository,
 		OrganizationRepository: usecases.Repositories.OrganizationRepository,
 		ExecutorFactory:        usecases.NewExecutorFactory(),

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -5,7 +5,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/decision_workflows"
 	"github.com/checkmarble/marble-backend/usecases/inboxes"
 	"github.com/checkmarble/marble-backend/usecases/indexes"
-	"github.com/checkmarble/marble-backend/usecases/scheduledexecution"
+	"github.com/checkmarble/marble-backend/usecases/scheduled_execution"
 	"github.com/checkmarble/marble-backend/usecases/security"
 	"github.com/checkmarble/marble-backend/usecases/transfers_data_read"
 )
@@ -207,8 +207,8 @@ func (usecases *UsecasesWithCreds) NewIngestionUseCase() IngestionUseCase {
 	}
 }
 
-func (usecases *UsecasesWithCreds) NewRunScheduledExecution() scheduledexecution.RunScheduledExecution {
-	return *scheduledexecution.NewRunScheduledExecution(
+func (usecases *UsecasesWithCreds) NewRunScheduledExecution() scheduled_execution.RunScheduledExecution {
+	return *scheduled_execution.NewRunScheduledExecution(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
 		*usecases.NewExportScheduleExecution(),


### PR DESCRIPTION
Parse the trigger condition AST node, to apply filters that can be applied on the query that returns the rows on which we want to run a batch execution of a scenario.

A "where" filter on the query will be applied in the following cases, for every row in the list of "AND" clause in the trigger condition where the operator is of the form "X OPS Y", with:
- OPS is one of the following operators: >,>=,<,<=,=,!=,is in, is not in, contains, does not contain. The "contains any of", "does not contain any of" operators are not handled.
- the left hand (X) and right hand (Y) operands are one of: a payload field, a constant, the now() operator, the date shift operator applied on a payload field or the now() operator. "is in list" operator only works with constant lists of strings (we could perhaps add custom list later, but I don't think it makes much of a difference).
- at least one of X and Y is a payload field, or derived from a payload field (date shift operator), this is what the actual filter in the query will act on

Some care had to be taken to make sure that we avoid any kind of sql injection (sanitization of the values we pass into the final query).
I do assume that the AST is in the form where we expect it (since it's presumably been validated), though I don't go to the point where I reconstruct a second AST validation. So there is some level of dependency between this feature and the AST.

To do at the point of writing:
- [x] works for (in)equality conditions
- [x] works for list conditions
- [x] works for string contains matching
- [x] run more extensive tests
- [x] handle nested parts in the conditions

---

One thing I'm not too happy about is that it kind of creates entanglement between pure logic on the AST and models on one side, and the SQL queries on the DB on the other hand.
But TBH I don't see a good way around it for now, at least not without going through excessive layers of abstraction that I'm not comfortable with right now, so I'll live with it.


--- 
## Local test example
<img width="870" alt="Capture d’écran 2024-09-27 à 16 02 11" src="https://github.com/user-attachments/assets/f720200a-77e3-4e64-95ef-b3e21c9779ba">

gives the following query:
```sql
SELECT
    account_name,
    after_migration,
    bool,
    not_uniq,
    num,
    object_id,
    uniq,
    updated_at
FROM
    "org-xpollens"."Accounts"
WHERE
    "org-xpollens"."Accounts".valid_until = $1
    AND now() + interval 'PT0S' < "org-xpollens"."Accounts"."updated_at"
    AND $2 < ($3 / NULLIF("org-xpollens"."Accounts"."num", 0))
    AND $4 = ANY ($5)
    AND $6 ILIKE CONCAT('%', $7, '%')
    AND "org-xpollens"."Accounts"."updated_at" < now()
    AND "org-xpollens"."Accounts"."after_migration" = ("org-xpollens"."Accounts"."bool" != $8)
```

and the following arguments:
<img width="472" alt="Capture d’écran 2024-09-27 à 16 02 40" src="https://github.com/user-attachments/assets/a1c3438e-774a-4855-89c6-3e3b0cb14bb4">
Lines 6, 7, 8 are not used to construct filters, as desired.