### PR TITLE
try uuid v7 for better data locality in index

### DIFF
--- a/models/decision.go
+++ b/models/decision.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models/ast"
-	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/google/uuid"
 )
 
 const (
@@ -91,7 +91,7 @@ func AdaptScenarExecToDecision(scenarioExecution ScenarioExecution, clientObject
 
 	return DecisionWithRuleExecutions{
 		Decision: Decision{
-			DecisionId:           pure_utils.NewPrimaryKey(scenarioExecution.OrganizationId),
+			DecisionId:           uuid.Must(uuid.NewV7()).String(),
 			CreatedAt:            time.Now(),
 			ClientObject:         clientObject,
 			Outcome:              scenarioExecution.Outcome,

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -522,7 +523,7 @@ func (repo *MarbleDbRepository) StoreDecision(
 
 		builderForRules = builderForRules.
 			Values(
-				pure_utils.NewPrimaryKey(organizationId),
+				uuid.Must(uuid.NewV7()).String(),
 				organizationId,
 				newDecisionId,
 				ruleExecution.ResultScoreModifier,


### PR DESCRIPTION
Inserts of decisions and decision rules are still slower than I'd like them to be.
I tried some things already but that didn't quite work.
I'd like to try this, using (ordered by time) v7 uuids for better data locality in indexes. See [link](https://www.percona.com/blog/uuids-are-popular-but-bad-for-performance-lets-discuss/) for discussion.

NB: this means dropping the assumption, that we have anyway not applied on all tables since a while, that we do uuids with a shared prefix for all ids in a given org. But that's fine as this wasn't really useful in the end.