### PR TITLE
WIP: rework batch execution

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--server",
         "--migrations"
       ],
-      // "console": "integratedTerminal"
+      "console": "integratedTerminal"
     },
     {
       "name": "Launch scenario scheduling job (.env)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
         "--server",
         "--migrations"
       ],
-      "console": "integratedTerminal"
+      // "console": "integratedTerminal"
     },
     {
       "name": "Launch scenario scheduling job (.env)",

--- a/api/handle_scheduled_execution.go
+++ b/api/handle_scheduled_execution.go
@@ -31,6 +31,7 @@ func handleGetScheduledExecution(uc usecases.Usecases) func(c *gin.Context) {
 	}
 }
 
+// TODO deprecated
 func handleGetScheduledExecutionDecisions(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		scheduledExecutionID := c.Param("execution_id")

--- a/api/routes.go
+++ b/api/routes.go
@@ -82,6 +82,8 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 
 	router.GET("/scheduled-executions", handleListScheduledExecution(uc))
 	router.GET("/scheduled-executions/:execution_id", handleGetScheduledExecution(uc))
+
+	// TODO deprecated
 	router.GET("/scheduled-executions/:execution_id/decisions.zip",
 		handleGetScheduledExecutionDecisions(uc))
 

--- a/dto/scheduled_scenario_executions.go
+++ b/dto/scheduled_scenario_executions.go
@@ -12,8 +12,8 @@ type ScheduledExecutionDto struct {
 	Status                     string     `json:"status"`
 	StartedAt                  time.Time  `json:"started_at"`
 	FinishedAt                 *time.Time `json:"finished_at"`
-	NumberOfCreatedDecisions   *int       `json:"number_of_created_decisions"`
-	NumberOfEvaluatedDecisions *int       `json:"number_of_evaluated_decisions"`
+	NumberOfCreatedDecisions   int        `json:"number_of_created_decisions"`
+	NumberOfEvaluatedDecisions int        `json:"number_of_evaluated_decisions"`
 	NumberOfPlannedDecisions   *int       `json:"number_of_planned_decisions"`
 	ScenarioId                 string     `json:"scenario_id"`
 	ScenarioName               string     `json:"scenario_name"`

--- a/dto/scheduled_scenario_executions.go
+++ b/dto/scheduled_scenario_executions.go
@@ -6,34 +6,34 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 )
 
-type APIScheduledExecution struct {
-	Id                        string     `json:"id"`
-	ScenarioIterationId       string     `json:"scenario_iteration_id"`
-	Status                    string     `json:"status"`
-	StartedAt                 time.Time  `json:"started_at"`
-	FinishedAt                *time.Time `json:"finished_at"`
-	NumberOfCreatedDecisions  int        `json:"number_of_created_decisions"`
-	ScenarioId                string     `json:"scenario_id"`
-	ScenarioName              string     `json:"scenario_name"`
-	ScenarioTriggerObjectType string     `json:"scenario_trigger_object_type"`
-	Manual                    bool       `json:"manual"`
+type ScheduledExecutionDto struct {
+	Id                         string     `json:"id"`
+	ScenarioIterationId        string     `json:"scenario_iteration_id"`
+	Status                     string     `json:"status"`
+	StartedAt                  time.Time  `json:"started_at"`
+	FinishedAt                 *time.Time `json:"finished_at"`
+	NumberOfCreatedDecisions   *int       `json:"number_of_created_decisions"`
+	NumberOfEvaluatedDecisions *int       `json:"number_of_evaluated_decisions"`
+	NumberOfPlannedDecisions   *int       `json:"number_of_planned_decisions"`
+	ScenarioId                 string     `json:"scenario_id"`
+	ScenarioName               string     `json:"scenario_name"`
+	ScenarioTriggerObjectType  string     `json:"scenario_trigger_object_type"`
+	Manual                     bool       `json:"manual"`
 }
 
-func AdaptScheduledExecutionDto(ExecutionBatch models.ScheduledExecution) APIScheduledExecution {
-	return APIScheduledExecution{
-		Id:                        ExecutionBatch.Id,
-		ScenarioIterationId:       ExecutionBatch.ScenarioIterationId,
-		Status:                    ExecutionBatch.Status.String(),
-		StartedAt:                 ExecutionBatch.StartedAt,
-		FinishedAt:                ExecutionBatch.FinishedAt,
-		NumberOfCreatedDecisions:  ExecutionBatch.NumberOfCreatedDecisions,
-		ScenarioId:                ExecutionBatch.ScenarioId,
-		ScenarioName:              ExecutionBatch.Scenario.Name,
-		ScenarioTriggerObjectType: ExecutionBatch.Scenario.TriggerObjectType,
-		Manual:                    ExecutionBatch.Manual,
+func AdaptScheduledExecutionDto(ExecutionBatch models.ScheduledExecution) ScheduledExecutionDto {
+	return ScheduledExecutionDto{
+		Id:                         ExecutionBatch.Id,
+		ScenarioIterationId:        ExecutionBatch.ScenarioIterationId,
+		Status:                     ExecutionBatch.Status.String(),
+		StartedAt:                  ExecutionBatch.StartedAt,
+		FinishedAt:                 ExecutionBatch.FinishedAt,
+		NumberOfCreatedDecisions:   ExecutionBatch.NumberOfCreatedDecisions,
+		NumberOfEvaluatedDecisions: ExecutionBatch.NumberOfEvaluatedDecisions,
+		NumberOfPlannedDecisions:   ExecutionBatch.NumberOfPlannedDecisions,
+		ScenarioId:                 ExecutionBatch.ScenarioId,
+		ScenarioName:               ExecutionBatch.Scenario.Name,
+		ScenarioTriggerObjectType:  ExecutionBatch.Scenario.TriggerObjectType,
+		Manual:                     ExecutionBatch.Manual,
 	}
-}
-
-type ListScheduledExecutionInput struct {
-	ScenarioId string `in:"query=scenario_id"`
 }

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -138,7 +138,12 @@ func createDecisionsBatch(
 		assert.FailNow(t, "Failed to get scheduled execution", err)
 	}
 	assert.Equal(t, models.ScheduledExecutionSuccess, se.Status, "Status should be success")
-	assert.Equal(t, 1, se.NumberOfCreatedDecisions, "Should have created 1 decision")
+	assert.NotNil(t, se.NumberOfCreatedDecisions, "Should have created decisions")
+	assert.NotNil(t, se.NumberOfEvaluatedDecisions, "Should have evaluated decisions")
+	assert.NotNil(t, se.NumberOfPlannedDecisions, "Should have planned decisions")
+	assert.Equal(t, 1, *se.NumberOfCreatedDecisions, "Should have created 1 decision")
+	assert.Equal(t, 1, *se.NumberOfEvaluatedDecisions, "Should have evaluated 1 decision")
+	assert.Equal(t, 1, *se.NumberOfPlannedDecisions, "Should have planned 1 decision")
 
 	decisionsUsecase := usecasesWithUserCreds.NewDecisionUsecase()
 	decisions, err := decisionsUsecase.ListDecisions(ctx, organizationId,

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -138,11 +138,9 @@ func createDecisionsBatch(
 		assert.FailNow(t, "Failed to get scheduled execution", err)
 	}
 	assert.Equal(t, models.ScheduledExecutionSuccess, se.Status, "Status should be success")
-	assert.NotNil(t, se.NumberOfCreatedDecisions, "Should have created decisions")
-	assert.NotNil(t, se.NumberOfEvaluatedDecisions, "Should have evaluated decisions")
 	assert.NotNil(t, se.NumberOfPlannedDecisions, "Should have planned decisions")
-	assert.Equal(t, 1, *se.NumberOfCreatedDecisions, "Should have created 1 decision")
-	assert.Equal(t, 1, *se.NumberOfEvaluatedDecisions, "Should have evaluated 1 decision")
+	assert.Equal(t, 1, se.NumberOfCreatedDecisions, "Should have created 1 decision")
+	assert.Equal(t, 1, se.NumberOfEvaluatedDecisions, "Should have evaluated 1 decision")
 	assert.Equal(t, 1, *se.NumberOfPlannedDecisions, "Should have planned 1 decision")
 
 	decisionsUsecase := usecasesWithUserCreds.NewDecisionUsecase()

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -9,16 +9,18 @@ import (
 )
 
 type ScheduledExecution struct {
-	Id                       string
-	OrganizationId           string
-	ScenarioId               string
-	ScenarioIterationId      string
-	Status                   ScheduledExecutionStatus
-	StartedAt                time.Time
-	FinishedAt               *time.Time
-	NumberOfCreatedDecisions int
-	Scenario                 Scenario
-	Manual                   bool
+	Id                         string
+	OrganizationId             string
+	ScenarioId                 string
+	ScenarioIterationId        string
+	Status                     ScheduledExecutionStatus
+	StartedAt                  time.Time
+	FinishedAt                 *time.Time
+	NumberOfCreatedDecisions   *int
+	NumberOfEvaluatedDecisions *int
+	NumberOfPlannedDecisions   *int
+	Scenario                   Scenario
+	Manual                     bool
 }
 
 type ScheduledExecutionStatus int

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -16,8 +16,8 @@ type ScheduledExecution struct {
 	Status                     ScheduledExecutionStatus
 	StartedAt                  time.Time
 	FinishedAt                 *time.Time
-	NumberOfCreatedDecisions   *int
-	NumberOfEvaluatedDecisions *int
+	NumberOfCreatedDecisions   int
+	NumberOfEvaluatedDecisions int
 	NumberOfPlannedDecisions   *int
 	Scenario                   Scenario
 	Manual                     bool

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -66,14 +66,14 @@ func ScheduledExecutionStatusFrom(s string) ScheduledExecutionStatus {
 type UpdateScheduledExecutionStatusInput struct {
 	Id                         string
 	Status                     ScheduledExecutionStatus
-	NumberOfCreatedDecisions   *int64
-	NumberOfEvaluatedDecisions *int64
+	NumberOfCreatedDecisions   *int
+	NumberOfEvaluatedDecisions *int
 	CurrentStatusCondition     ScheduledExecutionStatus // Used for optimistic locking
 }
 
 type UpdateScheduledExecutionInput struct {
 	Id                       string
-	NumberOfPlannedDecisions *int64
+	NumberOfPlannedDecisions *int
 }
 
 type CreateScheduledExecutionInput struct {
@@ -226,5 +226,5 @@ const (
 	DecisionToCreateStatusPending                  = "pending"
 	DecisionToCreateStatusCreated                  = "created"
 	DecisionToCreateStatusFailed                   = "failed"
-	DecisionToCreateStatusTriggerConditionMismatch = "trigger_condition_mismatch"
+	DecisionToCreateStatusTriggerConditionMismatch = "trigger_mismatch"
 )

--- a/repositories/dbmodels/db_decisions_to_create.go
+++ b/repositories/dbmodels/db_decisions_to_create.go
@@ -1,0 +1,32 @@
+package dbmodels
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+type DecisionToCreate struct {
+	Id                   string    `db:"id"`
+	ScheduledExecutionId string    `db:"scheduled_execution_id"`
+	ObjectId             string    `db:"object_id"`
+	Status               string    `db:"status"`
+	CreatedAt            time.Time `db:"created_at"`
+	UpdateAt             time.Time `db:"updated_at"`
+}
+
+const TABLE_DECISIONS_TO_CREATE = "decisions_to_create"
+
+var DecisionToCreateFields = utils.ColumnList[DecisionToCreate]()
+
+func AdaptDecisionToCrate(db DecisionToCreate) models.DecisionToCreate {
+	return models.DecisionToCreate{
+		Id:                   db.Id,
+		ScheduledExecutionId: db.ScheduledExecutionId,
+		ObjectId:             db.ObjectId,
+		Status:               models.DecisionToCreateStatus(db.Status),
+		CreatedAt:            db.CreatedAt,
+		UpdateAt:             db.UpdateAt,
+	}
+}

--- a/repositories/dbmodels/db_scheduled_executions.go
+++ b/repositories/dbmodels/db_scheduled_executions.go
@@ -14,8 +14,8 @@ type DBScheduledExecution struct {
 	Status                     string     `db:"status"`
 	StartedAt                  time.Time  `db:"started_at"`
 	FinishedAt                 *time.Time `db:"finished_at"`
-	NumberOfCreatedDecisions   *int       `db:"number_of_created_decisions"`
-	NumberOfEvaluatedDecisions *int       `db:"number_of_evaluated_decisions"`
+	NumberOfCreatedDecisions   int        `db:"number_of_created_decisions"`
+	NumberOfEvaluatedDecisions int        `db:"number_of_evaluated_decisions"`
 	NumberOfPlannedDecisions   *int       `db:"number_of_planned_decisions"`
 	Manual                     bool       `db:"manual"`
 }

--- a/repositories/dbmodels/db_scheduled_executions.go
+++ b/repositories/dbmodels/db_scheduled_executions.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 type DBScheduledExecution struct {
@@ -22,19 +23,7 @@ type DBScheduledExecution struct {
 
 const TABLE_SCHEDULED_EXECUTIONS = "scheduled_executions"
 
-var ScheduledExecutionFields = []string{
-	"id",
-	"organization_id",
-	"scenario_id",
-	"scenario_iteration_id",
-	"status",
-	"started_at",
-	"finished_at",
-	"number_of_created_decisions",
-	"number_of_evaluated_decisions",
-	"number_of_planned_decisions",
-	"manual",
-}
+var ScheduledExecutionFields = utils.ColumnList[DBScheduledExecution]()
 
 func AdaptScheduledExecution(db DBScheduledExecution, scenario models.Scenario) models.ScheduledExecution {
 	return models.ScheduledExecution{

--- a/repositories/dbmodels/db_scheduled_executions.go
+++ b/repositories/dbmodels/db_scheduled_executions.go
@@ -7,35 +7,48 @@ import (
 )
 
 type DBScheduledExecution struct {
-	Id                       string     `db:"id"`
-	OrganizationId           string     `db:"organization_id"`
-	ScenarioId               string     `db:"scenario_id"`
-	ScenarioIterationId      string     `db:"scenario_iteration_id"`
-	Status                   string     `db:"status"`
-	StartedAt                time.Time  `db:"started_at"`
-	FinishedAt               *time.Time `db:"finished_at"`
-	NumberOfCreatedDecisions int        `db:"number_of_created_decisions"`
-	Manual                   bool       `db:"manual"`
+	Id                         string     `db:"id"`
+	OrganizationId             string     `db:"organization_id"`
+	ScenarioId                 string     `db:"scenario_id"`
+	ScenarioIterationId        string     `db:"scenario_iteration_id"`
+	Status                     string     `db:"status"`
+	StartedAt                  time.Time  `db:"started_at"`
+	FinishedAt                 *time.Time `db:"finished_at"`
+	NumberOfCreatedDecisions   *int       `db:"number_of_created_decisions"`
+	NumberOfEvaluatedDecisions *int       `db:"number_of_evaluated_decisions"`
+	NumberOfPlannedDecisions   *int       `db:"number_of_planned_decisions"`
+	Manual                     bool       `db:"manual"`
 }
 
 const TABLE_SCHEDULED_EXECUTIONS = "scheduled_executions"
 
 var ScheduledExecutionFields = []string{
-	"id", "organization_id", "scenario_id",
-	"scenario_iteration_id", "status", "started_at", "finished_at", "number_of_created_decisions", "manual",
+	"id",
+	"organization_id",
+	"scenario_id",
+	"scenario_iteration_id",
+	"status",
+	"started_at",
+	"finished_at",
+	"number_of_created_decisions",
+	"number_of_evaluated_decisions",
+	"number_of_planned_decisions",
+	"manual",
 }
 
 func AdaptScheduledExecution(db DBScheduledExecution, scenario models.Scenario) models.ScheduledExecution {
 	return models.ScheduledExecution{
-		Id:                       db.Id,
-		OrganizationId:           db.OrganizationId,
-		ScenarioId:               db.ScenarioId,
-		ScenarioIterationId:      db.ScenarioIterationId,
-		Status:                   models.ScheduledExecutionStatusFrom(db.Status),
-		StartedAt:                db.StartedAt,
-		FinishedAt:               db.FinishedAt,
-		NumberOfCreatedDecisions: db.NumberOfCreatedDecisions,
-		Scenario:                 scenario,
-		Manual:                   db.Manual,
+		Id:                         db.Id,
+		OrganizationId:             db.OrganizationId,
+		ScenarioId:                 db.ScenarioId,
+		ScenarioIterationId:        db.ScenarioIterationId,
+		Status:                     models.ScheduledExecutionStatusFrom(db.Status),
+		StartedAt:                  db.StartedAt,
+		FinishedAt:                 db.FinishedAt,
+		NumberOfCreatedDecisions:   db.NumberOfCreatedDecisions,
+		NumberOfEvaluatedDecisions: db.NumberOfEvaluatedDecisions,
+		NumberOfPlannedDecisions:   db.NumberOfPlannedDecisions,
+		Scenario:                   scenario,
+		Manual:                     db.Manual,
 	}
 }

--- a/repositories/migrations/20241002123300_reworked_batch_execution.sql
+++ b/repositories/migrations/20241002123300_reworked_batch_execution.sql
@@ -5,16 +5,12 @@ CREATE TABLE
         id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4 (),
         scheduled_execution_id UUID REFERENCES scheduled_executions (id) ON DELETE SET NULL,
         object_id VARCHAR(100) NOT NULL,
-        status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (
-            status IN ('pending', 'created', 'failed', 'trigger_condition_mismatch', 'retry')
-        ),
+        status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'created', 'failed', 'trigger_mismatch', 'retry')),
         created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
     );
 
-CREATE INDEX decisions_to_create_scheduled_exec_id_idx ON decisions_to_create (scheduled_execution_id) INCLUDE (status);
-
-CREATE INDEX decisions_to_create_unique_per_batch_idx ON decisions_to_create (scheduled_execution_id, object_id);
+CREATE INDEX decisions_to_create_unique_per_batch_idx ON decisions_to_create (scheduled_execution_id, object_id) INCLUDE (status);
 
 ALTER TABLE scheduled_executions
 ADD COLUMN number_of_planned_decisions INT NOT NULL DEFAULT 0;
@@ -26,8 +22,6 @@ ADD COLUMN number_of_evaluated_decisions INT NOT NULL DEFAULT 0;
 -- +goose Down
 -- +goose StatementBegin
 DROP INDEX decisions_to_create_unique_per_batch_idx;
-
-DROP INDEX decisions_to_create_scheduled_exec_id_idx;
 
 DROP TABLE decisions_to_create;
 

--- a/repositories/migrations/20241002123300_reworked_batch_execution.sql
+++ b/repositories/migrations/20241002123300_reworked_batch_execution.sql
@@ -13,10 +13,18 @@ CREATE TABLE
 CREATE INDEX decisions_to_create_unique_per_batch_idx ON decisions_to_create (scheduled_execution_id, object_id) INCLUDE (status);
 
 ALTER TABLE scheduled_executions
-ADD COLUMN number_of_planned_decisions INT NOT NULL DEFAULT 0;
+ADD COLUMN number_of_planned_decisions INT;
 
 ALTER TABLE scheduled_executions
-ADD COLUMN number_of_evaluated_decisions INT NOT NULL DEFAULT 0;
+ADD COLUMN number_of_evaluated_decisions INT;
+
+ALTER TABLE scheduled_executions
+ALTER COLUMN number_of_created_decisions
+DROP NOT NULL;
+
+ALTER TABLE scheduled_executions
+ALTER COLUMN number_of_created_decisions
+DROP DEFAULT;
 
 -- +goose StatementEnd
 -- +goose Down
@@ -30,5 +38,13 @@ DROP COLUMN number_of_planned_decisions;
 
 ALTER TABLE scheduled_executions
 DROP COLUMN number_of_evaluated_decisions;
+
+ALTER TABLE scheduled_executions
+ALTER COLUMN number_of_created_decisions
+SET NOT NULL;
+
+ALTER TABLE scheduled_executions
+ALTER COLUMN number_of_created_decisions
+SET DEFAULT -1;
 
 -- +goose StatementEnd

--- a/repositories/migrations/20241002123300_reworked_batch_execution.sql
+++ b/repositories/migrations/20241002123300_reworked_batch_execution.sql
@@ -16,15 +16,11 @@ ALTER TABLE scheduled_executions
 ADD COLUMN number_of_planned_decisions INT;
 
 ALTER TABLE scheduled_executions
-ADD COLUMN number_of_evaluated_decisions INT;
+ADD COLUMN number_of_evaluated_decisions INT NOT NULL DEFAULT 0;
 
 ALTER TABLE scheduled_executions
 ALTER COLUMN number_of_created_decisions
-DROP NOT NULL;
-
-ALTER TABLE scheduled_executions
-ALTER COLUMN number_of_created_decisions
-DROP DEFAULT;
+SET DEFAULT 0;
 
 -- +goose StatementEnd
 -- +goose Down
@@ -38,10 +34,6 @@ DROP COLUMN number_of_planned_decisions;
 
 ALTER TABLE scheduled_executions
 DROP COLUMN number_of_evaluated_decisions;
-
-ALTER TABLE scheduled_executions
-ALTER COLUMN number_of_created_decisions
-SET NOT NULL;
 
 ALTER TABLE scheduled_executions
 ALTER COLUMN number_of_created_decisions

--- a/repositories/migrations/20241002123300_reworked_batch_execution.sql
+++ b/repositories/migrations/20241002123300_reworked_batch_execution.sql
@@ -1,0 +1,40 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE
+    decisions_to_create (
+        id UUID PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4 (),
+        scheduled_execution_id UUID REFERENCES scheduled_executions (id) ON DELETE SET NULL,
+        object_id VARCHAR(100) NOT NULL,
+        status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (
+            status IN ('pending', 'created', 'failed', 'trigger_condition_mismatch', 'retry')
+        ),
+        created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+CREATE INDEX decisions_to_create_scheduled_exec_id_idx ON decisions_to_create (scheduled_execution_id) INCLUDE (status);
+
+CREATE INDEX decisions_to_create_unique_per_batch_idx ON decisions_to_create (scheduled_execution_id, object_id);
+
+ALTER TABLE scheduled_executions
+ADD COLUMN number_of_planned_decisions INT NOT NULL DEFAULT 0;
+
+ALTER TABLE scheduled_executions
+ADD COLUMN number_of_evaluated_decisions INT NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX decisions_to_create_unique_per_batch_idx;
+
+DROP INDEX decisions_to_create_scheduled_exec_id_idx;
+
+DROP TABLE decisions_to_create;
+
+ALTER TABLE scheduled_executions
+DROP COLUMN number_of_planned_decisions;
+
+ALTER TABLE scheduled_executions
+DROP COLUMN number_of_evaluated_decisions;
+
+-- +goose StatementEnd

--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -19,7 +19,6 @@ type dbJoinScheduledExecutionAndScenario struct {
 
 func adaptJoinScheduledExecutionWithScenario(row pgx.CollectableRow) (models.ScheduledExecution, error) {
 	db, err := pgx.RowToStructByPos[dbJoinScheduledExecutionAndScenario](row)
-	// TODO: how the hell does it know where to put values ????
 	if err != nil {
 		return models.ScheduledExecution{}, err
 	}

--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -19,6 +19,7 @@ type dbJoinScheduledExecutionAndScenario struct {
 
 func adaptJoinScheduledExecutionWithScenario(row pgx.CollectableRow) (models.ScheduledExecution, error) {
 	db, err := pgx.RowToStructByPos[dbJoinScheduledExecutionAndScenario](row)
+	// TODO: how the hell does it know where to put values ????
 	if err != nil {
 		return models.ScheduledExecution{}, err
 	}

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
-	"github.com/adhocore/gronx"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/ast_eval"
 	"github.com/checkmarble/marble-backend/usecases/evaluate_scenario"
@@ -44,6 +41,18 @@ type RunScheduledExecutionRepository interface {
 	GetScenarioById(ctx context.Context, exec repositories.Executor, scenarioId string) (models.Scenario, error)
 	GetScenarioIteration(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (models.ScenarioIteration, error)
 
+	StoreDecisionsToCreate(
+		ctx context.Context,
+		exec repositories.Executor,
+		decisionsToCreate models.DecisionToCreateBatchCreateInput,
+	) ([]models.DecisionToCreate, error)
+	UpdateDecisionToCreateStatus(
+		ctx context.Context,
+		exec repositories.Executor,
+		id string,
+		status models.DecisionToCreateStatus,
+	) error
+
 	ListScheduledExecutions(ctx context.Context, exec repositories.Executor,
 		filters models.ListScheduledExecutionsFilters) ([]models.ScheduledExecution, error)
 	CreateScheduledExecution(ctx context.Context, exec repositories.Executor,
@@ -53,6 +62,11 @@ type RunScheduledExecutionRepository interface {
 		exec repositories.Executor,
 		updateScheduledEx models.UpdateScheduledExecutionStatusInput,
 	) (executed bool, err error)
+	UpdateScheduledExecution(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.UpdateScheduledExecutionInput,
+	) error
 	GetScheduledExecution(ctx context.Context, exec repositories.Executor, id string) (models.ScheduledExecution, error)
 }
 
@@ -68,7 +82,6 @@ type snoozesForDecisionReader interface {
 type RunScheduledExecution struct {
 	repository                     RunScheduledExecutionRepository
 	executorFactory                executor_factory.ExecutorFactory
-	exportScheduleExecution        ExportScheduleExecution
 	scenarioPublicationsRepository repositories.ScenarioPublicationRepository
 	dataModelRepository            repositories.DataModelRepository
 	ingestedDataReadRepository     repositories.IngestedDataReadRepository
@@ -83,7 +96,6 @@ type RunScheduledExecution struct {
 func NewRunScheduledExecution(
 	repository RunScheduledExecutionRepository,
 	executorFactory executor_factory.ExecutorFactory,
-	exportScheduleExecution ExportScheduleExecution,
 	scenarioPublicationsRepository repositories.ScenarioPublicationRepository,
 	dataModelRepository repositories.DataModelRepository,
 	ingestedDataReadRepository repositories.IngestedDataReadRepository,
@@ -97,7 +109,6 @@ func NewRunScheduledExecution(
 	return &RunScheduledExecution{
 		repository:                     repository,
 		executorFactory:                executorFactory,
-		exportScheduleExecution:        exportScheduleExecution,
 		scenarioPublicationsRepository: scenarioPublicationsRepository,
 		dataModelRepository:            dataModelRepository,
 		ingestedDataReadRepository:     ingestedDataReadRepository,
@@ -108,54 +119,6 @@ func NewRunScheduledExecution(
 		webhookEventsSender:            webhookEventsSender,
 		snoozesReader:                  snoozesReader,
 	}
-}
-
-func (usecase *RunScheduledExecution) ScheduleScenarioIfDue(ctx context.Context, organizationId string, scenarioId string) error {
-	exec := usecase.executorFactory.NewExecutor()
-	logger := utils.LoggerFromContext(ctx)
-	scenario, err := usecase.repository.GetScenarioById(ctx, exec, scenarioId)
-	if err != nil {
-		return err
-	}
-
-	publishedVersion, err := usecase.getPublishedScenarioIteration(ctx, exec, scenario)
-	if err != nil {
-		return err
-	}
-	if publishedVersion == nil {
-		logger.DebugContext(ctx, fmt.Sprintf("scenario %s has no published version", scenarioId))
-		return nil
-	}
-
-	previousExecutions, err := usecase.repository.ListScheduledExecutions(ctx, exec, models.ListScheduledExecutionsFilters{
-		ScenarioId: scenarioId, Status: []models.ScheduledExecutionStatus{
-			models.ScheduledExecutionPending, models.ScheduledExecutionProcessing,
-		},
-	})
-	if err != nil {
-		return err
-	}
-	if len(previousExecutions) > 0 {
-		logger.DebugContext(ctx, fmt.Sprintf("scenario %s has already a pending or processing scheduled execution", scenarioId))
-		return nil
-	}
-
-	isDue, err := usecase.scenarioIsDue(ctx, *publishedVersion, scenario)
-	if err != nil {
-		return err
-	}
-	if !isDue {
-		return nil
-	}
-
-	logger.DebugContext(ctx, fmt.Sprintf("Scenario iteration %s is due", publishedVersion.Id))
-	scheduledExecutionId := pure_utils.NewPrimaryKey(organizationId)
-	return usecase.repository.CreateScheduledExecution(ctx, exec, models.CreateScheduledExecutionInput{
-		OrganizationId:      organizationId,
-		ScenarioId:          scenarioId,
-		ScenarioIterationId: publishedVersion.Id,
-		Manual:              false,
-	}, scheduledExecutionId)
 }
 
 func (usecase *RunScheduledExecution) ExecuteAllScheduledScenarios(ctx context.Context) error {
@@ -221,7 +184,7 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 		return nil
 	}
 
-	numberOfCreatedDecisions, err := usecase.createScheduledScenarioDecisions(
+	completed, numberOfCreatedDecisions, err := usecase.createScheduledScenarioDecisions(
 		ctx,
 		scheduledExecution.Id,
 		scheduledExecution.Scenario,
@@ -243,14 +206,21 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 		return err
 	}
 
+	var finalStatus models.ScheduledExecutionStatus
+	if completed {
+		finalStatus = models.ScheduledExecutionSuccess
+	} else {
+		finalStatus = models.ScheduledExecutionPartialFailure
+	}
 	_, err = usecase.repository.UpdateScheduledExecutionStatus(
 		ctx,
 		exec,
 		models.UpdateScheduledExecutionStatusInput{
-			Id:                       scheduledExecution.Id,
-			Status:                   models.ScheduledExecutionSuccess,
-			NumberOfCreatedDecisions: &numberOfCreatedDecisions,
-			CurrentStatusCondition:   models.ScheduledExecutionProcessing,
+			Id:                         scheduledExecution.Id,
+			Status:                     finalStatus,
+			NumberOfCreatedDecisions:   &numberOfCreatedDecisions.created,
+			NumberOfEvaluatedDecisions: &numberOfCreatedDecisions.evaluated,
+			CurrentStatusCondition:     models.ScheduledExecutionProcessing,
 		},
 	)
 	if err != nil {
@@ -261,231 +231,224 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 	return nil
 }
 
-func (usecase *RunScheduledExecution) scenarioIsDue(
-	ctx context.Context,
-	publishedVersion models.PublishedScenarioIteration,
-	scenario models.Scenario,
-) (bool, error) {
-	exec := usecase.executorFactory.NewExecutor()
-	logger := utils.LoggerFromContext(ctx)
-	if publishedVersion.Body.Schedule == "" {
-		logger.DebugContext(ctx, fmt.Sprintf("Scenario iteration %s has no schedule", publishedVersion.Id))
-		return false, nil
-	}
-	gron := gronx.New()
-	ok := gron.IsValid(publishedVersion.Body.Schedule)
-	if !ok {
-		return false, fmt.Errorf("invalid schedule: %w", models.BadParameterError)
-	}
-
-	previousExecutions, err := usecase.repository.ListScheduledExecutions(ctx, exec, models.ListScheduledExecutionsFilters{
-		ScenarioId: scenario.Id, ExcludeManual: true,
-	})
-	if err != nil {
-		return false, fmt.Errorf("error listing scheduled executions: %w", err)
-	}
-
-	publications, err := usecase.scenarioPublicationsRepository.ListScenarioPublicationsOfOrganization(
-		ctx, exec, scenario.OrganizationId, models.ListScenarioPublicationsFilters{ScenarioId: &scenario.Id})
-	if err != nil {
-		return false, err
-	}
-
-	tz, err := time.LoadLocation("Europe/Paris")
-	if err != nil {
-		return false, errors.Wrap(err, "error loading timezone")
-	}
-	return executionIsDueNow(publishedVersion.Body.Schedule, previousExecutions, publications, tz)
-}
-
-func executionIsDueNow(
-	schedule string,
-	previousExecutions []models.ScheduledExecution,
-	publications []models.ScenarioPublication,
-	tz *time.Location,
-) (bool, error) {
-	if tz == nil {
-		return false, errors.New("Nil timezone passed in executionIsDueNow")
-	}
-	var referenceTime time.Time
-	if len(previousExecutions) > 0 {
-		referenceTime = previousExecutions[0].StartedAt.In(tz)
-	} else {
-		// if there is no previous execution, consider the last iteration publication time to be the last execution time
-		referenceTime = publications[0].CreatedAt.In(tz)
-	}
-
-	nextTick, err := gronx.NextTickAfter(schedule, referenceTime, false)
-	if err != nil {
-		return true, err
-	}
-	if nextTick.After(time.Now()) {
-		return false, nil
-	}
-	return true, nil
+type numbersOfDecisions struct {
+	evaluated int64
+	created   int64
 }
 
 func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
 	ctx context.Context,
 	scheduledExecutionId string,
 	scenario models.Scenario,
-) (int, error) {
+) (completed bool, nbDecisions numbersOfDecisions, err error) {
 	exec := usecase.executorFactory.NewExecutor()
 	dataModel, err := usecase.dataModelRepository.GetDataModel(ctx, exec, scenario.OrganizationId, false)
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
 	}
 	tables := dataModel.Tables
 	table, ok := tables[scenario.TriggerObjectType]
 	if !ok {
-		return 0, fmt.Errorf("trigger object type %s not found in data model: %w",
+		return false, numbersOfDecisions{}, fmt.Errorf(
+			"trigger object type %s not found in data model: %w",
 			scenario.TriggerObjectType, models.NotFoundError)
 	}
 
 	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, scenario.OrganizationId, nil)
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
 	}
 	pivot := models.FindPivot(pivotsMeta, scenario.TriggerObjectType, dataModel)
 
 	// list objects to score
-	numberOfCreatedDecisions := 0
-	var objects []models.ClientObject
 	db, err := usecase.executorFactory.NewClientDbExecutor(ctx, scenario.OrganizationId)
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
 	}
 
 	liveVersion, err := usecase.repository.GetScenarioIteration(ctx, exec, *scenario.LiveVersionID)
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
 	}
 	filters := selectFiltersFromTriggerAstRootAnd(
 		*liveVersion.TriggerConditionAstExpression,
 		models.TableIdentifier{Table: table.Name, Schema: db.DatabaseSchema().Schema},
 	)
 
-	objects, err = usecase.ingestedDataReadRepository.ListAllObjectsFromTable(ctx, db, table, filters...)
+	objectIds, err := usecase.ingestedDataReadRepository.ListAllObjectIdsFromTable(ctx, db, table, filters...)
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
 	}
 
-	tracer := utils.OpenTelemetryTracerFromContext(ctx)
-
-	sendWebhookEventId := make([]string, 0)
-	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Executor) error {
-		executionScenario := func(ctx context.Context, object models.ClientObject, i int) error {
-			ctx, span := tracer.Start(
-				ctx,
-				"Batch RunScheduledExecution.executeScheduledScenario",
-				trace.WithAttributes(
-					attribute.String("scenario_id", scenario.Id),
-					attribute.Int64("object_index", int64(i)),
-					attribute.String("object_type", scenario.TriggerObjectType),
-				))
-			defer span.End()
-			scenarioExecution, err := evaluate_scenario.EvalScenario(
-				ctx,
-				evaluate_scenario.ScenarioEvaluationParameters{
-					Scenario:     scenario,
-					ClientObject: object,
-					DataModel:    dataModel,
-					Pivot:        pivot,
-				},
-				evaluate_scenario.ScenarioEvaluationRepositories{
-					EvalScenarioRepository:     usecase.repository,
-					ExecutorFactory:            usecase.executorFactory,
-					IngestedDataReadRepository: usecase.ingestedDataReadRepository,
-					EvaluateAstExpression:      usecase.evaluateAstExpression,
-					SnoozeReader:               usecase.snoozesReader,
-				},
-			)
-
-			if errors.Is(err, models.ErrScenarioTriggerConditionAndTriggerObjectMismatch) {
-				logger := utils.LoggerFromContext(ctx)
-				logger.InfoContext(ctx,
-					fmt.Sprintf("Trigger condition and trigger object mismatch: %s", err.Error()),
-					"scenarioId", scenario.Id,
-					"object_index", i,
-					"triggerObjectType", scenario.TriggerObjectType,
-					"object", object)
-				return nil
-			} else if err != nil {
-				return errors.Wrapf(err, "error evaluating scenario in executeScheduledScenario %s", scenario.Id)
-			}
-
-			decision := models.AdaptScenarExecToDecision(scenarioExecution, object, &scheduledExecutionId)
-			err = usecase.decisionRepository.StoreDecision(
-				ctx,
-				tx,
-				decision,
-				scenario.OrganizationId,
-				decision.DecisionId,
-			)
-			if err != nil {
-				return errors.Wrapf(err, "error storing decision in executeScheduledScenario %s", scenario.Id)
-			}
-
-			webhookEventId := uuid.NewString()
-			err = usecase.webhookEventsSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
-				Id:             webhookEventId,
-				OrganizationId: decision.OrganizationId,
-				EventContent:   models.NewWebhookEventDecisionCreated(decision.DecisionId),
-			})
-			if err != nil {
-				return err
-			}
-			sendWebhookEventId = append(sendWebhookEventId, webhookEventId)
-
-			caseWebhookEventId := uuid.NewString()
-			webhookEventCreated, err := usecase.decisionWorkflows.AutomaticDecisionToCase(
-				ctx, tx, scenario, decision, caseWebhookEventId)
-			if err != nil {
-				return err
-			}
-			if webhookEventCreated {
-				sendWebhookEventId = append(sendWebhookEventId, caseWebhookEventId)
-			}
-
-			numberOfCreatedDecisions += 1
-			return nil
-		}
-
-		// execute scenario for each object
-		for i, object := range objects {
-			if err := executionScenario(ctx, object, i); err != nil {
-				return err
-			}
-		}
-		return nil
+	nbPlannedDecisions := int64(len(objectIds))
+	err = usecase.repository.UpdateScheduledExecution(ctx, exec, models.UpdateScheduledExecutionInput{
+		Id:                       scheduledExecutionId,
+		NumberOfPlannedDecisions: &nbPlannedDecisions,
 	})
 	if err != nil {
-		return 0, err
+		return false, numbersOfDecisions{}, err
+	}
+
+	decisionsToCreate, err := usecase.repository.StoreDecisionsToCreate(ctx, exec, models.DecisionToCreateBatchCreateInput{
+		ScheduledExecutionId: scheduledExecutionId,
+		ObjectId:             objectIds,
+	})
+	if err != nil {
+		return false, numbersOfDecisions{}, err
+	}
+
+	var nbEvaluatedDec int64
+	var nbCreatedDec int64
+	for i, decisionToCreate := range decisionsToCreate {
+		created, err := usecase.createSingleDecisionForObjectId(
+			ctx,
+			db,
+			decisionToCreate,
+			scenario,
+			dataModel,
+			scheduledExecutionId,
+			pivot,
+			i,
+		)
+		nbEvaluatedDec += 1
+		if err != nil {
+			updateErr := usecase.repository.UpdateDecisionToCreateStatus(
+				ctx,
+				exec,
+				decisionToCreate.Id,
+				models.DecisionToCreateStatusFailed,
+			)
+			if updateErr != nil {
+				utils.LogAndReportSentryError(ctx, updateErr)
+			}
+			// Stop at the first encountered error, store the number of created decisions on the scheduled execution
+			return false, numbersOfDecisions{
+				evaluated: nbEvaluatedDec,
+				created:   nbCreatedDec,
+			}, nil
+		}
+		if created {
+			nbCreatedDec += 1
+		}
+	}
+
+	return true, numbersOfDecisions{evaluated: nbEvaluatedDec, created: nbCreatedDec}, nil
+}
+
+func (usecase *RunScheduledExecution) createSingleDecisionForObjectId(
+	ctx context.Context,
+	db repositories.Executor,
+	decisionToCreate models.DecisionToCreate,
+	scenario models.Scenario,
+	dataModel models.DataModel,
+	scheduledExecutionId string,
+	pivot *models.Pivot,
+	objectIdx int,
+) (decisionCreated bool, err error) {
+	tracer := utils.OpenTelemetryTracerFromContext(ctx)
+	ctx, span := tracer.Start(
+		ctx,
+		"Batch RunScheduledExecution.executeScheduledScenario",
+		trace.WithAttributes(
+			attribute.String("scenario_id", scenario.Id),
+			attribute.Int64("object_index", int64(objectIdx)),
+			attribute.String("trigger_object_type", scenario.TriggerObjectType),
+		))
+	defer span.End()
+
+	table := dataModel.Tables[scenario.TriggerObjectType]
+
+	objectMap, err := usecase.ingestedDataReadRepository.QueryIngestedObject(ctx, db, table, decisionToCreate.ObjectId)
+	if err != nil {
+		return false, errors.Wrap(err, "error while querying ingested objects in RunScheduledExecution.createSingleDecisionForObjectId")
+	} else if len(objectMap) == 0 {
+		return false, fmt.Errorf("object %s not found in table %s", decisionToCreate.ObjectId, table.Name)
+	}
+	object := models.ClientObject{TableName: table.Name, Data: objectMap[0]}
+	scenarioExecution, err := evaluate_scenario.EvalScenario(
+		ctx,
+		evaluate_scenario.ScenarioEvaluationParameters{
+			Scenario:     scenario,
+			ClientObject: object,
+			DataModel:    dataModel,
+			Pivot:        pivot,
+		},
+		evaluate_scenario.ScenarioEvaluationRepositories{
+			EvalScenarioRepository:     usecase.repository,
+			ExecutorFactory:            usecase.executorFactory,
+			IngestedDataReadRepository: usecase.ingestedDataReadRepository,
+			EvaluateAstExpression:      usecase.evaluateAstExpression,
+			SnoozeReader:               usecase.snoozesReader,
+		},
+	)
+
+	if errors.Is(err, models.ErrScenarioTriggerConditionAndTriggerObjectMismatch) {
+		logger := utils.LoggerFromContext(ctx)
+		logger.InfoContext(ctx, "Trigger condition and trigger object mismatch",
+			"scenario_id", scenario.Id,
+			"object_index", objectIdx,
+			"trigger_object_type", scenario.TriggerObjectType,
+			"object", object)
+
+		if err := usecase.repository.UpdateDecisionToCreateStatus(
+			ctx,
+			usecase.executorFactory.NewExecutor(),
+			decisionToCreate.Id,
+			models.DecisionToCreateStatusTriggerConditionMismatch,
+		); err != nil {
+			return false, err
+		}
+		return false, nil
+	} else if err != nil {
+		return false, errors.Wrapf(err, "error evaluating scenario in executeScheduledScenario %s", scenario.Id)
+	}
+
+	decision := models.AdaptScenarExecToDecision(scenarioExecution, object, &scheduledExecutionId)
+	sendWebhookEventId := make([]string, 0, 2)
+	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Executor) error {
+		err = usecase.decisionRepository.StoreDecision(
+			ctx,
+			tx,
+			decision,
+			scenario.OrganizationId,
+			decision.DecisionId,
+		)
+		if err != nil {
+			return errors.Wrapf(err, "error storing decision in executeScheduledScenario %s", scenario.Id)
+		}
+
+		webhookEventId := uuid.NewString()
+		err = usecase.webhookEventsSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+			Id:             webhookEventId,
+			OrganizationId: decision.OrganizationId,
+			EventContent:   models.NewWebhookEventDecisionCreated(decision.DecisionId),
+		})
+		if err != nil {
+			return err
+		}
+		sendWebhookEventId = append(sendWebhookEventId, webhookEventId)
+
+		caseWebhookEventId := uuid.NewString()
+		webhookEventCreated, err := usecase.decisionWorkflows.AutomaticDecisionToCase(
+			ctx, tx, scenario, decision, caseWebhookEventId,
+		)
+		if err != nil {
+			return err
+		}
+
+		if webhookEventCreated {
+			sendWebhookEventId = append(sendWebhookEventId, caseWebhookEventId)
+		}
+
+		return usecase.repository.UpdateDecisionToCreateStatus(ctx, tx, decisionToCreate.Id, models.DecisionToCreateStatusCreated)
+	})
+	if err != nil {
+		return false, err
 	}
 
 	for _, webhookEventId := range sendWebhookEventId {
 		usecase.webhookEventsSender.SendWebhookEventAsync(ctx, webhookEventId)
 	}
 
-	return numberOfCreatedDecisions, nil
-}
-
-func (usecase *RunScheduledExecution) getPublishedScenarioIteration(
-	ctx context.Context,
-	exec repositories.Executor,
-	scenario models.Scenario,
-) (*models.PublishedScenarioIteration, error) {
-	if scenario.LiveVersionID == nil {
-		return nil, nil
-	}
-
-	liveVersion, err := usecase.repository.GetScenarioIteration(ctx, exec, *scenario.LiveVersionID)
-	if err != nil {
-		return nil, err
-	}
-	publishedVersion, err := models.NewPublishedScenarioIteration(liveVersion)
-	if err != nil {
-		return nil, err
-	}
-	return &publishedVersion, nil
+	return true, nil
 }

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -312,6 +312,7 @@ func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
 		)
 		nbEvaluatedDec += 1
 		if err != nil {
+			fmt.Printf("%+v\n", err)
 			updateErr := usecase.repository.UpdateDecisionToCreateStatus(
 				ctx,
 				exec,

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -3,7 +3,6 @@ package scheduled_execution
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"sync"
 
 	"github.com/cockroachdb/errors"
@@ -371,11 +370,6 @@ func (usecase *RunScheduledExecution) createSingleDecisionForObjectId(
 			attribute.String("trigger_object_type", scenario.TriggerObjectType),
 		))
 	defer span.End()
-
-	// randomly return an error 10% of the time
-	if rand.Intn(10) == 0 {
-		return false, fmt.Errorf("random error")
-	}
 
 	table := dataModel.Tables[scenario.TriggerObjectType]
 

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -144,8 +144,8 @@ func (usecase *RunScheduledExecution) ExecuteAllScheduledScenarios(ctx context.C
 		ctx = utils.StoreLoggerInContext(
 			ctx,
 			logger.
-				With("scheduledExecutionId", scheduledExecution.Id).
-				With("organizationId", scheduledExecution.OrganizationId),
+				With("scheduled_execution_id", scheduledExecution.Id).
+				With("organization_id", scheduledExecution.OrganizationId),
 		)
 		if err := usecase.executeScheduledScenario(ctx, scheduledExecution); err != nil {
 			executionErrorChan <- err
@@ -232,8 +232,8 @@ func (usecase *RunScheduledExecution) executeScheduledScenario(ctx context.Conte
 }
 
 type numbersOfDecisions struct {
-	evaluated int64
-	created   int64
+	evaluated int
+	created   int
 }
 
 func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
@@ -280,7 +280,7 @@ func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
 		return false, numbersOfDecisions{}, err
 	}
 
-	nbPlannedDecisions := int64(len(objectIds))
+	nbPlannedDecisions := len(objectIds)
 	err = usecase.repository.UpdateScheduledExecution(ctx, exec, models.UpdateScheduledExecutionInput{
 		Id:                       scheduledExecutionId,
 		NumberOfPlannedDecisions: &nbPlannedDecisions,
@@ -297,8 +297,7 @@ func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
 		return false, numbersOfDecisions{}, err
 	}
 
-	var nbEvaluatedDec int64
-	var nbCreatedDec int64
+	var nbEvaluatedDec, nbCreatedDec int
 	for i, decisionToCreate := range decisionsToCreate {
 		created, err := usecase.createSingleDecisionForObjectId(
 			ctx,
@@ -389,7 +388,7 @@ func (usecase *RunScheduledExecution) createSingleDecisionForObjectId(
 			"scenario_id", scenario.Id,
 			"object_index", objectIdx,
 			"trigger_object_type", scenario.TriggerObjectType,
-			"object", object)
+			"object_id", decisionToCreate.ObjectId)
 
 		if err := usecase.repository.UpdateDecisionToCreateStatus(
 			ctx,

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -311,16 +311,13 @@ func (usecase *RunScheduledExecution) createScheduledScenarioDecisions(
 		)
 		nbEvaluatedDec += 1
 		if err != nil {
-			fmt.Printf("%+v\n", err)
 			updateErr := usecase.repository.UpdateDecisionToCreateStatus(
 				ctx,
 				exec,
 				decisionToCreate.Id,
 				models.DecisionToCreateStatusFailed,
 			)
-			if updateErr != nil {
-				utils.LogAndReportSentryError(ctx, updateErr)
-			}
+			utils.LogAndReportSentryError(ctx, errors.Join(err, updateErr))
 			// Stop at the first encountered error, store the number of created decisions on the scheduled execution
 			return false, numbersOfDecisions{
 				evaluated: nbEvaluatedDec,

--- a/usecases/scheduled_execution/schedule_scenarios.go
+++ b/usecases/scheduled_execution/schedule_scenarios.go
@@ -1,0 +1,147 @@
+package scheduled_execution
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/adhocore/gronx"
+	"github.com/cockroachdb/errors"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+func (usecase *RunScheduledExecution) ScheduleScenarioIfDue(ctx context.Context, organizationId string, scenarioId string) error {
+	exec := usecase.executorFactory.NewExecutor()
+	logger := utils.LoggerFromContext(ctx)
+	scenario, err := usecase.repository.GetScenarioById(ctx, exec, scenarioId)
+	if err != nil {
+		return err
+	}
+
+	publishedVersion, err := usecase.getPublishedScenarioIteration(ctx, exec, scenario)
+	if err != nil {
+		return err
+	}
+	if publishedVersion == nil {
+		logger.DebugContext(ctx, fmt.Sprintf("scenario %s has no published version", scenarioId))
+		return nil
+	}
+
+	previousExecutions, err := usecase.repository.ListScheduledExecutions(ctx, exec, models.ListScheduledExecutionsFilters{
+		ScenarioId: scenarioId, Status: []models.ScheduledExecutionStatus{
+			models.ScheduledExecutionPending, models.ScheduledExecutionProcessing,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if len(previousExecutions) > 0 {
+		logger.DebugContext(ctx, fmt.Sprintf("scenario %s has already a pending or processing scheduled execution", scenarioId))
+		return nil
+	}
+
+	isDue, err := usecase.scenarioIsDue(ctx, *publishedVersion, scenario)
+	if err != nil {
+		return err
+	}
+	if !isDue {
+		return nil
+	}
+
+	logger.DebugContext(ctx, fmt.Sprintf("Scenario iteration %s is due", publishedVersion.Id))
+	scheduledExecutionId := pure_utils.NewPrimaryKey(organizationId)
+	return usecase.repository.CreateScheduledExecution(ctx, exec, models.CreateScheduledExecutionInput{
+		OrganizationId:      organizationId,
+		ScenarioId:          scenarioId,
+		ScenarioIterationId: publishedVersion.Id,
+		Manual:              false,
+	}, scheduledExecutionId)
+}
+
+func (usecase *RunScheduledExecution) scenarioIsDue(
+	ctx context.Context,
+	publishedVersion models.PublishedScenarioIteration,
+	scenario models.Scenario,
+) (bool, error) {
+	exec := usecase.executorFactory.NewExecutor()
+	logger := utils.LoggerFromContext(ctx)
+	if publishedVersion.Body.Schedule == "" {
+		logger.DebugContext(ctx, fmt.Sprintf("Scenario iteration %s has no schedule", publishedVersion.Id))
+		return false, nil
+	}
+	gron := gronx.New()
+	ok := gron.IsValid(publishedVersion.Body.Schedule)
+	if !ok {
+		return false, fmt.Errorf("invalid schedule: %w", models.BadParameterError)
+	}
+
+	previousExecutions, err := usecase.repository.ListScheduledExecutions(ctx, exec, models.ListScheduledExecutionsFilters{
+		ScenarioId: scenario.Id, ExcludeManual: true,
+	})
+	if err != nil {
+		return false, fmt.Errorf("error listing scheduled executions: %w", err)
+	}
+
+	publications, err := usecase.scenarioPublicationsRepository.ListScenarioPublicationsOfOrganization(
+		ctx, exec, scenario.OrganizationId, models.ListScenarioPublicationsFilters{ScenarioId: &scenario.Id})
+	if err != nil {
+		return false, err
+	}
+
+	tz, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		return false, errors.Wrap(err, "error loading timezone")
+	}
+	return executionIsDueNow(publishedVersion.Body.Schedule, previousExecutions, publications, tz)
+}
+
+func executionIsDueNow(
+	schedule string,
+	previousExecutions []models.ScheduledExecution,
+	publications []models.ScenarioPublication,
+	tz *time.Location,
+) (bool, error) {
+	if tz == nil {
+		return false, errors.New("Nil timezone passed in executionIsDueNow")
+	}
+	var referenceTime time.Time
+	if len(previousExecutions) > 0 {
+		referenceTime = previousExecutions[0].StartedAt.In(tz)
+	} else {
+		// if there is no previous execution, consider the last iteration publication time to be the last execution time
+		referenceTime = publications[0].CreatedAt.In(tz)
+	}
+
+	nextTick, err := gronx.NextTickAfter(schedule, referenceTime, false)
+	if err != nil {
+		return true, err
+	}
+	if nextTick.After(time.Now()) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (usecase *RunScheduledExecution) getPublishedScenarioIteration(
+	ctx context.Context,
+	exec repositories.Executor,
+	scenario models.Scenario,
+) (*models.PublishedScenarioIteration, error) {
+	if scenario.LiveVersionID == nil {
+		return nil, nil
+	}
+
+	liveVersion, err := usecase.repository.GetScenarioIteration(ctx, exec, *scenario.LiveVersionID)
+	if err != nil {
+		return nil, err
+	}
+	publishedVersion, err := models.NewPublishedScenarioIteration(liveVersion)
+	if err != nil {
+		return nil, err
+	}
+	return &publishedVersion, nil
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -211,7 +211,7 @@ func (usecases *UsecasesWithCreds) NewRunScheduledExecution() scheduled_executio
 	return *scheduled_execution.NewRunScheduledExecution(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
-		*usecases.NewExportScheduleExecution(),
+		// *usecases.NewExportScheduleExecution(),
 		usecases.Repositories.ScenarioPublicationRepository,
 		usecases.Repositories.DataModelRepository,
 		usecases.Repositories.IngestedDataReadRepository,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -211,7 +211,6 @@ func (usecases *UsecasesWithCreds) NewRunScheduledExecution() scheduled_executio
 	return *scheduled_execution.NewRunScheduledExecution(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
-		// *usecases.NewExportScheduleExecution(),
 		usecases.Repositories.ScenarioPublicationRepository,
 		usecases.Repositories.DataModelRepository,
 		usecases.Repositories.IngestedDataReadRepository,


### PR DESCRIPTION
## Content
In this PR:
- the ids of (ingested) objects on which we want to take decisions are written to the DB ahead of creating the decisions
- the details of every object is only read when we actually create the decision on it
- decisions are then created one by one, each one in its own transaction, until an error encountered or all decisions have been created
- at the end, the scheduled execution is updated with its final status (can now be `"partial_failure"`) and with:
    - the number of decisions that were planned to evaluate
    - the number of decisions that have actually been evaluated
    - the number of decisions that have been created (trigger condition match & no error)
- intermediate "decisions waiting to be created" are written to their own table, and their status is updated when they are completed. **_However_**, I'm keeping open the option to not conserve them indefinitely, and I'd rather no application logic relies on them too much

----
## Front end side
Add the display of the different decision numbers, remove the decision download button.
See https://github.com/checkmarble/marble-frontend/pull/556

---- 

Notes: currently we write `the number of decisions that have actually been evaluated` to the field named `number_of_created_decisions`, which is obviously misleading, and is fixed in this PR