### PR TITLE
v1: it works (but ugly naming & cleanup to do)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/pressly/goose/v3 v3.20.0
 	github.com/riverqueue/river v0.13.0
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.13.0
+	github.com/riverqueue/river/rivertype v0.13.0
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.18.0
@@ -172,7 +173,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/riverqueue/river/riverdriver v0.13.0 // indirect
 	github.com/riverqueue/river/rivershared v0.13.0 // indirect
-	github.com/riverqueue/river/rivertype v0.13.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/segmentio/backo-go v1.1.0 // indirect

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -14,12 +14,9 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 )
 
-const expectedQueryDbFieldExpectedWithoutJoin string = "SELECT test_schema.second.int_var FROM test_schema.second " +
-	"WHERE test_schema.second.id = $1 AND test_schema.second.valid_until = $2"
+const expectedQueryDbFieldExpectedWithoutJoin string = "SELECT table_1.int_var FROM test_schema.second AS table_1 WHERE table_1.id = $1 AND table_1.valid_until = $2"
 
-const expectedQueryDbFieldWithJoin string = "SELECT test_schema.third.int_var " +
-	"FROM test_schema.second JOIN test_schema.third ON test_schema.second.id = test_schema.third.id " +
-	"WHERE test_schema.second.id = $1 AND test_schema.second.valid_until = $2 AND test_schema.third.valid_until = $3"
+const expectedQueryDbFieldWithJoin string = "SELECT table_2.int_var FROM test_schema.second AS table_1 JOIN test_schema.third AS table_2 ON table_1.id = table_2.id WHERE table_1.id = $1 AND table_1.valid_until = $2 AND table_2.valid_until = $3"
 
 const expectedQueryAggregatedWithoutFilter string = "SELECT AVG(int_var)::float8 FROM test_schema.first " +
 	"WHERE test_schema.first.valid_until = $1"


### PR DESCRIPTION
## Intent 
The bug I'm trying to fix is the following:


When we execute the "db field read" operator, say with the params defined as in the screenshot below, meaning `trigger_table=table_a, path = [table_b, table_c, table_b_loop]` (those are the link names), the query that is generated essentially does `select table_b.field_name from table_b join table_c join table_b`.

<img width="483" alt="Capture d’écran 2024-10-22 à 22 54 34" src="https://github.com/user-attachments/assets/c8e246d2-9873-4c6f-b34f-eb8dd25f0db6">

Now, this logic works fine if every table appears only once, but the generated SQL is ambiguous if a table name appears several times. So I need to alias them.

I could rework this to alias them like `"table_b_1", "table_c_", ...`, but at the end of the day this would never be visible except to some extent in tracing data on DB queries - and even there it's not so interesting, because this query is never expected to be a DB perf bottleneck, contrary to aggregation queries.
Also it's a bit of a pain because of table name escaping.
So I think I'll leave it at that.

--- 
### Before
```sql
SELECT
    "org-xpollens"."table_b".table_c_id
FROM
    "org-xpollens"."table_b"
    JOIN "org-xpollens"."table_c" ON "org-xpollens"."table_b".table_c_id = "org-xpollens"."table_c".object_id
    JOIN "org-xpollens"."table_b" ON "org-xpollens"."table_c".table_b_id = "org-xpollens"."table_b".object_id
WHERE
    "org-xpollens"."table_b".object_id = $1
    AND "org-xpollens"."table_b".valid_until = $2
    AND "org-xpollens"."table_c".valid_until = $3
    AND "org-xpollens"."table_b".valid_until = $4
```
=> `"org-xpollens"."table_b"` is ambiguous because it appears several times, once as the table where the query stats and once in a join


### After
```sql
SELECT
    table_3.table_c_id
FROM
    "org-xpollens"."table_b" AS table_1
    JOIN "org-xpollens"."table_c" AS table_2 ON table_1.table_c_id = table_2.object_id
    JOIN "org-xpollens"."table_b" AS table_3 ON table_2.table_b_id = table_3.object_id
WHERE
    table_1.object_id = $1
    AND table_1.valid_until = $2
    AND table_2.valid_until = $3
    AND table_3.valid_until = $4
```

--- 
(and actually, reading the final diff, the code might even be clearer now than it was before. Though this part of the codebase is still a mess. Sorry)