### PR TITLE
fix: better error handling on transfercheck

### DIFF
--- a/api/present_error.go
+++ b/api/present_error.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+const timeoutMst = "Sorry, the API timed out. Please try again later."
+
 func presentError(ctx context.Context, c *gin.Context, err error) bool {
 	if err == nil {
 		return false
@@ -43,10 +45,10 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 
 	case errors.Is(err, context.DeadlineExceeded):
 		logger.WarnContext(ctx, fmt.Sprintf("Deadline exceeded: %v", err))
-		c.JSON(http.StatusRequestTimeout, errorResponse)
+		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
 	case errors.Is(err, context.Canceled):
 		logger.WarnContext(ctx, fmt.Sprintf("Deadline exceeded: %v", err))
-		c.JSON(http.StatusRequestTimeout, errorResponse)
+		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
 
 	default:
 		logger.ErrorContext(ctx, fmt.Sprintf("Unexpected Error: %+v", err))

--- a/usecases/transfer_check_usecase.go
+++ b/usecases/transfer_check_usecase.go
@@ -216,9 +216,7 @@ func (usecase *TransferCheckUsecase) CreateTransfer(
 		},
 	)
 	if err != nil {
-		return models.Transfer{}, errors.Wrapf(
-			errors.Handled(err),
-			"Error while creating decision in transfercheck")
+		return models.Transfer{}, handleTransferCheckDecisionError(err)
 	}
 
 	return models.Transfer{
@@ -515,9 +513,7 @@ func (usecase *TransferCheckUsecase) ScoreTransfer(
 		},
 	)
 	if err != nil {
-		return models.Transfer{}, errors.Wrapf(
-			errors.Handled(err),
-			"Error while creating decision in transfercheck")
+		return models.Transfer{}, handleTransferCheckDecisionError(err)
 	}
 
 	transfer := models.Transfer{
@@ -592,4 +588,11 @@ func (usecase *TransferCheckUsecase) beneficiaryIsInNetwork(ctx context.Context,
 	}
 
 	return true, nil
+}
+
+func handleTransferCheckDecisionError(err error) error {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return err
+	}
+	return errors.Wrapf(errors.Handled(err), "Error while creating decision in transfercheck")
 }


### PR DESCRIPTION
Goal of this PR: make those error messages go away.
<img width="1968" alt="Capture d’écran 2024-10-28 à 12 46 15" src="https://github.com/user-attachments/assets/f05fb2ec-60a3-4eb3-b884-b4e5ecef65bf">
To be clear they do deserve monitoring, but not in this format.