### PR TITLE
fix: typehint to let postgres prepare statement

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -6,7 +6,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/models/scheduled_scenario_execution_test.go
+++ b/models/scheduled_scenario_execution_test.go
@@ -43,7 +43,7 @@ func TestFilterToSql(t *testing.T) {
 				Operator:   ast.FUNC_STRING_CONTAINS,
 				RightValue: "mit",
 			},
-			expected: "? ILIKE CONCAT('%',?,'%')",
+			expected: "? ILIKE CONCAT('%',?::text,'%')",
 			args:     []any{"COMMIT", "mit"},
 		},
 		{

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -195,7 +195,7 @@ func (f Filter) ToSql() (sql string, args []any) {
 				mathComparisonFuncToString(f.Operator), right)
 		}
 	} else if isStringComparison(f.Operator) {
-		sql = fmt.Sprintf("%s ILIKE CONCAT('%%',%s,'%%')", left, right)
+		sql = fmt.Sprintf("%s ILIKE CONCAT('%%',%s::text,'%%')", left, right)
 	} else if isInListComparison(f.Operator) {
 		sql = fmt.Sprintf("%s = ANY(%s)", left, right)
 	}

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -76,6 +76,12 @@ func EvalScenario(
 	logger.InfoContext(ctx, "Evaluating scenario", "scenarioId", params.Scenario.Id)
 	exec := repositories.ExecutorFactory.NewExecutor()
 
+	// If the scenario has no live version, don't try to Eval() it, return early
+	if params.Scenario.LiveVersionID == nil {
+		return models.ScenarioExecution{}, errors.Wrap(models.ErrScenarioHasNoLiveVersion,
+			"scenario has no live version in EvalScenario")
+	}
+
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
 	ctx, span := tracer.Start(ctx, "evaluate_scenario.EvalScenario",
 		trace.WithAttributes(
@@ -86,12 +92,6 @@ func EvalScenario(
 		),
 	)
 	defer span.End()
-
-	// If the scenario has no live version, don't try to Eval() it, return early
-	if params.Scenario.LiveVersionID == nil {
-		return models.ScenarioExecution{}, errors.Wrap(models.ErrScenarioHasNoLiveVersion,
-			"scenario has no live version in EvalScenario")
-	}
 
 	liveVersion, err := repositories.EvalScenarioRepository.GetScenarioIteration(ctx, exec, *params.Scenario.LiveVersionID)
 	if err != nil {


### PR DESCRIPTION
I learned something new on how pgx works, it first runs a prepare statement on all queries (by default) where the query is parsed but the parameter values are not used. Hence, pg is not able to parse `CONCAT('str_a', $1, 'str_b')` because it can't know the type of $1 which will only be known at query runtime.
In other situations, pg is able to infer the type, for instance if operators like `=` are used.
The recommended fix is to add type hints where query is possibly ambiguous.

In practice, this error was happening if the right-hand side of the equation contained a constant (it works with a field identifier).