### PR TITLE
use client-side uuidv7 for ingested objects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ PG_PASSWORD=marble
 PG_SSL_MODE=prefer
 
 # pointing to the file with the configuration for the client dbs
-CLIENT_DB_CONFIG_FILE="/Users/pascal/Documents/marble/marble-backend/client_db_config.json"
+CLIENT_DB_CONFIG_FILE=""
 
 MARBLE_APP_HOST="localhost:3000"
 MARBLE_BACKOFFICE_HOST="localhost:3003"

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -165,7 +165,7 @@ func (repo *IngestionRepositoryImpl) batchInsertPayloads(ctx context.Context, ex
 
 		insertValues := generateInsertValues(payload, columnNames)
 		// Add UUID to the insert values for the "id" field
-		insertValues = append(insertValues, uuid.NewString())
+		insertValues = append(insertValues, uuid.Must(uuid.NewV7()).String())
 		query = query.Values(insertValues...)
 	}
 

--- a/repositories/organization_schema_repository.go
+++ b/repositories/organization_schema_repository.go
@@ -49,7 +49,7 @@ func (repo *OrganizationSchemaRepositoryPostgresql) CreateTable(ctx context.Cont
 
 	sanitizedTableName := pgx.Identifier.Sanitize([]string{exec.DatabaseSchema().Schema, tableName})
 	sql := fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
-		id UUID NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+		id UUID NOT NULL PRIMARY KEY,
 		object_id TEXT NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		valid_from TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
Two goals in one step:
- use uuid v7, which we've seen has better write performance
- don't rely (at the db schema level, even if it's not used in the code in practice) on the uuid extension - it was added on the marble schema, now that I've migrated the clients org to another DB it prevents me from removing the marble schema (unused on that db) because it depends on the extension.