### PR TITLE
temp workaround: make decisions filtering less broken

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -31,7 +31,12 @@ const (
 	BATCH_INGESTION_TIMEOUT = 55 * time.Second
 
 	SEQUENTIAL_DECISION_TIMEOUT = 30 * time.Second
-	DEFAULT_TIMEOUT             = 5 * time.Second
+
+	// TODO: temporary workaround, what we need to do is to make the endpoint reliably respond quickly even
+	// without warmup
+	LIST_DECISION_TIMEOUT = 10 * time.Second
+
+	DEFAULT_TIMEOUT = 5 * time.Second
 )
 
 func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc usecases.Usecases, marbleAppHost string) {
@@ -47,7 +52,7 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 
 	router.GET("/ast-expression/available-functions", tom, handleAvailableFunctions)
 
-	router.GET("/decisions", tom, handleListDecisions(uc, marbleAppHost))
+	router.GET("/decisions", timeoutMiddleware(LIST_DECISION_TIMEOUT), handleListDecisions(uc, marbleAppHost))
 	router.POST("/decisions", timeoutMiddleware(models.DECISION_TIMEOUT), handlePostDecision(uc, marbleAppHost))
 	router.POST("/decisions/all",
 		timeoutMiddleware(SEQUENTIAL_DECISION_TIMEOUT),

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -25,7 +25,7 @@ type (
 )
 
 const (
-	COUNT_ROWS_LIMIT              = 9000
+	COUNT_ROWS_LIMIT              = 1000
 	SortingOrderAsc  SortingOrder = "ASC"
 	SortingOrderDesc SortingOrder = "DESC"
 )


### PR DESCRIPTION
### TL:DR
- returning the total count of rows when filtering decisions is fundamentally broken and we need to get rid of it (as well as returning the "item index" on the returned decisions), as already previously discussed
- even if we apply a "limit 9000" (now limit 1000 after this PR), depending on the filters used, we can have pathological cases where the count gets dramatically slow, especially when the data is not in memory cache by the DB
- this PR is a temporary workaround that makes the app less broken, but it's not a full fix


--- 
### Detail
What's happening here, for S&P, is the following:
- listing all decisions works fine, the count will stop after scanning 9000 rows, responds fast
- when applying a filter "outcome=approve", pretty much the same thing happens, they have ~500k decisions, almost all are approve
- when applying a filter "outcome=review", for which in total ~11k rows match, we almost need to scan all of their decisions before we "stop" because we've seen 9000
it's a pathological case, but it's not so unusual either and I don't think there is a good and scalable very general solution to this.

(this is all happening for an index-only query, on an index on `(org_id, created_at desc) storing(outcome)`