### PR TITLE
implement isEmpty, isNotEmpty operators

### DIFF
--- a/dto/func_attributes_dto.go
+++ b/dto/func_attributes_dto.go
@@ -5,15 +5,13 @@ import (
 )
 
 type FuncAttributesDto struct {
-	Name              string   `json:"name"`
-	NumberOfArguments int      `json:"number_of_arguments,omitempty"`
-	NamedArguments    []string `json:"named_arguments,omitempty"`
+	Name           string   `json:"name"`
+	NamedArguments []string `json:"named_arguments,omitempty"`
 }
 
 func AdaptFuncAttributesDto(attributes ast.FuncAttributes) FuncAttributesDto {
 	return FuncAttributesDto{
-		Name:              attributes.AstName,
-		NumberOfArguments: attributes.NumberOfArguments,
-		NamedArguments:    attributes.NamedArguments,
+		Name:           attributes.AstName,
+		NamedArguments: attributes.NamedArguments,
 	}
 }

--- a/models/ast/ast_aggregator.go
+++ b/models/ast/ast_aggregator.go
@@ -13,8 +13,7 @@ const (
 )
 
 var FuncAggregatorAttributes = FuncAttributes{
-	DebugName:         "FUNC_AGGREGATOR",
-	AstName:           "Aggregator",
-	NumberOfArguments: 4,
-	NamedArguments:    []string{"tableName", "fieldName", "aggregator", "filters", "label"},
+	DebugName:      "FUNC_AGGREGATOR",
+	AstName:        "Aggregator",
+	NamedArguments: []string{"tableName", "fieldName", "aggregator", "filters", "label"},
 }

