### PR TITLE
Pascal/transfercheck timeout proper mutex handling

### DIFF
--- a/repositories/transfercheck_enrichment.go
+++ b/repositories/transfercheck_enrichment.go
@@ -110,7 +110,7 @@ func (r *TransferCheckEnrichmentRepository) readIpCountryRangesFromBlob(ctx cont
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
 	ctx, span := tracer.Start(
 		ctx,
-		"repositories.TransferCheckEnrichmentRepository.setupIpCountryRanges",
+		"repositories.TransferCheckEnrichmentRepository.readIpCountryRangesFromBlob",
 	)
 	defer span.End()
 
@@ -122,6 +122,11 @@ func (r *TransferCheckEnrichmentRepository) readIpCountryRangesFromBlob(ctx cont
 	fileReader := csv.NewReader(file.ReadCloser)
 	record, err := fileReader.Read()
 
+	_, span = tracer.Start(
+		ctx,
+		"repositories.TransferCheckEnrichmentRepository.readIpCountryRangesFromBlob - parse and sort",
+	)
+	defer span.End()
 	var ipRanges []ipCountryRange
 	var ipRange netip.Prefix
 	for err == nil {
@@ -222,7 +227,7 @@ func (r *TransferCheckEnrichmentRepository) readIpTypeRangesFromBlob(ctx context
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
 	ctx, span := tracer.Start(
 		ctx,
-		"repositories.TransferCheckEnrichmentRepository.setupIpTypeRanges",
+		"repositories.TransferCheckEnrichmentRepository.readIpTypeRangesFromBlob",
 	)
 	defer span.End()
 	var ipRanges []ipTypeRange

--- a/repositories/transfercheck_enrichment.go
+++ b/repositories/transfercheck_enrichment.go
@@ -32,14 +32,16 @@ type ipTypeRange struct {
 }
 
 type TransferCheckEnrichmentRepository struct {
-	blobRepository        BlobRepository
-	bucket                string
+	blobRepository BlobRepository
+	bucket         string
+
 	ipCountryRanges       []ipCountryRange
-	ipTypeRanges          []ipTypeRange
 	muCountries           sync.Mutex
-	muIpTypes             sync.Mutex
 	countryRangesExpireAt time.Time
-	ipTypeRangesExpireAt  time.Time
+
+	ipTypeRanges         []ipTypeRange
+	muIpTypes            sync.Mutex
+	ipTypeRangesExpireAt time.Time
 }
 
 func NewTransferCheckEnrichmentRepository(blobRepository BlobRepository, bucket string) *TransferCheckEnrichmentRepository {
@@ -49,55 +51,7 @@ func NewTransferCheckEnrichmentRepository(blobRepository BlobRepository, bucket 
 	}
 }
 
-// Expects a CSV file with two columns: IP range and country code (ISO 3166-1 alpha-3) containing both ipv4 and ipv6 ranges.
-func (r *TransferCheckEnrichmentRepository) setupIpCountryRanges(ctx context.Context) error {
-	tracer := utils.OpenTelemetryTracerFromContext(ctx)
-	ctx, span := tracer.Start(
-		ctx,
-		"repositories.TransferCheckEnrichmentRepository.setupIpCountryRanges",
-	)
-	defer span.End()
-	r.muCountries.Lock()
-	defer r.muCountries.Unlock()
-	if time.Now().Before(r.countryRangesExpireAt) {
-		return nil
-	}
-
-	file, err := r.blobRepository.GetBlob(ctx, r.bucket, IP_COUNTRY_RANGE_FILE)
-	if err != nil {
-		return err
-	}
-	defer file.ReadCloser.Close()
-	fileReader := csv.NewReader(file.ReadCloser)
-	record, err := fileReader.Read()
-	var ipRange netip.Prefix
-	for err == nil {
-		ipRange, err = netip.ParsePrefix(record[0])
-		if err != nil {
-			return errors.Wrapf(err, "failed to parse IP range '%s'", record[0])
-		}
-		r.ipCountryRanges = append(r.ipCountryRanges, ipCountryRange{
-			ipRange: ipRange,
-			country: record[1],
-		})
-		record, err = fileReader.Read()
-	}
-	if err != io.EOF { //nolint:errorlint
-		return err
-	}
-
-	slices.SortFunc(r.ipCountryRanges, func(range1, range2 ipCountryRange) int {
-		if range1.ipRange == range2.ipRange {
-			return 0
-		} else if range1.ipRange.Addr().Less(range2.ipRange.Addr()) {
-			return -1
-		}
-		return 1
-	})
-
-	r.countryRangesExpireAt = time.Now().Add(IP_RANGE_FILES_EXPIRATION)
-	return nil
-}
+// IP country methods
 
 func (r *TransferCheckEnrichmentRepository) GetIPCountry(ctx context.Context, ip netip.Addr) (string, error) {
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
@@ -107,23 +61,24 @@ func (r *TransferCheckEnrichmentRepository) GetIPCountry(ctx context.Context, ip
 	)
 	defer span.End()
 
-	if err := r.setupIpCountryRanges(ctx); err != nil {
+	return r.findCountryDichotomy(ctx, ip)
+}
+
+func (r *TransferCheckEnrichmentRepository) findCountryDichotomy(ctx context.Context, ip netip.Addr) (string, error) {
+	ranges, err := r.getIpCountryRanges(ctx)
+	if err != nil {
 		return "", err
 	}
 
-	return r.findCountryDichotomy(ip), nil
-}
-
-func (r *TransferCheckEnrichmentRepository) findCountryDichotomy(ip netip.Addr) string {
 	left := 0
-	right := len(r.ipCountryRanges) - 1
+	right := len(ranges) - 1
 
 	for right >= left {
 		mid := left + (right-left)/2
 
-		ipRange := r.ipCountryRanges[mid].ipRange
+		ipRange := ranges[mid].ipRange
 		if ipRange.Contains(ip) {
-			return r.ipCountryRanges[mid].country
+			return ranges[mid].country, nil
 		} else if ip.Less(ipRange.Addr()) {
 			right = mid - 1
 		} else {
@@ -131,8 +86,72 @@ func (r *TransferCheckEnrichmentRepository) findCountryDichotomy(ip netip.Addr) 
 		}
 	}
 
-	return ""
+	return "", nil
 }
+
+func (r *TransferCheckEnrichmentRepository) getIpCountryRanges(ctx context.Context) ([]ipCountryRange, error) {
+	r.muCountries.Lock()
+	defer r.muCountries.Unlock()
+
+	if time.Now().After(r.countryRangesExpireAt) {
+		ranges, err := r.readIpCountryRanges(ctx)
+		if err != nil {
+			return nil, err
+		}
+		r.ipCountryRanges = ranges
+		r.countryRangesExpireAt = time.Now().Add(IP_RANGE_FILES_EXPIRATION)
+	}
+
+	return r.ipCountryRanges, nil
+}
+
+// Expects a CSV file with two columns: IP range and country code (ISO 3166-1 alpha-3) containing both ipv4 and ipv6 ranges.
+func (r *TransferCheckEnrichmentRepository) readIpCountryRanges(ctx context.Context) ([]ipCountryRange, error) {
+	tracer := utils.OpenTelemetryTracerFromContext(ctx)
+	ctx, span := tracer.Start(
+		ctx,
+		"repositories.TransferCheckEnrichmentRepository.setupIpCountryRanges",
+	)
+	defer span.End()
+
+	file, err := r.blobRepository.GetBlob(ctx, r.bucket, IP_COUNTRY_RANGE_FILE)
+	if err != nil {
+		return nil, err
+	}
+	defer file.ReadCloser.Close()
+	fileReader := csv.NewReader(file.ReadCloser)
+	record, err := fileReader.Read()
+
+	var ipRanges []ipCountryRange
+	var ipRange netip.Prefix
+	for err == nil {
+		ipRange, err = netip.ParsePrefix(record[0])
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse IP range '%s'", record[0])
+		}
+		ipRanges = append(ipRanges, ipCountryRange{
+			ipRange: ipRange,
+			country: record[1],
+		})
+		record, err = fileReader.Read()
+	}
+	if err != io.EOF { //nolint:errorlint
+		return nil, err
+	}
+
+	slices.SortFunc(ipRanges, func(range1, range2 ipCountryRange) int {
+		if range1.ipRange == range2.ipRange {
+			return 0
+		} else if range1.ipRange.Addr().Less(range2.ipRange.Addr()) {
+			return -1
+		}
+		return 1
+	})
+
+	return ipRanges, nil
+}
+
+// IP type methods
 
 func (r *TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip netip.Addr) (string, error) {
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
@@ -142,11 +161,11 @@ func (r *TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip ne
 	)
 	defer span.End()
 
-	if err := r.setupIpTypeRanges(ctx); err != nil {
+	ipType, err := r.findIpTypeDichotomy(ctx, ip)
+	if err != nil {
 		return "", err
 	}
 
-	ipType := r.findIpTypeDichotomy(ip)
 	if ipType != "" {
 		return ipType, nil
 	}
@@ -154,16 +173,21 @@ func (r *TransferCheckEnrichmentRepository) GetIPType(ctx context.Context, ip ne
 	return models.RegularIP, nil
 }
 
-func (r *TransferCheckEnrichmentRepository) findIpTypeDichotomy(ip netip.Addr) string {
+func (r *TransferCheckEnrichmentRepository) findIpTypeDichotomy(ctx context.Context, ip netip.Addr) (string, error) {
+	ranges, err := r.getIpTypeRanges(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	left := 0
-	right := len(r.ipTypeRanges) - 1
+	right := len(ranges) - 1
 
 	for right >= left {
 		mid := left + (right-left)/2
 
-		ipRange := r.ipTypeRanges[mid].ipRange
+		ipRange := ranges[mid].ipRange
 		if ipRange.Contains(ip) {
-			return r.ipTypeRanges[mid].ipType
+			return ranges[mid].ipType, nil
 		} else if ip.Less(ipRange.Addr()) {
 			right = mid - 1
 		} else {
@@ -171,29 +195,40 @@ func (r *TransferCheckEnrichmentRepository) findIpTypeDichotomy(ip netip.Addr) s
 		}
 	}
 
-	return ""
+	return "", nil
+}
+
+func (r *TransferCheckEnrichmentRepository) getIpTypeRanges(ctx context.Context) ([]ipTypeRange, error) {
+	r.muIpTypes.Lock()
+	defer r.muIpTypes.Unlock()
+
+	if time.Now().After(r.ipTypeRangesExpireAt) {
+		ranges, err := r.readIpTypeRanges(ctx)
+		if err != nil {
+			return nil, err
+		}
+		r.ipTypeRanges = ranges
+		r.ipTypeRangesExpireAt = time.Now().Add(IP_RANGE_FILES_EXPIRATION)
+	}
+
+	return r.ipTypeRanges, nil
 }
 
 // Expects two CSV files:
 // one with one column (CIDR IP range) containing both ipv4 and ipv6 ranges with VPN address ranges
 // one with one column (IP addresses) containing  both ipv4 and ipv6 with TOR exit nodes
 // The ips & ranges between the two files may overlap.
-func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Context) error {
+func (r *TransferCheckEnrichmentRepository) readIpTypeRanges(ctx context.Context) ([]ipTypeRange, error) {
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
 	ctx, span := tracer.Start(
 		ctx,
 		"repositories.TransferCheckEnrichmentRepository.setupIpTypeRanges",
 	)
 	defer span.End()
-	r.muIpTypes.Lock()
-	defer r.muIpTypes.Unlock()
-	if time.Now().Before(r.ipTypeRangesExpireAt) {
-		return nil
-	}
 
 	file, err := r.blobRepository.GetBlob(ctx, r.bucket, IP_VPN_RANGE_FILE)
 	if err != nil {
-		return errors.Wrap(err, "failed to get VPN IP file")
+		return nil, errors.Wrap(err, "failed to get VPN IP file")
 	}
 	defer file.ReadCloser.Close()
 	fileReader := csv.NewReader(file.ReadCloser)
@@ -202,7 +237,7 @@ func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Contex
 	for err == nil {
 		ipRange, err = netip.ParsePrefix(record[0])
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse VPN IP range %s", record[0])
+			return nil, errors.Wrapf(err, "failed to parse VPN IP range %s", record[0])
 		}
 		r.ipTypeRanges = append(r.ipTypeRanges, ipTypeRange{
 			ipRange: ipRange,
@@ -211,34 +246,36 @@ func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Contex
 		record, err = fileReader.Read()
 	}
 	if err != io.EOF { //nolint:errorlint
-		return errors.Wrap(err, "failed to read VPN IP file")
+		return nil, errors.Wrap(err, "failed to read VPN IP file")
 	}
 
 	file, err = r.blobRepository.GetBlob(ctx, r.bucket, IP_TOR_RANGE_FILE)
 	if err != nil {
-		return errors.Wrap(err, "failed to get TOR IP file")
+		return nil, errors.Wrap(err, "failed to get TOR IP file")
 	}
 	defer file.ReadCloser.Close()
 	fileReader = csv.NewReader(file.ReadCloser)
 	record, err = fileReader.Read()
+
+	var ipRanges []ipTypeRange
 	var ip netip.Addr
 	for err == nil {
 		ip, err = netip.ParseAddr(record[0])
 		if err != nil {
-			return errors.Wrapf(err, "failed to parse TOR IP address %s", record[0])
+			return nil, errors.Wrapf(err, "failed to parse TOR IP address %s", record[0])
 		}
-		r.ipTypeRanges = append(r.ipTypeRanges, ipTypeRange{
+		ipRanges = append(ipRanges, ipTypeRange{
 			ipRange: netip.PrefixFrom(ip, ip.BitLen()),
 			ipType:  models.TorIP,
 		})
 		record, err = fileReader.Read()
 	}
 	if err != io.EOF { //nolint:errorlint
-		return errors.Wrap(err, "failed to read TOR IP file")
+		return nil, errors.Wrap(err, "failed to read TOR IP file")
 	}
 
 	// at the end, sort the full slice of ip ranges
-	slices.SortFunc(r.ipTypeRanges, func(range1, range2 ipTypeRange) int {
+	slices.SortFunc(ipRanges, func(range1, range2 ipTypeRange) int {
 		// multiple ip ranges may have the same start address, but we don't care about how there ordered between them
 		if range1.ipRange == range2.ipRange {
 			return 0
@@ -248,8 +285,7 @@ func (r *TransferCheckEnrichmentRepository) setupIpTypeRanges(ctx context.Contex
 		return 1
 	})
 
-	r.ipTypeRangesExpireAt = time.Now().Add(IP_RANGE_FILES_EXPIRATION)
-	return nil
+	return ipRanges, nil
 }
 
 func (r *TransferCheckEnrichmentRepository) GetSenderBicRiskLevel(ctx context.Context, bic string) (string, error) {


### PR DESCRIPTION
Fixes some errors with mutex handling in the transfercheck enrichment repo.

- reading ip was not thread safe
- the ip ranges were never reset, so effectively the slice of ip ranges just kept growing

I was trying to fix a timeout issue related to reading from GCS, which I'm not sure it fixes. But the changes make sense anyway, so let's already ship this.