### PR TITLE
fix: because PG_CONNECTION_STRING is an option, PG_PASSWORD no longer…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,14 @@ ENV=development
 PORT=8080
 # port used by cloud run to probe container health when running the worker on Cloud Run
 CLOUD_RUN_PROBE_PORT=9000
-# replace me in a production environment
+
+# Use one of AUTHENTICATION_JWT_SIGNING_KEY or AUTHENTICATION_JWT_SIGNING_KEY_FILE:
+#    (AUTHENTICATION_JWT_SIGNING_KEY_FILE is recommended due to encoding issues with multiline env variables)
+# Expects a PKCS#1 or PKCS#8 PEM encoded private RSA key
+# Replace me in a production environment
 AUTHENTICATION_JWT_SIGNING_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs+6r50m7qqLHHy7CvfmJPnAi+t/tubi7DPSM2jvA1etT1jEX\nrwbFbmooOu9LTgmjmxOq01p+XwkW1f7iPZViKrf7dEDEuqmpqYG9jPX4G/7xFcci\nGn1iSOiNx9awIKSYZa1wodlMCRM081DGqFNDMf1PScWIyM40nIwaGqLZht4HcOAq\nLbKDa15bxubBqZ9o/YnE1KmyBfq1tTnk0KzAb12Axt0xN4qB2zktsV/LLds+szMk\n/gRHjann1+fCZvxw1JzzRPtgeHLLYzn4ks3mwzy67RO3q/663KPZCsuYhlNCsMqp\n/HAbrF5PaihqzCZqLTDoIXXciCFFgwtLwm951wIDAQABAoIBAQCpb60tJX+1VYeQ\n06XK43rb8xjdiZUA+PYbYwZoUzBpwSq3Xo9g4E12hjzQEpqlJ+qKk+CfGm457AM3\nDMfbGhrRA2Oku4EGDdKYrnXikZVMN6yqx1RUAZJV+bfZYU+Fzbk8tjCEGG3DdfS8\n02nfBFkYb+MEIyGFhriAWmYSgxu4JTN0XRTyPqBytoSLqVCFbv0/yV2oJQDaXW08\nWAA8JtWhzqxACbFnPYe0hYUnrCA71t0v1P/N5uB4kKxI0tulGtW84noSyWA2LSdn\nJlKQW5WsyeMulGBMnIpj/OQJtQErupoITsh1TNi+6ffGgmuMCT1za70DHXVq9Ihu\nkpKBe0wRAoGBAOSarLfNvsS2lTH/8zPyhWBddCS5CfQAeUFLD5xWhQ7/6SenYzYY\n+oiiH2uL7d8grkobX5QLVvJ5ZXziYWoKgJe3SlrvRuNJZCAxvuynUCahhCT+chwW\nGz7ihXh3bGD0gtO6iogGBfrAkvRQnorkdSmVEZd1PsJV/lXp8LKgxJ91AoGBAMl+\ny/6NbzVHt9oQsrVrG/sCAOlqlfTt5KW6pI1WC4LoKBaGe+hy4emZ0G/M2feAJEPR\n92QrPRkVF5bVCjalJj42/7gQIl6r+DQ4+08gLB1MSpWua2M3UtEi/2gsMcQff/wg\n6kmNZObW5Jcnqpp6u72zQTQwF4H29XucV/Yw93abAoGADGvfIKmcSQIGv03CADuY\nRbEuQ2SOhuSTshmLApqs5jC/kXkF6gWXb18nx+c1iJ80+S/dlKS9F7XC7vM6CdIC\nRLwf3SsNNgJh32H0ltVMhJzYGk59EsuctWEHkZEjoW0HwstrBZMWNhbKpV3QD4n0\nV8sSxqEHRPX5ON/aRUp5BJUCgYEAlsymr2P6js2V80X7+Xqn/juJoyd6A0znioEd\nFgoHo3lMR09u/JC+Mq5DKOkPWAQ3H+rMU9NobpUyilf2xN7kuDtBNugcUO4zXCIp\nMxbI7URjrZJUHHUTLiIbNEOfG0DX8EJSFaoUkg7SFa5CKEsipt65Ne2oKkRBhLmF\nu2L6UXECgYBH1bpi0R6j7lIADtZtIJII/TezQbp+VK2R9qoNgkTnHoDjkRVR7v3m\n75wReMvTy1h0Qx/ROtStZz8d5uQuhdeJvbQPQR8KGFUFZDmVWxU+y15WI2H39FMA\nMireKxzCfGGtTsZnhDqYl9NuRPcAGYt5jvoERXlz7b69rkqQUrfy+Q==\n-----END RSA PRIVATE KEY-----"
+# Or alternatively (set me and create a file if you want to use a file)
+AUTHENTICATION_JWT_SIGNING_KEY_FILE=""
 
 # Env variables for the postgresql database
 PG_CONNECTION_STRING=

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ e2e_test
 
 # client db config file
 *client_db_config.json
+*.pem