--- a/models/ast/ast_filter.go
+++ b/models/ast/ast_filter.go
@@ -22,9 +22,8 @@ type Filter struct {
 }
 
 var FuncFilterAttributes = FuncAttributes{
-	DebugName:         "FUNC_FILTER",
-	AstName:           "Filter",
-	NumberOfArguments: 4,
+	DebugName: "FUNC_FILTER",
+	AstName:   "Filter",
 	NamedArguments: []string{
 		"tableName",
 		"fieldName",

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -59,15 +59,16 @@ const (
 	FUNC_FILTER
 	FUNC_FUZZY_MATCH
 	FUNC_FUZZY_MATCH_ANY_OF
+	FUNC_IS_EMPTY
+	FUNC_IS_NOT_EMPTY
 	FUNC_UNDEFINED Function = -1
 	FUNC_UNKNOWN   Function = -2
 )
 
 type FuncAttributes struct {
-	DebugName         string
-	AstName           string
-	NumberOfArguments int
-	NamedArguments    []string
+	DebugName      string
+	AstName        string
+	NamedArguments []string
 }
 
 // If number of arguments -1 the function can take any number of arguments
@@ -81,122 +82,99 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 		AstName:   "",
 	},
 	FUNC_ADD: {
-		DebugName:         "FUNC_ADD",
-		AstName:           "+",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_ADD",
+		AstName:   "+",
 	},
 	FUNC_SUBTRACT: {
-		DebugName:         "FUNC_SUBTRACT",
-		AstName:           "-",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_SUBTRACT",
+		AstName:   "-",
 	},
 	FUNC_MULTIPLY: {
-		DebugName:         "FUNC_MULTIPLY",
-		AstName:           "*",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_MULTIPLY",
+		AstName:   "*",
 	},
 	FUNC_DIVIDE: {
-		DebugName:         "FUNC_DIVIDE",
-		AstName:           "/",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_DIVIDE",
+		AstName:   "/",
 	},
 	FUNC_GREATER: {
-		DebugName:         "FUNC_GREATER",
-		AstName:           ">",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_GREATER",
+		AstName:   ">",
 	},
 	FUNC_GREATER_OR_EQUAL: {
-		DebugName:         "FUNC_GREATER_OR_EQUAL",
-		AstName:           ">=",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_GREATER_OR_EQUAL",
+		AstName:   ">=",
 	},
 	FUNC_LESS: {
-		DebugName:         "FUNC_LESS",
-		AstName:           "<",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_LESS",
+		AstName:   "<",
 	},
 	FUNC_LESS_OR_EQUAL: {
-		DebugName:         "FUNC_LESS_OR_EQUAL",
-		AstName:           "<=",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_LESS_OR_EQUAL",
+		AstName:   "<=",
 	},
 	FUNC_EQUAL: {
-		DebugName:         "FUNC_EQUAL",
-		AstName:           "=",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_EQUAL",
+		AstName:   "=",
 	},
 	FUNC_NOT_EQUAL: {
-		DebugName:         "FUNC_NOT_EQUAL",
-		AstName:           "≠",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_NOT_EQUAL",
+		AstName:   "≠",
 	},
 	FUNC_NOT: {
-		DebugName:         "FUNC_NOT",
-		AstName:           "Not",
-		NumberOfArguments: 1,
+		DebugName: "FUNC_NOT",
+		AstName:   "Not",
 	},
 	FUNC_AND: {
-		DebugName:         "FUNC_AND",
-		AstName:           "And",
-		NumberOfArguments: -1,
+		DebugName: "FUNC_AND",
+		AstName:   "And",
 	},
 	FUNC_OR: {
-		DebugName:         "FUNC_OR",
-		AstName:           "Or",
-		NumberOfArguments: -1,
+		DebugName: "FUNC_OR",
+		AstName:   "Or",
 	},
 	FUNC_TIME_ADD: {
-		DebugName:         "FUNC_TIME_ADD",
-		AstName:           "TimeAdd",
-		NumberOfArguments: 3,
-		NamedArguments:    []string{"timestampField", "duration", "sign"},
+		DebugName:      "FUNC_TIME_ADD",
+		AstName:        "TimeAdd",
+		NamedArguments: []string{"timestampField", "duration", "sign"},
 	},
 	FUNC_TIME_NOW: {
-		DebugName:         "FUNC_TIME_NOW",
-		AstName:           "TimeNow",
-		NumberOfArguments: 0,
+		DebugName: "FUNC_TIME_NOW",
+		AstName:   "TimeNow",
 	},
 	FUNC_PARSE_TIME: {
-		DebugName:         "FUNC_PARSE_TIME",
-		AstName:           "ParseTime",
-		NumberOfArguments: 1,
+		DebugName: "FUNC_PARSE_TIME",
+		AstName:   "ParseTime",
 	},
 	FUNC_PAYLOAD: {
-		DebugName:         "FUNC_PAYLOAD",
-		AstName:           "Payload",
-		NumberOfArguments: 1,
+		DebugName: "FUNC_PAYLOAD",
+		AstName:   "Payload",
 	},
 	FUNC_DB_ACCESS:          AttributeFuncDbAccess.FuncAttributes,
 	FUNC_CUSTOM_LIST_ACCESS: AttributeFuncCustomListAccess.FuncAttributes,
 	FUNC_IS_IN_LIST: {
-		DebugName:         "FUNC_IS_IN_LIST",
-		AstName:           "IsInList",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_IS_IN_LIST",
+		AstName:   "IsInList",
 	},
 	FUNC_IS_NOT_IN_LIST: {
-		DebugName:         "FUNC_IS_NOT_IN_LIST",
-		AstName:           "IsNotInList",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_IS_NOT_IN_LIST",
+		AstName:   "IsNotInList",
 	},
 	FUNC_STRING_CONTAINS: {
-		DebugName:         "FUNC_STRING_CONTAINS",
-		AstName:           "StringContains",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_STRING_CONTAINS",
+		AstName:   "StringContains",
 	},
 	FUNC_STRING_NOT_CONTAIN: {
-		DebugName:         "FUNC_STRING_NOT_CONTAIN",
-		AstName:           "StringNotContain",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_STRING_NOT_CONTAIN",
+		AstName:   "StringNotContain",
 	},
 	FUNC_CONTAINS_ANY: {
-		DebugName:         "FUNC_CONTAINS_ANY",
-		AstName:           "ContainsAnyOf",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_CONTAINS_ANY",
+		AstName:   "ContainsAnyOf",
 	},
 	FUNC_CONTAINS_NONE: {
-		DebugName:         "FUNC_CONTAINS_NONE",
-		AstName:           "ContainsNoneOf",
-		NumberOfArguments: 2,
+		DebugName: "FUNC_CONTAINS_NONE",
+		AstName:   "ContainsNoneOf",
 	},
 	FUNC_AGGREGATOR: FuncAggregatorAttributes,
 	FUNC_LIST: {
@@ -204,16 +182,22 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 		AstName:   "List",
 	},
 	FUNC_FUZZY_MATCH: {
-		DebugName:         "FUNC_FUZZY_MATCH",
-		AstName:           "FuzzyMatch",
-		NumberOfArguments: 2,
-		NamedArguments:    []string{"algorithm"},
+		DebugName:      "FUNC_FUZZY_MATCH",
+		AstName:        "FuzzyMatch",
+		NamedArguments: []string{"algorithm"},
 	},
 	FUNC_FUZZY_MATCH_ANY_OF: {
-		DebugName:         "FUNC_FUZZY_MATCH_ANY_OF",
-		AstName:           "FuzzyMatchAnyOf",
-		NumberOfArguments: 2,
-		NamedArguments:    []string{"algorithm"},
+		DebugName:      "FUNC_FUZZY_MATCH_ANY_OF",
+		AstName:        "FuzzyMatchAnyOf",
+		NamedArguments: []string{"algorithm"},
+	},
+	FUNC_IS_EMPTY: {
+		DebugName: "FUNC_IS_EMPTY",
+		AstName:   "IsEmpty",
+	},
+	FUNC_IS_NOT_EMPTY: {
+		DebugName: "FUNC_IS_NOT_EMPTY",
+		AstName:   "IsNotEmpty",
 	},
 	FUNC_FILTER: FuncFilterAttributes,
 }

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -25,6 +25,8 @@ var FuncOperators = []Function{
 	FUNC_STRING_NOT_CONTAIN,
 	FUNC_CONTAINS_ANY,
 	FUNC_CONTAINS_NONE,
+	FUNC_IS_EMPTY,
+	FUNC_IS_NOT_EMPTY,
 }
 
 const (

--- a/models/scheduled_scenario_execution_test.go
+++ b/models/scheduled_scenario_execution_test.go
@@ -70,6 +70,15 @@ func TestFilterToSql(t *testing.T) {
 			expected: "? < (? / NULLIF(\"schema\".\"table\".\"num\", 0))",
 			args:     []any{float64(1), float64(3)},
 		},
+		{
+			name: "is empty check",
+			filter: Filter{
+				LeftSql:  "left",
+				Operator: ast.FUNC_IS_EMPTY,
+			},
+			expected: "(left IS NULL OR left = '')",
+			args:     nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -198,6 +198,10 @@ func (f Filter) ToSql() (sql string, args []any) {
 		sql = fmt.Sprintf("%s ILIKE CONCAT('%%',%s::text,'%%')", left, right)
 	} else if isInListComparison(f.Operator) {
 		sql = fmt.Sprintf("%s = ANY(%s)", left, right)
+	} else if f.Operator == ast.FUNC_IS_EMPTY {
+		sql = fmt.Sprintf("(%s IS NULL OR %s = '')", left, left)
+	} else if f.Operator == ast.FUNC_IS_NOT_EMPTY {
+		sql = fmt.Sprintf("(%s IS NOT NULL AND %s != '')", left, left)
 	}
 
 	return sql, args

--- a/usecases/ast_eval/evaluate/eval_is_empty.go
+++ b/usecases/ast_eval/evaluate/eval_is_empty.go
@@ -1,0 +1,33 @@
+package evaluate
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+type IsEmpty struct{}
+
+func (f IsEmpty) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
+	if err := verifyNumberOfArguments(arguments.Args, 1); err != nil {
+		return MakeEvaluateError(err)
+	}
+	if arguments.Args[0] == nil || arguments.Args[0] == "" {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+type IsNotEmpty struct{}
+
+func (f IsNotEmpty) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
+	if err := verifyNumberOfArguments(arguments.Args, 1); err != nil {
+		return MakeEvaluateError(err)
+	}
+	if arguments.Args[0] == nil || arguments.Args[0] == "" {
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/usecases/ast_eval/evaluate/eval_is_empty_test.go
+++ b/usecases/ast_eval/evaluate/eval_is_empty_test.go
@@ -1,0 +1,101 @@
+package evaluate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsEmpty_Evaluate(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments ast.Arguments
+		expected  any
+	}{
+		{
+			name: "Argument is nil",
+			arguments: ast.Arguments{
+				Args: []any{nil},
+			},
+			expected: true,
+		},
+		{
+			name: "Argument is empty string",
+			arguments: ast.Arguments{
+				Args: []any{""},
+			},
+			expected: true,
+		},
+		{
+			name: "Argument is non-empty string",
+			arguments: ast.Arguments{
+				Args: []any{"non-empty"},
+			},
+			expected: false,
+		},
+		{
+			name: "Argument is non-empty integer",
+			arguments: ast.Arguments{
+				Args: []any{123},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isEmpty := IsEmpty{}
+			result, err := isEmpty.Evaluate(context.Background(), tt.arguments)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsNotEmpty_Evaluate(t *testing.T) {
+	tests := []struct {
+		name      string
+		arguments ast.Arguments
+		expected  any
+	}{
+		{
+			name: "Argument is nil",
+			arguments: ast.Arguments{
+				Args: []any{nil},
+			},
+			expected: false,
+		},
+		{
+			name: "Argument is empty string",
+			arguments: ast.Arguments{
+				Args: []any{""},
+			},
+			expected: false,
+		},
+		{
+			name: "Argument is non-empty string",
+			arguments: ast.Arguments{
+				Args: []any{"non-empty"},
+			},
+			expected: true,
+		},
+		{
+			name: "Argument is non-empty integer",
+			arguments: ast.Arguments{
+				Args: []any{123},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isNotEmpty := IsNotEmpty{}
+			result, err := isNotEmpty.Evaluate(context.Background(), tt.arguments)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -67,5 +67,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_LIST, evaluate.List{})
 	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH, evaluate.FuzzyMatch{})
 	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH_ANY_OF, evaluate.FuzzyMatchAnyOf{})
+	environment.AddEvaluator(ast.FUNC_IS_EMPTY, evaluate.IsEmpty{})
+	environment.AddEvaluator(ast.FUNC_IS_NOT_EMPTY, evaluate.IsNotEmpty{})
 	return environment
 }

--- a/usecases/scheduled_execution/batch_filtering.go
+++ b/usecases/scheduled_execution/batch_filtering.go
@@ -50,9 +50,12 @@ func filterFromComparisonNode(node ast.Node, table models.TableIdentifier, depth
 		return models.Filter{}, false
 	}
 
-	rightVal := comparisonValueFromNode(node.Children[1], table, depth)
-	if !rightVal.valid {
-		return models.Filter{}, false
+	var rightVal parsedFilterValue
+	if len(node.Children) == 2 {
+		rightVal = comparisonValueFromNode(node.Children[1], table, depth)
+		if !rightVal.valid {
+			return models.Filter{}, false
+		}
 	}
 
 	return models.Filter{
@@ -173,6 +176,8 @@ func canBeNestedNode(node ast.Node) bool {
 			ast.FUNC_ADD,
 			ast.FUNC_MULTIPLY,
 			ast.FUNC_DIVIDE,
+			ast.FUNC_IS_EMPTY,
+			ast.FUNC_IS_NOT_EMPTY,
 		},
 		node.Function)
 }

--- a/usecases/scheduled_execution/batch_filtering_test.go
+++ b/usecases/scheduled_execution/batch_filtering_test.go
@@ -164,6 +164,21 @@ func TestFilterFromComparisonNode(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "is empty check",
+			ruleJson: `
+			{
+				"name": "IsEmpty",
+				"children": [
+					{ "name": "Payload", "children": [{ "constant": "after_migration" }] }
+				]
+			}`,
+			valid: true,
+			expected: models.Filter{
+				LeftSql:  "\"schema\".\"table\".\"after_migration\"",
+				Operator: ast.FUNC_IS_EMPTY,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Goes with PR https://github.com/checkmarble/marble-frontend/pull/602 on the frontend.
Implements the IsEmpty and IsNotEmpty operators, but only on the main AST (not for aggregator filters).
The operator returns true if the value is NULL or empty string, else false.

Also remove the unused and badly defined `NumberOfArguments` property of FuncAttributes (previously returned by the API used by the front for the list of operators). The source of truth for this is in the implementation of `Evaluate` for each function in `ast_eval`.

Tested on unit decisions with API, also tested that the batch run still works with isEmpty operators in the trigger condition (to test the SQL pre-filter)

Nb: the same filter for aggregates has voluntarily not been implemented now (mostly because I think it's less urgent and it's also just late for today)