### PR TITLE
fix permissions: create transfercheck user

### DIFF
--- a/models/role.go
+++ b/models/role.go
@@ -25,6 +25,13 @@ func GetValidUserRoles() []Role {
 		PUBLISHER,
 		ADMIN,
 		MARBLE_ADMIN,
+		TRANSFER_CHECK_USER,
+	}
+}
+
+func GetValidTransfercheckUserRoles() []Role {
+	return []Role{
+		TRANSFER_CHECK_USER,
 	}
 }
 

--- a/usecases/security/enforce_security_user.go
+++ b/usecases/security/enforce_security_user.go
@@ -37,6 +37,13 @@ func (e *EnforceSecurityUserImpl) CreateUser(input models.CreateUser) error {
 		)
 	}
 
+	if input.Role == models.TRANSFER_CHECK_USER && e.Credentials.Role != models.MARBLE_ADMIN {
+		return errors.Wrap(
+			models.ForbiddenError,
+			"only marble admins can create transfer check users",
+		)
+	}
+
 	// should already be handled by the fact that only the ADMIN & MARBLE_ADMIN roles have the
 	// MARBLE_USER_CREATE permission, but make double sure
 	if input.Role == models.ADMIN &&
@@ -44,15 +51,6 @@ func (e *EnforceSecurityUserImpl) CreateUser(input models.CreateUser) error {
 		return errors.Wrap(
 			models.ForbiddenError,
 			"only org admins and marble admins can create org admins",
-		)
-	}
-
-	if input.PartnerId != nil && (e.Credentials.Role != models.MARBLE_ADMIN ||
-		e.Credentials.PartnerId == nil ||
-		*e.Credentials.PartnerId != *input.PartnerId) {
-		return errors.Wrap(
-			models.ForbiddenError,
-			"only marble admins can create users with partner_id",
 		)
 	}
 
@@ -70,6 +68,13 @@ func (e *EnforceSecurityUserImpl) UpdateUser(targetUser models.User, updateUser 
 		return errors.Wrap(
 			models.BadParameterError,
 			"only marble admins can create marble admins")
+	}
+
+	if updateUser.Role != nil &&
+		*updateUser.Role == models.TRANSFER_CHECK_USER {
+		return errors.Wrap(
+			models.BadParameterError,
+			"cannot update an existing user to TRANSFER_CHECK_USER")
 	}
 
 	// Only org admins and marble admins can create org admins


### PR DESCRIPTION
Transfercheck user creation was broken in the last refactor of the create user usecase permissions.