### PR TITLE
fix: constant only filters computed from the trigger cond, break the …

### DIFF
--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -166,7 +166,6 @@ func (repo *MarbleDbRepository) UpdateScheduledExecution(
 	exec Executor,
 	input models.UpdateScheduledExecutionInput,
 ) error {
-	// uses optimistic locking based on the current status to avoid overwriting the status incorrectly
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
 	}


### PR DESCRIPTION
Constant only filters computed from the trigger condition, break the SQL filter.
See https://checkmarble.slack.com/archives/C04JB5ZADBN/p1727947744209919


works:
```go
    ctx := context.Background()
	pool, err := pgxpool.New(ctx, "postgres://postgres:marble@localhost:5432/marble")
	if err != nil {
		panic(err)
	}
	defer pool.Close()
	err = pool.Ping(ctx)
	if err != nil {
		panic(err)
	}

	_, err = pool.Exec(ctx, "select * from users where $1=1", 1)
	if err != nil {
		panic(err)
	}

	fmt.Println("done")
```

does not work: pgx does not know how to encode both sides of the equality condition
```go
    ctx := context.Background()
	pool, err := pgxpool.New(ctx, "postgres://postgres:marble@localhost:5432/marble")
	if err != nil {
		panic(err)
	}
	defer pool.Close()
	err = pool.Ping(ctx)
	if err != nil {
		panic(err)
	}

	_, err = pool.Exec(ctx, "select * from users where $1=$2", 1, 1)
	if err != nil {
		panic(err)
	}

	fmt.Println("done")
```