### PR TITLE
first batch: allow to use null values in the AST, and return them as an error at the top level if null bubbles up

### DIFF
--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -48,6 +48,7 @@ type DecisionRule struct {
 	Result        bool      `json:"result"`
 	RuleId        string    `json:"rule_id"`
 	ScoreModifier int       `json:"score_modifier"`
+	ErrorCode     *int      `json:"error_code"`
 
 	// RuleEvaluation is not returned by default, it only is for endpoints consumed by the frontend
 	RuleEvaluation *ast.NodeEvaluationDto `json:"rule_evaluation,omitempty"`

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -510,8 +510,8 @@ func createDecisions(
 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
 	if assert.NotEmpty(t, approveNoRecordDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveNoRecordDecision.RuleExecutions, "Check on account name")
-		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNoRowsRead,
-			"Expected error to be \"%s\", got \"%s\"", ast.ErrNoRowsRead, ruleExecution.Error)
+		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
 	}
 
 	// Create a decision [APPROVE] without a field in payload (null field read)
@@ -521,13 +521,12 @@ func createDecisions(
 		"account_id": "{account_id_approve}"
 	}`)
 	approveMissingFieldInPayloadDecision := createAndTestDecision(ctx, t, transactionPayloadJson,
-		table, decisionUsecase, organizationId, scenarioId, 1)
+		table, decisionUsecase, organizationId, scenarioId, 11)
 	assert.Equal(t, models.Approve, approveMissingFieldInPayloadDecision.Outcome,
 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
 	if assert.NotEmpty(t, approveMissingFieldInPayloadDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveMissingFieldInPayloadDecision.RuleExecutions, "Check on account name")
-		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
-			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+		assert.Nil(t, ruleExecution.Error, "Expected error to be nil, got \"%s\"", ruleExecution.Error)
 	}
 
 	// Create a decision [APPROVE] with a division by zero

--- a/models/ast/ast_node_evaluation.go
+++ b/models/ast/ast_node_evaluation.go
@@ -32,6 +32,10 @@ func (root NodeEvaluation) FlattenErrors() []error {
 }
 
 func (root NodeEvaluation) GetBoolReturnValue() (bool, error) {
+	if root.ReturnValue == nil {
+		return false, ErrNullFieldRead
+	}
+
 	if returnValue, ok := root.ReturnValue.(bool); ok {
 		return returnValue, nil
 	}

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -56,7 +56,7 @@ func (repo *IngestedDataReadRepositoryImpl) GetDbField(ctx context.Context, exec
 	var output any
 	err = row.Scan(&output)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("no rows scanned while reading DB: %w", ast.ErrNoRowsRead)
+		return nil, nil
 	} else if err != nil {
 		return nil, err
 	}

--- a/usecases/ast_eval/evaluate/eval_comparaison.go
+++ b/usecases/ast_eval/evaluate/eval_comparaison.go
@@ -25,6 +25,9 @@ func (f Comparison) Evaluate(ctx context.Context, arguments ast.Arguments) (any,
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	leftFloat, rightFloat, errs := adaptLeftAndRight(leftAny, rightAny, promoteArgumentToFloat64)
 	if len(errs) == 0 {

--- a/usecases/ast_eval/evaluate/eval_comparaison_test.go
+++ b/usecases/ast_eval/evaluate/eval_comparaison_test.go
@@ -121,7 +121,13 @@ func TestComparison_wrongnumber_of_argument(t *testing.T) {
 }
 
 func TestComparison_required(t *testing.T) {
-	_, errs := NewComparison(ast.FUNC_ADD).Evaluate(context.TODO(), ast.Arguments{Args: []any{4, nil}})
+	_, errs := NewComparison(ast.FUNC_ADD).Evaluate(context.TODO(), ast.Arguments{Args: []any{4, "5"}})
 	assert.Equal(t, len(errs), 1)
 	assert.ErrorIs(t, errs[0], ast.ErrArgumentMustBeIntFloatOrTime)
+}
+
+func TestComparison_with_null(t *testing.T) {
+	out, errs := NewComparison(ast.FUNC_ADD).Evaluate(context.TODO(), ast.Arguments{Args: []any{4, nil}})
+	assert.Equal(t, len(errs), 0)
+	assert.Equal(t, out, nil)
 }

--- a/usecases/ast_eval/evaluate/eval_contains_any.go
+++ b/usecases/ast_eval/evaluate/eval_contains_any.go
@@ -25,6 +25,10 @@ func (f ContainsAny) Evaluate(ctx context.Context, arguments ast.Arguments) (any
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
+
 	left, err := adaptArgumentToString(leftAny)
 	if err != nil {
 		return MakeEvaluateError(err)

--- a/usecases/ast_eval/evaluate/eval_equal.go
+++ b/usecases/ast_eval/evaluate/eval_equal.go
@@ -17,6 +17,9 @@ func (f Equal) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []er
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	if left, right, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToString); len(errs) == 0 {
 		return MakeEvaluateResult(left == right)

--- a/usecases/ast_eval/evaluate/eval_fuzzy_match.go
+++ b/usecases/ast_eval/evaluate/eval_fuzzy_match.go
@@ -21,6 +21,9 @@ func (fuzzyMatcher FuzzyMatch) Evaluate(ctx context.Context, arguments ast.Argum
 	if err != nil {
 		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function FuzzyMatch"))
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	left, errLeft := adaptArgumentToString(leftAny)
 	right, errRight := adaptArgumentToString(rightAny)

--- a/usecases/ast_eval/evaluate/eval_not.go
+++ b/usecases/ast_eval/evaluate/eval_not.go
@@ -12,6 +12,9 @@ func (f Not) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []erro
 	if err := verifyNumberOfArguments(arguments.Args, 1); err != nil {
 		return MakeEvaluateError(err)
 	}
+	if arguments.Args[0] == nil {
+		return nil, nil
+	}
 
 	v, err := adaptArgumentToBool(arguments.Args[0])
 	errs := MakeAdaptedArgsErrors([]error{err})

--- a/usecases/ast_eval/evaluate/eval_not_equal.go
+++ b/usecases/ast_eval/evaluate/eval_not_equal.go
@@ -16,6 +16,9 @@ func (f NotEqual) Evaluate(ctx context.Context, arguments ast.Arguments) (any, [
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	if left, right, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToString); len(errs) == 0 {
 		return MakeEvaluateResult(left != right)

--- a/usecases/ast_eval/evaluate/eval_string_contains.go
+++ b/usecases/ast_eval/evaluate/eval_string_contains.go
@@ -25,6 +25,9 @@ func (f StringContains) Evaluate(ctx context.Context, arguments ast.Arguments) (
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	left, right, errs := adaptLeftAndRight(leftAny, rightAny, adaptArgumentToString)
 

--- a/usecases/ast_eval/evaluate/eval_string_in_list.go
+++ b/usecases/ast_eval/evaluate/eval_string_in_list.go
@@ -25,6 +25,9 @@ func (f StringInList) Evaluate(ctx context.Context, arguments ast.Arguments) (an
 	if err != nil {
 		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function StringInList"))
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	left, errLeft := adaptArgumentToString(leftAny)
 	right, errRight := adaptArgumentToListOfStrings(rightAny)

--- a/usecases/ast_eval/evaluate/evaluate_aggregator.go
+++ b/usecases/ast_eval/evaluate/evaluate_aggregator.go
@@ -82,6 +82,10 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 					ast.NewNamedArgumentError("filters"),
 				))
 			}
+			// At the first nil filter value found, stop and just return the default value for the aggregator
+			if filter.Value == nil {
+				return a.defaultValueForAggregator(aggregator)
+			}
 		}
 	}
 
@@ -123,8 +127,7 @@ func (a AggregatorEvaluator) defaultValueForAggregator(aggregator ast.Aggregator
 	case ast.AGGREGATOR_COUNT, ast.AGGREGATOR_COUNT_DISTINCT:
 		return 0, nil
 	case ast.AGGREGATOR_AVG, ast.AGGREGATOR_MAX, ast.AGGREGATOR_MIN:
-		return MakeEvaluateError(errors.Wrap(ast.ErrNullFieldRead,
-			fmt.Sprintf("aggregation %s returned null", aggregator)))
+		return nil, nil
 	default:
 		return MakeEvaluateError(errors.Wrap(ast.ErrRuntimeExpression,
 			fmt.Sprintf("aggregation %s not supported", aggregator)))

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic.go
@@ -24,6 +24,9 @@ func (f Arithmetic) Evaluate(ctx context.Context, arguments ast.Arguments) (any,
 	if err != nil {
 		return MakeEvaluateError(err)
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	// try to promote to int64
 	if left, right, errs := adaptLeftAndRight(leftAny, rightAny, promoteArgumentToInt64); len(errs) == 0 {

--- a/usecases/ast_eval/evaluate/evaluate_arithmetic_divide.go
+++ b/usecases/ast_eval/evaluate/evaluate_arithmetic_divide.go
@@ -15,6 +15,9 @@ func (f ArithmeticDivide) Evaluate(ctx context.Context, arguments ast.Arguments)
 	if err != nil {
 		return MakeEvaluateError(errors.Wrap(err, "Error in Evaluate function Divide"))
 	}
+	if leftAny == nil || rightAny == nil {
+		return nil, nil
+	}
 
 	// promote to float64
 	left, right, errs := adaptLeftAndRight(leftAny, rightAny, promoteArgumentToFloat64)

--- a/usecases/ast_eval/evaluate/evaluate_boolean_arithmetic_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_boolean_arithmetic_test.go
@@ -47,3 +47,107 @@ func TestBooleanArithmetic_zero_operator(t *testing.T) {
 		assert.ErrorIs(t, errs[0], ast.ErrWrongNumberOfArgument)
 	}
 }
+
+func TestBooleanArithmeticEvalOr(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		err      error
+	}{
+		{
+			name:     "all false",
+			args:     []any{false, false, false},
+			expected: false,
+			err:      nil,
+		},
+		{
+			name:     "one true",
+			args:     []any{false, true, false},
+			expected: true,
+			err:      nil,
+		},
+		{
+			name:     "all true",
+			args:     []any{true, true, true},
+			expected: true,
+			err:      nil,
+		},
+		{
+			name:     "contains nil",
+			args:     []any{false, nil, false},
+			expected: nil,
+			err:      nil,
+		},
+		{
+			name:     "non-boolean argument",
+			args:     []any{false, "string", false},
+			expected: nil,
+			err:      ast.ErrArgumentMustBeBool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := booleanArithmeticEvalOr(tt.args)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBooleanArithmeticEvalAnd(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected any
+		err      error
+	}{
+		{
+			name:     "all true",
+			args:     []any{true, true, true},
+			expected: true,
+			err:      nil,
+		},
+		{
+			name:     "one false",
+			args:     []any{true, false, true},
+			expected: false,
+			err:      nil,
+		},
+		{
+			name:     "all false",
+			args:     []any{false, false, false},
+			expected: false,
+			err:      nil,
+		},
+		{
+			name:     "contains nil",
+			args:     []any{true, nil, true},
+			expected: nil,
+			err:      nil,
+		},
+		{
+			name:     "non-boolean argument",
+			args:     []any{true, "string", true},
+			expected: nil,
+			err:      ast.ErrArgumentMustBeBool,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := booleanArithmeticEvalAnd(tt.args)
+			if tt.err != nil {
+				assert.ErrorIs(t, err, tt.err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -48,19 +48,14 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 	}
 
 	fieldValue, err := d.getDbField(ctx, tableName, fieldName, pathStringArr)
-	if err != nil {
+	if errors.Is(err, ast.ErrNullFieldRead) {
+		return nil, nil
+	} else if err != nil {
 		errorMsg := fmt.Sprintf("Error reading value in DatabaseAccess: tableName %s, fieldName %s, path %v", tableName, fieldName, path)
 		return MakeEvaluateError(errors.Join(
 			errors.Wrap(ast.ErrDatabaseAccessNotFound, errorMsg),
 			err,
 		))
-	}
-
-	if fieldValue == nil {
-		errorMsg := fmt.Sprintf("tableName: %s, fieldName: %s, path: %v", tableName, fieldName, path)
-		objectId, _ := d.getDbField(ctx, tableName, "object_id", pathStringArr)
-		return MakeEvaluateError(errors.Wrap(ast.ErrNullFieldRead,
-			fmt.Sprintf("value is null for object_id %s, in %s", objectId, errorMsg)))
 	}
 
 	fieldValueStr, ok := fieldValue.(string)

--- a/usecases/ast_eval/evaluate/evaluate_read_payload.go
+++ b/usecases/ast_eval/evaluate/evaluate_read_payload.go
@@ -2,9 +2,6 @@ package evaluate
 
 import (
 	"context"
-	"fmt"
-
-	"github.com/cockroachdb/errors"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
@@ -29,16 +26,7 @@ func (p Payload) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []
 		return nil, MakeAdaptedArgsErrors([]error{err})
 	}
 
-	value, ok := p.ClientObject.Data[payloadFieldName]
-	if !ok {
-		return MakeEvaluateError(errors.Wrap(ast.ErrPayloadFieldNotFound,
-			fmt.Sprintf("payload var does not exist: %s", payloadFieldName)))
-	}
-
-	if value == nil {
-		return MakeEvaluateError(errors.Wrap(ast.ErrNullFieldRead,
-			fmt.Sprintf("value is null in payload field '%s'", payloadFieldName)))
-	}
+	value := p.ClientObject.Data[payloadFieldName]
 
 	valueStr, ok := value.(string)
 	if ok {

--- a/usecases/ast_eval/evaluate/evaluate_time.go
+++ b/usecases/ast_eval/evaluate/evaluate_time.go
@@ -32,6 +32,9 @@ func (f TimeFunctions) Evaluate(ctx context.Context, arguments ast.Arguments) (a
 		if err := verifyNumberOfArguments(arguments.Args, 1); err != nil {
 			return MakeEvaluateError(err)
 		}
+		if arguments.Args[0] == nil {
+			return nil, nil
+		}
 
 		timeString, err := adaptArgumentToString(arguments.Args[0])
 		if err != nil {

--- a/usecases/ast_eval/evaluate/evaluate_time_arithmetic.go
+++ b/usecases/ast_eval/evaluate/evaluate_time_arithmetic.go
@@ -27,6 +27,10 @@ func NewTimeArithmetic(f ast.Function) TimeArithmetic {
 func (f TimeArithmetic) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
 	switch f.Function {
 	case ast.FUNC_TIME_ADD:
+		if val, ok := arguments.NamedArgs["timestampField"]; ok && val == nil {
+			return nil, nil
+		}
+
 		time, timeErr := AdaptNamedArgument(arguments.NamedArgs, "timestampField", adaptArgumentToTime)
 		duration, durationErr := AdaptNamedArgument(arguments.NamedArgs, "duration", adaptArgumentToDuration)
 		sign, signErr := AdaptNamedArgument(arguments.NamedArgs, "sign", adaptArgumentToString)

--- a/usecases/ast_eval/evaluate/evaluate_time_arithmetic_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_time_arithmetic_test.go
@@ -101,6 +101,20 @@ func TestTimeArithmetic_missing_timestampField(t *testing.T) {
 	}
 }
 
+func TestTimeArithmetic_nil_timestampField(t *testing.T) {
+	arguments := ast.Arguments{
+		NamedArgs: map[string]any{
+			"timestampField": nil,
+			"duration":       "PT1H",
+			"sign":           "+",
+		},
+	}
+
+	result, errs := timeArithmetic.Evaluate(context.TODO(), arguments)
+	assert.Empty(t, errs)
+	assert.Nil(t, result)
+}
+
 func TestTimeArithmetic_missing_duration(t *testing.T) {
 	arguments := ast.Arguments{
 		NamedArgs: map[string]any{


### PR DESCRIPTION


## Behavior
- null values "bubble up" the AST of rule execution
- basically any operator that gets a nil value in one of its expected children, returns nil to its parent
- by exception, a series of `OR` (resp `AND`) returns `true` (resp. `false`) if it is "the obvious thing to return" (`true OR NULL = true`... see code)
- `isEmpty` operator coming soon in another PR
- a rule returns a `models.ErrNullFieldRead` error if a null value reaches the "top" of the AST

> ⚠️  An aggregation operator now returns nil if at least one filter value is nil, where it previously returned an error. As a consequence, depending on the other conditions in OR above, a rule may now return a hit where it returned an error previously. This is technically a breaking change but seems closer to what people should expect.

--- 

Paired with https://github.com/checkmarble/marble-frontend/pull/595


