### PR TITLE
improvements on memory handling for batch exec

### DIFF
--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -217,8 +217,8 @@ func (repo *IngestedDataReadRepositoryImpl) ListAllObjectIdsFromTable(
 	}
 
 	output := make([]string, len(objectsAsMap))
-	for i, objectAsMap := range objectsAsMap {
-		output[i] = objectAsMap["object_id"].(string)
+	for i := range objectsAsMap {
+		output[i] = objectsAsMap[i]["object_id"].(string)
 	}
 
 	return output, nil


### PR DESCRIPTION
See https://checkmarble.slack.com/archives/C04JB5ZADBN/p1728377329077489

It turned out that the initial implementation was failing for large-ish numbers of decisions to create:
- because the memory usage was of the order of 10+ times the memory needed to store the list of object_ids on which we want to create the decisions (due to unnecessary allocations and passing big arrays of values (not slices) as function params)
- because in any case, postgres will only allow 65535 (an int16 worth of) parameters in a given exec statement - you can create more rows at a time, but then you can't pass the values as params, they must be hard coded in the query)

---
Note: we could also improve memory usage by starting to use proper uuid types for uuids instead of passing them around as strings, which would also help with input validation at the API level, but no hurry on this.