### PR TITLE
replace timeout middleware

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -8,21 +8,17 @@ import (
 	"github.com/checkmarble/marble-backend/usecases"
 
 	limits "github.com/gin-contrib/size"
-	"github.com/gin-contrib/timeout"
 	"github.com/gin-gonic/gin"
+	timeout "github.com/vearne/gin-timeout"
 )
 
 const maxCaseFileSize = 30 * 1024 * 1024 // 30MB
 
 func timeoutMiddleware(duration time.Duration) gin.HandlerFunc {
-	return timeout.New(
+	return timeout.Timeout(
 		timeout.WithTimeout(duration),
-		timeout.WithHandler(func(c *gin.Context) {
-			c.Next()
-		}),
-		timeout.WithResponse(func(c *gin.Context) {
-			c.String(http.StatusRequestTimeout, "timeout")
-		}),
+		timeout.WithErrorHttpCode(http.StatusRequestTimeout),
+		timeout.WithDefaultMsg("Request timeout"),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/getsentry/sentry-go v0.28.1
 	github.com/gin-contrib/cors v1.7.2
 	github.com/gin-contrib/size v1.0.1
-	github.com/gin-contrib/timeout v1.0.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/golang-jwt/jwt/v4 v4.5.1
 	github.com/google/uuid v1.6.0
@@ -35,6 +34,7 @@ require (
 	github.com/segmentio/analytics-go/v3 v3.3.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.18.0
+	github.com/vearne/gin-timeout v0.2.0
 	go.opentelemetry.io/contrib/detectors/gcp v1.27.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.52.0
 	go.opentelemetry.io/otel v1.28.0

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,6 @@ github.com/gin-contrib/size v1.0.1 h1:GreQH9js/8s683t6zeoAzpO936TIUOLg7/FPX+lln2
 github.com/gin-contrib/size v1.0.1/go.mod h1:OdxqPUhQ3lW9y9zB1wR7MjkSDHMbaPJ5PVSMkGgQF1A=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
-github.com/gin-contrib/timeout v1.0.1 h1:OV3uH0MSbWQdy8Q9KdGSze8e2sgShPC8Qxw/3Ct7+Ng=
-github.com/gin-contrib/timeout v1.0.1/go.mod h1:m/IWlsEvNRinlQV/cSDdTGZfKTTe0Guy8YHbhKYylwE=
 github.com/gin-gonic/gin v1.9.1/go.mod h1:hPrL7YrpYKXt5YId3A/Tnip5kqbEAP+KLuI3SUcPTeU=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
@@ -484,6 +482,8 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.52.0 h1:wqBQpxH71XW0e2g+Og4dzQM8pk34aFYlA1Ga8db7gU0=
 github.com/valyala/fasthttp v1.52.0/go.mod h1:hf5C4QnVMkNXMspnsUlfM3WitlgYflyhHYoKol/szxQ=
+github.com/vearne/gin-timeout v0.2.0 h1:KobNPr4YSMtrucHH+3Ce6aE/s99gxMLynu+IktWXeDs=
+github.com/vearne/gin-timeout v0.2.0/go.mod h1:BKCWwia+RoBi1gv+RS4FtVrcM7bVhNkfUg+jTvtHa1A=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=


### PR DESCRIPTION
The TL:DR is that gin-contrib.timeout [uses a goroutine internally](https://github.com/gin-contrib/timeout/blob/master/timeout.go#L49), which can cause weird ass bugs when a request continues to execute things and starts reading a context that is now another requests'.
vearne.gin-timeout avoids this by [starting off by deep-copying the gin context](https://github.com/vearne/gin-timeout/blob/master/timeout.go#L35) before doing anything else. 

---- 

## ask the AI
copilot chat approves:


<img width="709" alt="Capture d’écran 2024-11-25 à 22 23 22" src="https://github.com/user-attachments/assets/e1d808ad-a5b4-4bb1-9328-db17f42b0b60">
<img width="656" alt="Capture d’écran 2024-11-25 à 22 23 34" src="https://github.com/user-attachments/assets/e7bdf828-c980-405f-bfac-e2711e9f86bb">