--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -21,16 +21,15 @@ func RunBatchIngestion() error {
 		ProjectId:     utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 	}
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		MaxPoolConnections:  utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
-		ClientDbConfigFile:  utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:           "marble",
+		Hostname:           utils.GetEnv("PG_HOSTNAME", ""),
+		Password:           utils.GetEnv("PG_PASSWORD", ""),
+		Port:               utils.GetEnv("PG_PORT", "5432"),
+		User:               utils.GetEnv("PG_USER", ""),
+		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
+		ClientDbConfigFile: utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
+		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),

--- a/cmd/migrations.go
+++ b/cmd/migrations.go
@@ -11,14 +11,13 @@ import (
 
 func RunMigrations() error {
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString: utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:         "marble",
+		Hostname:         utils.GetEnv("PG_HOSTNAME", ""),
+		Password:         utils.GetEnv("PG_PASSWORD", ""),
+		Port:             utils.GetEnv("PG_PORT", "5432"),
+		User:             utils.GetEnv("PG_USER", ""),
+		SslMode:          utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 
 	logger := utils.NewLogger(utils.GetEnv("LOGGING_FORMAT", "text"))

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -24,16 +24,15 @@ func RunScheduledExecuter() error {
 		ProjectId:     utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 	}
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		MaxPoolConnections:  utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
-		ClientDbConfigFile:  utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:           "marble",
+		Hostname:           utils.GetEnv("PG_HOSTNAME", ""),
+		Password:           utils.GetEnv("PG_PASSWORD", ""),
+		Port:               utils.GetEnv("PG_PORT", "5432"),
+		User:               utils.GetEnv("PG_USER", ""),
+		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
+		ClientDbConfigFile: utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
+		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -21,15 +21,14 @@ func RunSendPendingWebhookEvents() error {
 		ProjectId:     utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 	}
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		MaxPoolConnections:  utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:           "marble",
+		Hostname:           utils.GetEnv("PG_HOSTNAME", ""),
+		Password:           utils.GetEnv("PG_PASSWORD", ""),
+		Port:               utils.GetEnv("PG_PORT", "5432"),
+		User:               utils.GetEnv("PG_USER", ""),
+		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
+		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -76,6 +76,7 @@ func RunServer() error {
 		caseManagerBucket                string
 		ingestionBucketUrl               string
 		jwtSigningKey                    string
+		jwtSigningKeyFile                string
 		loggingFormat                    string
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
@@ -84,6 +85,7 @@ func RunServer() error {
 		caseManagerBucket:                utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
 		ingestionBucketUrl:               utils.GetEnv("INGESTION_BUCKET_URL", ""),
 		jwtSigningKey:                    utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY", ""),
+		jwtSigningKeyFile:                utils.GetEnv("AUTHENTICATION_JWT_SIGNING_KEY_FILE", ""),
 		loggingFormat:                    utils.GetEnv("LOGGING_FORMAT", "text"),
 		sentryDsn:                        utils.GetEnv("SENTRY_DSN", ""),
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
@@ -91,7 +93,7 @@ func RunServer() error {
 
 	logger := utils.NewLogger(serverConfig.loggingFormat)
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
-	marbleJwtSigningKey := infra.ParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey)
+	marbleJwtSigningKey := infra.ReadParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey, serverConfig.jwtSigningKeyFile)
 	license := infra.VerifyLicense(licenseConfig)
 
 	infra.SetupSentry(serverConfig.sentryDsn, apiConfig.Env)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -37,16 +37,15 @@ func RunServer() error {
 		GoogleApplicationCredentials: utils.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""),
 	}
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		MaxPoolConnections:  utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
-		ClientDbConfigFile:  utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:           "marble",
+		Hostname:           utils.GetEnv("PG_HOSTNAME", ""),
+		Password:           utils.GetEnv("PG_PASSWORD", ""),
+		Port:               utils.GetEnv("PG_PORT", "5432"),
+		User:               utils.GetEnv("PG_USER", ""),
+		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
+		ClientDbConfigFile: utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
+		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 	metabaseConfig := infra.MetabaseConfiguration{
 		SiteUrl:             utils.GetEnv("METABASE_SITE_URL", ""),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -30,16 +30,15 @@ func RunTaskQueue() error {
 		ProjectId:     utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 	}
 	pgConfig := infra.PgConfig{
-		ConnectionString:    utils.GetEnv("PG_CONNECTION_STRING", ""),
-		Database:            "marble",
-		DbConnectWithSocket: utils.GetEnv("PG_CONNECT_WITH_SOCKET", false),
-		Hostname:            utils.GetRequiredEnv[string]("PG_HOSTNAME"),
-		Password:            utils.GetRequiredEnv[string]("PG_PASSWORD"),
-		Port:                utils.GetEnv("PG_PORT", "5432"),
-		User:                utils.GetRequiredEnv[string]("PG_USER"),
-		MaxPoolConnections:  utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
-		ClientDbConfigFile:  utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
-		SslMode:             utils.GetEnv("PG_SSL_MODE", "prefer"),
+		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
+		Database:           "marble",
+		Hostname:           utils.GetEnv("PG_HOSTNAME", ""),
+		Password:           utils.GetEnv("PG_PASSWORD", ""),
+		Port:               utils.GetEnv("PG_PORT", "5432"),
+		User:               utils.GetEnv("PG_USER", ""),
+		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
+		ClientDbConfigFile: utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
+		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 	}
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),

--- a/infra/config.go
+++ b/infra/config.go
@@ -13,21 +13,24 @@ type GcpConfig struct {
 }
 
 type PgConfig struct {
-	ConnectionString    string
-	Database            string
-	DbConnectWithSocket bool
-	Hostname            string
-	Password            string
-	Port                string
-	User                string
-	MaxPoolConnections  int
-	ClientDbConfigFile  string
-	SslMode             string
+	ConnectionString   string
+	Database           string
+	Hostname           string
+	Password           string
+	Port               string
+	User               string
+	MaxPoolConnections int
+	ClientDbConfigFile string
+	SslMode            string
 }
 
 func (config PgConfig) GetConnectionString() string {
 	if config.ConnectionString != "" {
 		return config.ConnectionString
+	}
+
+	if config.Hostname == "" || config.User == "" || config.Password == "" || config.Database == "" {
+		panic("Missing required configuration for connecting to PostgreSQL in PgConfig")
 	}
 
 	if config.SslMode == "" {
@@ -36,9 +39,9 @@ func (config PgConfig) GetConnectionString() string {
 
 	connectionString := fmt.Sprintf("host=%s user=%s password=%s database=%s sslmode=%s",
 		config.Hostname, config.User, config.Password, config.Database, config.SslMode)
-	if !config.DbConnectWithSocket {
-		// Cloud Run connects to the DB through a proxy and a unix socket, so we don't need need to specify the port
-		// but we do when running locally
+	if config.Port != "" {
+		// In some cases, the port is not required. E.g. Cloud Run connects to the DB through a managed proxy
+		// and a unix socket, so we don't need need to specify the port in that case.
 		connectionString = fmt.Sprintf("%s port=%s", connectionString, config.Port)
 	}
 	return connectionString

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -121,7 +121,7 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}
 
-	privateKey := infra.ParseOrGenerateSigningKey(ctx, "")
+	privateKey := infra.ReadParseOrGenerateSigningKey(ctx, "", "")
 
 	workers := river.NewWorkers()
 	// AddWorker panics if the worker is already registered or invalid

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -634,8 +634,8 @@ func (usecase *IngestionUseCase) insertEnumValuesAndIngest(
 
 	go func() {
 		// I'm giving it a short deadline because it's not critical to the user - in any situation i'd rather it fails
-		// than take more than 10ms
-		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Millisecond*10)
+		// than take more than 40ms
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Millisecond*40)
 		defer cancel()
 		enumValues := buildEnumValuesContainersFromTable(table)
 		for _, payload := range payloads {

--- a/utils/context_logging.go
+++ b/utils/context_logging.go
@@ -53,7 +53,7 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 	logger, found := ctx.Value(ContextKeyLogger).(*slog.Logger)
 	if !found {
 		logger = NewLogger("")
-		logger.ErrorContext(ctx, "logger not found in context. Falling back to a new logger, but it will be missing context keys")
+		logger.WarnContext(ctx, "logger not found in context. Falling back to a new logger, but it will be missing context keys")
 	}
 	return logger
 }


### PR DESCRIPTION
### Part 1 (commit (7c1af89))
A previous PR allowed to connect to postgres by passing a connection string rather than host/db/password/user separately, but the latter environment variables were still required, even if they were not used.

### Part 2: RSA private key handling, Goal and context
Copy pasted from the discussion on community slack (in DM) with the guy from Reyts:

Ok, I think I managed to replicate and fix your issue.
So, what is happening is that the code, as it is currently, expects a RSA private key in .pem format and beginning with `-----BEGIN RSA PRIVATE KEY-----....`, AKA PKCS#1 format.
Depending on how you generated your private/public key pari with openssl, you may have instead a file starting with `-----BEGIN PRIVATE KEY-----...` , AKA PKCS#8 format, with the algorithm being set in the key body as RSA (if it contains anything else than a RSA key, we are not treating it currently).

The problem that you probably encounter is that you are in the second case (`BEGIN PRIVATE KEY`), and this case was until now not handled well.

I am releasing a fix for this issue, which will be released in the next prod release next week.
In the meantime, your options are:
- keep the variable empty, this really should work
- generate a key in PKCS#1 format (AKA "BEGIN RSA PRIVATE KEY") and use it
- or, this should work now but I don't recommend to do it systematically, use the :latest tag on our backend docker image, as soon as I have merged the PR that I'm working on (I'll ping you to let you know)

### Others
- increase the timeout for async enum value insertion (let's debug later if it's taking longer than it should)
- decrease logging level if logger not found in context, super noisy in tests otherwise