### PR TITLE
bugfix: bad error message when timeout

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
+++ b/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
@@ -40,8 +40,12 @@ func (clva CustomListValuesAccess) Evaluate(ctx context.Context, arguments ast.A
 	}
 
 	list, err := clva.CustomListRepository.GetCustomListById(ctx, exec, listId)
-	if err != nil {
+	if errors.Is(err, models.NotFoundError) {
 		return MakeEvaluateError(ast.ErrListNotFound)
+	} else if err != nil {
+		return MakeEvaluateError(errors.Wrap(
+			err,
+			fmt.Sprintf("Error reading list %s", listId)))
 	}
 	if err := clva.EnforceSecurity.ReadOrganization(list.OrganizationId); err != nil {
 		return MakeEvaluateError(errors.Wrap(err,


### PR DESCRIPTION
Fixes this sentry issue, which looks like a "list not found" but is actually a timeout
https://checkmarble.sentry.io/issues/6053673843/?environment=production&project=4506439156236288&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=0