### PR TITLE
doc: batch ingestion on api page

### DIFF
--- a/dto/openapi.go
+++ b/dto/openapi.go
@@ -29,10 +29,10 @@ type Property struct {
 }
 
 type Schema struct {
-	Ref       string  `json:"$ref"`
-	Type      string  `json:"type,omitempty"`
-	Items     *Schema `json:"items,omitempty"`
-	MaxLength int     `json:"maxLength,omitempty"`
+	Ref      string  `json:"$ref"`
+	Type     string  `json:"type,omitempty"`
+	Items    *Schema `json:"items,omitempty"`
+	MaxItems int     `json:"maxItems,omitempty"`
 }
 
 type ApplicationJSON struct {
@@ -433,7 +433,7 @@ func OpenAPIFromDataModel(dataModel models.DataModel) Reference {
 								Items: &Schema{
 									Ref: fmt.Sprintf("#/components/schemas/%s", table.Name),
 								},
-								MaxLength: 100,
+								MaxItems: 100,
 							},
 						},
 					},

--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -45,6 +45,37 @@ paths:
           description: The provided object is invalid.
         500:
           description: An error happened while ingesting the object.
+  /ingestion/{object_type}/multiple:
+    post:
+      summary: Ingest new objects by batch
+      tags:
+        - Ingestion
+      security:
+        - ApiKeyAuth: []
+      description: Ingest a new object from the data model
+      parameters:
+        - in: path
+          name: object_type
+          schema:
+            type: string
+            example: transactions
+          required: true
+          description: name of the object type used for ingestion.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/data_model_object"
+              maxLength: 100
+      responses:
+        200:
+          description: The object was successfully ingested.
+        400:
+          description: One of the provided object is invalid (with respect to the data model), or too many objects have been sent.
+        500:
+          description: An error happened while ingesting the object.
   /decisions:
     post:
       tags:

--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -68,7 +68,7 @@ paths:
               type: array
               items:
                 $ref: "#/components/schemas/data_model_object"
-              maxLength: 100
+              maxItems: 100
       responses:
         200:
           description: The object was successfully ingested.


### PR DESCRIPTION
- add the doc for batch ingestion API
    - to our API page in the app
    - on the docs.checkmarble.com Api reference page
- also add the (missing) doc for "create all decisions on a payload" endpoint
----
See the doc page: https://docs.checkmarble.com/reference/post_ingestion-object-type-multiple

----
## Screenshots
**Multiple ingestion api**
<img width="1666" alt="Capture d’écran 2024-10-08 à 12 15 49" src="https://github.com/user-attachments/assets/933772bb-d21b-4f84-a0c3-05f100f102ea">

**Create all decisions API endpoint**
<img width="1640" alt="Capture d’écran 2024-10-08 à 12 33 56" src="https://github.com/user-attachments/assets/d19f4199-ad93-4973-b5e8-bfe458dd15aa">

**Create all decisions endpoint return schema**
<img width="1618" alt="Capture d’écran 2024-10-08 à 12 34 00" src="https://github.com/user-attachments/assets/29d5f799-fa7a-4cfc-97fd-54b6fa1f086f">
