### PR TITLE
ingest by batch via API

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -49,6 +49,7 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 	router.POST("/decisions/:decision_id/snooze", handleSnoozeDecision(uc))
 
 	router.POST("/ingestion/:object_type", handleIngestion(uc))
+	router.POST("/ingestion/:object_type/multiple", handleIngestionMultiple(uc))
 	router.POST("/ingestion/:object_type/batch", timeoutMiddleware(batchIngestionTimeout), handlePostCsvIngestion(uc))
 	router.GET("/ingestion/:object_type/upload-logs", handleListUploadLogs(uc))
 

--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -86,7 +86,7 @@ func RunBatchIngestion() error {
 		),
 	)
 	uc := usecases.NewUsecases(repositories,
-		usecases.WithGcsIngestionBucket(jobConfig.ingestionBucketUrl),
+		usecases.WithIngestionBucketUrl(jobConfig.ingestionBucketUrl),
 		usecases.WithLicense(license))
 
 	err = jobs.IngestDataFromCsv(ctx, uc)

--- a/cmd/run_job_scheduler.go
+++ b/cmd/run_job_scheduler.go
@@ -87,7 +87,7 @@ func RunJobScheduler() error {
 		),
 	)
 	uc := usecases.NewUsecases(repositories,
-		usecases.WithGcsIngestionBucket(jobConfig.ingestionBucketUrl),
+		usecases.WithIngestionBucketUrl(jobConfig.ingestionBucketUrl),
 		usecases.WithFailedWebhooksRetryPageSize(jobConfig.failedWebhooksRetryPageSize),
 		usecases.WithLicense(license))
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -122,8 +122,8 @@ func RunServer() error {
 
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithBatchIngestionMaxSize(serverConfig.batchIngestionMaxSize),
-		usecases.WithGcsIngestionBucket(serverConfig.ingestionBucketUrl),
-		usecases.WithGcsCaseManagerBucket(serverConfig.caseManagerBucket),
+		usecases.WithIngestionBucketUrl(serverConfig.ingestionBucketUrl),
+		usecases.WithCaseManagerBucketUrl(serverConfig.caseManagerBucket),
 		usecases.WithLicense(license),
 	)
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -77,7 +77,7 @@ func RunServer() error {
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
 	}{
-		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", usecases.DefaultApiBatchIngestionSize),
+		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", 0),
 		caseManagerBucket:                utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
 		ingestionBucketUrl:               utils.GetEnv("INGESTION_BUCKET_URL", ""),
 		jwtSigningKey:                    utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,6 +69,7 @@ func RunServer() error {
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
 	}
 	serverConfig := struct {
+		batchIngestionMaxSize            int
 		caseManagerBucket                string
 		ingestionBucketUrl               string
 		jwtSigningKey                    string
@@ -76,6 +77,7 @@ func RunServer() error {
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
 	}{
+		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", usecases.DefaultApiBatchIngestionSize),
 		caseManagerBucket:                utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
 		ingestionBucketUrl:               utils.GetEnv("INGESTION_BUCKET_URL", ""),
 		jwtSigningKey:                    utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),
@@ -119,6 +121,7 @@ func RunServer() error {
 	)
 
 	uc := usecases.NewUsecases(repositories,
+		usecases.WithBatchIngestionMaxSize(serverConfig.batchIngestionMaxSize),
 		usecases.WithGcsIngestionBucket(serverConfig.ingestionBucketUrl),
 		usecases.WithGcsCaseManagerBucket(serverConfig.caseManagerBucket),
 		usecases.WithLicense(license),

--- a/integration_test/api_end_to_end_test.go
+++ b/integration_test/api_end_to_end_test.go
@@ -291,6 +291,29 @@ func ingestAndCreateDecision(authApiKey *httpexpect.Expect, scenarioId string) {
 }`)).
 		Expect().Status(http.StatusCreated)
 
+	// also do some batch ingestion
+	authApiKey.POST("/ingestion/transactions/multiple").
+		WithBytes([]byte(`
+		[
+			{
+				"object_id": "my-unique-id",
+				"updated_at": "2024-01-01T00:00:00Z",
+				"account_id": "my-account-id",
+				"amount": 100,
+				"status": "validated",
+				"transaction_at": "2024-01-01T00:00:00Z"
+			},
+			{
+				"object_id": "my-unique-id-2",
+				"updated_at": "2024-01-01T00:00:00Z",
+				"account_id": "my-account-id-2",
+				"amount": 100,
+				"status": "validated",
+				"transaction_at": "2024-01-01T00:00:00Z"
+			}
+		]`)).
+		Expect().Status(http.StatusCreated)
+
 	objectMap := map[string]any{
 		"object_id":      "my-unique-id",
 		"updated_at":     "2024-01-01T00:00:00Z",

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -129,8 +129,8 @@ func TestMain(m *testing.M) {
 
 	testUsecases = usecases.NewUsecases(repos,
 		usecases.WithLicense(models.NewFullLicense()),
-		usecases.WithGcsIngestionBucket("file://./tempFiles?create_dir=true"),
-		usecases.WithGcsCaseManagerBucket("file://./tempFiles?create_dir=true"),
+		usecases.WithIngestionBucketUrl("file://./tempFiles?create_dir=true"),
+		usecases.WithCaseManagerBucketUrl("file://./tempFiles?create_dir=true"),
 	)
 
 	// select a random port

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -419,15 +419,15 @@ func ingestAccounts(
 		"updated_at": "2020-01-01T00:00:00Z"
 	}`)
 
-	_, err := ingestionUsecase.IngestObjects(ctx, organizationId, tableName, accountPayloadJson1)
+	_, err := ingestionUsecase.IngestObject(ctx, organizationId, tableName, accountPayloadJson1)
 	if err != nil {
 		assert.FailNow(t, "Could not ingest data", err)
 	}
-	_, err = ingestionUsecase.IngestObjects(ctx, organizationId, tableName, accountPayloadJson2)
+	_, err = ingestionUsecase.IngestObject(ctx, organizationId, tableName, accountPayloadJson2)
 	if err != nil {
 		assert.FailNow(t, "Could not ingest data", err)
 	}
-	_, err = ingestionUsecase.IngestObjects(ctx, organizationId, tableName, accountPayloadJson3)
+	_, err = ingestionUsecase.IngestObject(ctx, organizationId, tableName, accountPayloadJson3)
 	if err != nil {
 		assert.FailNow(t, "Could not ingest data", err)
 	}

--- a/repositories/blob_repository.go
+++ b/repositories/blob_repository.go
@@ -166,7 +166,7 @@ func (repository *blobRepository) GetBlob(ctx context.Context, bucketUrl, key st
 
 	reader, err := bucket.NewReader(ctx, key, nil)
 	if err != nil {
-		return models.Blob{}, errors.Wrapf(err, "failed to read GCS object %s/%s", bucketUrl, key)
+		return models.Blob{}, errors.Wrapf(err, "failed to read blob %s/%s", bucketUrl, key)
 	}
 
 	return models.Blob{FileName: key, ReadCloser: reader}, nil

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -11,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/utils"
 )
 
 type IngestionRepository interface {
@@ -26,7 +24,6 @@ func (repo *IngestionRepositoryImpl) IngestObjects(
 	payloads []models.ClientObject,
 	table models.Table,
 ) (int, error) {
-	logger := utils.LoggerFromContext(ctx)
 	if err := validateClientDbExecutor(exec); err != nil {
 		return 0, err
 	}
@@ -60,10 +57,6 @@ func (repo *IngestionRepositoryImpl) IngestObjects(
 			return 0, err
 		}
 	}
-
-	logger.InfoContext(ctx, "Inserted objects in db",
-		slog.String("type", tableNameWithSchema(exec, table.Name)),
-		slog.Int("nb_objects", len(payloadsToInsert)))
 
 	return len(payloadsToInsert), nil
 }

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"strconv"
 	"strings"
 	"sync"
@@ -99,7 +100,17 @@ func (usecase *IngestionUseCase) IngestObject(
 		})
 	}
 	err = retryIngestion(ctx, ingestClosure)
