### PR TITLE
fix: the migration was broken because of independently created views

### DIFF
--- a/repositories/migrations/20241015171200_fields_and_constraint_cleanup.sql
+++ b/repositories/migrations/20241015171200_fields_and_constraint_cleanup.sql
@@ -1,5 +1,11 @@
 -- +goose Up
 -- +goose StatementBegin
+--- those views are created outside if this migration file, but we need to drop it here becauses it uses the table name
+-- (it wil be recreated as the migrations script is run)
+DROP VIEW IF EXISTS analytics.decisions;
+
+DROP VIEW IF EXISTS analytics.decision_rules;
+
 -- deprecated fields cleanup
 ALTER TABLE decisions
 DROP COLUMN error_code;


### PR DESCRIPTION
TL:DR:
We create views independently of the main migrations (see the `repositories/analytics_views` folder), but they create dependencies which prevent us from modifying/removing fields that they use in the main migrations.
This is not visible when running the migrations from 0, and I think I fixed it manually without realizing this was breaking the order of operations when I ran it in my local DB.

I think we can find a more long-term solution when we start serving the analytics tool from a BQ replica of the DB rather than from a schema on the main db replica.