### PR TITLE
introduce stable rule id on rules

### DIFF
--- a/models/rule.go
+++ b/models/rule.go
@@ -22,6 +22,7 @@ type Rule struct {
 	CreatedAt            time.Time
 	RuleGroup            string
 	SnoozeGroupId        *string
+	StableRuleId         *string
 }
 
 type CreateRuleInput struct {
@@ -35,6 +36,7 @@ type CreateRuleInput struct {
 	ScoreModifier        int
 	RuleGroup            string
 	SnoozeGroupId        *string
+	StableRuleId         *string
 }
 
 type UpdateRuleInput struct {
@@ -46,4 +48,5 @@ type UpdateRuleInput struct {
 	ScoreModifier        *int
 	RuleGroup            *string
 	SnoozeGroupId        *string
+	StableRuleId         *string
 }

--- a/repositories/dbmodels/db_rule.go
+++ b/repositories/dbmodels/db_rule.go
@@ -27,6 +27,7 @@ type DBRule struct {
 	DeletedAt            pgtype.Time `db:"deleted_at"`
 	RuleGroup            string      `db:"rule_group"`
 	SnoozeGroupId        *string     `db:"snooze_group_id"`
+	StableRuleId         *string     `db:"stable_rule_id"`
 }
 
 func AdaptRule(db DBRule) (models.Rule, error) {
@@ -47,6 +48,7 @@ func AdaptRule(db DBRule) (models.Rule, error) {
 		CreatedAt:            db.CreatedAt,
 		RuleGroup:            db.RuleGroup,
 		SnoozeGroupId:        db.SnoozeGroupId,
+		StableRuleId:         db.StableRuleId,
 	}, nil
 }
 
@@ -61,6 +63,7 @@ type DBCreateRuleInput struct {
 	FormulaAstExpression *[]byte `db:"formula_ast_expression"`
 	RuleGroup            string  `db:"rule_group"`
 	SnoozeGroupId        *string `db:"snooze_group_id"`
+	StableRuleId         *string `db:"stable_rule_id"`
 }
 
 func AdaptDBCreateRuleInput(rule models.CreateRuleInput) (DBCreateRuleInput, error) {
@@ -80,6 +83,7 @@ func AdaptDBCreateRuleInput(rule models.CreateRuleInput) (DBCreateRuleInput, err
 		FormulaAstExpression: formulaAstExpression,
 		RuleGroup:            rule.RuleGroup,
 		SnoozeGroupId:        rule.SnoozeGroupId,
+		StableRuleId:         rule.StableRuleId,
 	}, nil
 }
 
@@ -92,6 +96,7 @@ type DBUpdateRuleInput struct {
 	FormulaAstExpression *[]byte `db:"formula_ast_expression"`
 	RuleGroup            *string `db:"rule_group"`
 	SnoozeGroupId        *string `db:"snooze_group_id"`
+	StableRuleId         *string `db:"stable_rule_id"`
 }
 
 func AdaptDBUpdateRuleInput(rule models.UpdateRuleInput) (DBUpdateRuleInput, error) {
@@ -109,5 +114,6 @@ func AdaptDBUpdateRuleInput(rule models.UpdateRuleInput) (DBUpdateRuleInput, err
 		FormulaAstExpression: formulaAstExpression,
 		RuleGroup:            rule.RuleGroup,
 		SnoozeGroupId:        rule.SnoozeGroupId,
+		StableRuleId:         rule.StableRuleId,
 	}, nil
 }

--- a/repositories/migrations/20241203135200_scenario_rules_stable_id.sql
+++ b/repositories/migrations/20241203135200_scenario_rules_stable_id.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE scenario_iteration_rules
+ADD COLUMN stable_rule_id uuid;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE scenario_iteration_rules
+DROP COLUMN stable_rule_id;
+
+-- +goose StatementEnd

--- a/repositories/rules.go
+++ b/repositories/rules.go
@@ -8,6 +8,7 @@ import (
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/google/uuid"
 
 	"github.com/Masterminds/squirrel"
 )
@@ -82,6 +83,12 @@ func (repo *MarbleDbRepository) CreateRules(ctx context.Context, exec Executor, 
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return nil, err
 	}
+	for i := range rules {
+		if rules[i].StableRuleId == nil {
+			newId := uuid.NewString()
+			rules[i].StableRuleId = &newId
+		}
+	}
 
 	dbCreateRuleInputs, err := pure_utils.MapErr(rules, dbmodels.AdaptDBCreateRuleInput)
 	if err != nil {
@@ -101,6 +108,7 @@ func (repo *MarbleDbRepository) CreateRules(ctx context.Context, exec Executor, 
 			"score_modifier",
 			"rule_group",
 			"snooze_group_id",
+			"stable_rule_id",
 		).
 		Suffix("RETURNING *")
 
@@ -116,6 +124,7 @@ func (repo *MarbleDbRepository) CreateRules(ctx context.Context, exec Executor, 
 			rule.ScoreModifier,
 			rule.RuleGroup,
 			rule.SnoozeGroupId,
+			rule.StableRuleId,
 		)
 	}
 


### PR DESCRIPTION
## Summary
Introduce a new stable rule id on rules, that identifies a rule throughout its successive versions.
> NB: the "snooze_group_id" that exists on rules already implements some of the properties below, but not all of them and it has its own usage anyway (even if we discussed creating this generic "stable rule id" back when we worked on snoozing this summer).

### Business rules
1. A newly rule acquires a new stable id
2. Existing rules (created prior to the release) don't have one for now, though see point 3 below
3. When a new draft is created from an existing version, new stable ids are generated for the rules in its existing version (and applied on their copies in the new draft)
4. A rule that is cloned takes a new stable id
5. In the future, we may backfill random stable rule ids for all old rules (with the assumption that by then, no one will be going back to those really old rules)