-	return nb, err
+	if err != nil {
+		return 0, err
+	}
+
+	logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
+		slog.String("organization_id", organizationId),
+		slog.String("object_type", objectType),
+		slog.Int("nb_objects", nb),
+	)
+
+	return nb, nil
 }
 
 func (usecase *IngestionUseCase) IngestObjects(
@@ -179,7 +190,12 @@ func (usecase *IngestionUseCase) IngestObjects(
 		return 0, err
 	}
 
-	logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested %d objects", nb))
+	logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
+		slog.String("organization_id", organizationId),
+		slog.String("object_type", objectType),
+		slog.Int("nb_objects", nb),
+	)
+
 	return nb, nil
 }
 

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -15,6 +15,7 @@ import (
 
 type Usecases struct {
 	Repositories                repositories.Repositories
+	batchIngestionMaxSize       int
 	gcsIngestionBucket          string
 	gcsCaseManagerBucket        string
 	failedWebhooksRetryPageSize int
@@ -47,7 +48,14 @@ func WithLicense(license models.LicenseValidation) Option {
 	}
 }
 
+func WithBatchIngestionMaxSize(size int) Option {
+	return func(o *options) {
+		o.batchIngestionMaxSize = size
+	}
+}
+
 type options struct {
+	batchIngestionMaxSize       int
 	gcsIngestionBucket          string
 	gcsCaseManagerBucket        string
 	failedWebhooksRetryPageSize int

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -16,23 +16,23 @@ import (
 type Usecases struct {
 	Repositories                repositories.Repositories
 	batchIngestionMaxSize       int
-	gcsIngestionBucket          string
-	gcsCaseManagerBucket        string
+	ingestionBucketUrl          string
+	caseManagerBucketUrl        string
 	failedWebhooksRetryPageSize int
 	license                     models.LicenseValidation
 }
 
 type Option func(*options)
 
-func WithGcsIngestionBucket(bucket string) Option {
+func WithIngestionBucketUrl(bucket string) Option {
 	return func(o *options) {
-		o.gcsIngestionBucket = bucket
+		o.ingestionBucketUrl = bucket
 	}
 }
 
-func WithGcsCaseManagerBucket(bucket string) Option {
+func WithCaseManagerBucketUrl(bucket string) Option {
 	return func(o *options) {
-		o.gcsCaseManagerBucket = bucket
+		o.caseManagerBucketUrl = bucket
 	}
 }
 
@@ -56,8 +56,8 @@ func WithBatchIngestionMaxSize(size int) Option {
 
 type options struct {
 	batchIngestionMaxSize       int
-	gcsIngestionBucket          string
-	gcsCaseManagerBucket        string
+	ingestionBucketUrl          string
+	caseManagerBucketUrl        string
 	failedWebhooksRetryPageSize int
 	license                     models.LicenseValidation
 }
@@ -65,8 +65,8 @@ type options struct {
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
 	return Usecases{
 		Repositories:                repositories,
-		gcsIngestionBucket:          o.gcsIngestionBucket,
-		gcsCaseManagerBucket:        o.gcsCaseManagerBucket,
+		ingestionBucketUrl:          o.ingestionBucketUrl,
+		caseManagerBucketUrl:        o.caseManagerBucketUrl,
 		failedWebhooksRetryPageSize: o.failedWebhooksRetryPageSize,
 		license:                     o.license,
 	}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -63,6 +63,9 @@ type options struct {
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
+	if o.batchIngestionMaxSize == 0 {
+		o.batchIngestionMaxSize = DefaultApiBatchIngestionSize
+	}
 	return Usecases{
 		Repositories:                repositories,
 		batchIngestionMaxSize:       o.batchIngestionMaxSize,

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -65,6 +65,7 @@ type options struct {
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
 	return Usecases{
 		Repositories:                repositories,
+		batchIngestionMaxSize:       o.batchIngestionMaxSize,
 		ingestionBucketUrl:          o.ingestionBucketUrl,
 		caseManagerBucketUrl:        o.caseManagerBucketUrl,
 		failedWebhooksRetryPageSize: o.failedWebhooksRetryPageSize,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -195,14 +195,15 @@ func (usecases *UsecasesWithCreds) NewDataModelUseCase() DataModelUseCase {
 
 func (usecases *UsecasesWithCreds) NewIngestionUseCase() IngestionUseCase {
 	return IngestionUseCase{
-		enforceSecurity:     usecases.NewEnforceIngestionSecurity(),
-		transactionFactory:  usecases.NewTransactionFactory(),
-		executorFactory:     usecases.NewExecutorFactory(),
-		ingestionRepository: usecases.Repositories.IngestionRepository,
-		blobRepository:      usecases.Repositories.BlobRepository,
-		dataModelRepository: usecases.Repositories.DataModelRepository,
-		uploadLogRepository: usecases.Repositories.UploadLogRepository,
-		GcsIngestionBucket:  usecases.gcsIngestionBucket,
+		enforceSecurity:       usecases.NewEnforceIngestionSecurity(),
+		transactionFactory:    usecases.NewTransactionFactory(),
+		executorFactory:       usecases.NewExecutorFactory(),
+		ingestionRepository:   usecases.Repositories.IngestionRepository,
+		blobRepository:        usecases.Repositories.BlobRepository,
+		dataModelRepository:   usecases.Repositories.DataModelRepository,
+		uploadLogRepository:   usecases.Repositories.UploadLogRepository,
+		ingestionBucketUrl:    usecases.gcsIngestionBucket,
+		batchIngestionMaxSize: usecases.Usecases.batchIngestionMaxSize,
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -202,7 +202,7 @@ func (usecases *UsecasesWithCreds) NewIngestionUseCase() IngestionUseCase {
 		blobRepository:        usecases.Repositories.BlobRepository,
 		dataModelRepository:   usecases.Repositories.DataModelRepository,
 		uploadLogRepository:   usecases.Repositories.UploadLogRepository,
-		ingestionBucketUrl:    usecases.gcsIngestionBucket,
+		ingestionBucketUrl:    usecases.ingestionBucketUrl,
 		batchIngestionMaxSize: usecases.Usecases.batchIngestionMaxSize,
 	}
 }
@@ -258,7 +258,7 @@ func (usecases *UsecasesWithCreds) NewCaseUseCase() *CaseUseCase {
 			Credentials:     usecases.Credentials,
 			ExecutorFactory: usecases.NewExecutorFactory(),
 		},
-		gcsCaseManagerBucket: usecases.gcsCaseManagerBucket,
+		caseManagerBucketUrl: usecases.caseManagerBucketUrl,
 		blobRepository:       usecases.Repositories.BlobRepository,
 		webhookEventsUsecase: usecases.NewWebhookEventsUsecase(),
 	}


### PR DESCRIPTION
### Content
We can now ingest objects by batch. The number of max items in a batch is set to 100 by default and in our SaaS offering, but can be customized by on-premise customers if it makes sense for them, by setting the `"BATCH_INGESTION_MAX_SIZE"` env variable.

---
### Fixes
Renamed some variables/object properties that still contained "GCS" instead of "URL"

---
### QA
Tested with https://github.com/checkmarble/marble-backoffice/pull/29 and with a test case in the end to end test.