### PR TITLE
db schema cleanup, remove constraints & indexes on decision_rules

### DIFF
--- a/models/decision.go
+++ b/models/decision.go
@@ -93,6 +93,7 @@ func AdaptScenarExecToDecision(scenarioExecution ScenarioExecution, clientObject
 	return DecisionWithRuleExecutions{
 		Decision: Decision{
 			DecisionId:           pure_utils.NewPrimaryKey(scenarioExecution.OrganizationId),
+			CreatedAt:            time.Now(),
 			ClientObject:         clientObject,
 			Outcome:              scenarioExecution.Outcome,
 			OrganizationId:       scenarioExecution.OrganizationId,

--- a/repositories/analytics_views/decisions.sql
+++ b/repositories/analytics_views/decisions.sql
@@ -15,7 +15,6 @@ SELECT
       scenario_name,
       scenario_version,
       score,
-      deleted_at,
       trigger_object_type,
       scheduled_execution_id,
       case_id

--- a/repositories/dbmodels/db_decision.go
+++ b/repositories/dbmodels/db_decision.go
@@ -7,32 +7,28 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
-
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const TABLE_DECISIONS = "decisions"
 
 type DbDecision struct {
-	Id             string    `db:"id"`
-	OrganizationId string    `db:"org_id"`
-	CaseId         *string   `db:"case_id"`
-	CreatedAt      time.Time `db:"created_at"`
-	// ErrorCode            int         `db:"error_code"` TODO: remove this deprecated field
-	DeletedAt            pgtype.Time `db:"deleted_at"`
-	Outcome              string      `db:"outcome"`
-	PivotId              *string     `db:"pivot_id"`
-	PivotValue           *string     `db:"pivot_value"`
-	ReviewStatus         *string     `db:"review_status"`
-	ScenarioId           string      `db:"scenario_id"`
-	ScenarioIterationId  string      `db:"scenario_iteration_id"`
-	ScenarioName         string      `db:"scenario_name"`
-	ScenarioDescription  string      `db:"scenario_description"`
-	ScenarioVersion      int         `db:"scenario_version"`
-	ScheduledExecutionId *string     `db:"scheduled_execution_id"`
-	Score                int         `db:"score"`
-	TriggerObjectRaw     []byte      `db:"trigger_object"`
-	TriggerObjectType    string      `db:"trigger_object_type"`
+	Id                   string    `db:"id"`
+	OrganizationId       string    `db:"org_id"`
+	CaseId               *string   `db:"case_id"`
+	CreatedAt            time.Time `db:"created_at"`
+	Outcome              string    `db:"outcome"`
+	PivotId              *string   `db:"pivot_id"`
+	PivotValue           *string   `db:"pivot_value"`
+	ReviewStatus         *string   `db:"review_status"`
+	ScenarioId           string    `db:"scenario_id"`
+	ScenarioIterationId  string    `db:"scenario_iteration_id"`
+	ScenarioName         string    `db:"scenario_name"`
+	ScenarioDescription  string    `db:"scenario_description"`
+	ScenarioVersion      int       `db:"scenario_version"`
+	ScheduledExecutionId *string   `db:"scheduled_execution_id"`
+	Score                int       `db:"score"`
+	TriggerObjectRaw     []byte    `db:"trigger_object"`
+	TriggerObjectType    string    `db:"trigger_object_type"`
 }
 
 type DbJoinDecisionAndCase struct {

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -425,6 +425,8 @@ func (repo *MarbleDbRepository) DecisionsOfScheduledExecution(
 	)
 }
 
+// Nb: Beware that the decision usecase sends a complete decision object, and only reads it back if a case has been added
+// => do not add values directly at the repository or db level, or adjust the usecase logic accordingly.
 func (repo *MarbleDbRepository) StoreDecision(
 	ctx context.Context,
 	exec Executor,
@@ -450,6 +452,7 @@ func (repo *MarbleDbRepository) StoreDecision(
 			Columns(
 				"id",
 				"org_id",
+				"created_at",
 				"outcome",
 				"pivot_id",
 				"pivot_value",
@@ -460,7 +463,6 @@ func (repo *MarbleDbRepository) StoreDecision(
 				"scenario_description",
 				"scenario_version",
 				"score",
-				// "error_code",
 				"trigger_object",
 				"trigger_object_type",
 				"scheduled_execution_id",
@@ -468,6 +470,7 @@ func (repo *MarbleDbRepository) StoreDecision(
 			Values(
 				newDecisionId,
 				organizationId,
+				decision.CreatedAt,
 				decision.Outcome.String(),
 				decision.PivotId,
 				decision.PivotValue,
@@ -478,7 +481,6 @@ func (repo *MarbleDbRepository) StoreDecision(
 				decision.ScenarioDescription,
 				decision.ScenarioVersion,
 				decision.Score,
-				// 0, // TODO: cleanup, remove the field in db (it's nullable now)
 				decision.ClientObject.Data,
 				decision.ClientObject.TableName,
 				decision.ScheduledExecutionId,
@@ -504,8 +506,6 @@ func (repo *MarbleDbRepository) StoreDecision(
 			"id",
 			"org_id",
 			"decision_id",
-			// "name",        // TODO: remove this field after it's been made nullable, reads are now denormalized
-			// "description", // TODO: remove this field after it's been made nullable, reads are now denormalized
 			"score_modifier",
 			"result",
 			"error_code",
@@ -525,8 +525,6 @@ func (repo *MarbleDbRepository) StoreDecision(
 				pure_utils.NewPrimaryKey(organizationId),
 				organizationId,
 				newDecisionId,
-				// "", // TODO: remove this field after it's been made nullable, reads are now denormalized
-				// "", // TODO: remove this field after it's been made nullable, reads are now denormalized
 				ruleExecution.ResultScoreModifier,
 				ruleExecution.Result,
 				ast.AdaptExecutionError(ruleExecution.Error),

--- a/repositories/migrations/20241015171200_fields_and_constraint_cleanup.sql
+++ b/repositories/migrations/20241015171200_fields_and_constraint_cleanup.sql
@@ -1,0 +1,76 @@
+-- +goose Up
+-- +goose StatementBegin
+-- deprecated fields cleanup
+ALTER TABLE decisions
+DROP COLUMN error_code;
+
+ALTER TABLE decision_rules
+DROP COLUMN name;
+
+ALTER TABLE decision_rules
+DROP COLUMN description;
+
+ALTER TABLE decision_rules
+DROP COLUMN deleted_at;
+
+-- unnecessary "max len 10" in varchar
+ALTER TABLE decision_rules
+ALTER COLUMN outcome
+TYPE VARCHAR;
+
+-- on a big table like decision rules, those constraints are having quite an impact on write performance, for not too much added value.
+-- We'll need to cleanup manually orphan decision_rules when we remove organizations though (but that's ok)
+ALTER TABLE decision_rules
+DROP CONSTRAINT fk_decision_rules_org;
+
+ALTER TABLE decision_rules
+DROP CONSTRAINT fk_decision_rules_decisions;
+
+ALTER TABLE decision_rules
+DROP CONSTRAINT decision_rules_rule_id_fkey;
+
+-- with the constraints above gone, we also don't need the indexes that were just used for better org delete speed
+DROP INDEX decision_rules_rule_id_idx;
+
+DROP INDEX decision_rules_org_id_idx;
+
+-- another unused field
+ALTER TABLE decisions
+DROP COLUMN deleted_at;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE decisions
+ADD COLUMN error_code INTEGER;
+
+ALTER TABLE decision_rules
+ADD COLUMN name VARCHAR;
+
+ALTER TABLE decision_rules
+ADD COLUMN description VARCHAR;
+
+ALTER TABLE decision_rules
+ADD COLUMN deleted_at TIMESTAMP;
+
+ALTER TABLE decision_rules
+ALTER COLUMN outcome
+TYPE VARCHAR(10);
+
+ALTER TABLE decision_rules
+ADD CONSTRAINT fk_decision_rules_org FOREIGN KEY (org_id) REFERENCES organizations (id) ON DELETE CASCADE;
+
+ALTER TABLE decision_rules
+ADD CONSTRAINT fk_decision_rules_decisions FOREIGN KEY (decision_id) REFERENCES decisions (id) ON DELETE CASCADE;
+
+ALTER TABLE decision_rules
+ADD CONSTRAINT decision_rules_rule_id_fkey FOREIGN KEY (rule_id) REFERENCES decision_rules (id) ON DELETE CASCADE;
+
+CREATE INDEX decision_rules_rule_id_idx ON decision_rules (rule_id);
+
+CREATE INDEX decision_rules_org_id_idx ON decision_rules (org_id);
+
+ALTER TABLE decisions
+ADD COLUMN deleted_at TIMESTAMP WITH TIME ZONE;
+
+-- +goose StatementEnd

--- a/usecases/decision_workflows/decision_workflows.go
+++ b/usecases/decision_workflows/decision_workflows.go
@@ -72,7 +72,7 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 	scenario models.Scenario,
 	decision models.DecisionWithRuleExecutions,
 	webhookEventId string,
-) (webhookEventCreated bool, err error) {
+) (addedToCase bool, err error) {
 	if scenario.DecisionToCaseWorkflowType == models.WorkflowDisabled ||
 		scenario.DecisionToCaseOutcomes == nil ||
 		!slices.Contains(scenario.DecisionToCaseOutcomes, decision.Outcome) ||

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Maximum number of rules executed concurrently
-// TODO : set value from configuration/env instead
+// TODO: set value from configuration/env instead
 const MAX_CONCURRENT_RULE_EXECUTIONS = 5
 
 type ScenarioEvaluationParameters struct {


### PR DESCRIPTION
- dropping constraints and indexes on the decision_rules table - it's the highest point of charge on the db and adding latency to transfercheck, for no good reason
- also removing a useless re-read of decision if it has not changed in the decision usecase (keeping it to read the case if it has been added, could be done more efficiently but I mostly want it to be faster in the transfercheck case for now).
- removing some deprecated fields