### PR TITLE
update cases & decisions list dto: no more count, return has_next_page

### DIFF
--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 )
@@ -49,22 +48,7 @@ func handleListCases(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		if len(cases) == 0 {
-			c.JSON(http.StatusOK, gin.H{
-				"total_count": dto.AdaptTotalCount(models.TotalCount{}),
-				"start_index": 0,
-				"end_index":   0,
-				"items":       []dto.APICase{},
-			})
-			return
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"total_count": dto.AdaptTotalCount(cases[0].TotalCount),
-			"start_index": cases[0].RankNumber,
-			"end_index":   cases[len(cases)-1].RankNumber,
-			"items":       pure_utils.Map(cases, func(c models.CaseWithRank) dto.APICase { return dto.AdaptCaseDto(c.Case) }),
-		})
+		c.JSON(http.StatusOK, dto.AdaptCaseListPage(cases))
 	}
 }
 

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -14,7 +14,7 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 )
 
-var casesPaginationDefaults = dto.PaginationDefaults{
+var casesPaginationDefaults = models.PaginationDefaults{
 	Limit:  25,
 	SortBy: models.CasesSortingCreatedAt,
 	Order:  models.SortingOrderDesc,
@@ -34,16 +34,16 @@ func handleListCases(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		var paginationAndSorting dto.PaginationAndSortingInput
-		if err := c.ShouldBind(&paginationAndSorting); err != nil {
+		var paginationAndSortingDto dto.PaginationAndSorting
+		if err := c.ShouldBind(&paginationAndSortingDto); err != nil {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		paginationAndSorting = dto.WithPaginationDefaults(paginationAndSorting, casesPaginationDefaults)
+		paginationAndSorting := models.WithPaginationDefaults(
+			dto.AdaptPaginationAndSorting(paginationAndSortingDto), casesPaginationDefaults)
 
 		usecase := usecasesWithCreds(ctx, uc).NewCaseUseCase()
-		cases, err := usecase.ListCases(ctx, organizationId,
-			dto.AdaptPaginationAndSortingInput(paginationAndSorting), filters)
+		cases, err := usecase.ListCases(ctx, organizationId, paginationAndSorting, filters)
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -13,7 +13,7 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 )
 
-var decisionPaginationDefaults = dto.PaginationDefaults{
+var decisionPaginationDefaults = models.PaginationDefaults{
 	Limit:  25,
 	SortBy: models.DecisionSortingCreatedAt,
 	Order:  models.SortingOrderDesc,
@@ -48,20 +48,16 @@ func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin
 			return
 		}
 
-		var paginationAndSorting dto.PaginationAndSortingInput
-		if err := c.ShouldBind(&paginationAndSorting); err != nil {
+		var paginationAndSortingDto dto.PaginationAndSorting
+		if err := c.ShouldBind(&paginationAndSortingDto); err != nil {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		paginationAndSorting = dto.WithPaginationDefaults(paginationAndSorting, decisionPaginationDefaults)
+		paginationAndSorting := models.WithPaginationDefaults(
+			dto.AdaptPaginationAndSorting(paginationAndSortingDto), decisionPaginationDefaults)
 
 		usecase := usecasesWithCreds(ctx, uc).NewDecisionUsecase()
-		decisions, err := usecase.ListDecisions(
-			ctx,
-			organizationId,
-			dto.AdaptPaginationAndSortingInput(paginationAndSorting),
-			filters,
-		)
+		decisions, err := usecase.ListDecisions(ctx, organizationId, paginationAndSorting, filters)
 		if presentError(ctx, c, err) {
 			return
 		}
@@ -85,20 +81,16 @@ func handleListDecisionsInternal(uc usecases.Usecases, marbleAppHost string) fun
 			return
 		}
 
-		var paginationAndSorting dto.PaginationAndSortingInput
-		if err := c.ShouldBind(&paginationAndSorting); err != nil {
+		var paginationAndSortingDto dto.PaginationAndSorting
+		if err := c.ShouldBind(&paginationAndSortingDto); err != nil {
 			c.Status(http.StatusBadRequest)
 			return
 		}
-		paginationAndSorting = dto.WithPaginationDefaults(paginationAndSorting, decisionPaginationDefaults)
+		paginationAndSorting := models.WithPaginationDefaults(
+			dto.AdaptPaginationAndSorting(paginationAndSortingDto), decisionPaginationDefaults)
 
 		usecase := usecasesWithCreds(ctx, uc).NewDecisionUsecase()
-		decisions, err := usecase.ListDecisionsWithIndexes(
-			ctx,
-			organizationId,
-			dto.AdaptPaginationAndSortingInput(paginationAndSorting),
-			filters,
-		)
+		decisions, err := usecase.ListDecisionsWithIndexes(ctx, organizationId, paginationAndSorting, filters)
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -33,6 +33,7 @@ func handleGetDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.C
 	}
 }
 
+// Endpoint used by the public API, that does not return the output decision ranks
 func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -69,6 +70,7 @@ func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin
 	}
 }
 
+// Endpoint used by the internal API to serve the app, that returns the output decision ranks
 func handleListDecisionsInternal(uc usecases.Usecases, marbleAppHost string) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -91,7 +93,7 @@ func handleListDecisionsInternal(uc usecases.Usecases, marbleAppHost string) fun
 		paginationAndSorting = dto.WithPaginationDefaults(paginationAndSorting, decisionPaginationDefaults)
 
 		usecase := usecasesWithCreds(ctx, uc).NewDecisionUsecase()
-		decisions, err := usecase.ListDecisions(
+		decisions, err := usecase.ListDecisionsWithIndexes(
 			ctx,
 			organizationId,
 			dto.AdaptPaginationAndSortingInput(paginationAndSorting),

--- a/api/routes.go
+++ b/api/routes.go
@@ -49,6 +49,7 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 	router.GET("/ast-expression/available-functions", tom, handleAvailableFunctions)
 
 	router.GET("/decisions", timeoutMiddleware(LIST_DECISION_TIMEOUT), handleListDecisions(uc, marbleAppHost))
+	router.GET("/decisions/internal", tom, handleListDecisionsInternal(uc, marbleAppHost))
 	router.POST("/decisions", timeoutMiddleware(models.DECISION_TIMEOUT), handlePostDecision(uc, marbleAppHost))
 	router.POST("/decisions/all",
 		timeoutMiddleware(SEQUENTIAL_DECISION_TIMEOUT),

--- a/api/routes.go
+++ b/api/routes.go
@@ -49,7 +49,7 @@ func addRoutes(r *gin.Engine, auth Authentication, tokenHandler TokenHandler, uc
 	router.GET("/ast-expression/available-functions", tom, handleAvailableFunctions)
 
 	router.GET("/decisions", timeoutMiddleware(LIST_DECISION_TIMEOUT), handleListDecisions(uc, marbleAppHost))
-	router.GET("/decisions/internal", tom, handleListDecisionsInternal(uc, marbleAppHost))
+	router.GET("/decisions/with-ranks", tom, handleListDecisionsInternal(uc, marbleAppHost))
 	router.POST("/decisions", timeoutMiddleware(models.DECISION_TIMEOUT), handlePostDecision(uc, marbleAppHost))
 	router.POST("/decisions/all",
 		timeoutMiddleware(SEQUENTIAL_DECISION_TIMEOUT),

--- a/dto/case_dto.go
+++ b/dto/case_dto.go
@@ -40,6 +40,22 @@ func AdaptCaseDto(c models.Case) APICase {
 	}
 }
 
+type CastListPage struct {
+	Cases       []APICase `json:"cases"`
+	StartIndex  int       `json:"start_index"`
+	EndIndex    int       `json:"end_index"`
+	HasNextPage bool      `json:"has_next_page"`
+}
+
+func AdaptCaseListPage(casesPage models.CaseListPage) CastListPage {
+	return CastListPage{
+		Cases:       pure_utils.Map(casesPage.Cases, AdaptCaseDto),
+		StartIndex:  casesPage.StartIndex,
+		EndIndex:    casesPage.EndIndex,
+		HasNextPage: casesPage.HasNextPage,
+	}
+}
+
 func AdaptCaseWithDecisionsDto(c models.Case) APICaseWithDecisions {
 	return APICaseWithDecisions{
 		APICase: AdaptCaseDto(c),

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -25,6 +25,45 @@ type DecisionFilters struct {
 	TriggerObjects        []string  `form:"trigger_object[]"`
 }
 
+type DecisionListPageWithIndexesDto struct {
+	Items       []Decision `json:"items"`
+	StartIndex  int        `json:"start_index"`
+	EndIndex    int        `json:"end_index"`
+	HasNextPage bool       `json:"has_next_page"`
+}
+
+func AdaptDecisionListPageWithIndexesDto(decisionsPage models.DecisionListPageWithIndexes, marbleAppHost string) DecisionListPageWithIndexesDto {
+	// initialize as a non nil slice, so that it is serialized as an empty array instead of null
+	items := make([]Decision, len(decisionsPage.Decisions))
+	for i, decision := range decisionsPage.Decisions {
+		items[i] = NewDecisionDto(decision, marbleAppHost)
+	}
+
+	return DecisionListPageWithIndexesDto{
+		Items:       items,
+		StartIndex:  decisionsPage.StartIndex,
+		EndIndex:    decisionsPage.EndIndex,
+		HasNextPage: decisionsPage.HasNextPage,
+	}
+}
+
+type DecisionListPageDto struct {
+	Items       []Decision `json:"items"`
+	HasNextPage bool       `json:"has_next_page"`
+}
+
+func AdaptDecisionListPageDto(decisionsPage models.DecisionListPageWithIndexes, marbleAppHost string) DecisionListPageDto {
+	items := make([]Decision, len(decisionsPage.Decisions))
+	for i, decision := range decisionsPage.Decisions {
+		items[i] = NewDecisionDto(decision, marbleAppHost)
+	}
+
+	return DecisionListPageDto{
+		Items:       items,
+		HasNextPage: decisionsPage.HasNextPage,
+	}
+}
+
 type CreateDecisionBody struct {
 	TriggerObject json.RawMessage `json:"trigger_object" binding:"required"`
 	ObjectType    string          `json:"object_type" binding:"required"`

--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -52,7 +52,7 @@ type DecisionListPageDto struct {
 	HasNextPage bool       `json:"has_next_page"`
 }
 
-func AdaptDecisionListPageDto(decisionsPage models.DecisionListPageWithIndexes, marbleAppHost string) DecisionListPageDto {
+func AdaptDecisionListPageDto(decisionsPage models.DecisionListPage, marbleAppHost string) DecisionListPageDto {
 	items := make([]Decision, len(decisionsPage.Decisions))
 	for i, decision := range decisionsPage.Decisions {
 		items[i] = NewDecisionDto(decision, marbleAppHost)

--- a/dto/pagination.go
+++ b/dto/pagination.go
@@ -2,40 +2,18 @@ package dto
 
 import "github.com/checkmarble/marble-backend/models"
 
-type PaginationAndSortingInput struct {
-	OffsetId string              `form:"offset_id"`
-	Sorting  models.SortingField `form:"sorting"`
-	Order    models.SortingOrder `form:"order"`
-	Limit    int                 `form:"limit" binding:"min=1,max=100"`
+type PaginationAndSorting struct {
+	OffsetId string `form:"offset_id"`
+	Sorting  string `form:"sorting"`
+	Order    string `form:"order"`
+	Limit    int    `form:"limit" binding:"min=1,max=100"`
 }
 
-func AdaptPaginationAndSortingInput(input PaginationAndSortingInput) models.PaginationAndSorting {
+func AdaptPaginationAndSorting(input PaginationAndSorting) models.PaginationAndSorting {
 	return models.PaginationAndSorting{
 		OffsetId: input.OffsetId,
-		Sorting:  input.Sorting,
-		Order:    input.Order,
+		Sorting:  models.SortingFieldFrom(input.Sorting),
+		Order:    models.SortingOrderFrom(input.Order),
 		Limit:    input.Limit,
 	}
-}
-
-type PaginationDefaults struct {
-	Limit  int
-	SortBy models.SortingField
-	Order  models.SortingOrder
-}
-
-func WithPaginationDefaults(pagination PaginationAndSortingInput, defaults PaginationDefaults) PaginationAndSortingInput {
-	if pagination.Sorting == "" {
-		pagination.Sorting = defaults.SortBy
-	}
-
-	if pagination.Order == "" {
-		pagination.Order = defaults.Order
-	}
-
-	if pagination.Limit == 0 {
-		pagination.Limit = defaults.Limit
-	}
-
-	return pagination
 }

--- a/dto/pagination.go
+++ b/dto/pagination.go
@@ -4,18 +4,14 @@ import "github.com/checkmarble/marble-backend/models"
 
 type PaginationAndSortingInput struct {
 	OffsetId string              `form:"offset_id"`
-	Previous bool                `form:"previous"`
-	Next     bool                `form:"next"`
 	Sorting  models.SortingField `form:"sorting"`
 	Order    models.SortingOrder `form:"order"`
-	Limit    int                 `form:"limit" binding:"max=100"`
+	Limit    int                 `form:"limit" binding:"min=1,max=100"`
 }
 
 func AdaptPaginationAndSortingInput(input PaginationAndSortingInput) models.PaginationAndSorting {
 	return models.PaginationAndSorting{
 		OffsetId: input.OffsetId,
-		Previous: input.Previous,
-		Next:     input.Next,
 		Sorting:  input.Sorting,
 		Order:    input.Order,
 		Limit:    input.Limit,

--- a/dto/pagination.go
+++ b/dto/pagination.go
@@ -39,15 +39,3 @@ func WithPaginationDefaults(pagination PaginationAndSortingInput, defaults Pagin
 
 	return pagination
 }
-
-type TotalCount struct {
-	Value      int  `json:"value"`
-	IsMaxCount bool `json:"is_max_count"`
-}
-
-func AdaptTotalCount(totalCount models.TotalCount) TotalCount {
-	return TotalCount{
-		Value:      totalCount.Value,
-		IsMaxCount: totalCount.IsMaxCount,
-	}
-}

--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -168,9 +168,9 @@ func createDecisionsBatch(
 	if err != nil {
 		assert.FailNow(t, "Error while listing decisions", err)
 	}
-	assert.Equalf(t, 1, len(decisions), "Expected 1 decision, got %d", len(decisions))
-	assert.Equalf(t, models.Decline, decisions[0].Outcome,
-		"Decision should be in review status, got %s", decisions[0].Outcome)
+	assert.Equalf(t, 1, len(decisions.Decisions), "Expected 1 decision, got %d", len(decisions.Decisions))
+	assert.Equalf(t, models.Decline, decisions.Decisions[0].Outcome,
+		"Decision should be in review status, got %s", decisions.Decisions[0].Outcome)
 }
 
 func getRulesForBatchTest() []models.CreateRuleInput {

--- a/models/case.go
+++ b/models/case.go
@@ -85,9 +85,7 @@ type CaseWithRank struct {
 	RankNumber int
 }
 
-const (
-	CasesSortingCreatedAt SortingField = "created_at"
-)
+const CasesSortingCreatedAt = SortingFieldCreatedAt
 
 func ValidateCaseStatuses(statuses []string) ([]CaseStatus, error) {
 	sanitizedStatuses := make([]CaseStatus, len(statuses))

--- a/models/case.go
+++ b/models/case.go
@@ -73,6 +73,13 @@ type CaseFilters struct {
 	InboxIds       []string
 }
 
+type CaseListPage struct {
+	Cases       []Case
+	StartIndex  int
+	EndIndex    int
+	HasNextPage bool
+}
+
 type CaseWithRank struct {
 	Case
 	RankNumber int

--- a/models/case.go
+++ b/models/case.go
@@ -83,7 +83,6 @@ type CaseListPage struct {
 type CaseWithRank struct {
 	Case
 	RankNumber int
-	TotalCount TotalCount
 }
 
 const (

--- a/models/decision.go
+++ b/models/decision.go
@@ -161,6 +161,18 @@ type DecisionFilters struct {
 	TriggerObjects        []string
 }
 
+type DecisionListPageWithIndexes struct {
+	Decisions   []Decision
+	StartIndex  int
+	EndIndex    int
+	HasNextPage bool
+}
+
+type DecisionListPage struct {
+	Decisions   []Decision
+	HasNextPage bool
+}
+
 const (
 	DecisionSortingCreatedAt SortingField = "created_at"
 )

--- a/models/decision.go
+++ b/models/decision.go
@@ -172,9 +172,7 @@ type DecisionListPage struct {
 	HasNextPage bool
 }
 
-const (
-	DecisionSortingCreatedAt SortingField = "created_at"
-)
+const DecisionSortingCreatedAt SortingField = SortingFieldCreatedAt
 
 type DecisionWorkflowFilters struct {
 	InboxId        string

--- a/models/decision.go
+++ b/models/decision.go
@@ -62,7 +62,6 @@ type DecisionsByVersionByOutcome struct {
 type DecisionWithRank struct {
 	Decision
 	RankNumber int
-	TotalCount TotalCount
 }
 
 type ScenarioExecution struct {

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -4,8 +4,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const COUNT_ROWS_LIMIT = 1000
-
 type PaginationAndSorting struct {
 	OffsetId string
 	Sorting  SortingField

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -37,15 +37,3 @@ func ValidatePagination(pagination PaginationAndSorting) error {
 	}
 	return nil
 }
-
-func ReverseOrder(order SortingOrder) SortingOrder {
-	if order == "DESC" {
-		return "ASC"
-	}
-	return "DESC"
-}
-
-type TotalCount struct {
-	Value      int
-	IsMaxCount bool
-}

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -7,8 +7,6 @@ type PaginationAndSorting struct {
 	Sorting  SortingField
 	Order    SortingOrder
 	Limit    int
-	Previous bool
-	Next     bool
 }
 
 func NewDefaultPaginationAndSorting(sortColumnName string) PaginationAndSorting {
@@ -31,16 +29,11 @@ const (
 )
 
 func ValidatePagination(pagination PaginationAndSorting) error {
-	if pagination.OffsetId != "" {
-		if pagination.Previous && pagination.Next {
-			return fmt.Errorf("invalid pagination: both previous and next are true: %w", BadParameterError)
-		}
-		if !pagination.Previous && !pagination.Next {
-			return fmt.Errorf("invalid pagination: both previous and next are false: %w", BadParameterError)
-		}
-	}
 	if pagination.Order != SortingOrderAsc && pagination.Order != SortingOrderDesc {
 		return fmt.Errorf("invalid pagination: order must be either ASC or DESC: %w", BadParameterError)
+	}
+	if pagination.Limit <= 0 {
+		return fmt.Errorf("invalid pagination: limit must be greater than 0: %w", BadParameterError)
 	}
 	return nil
 }

--- a/models/pagination_and_sorting.go
+++ b/models/pagination_and_sorting.go
@@ -1,6 +1,10 @@
 package models
 
-import "fmt"
+import (
+	"github.com/cockroachdb/errors"
+)
+
+const COUNT_ROWS_LIMIT = 1000
 
 type PaginationAndSorting struct {
 	OffsetId string
@@ -11,29 +15,101 @@ type PaginationAndSorting struct {
 
 func NewDefaultPaginationAndSorting(sortColumnName string) PaginationAndSorting {
 	return PaginationAndSorting{
-		Sorting: SortingField(sortColumnName),
+		Sorting: SortingFieldFrom(sortColumnName),
 		Order:   SortingOrderDesc,
 		Limit:   100,
 	}
 }
 
-type (
-	SortingField string
-	SortingOrder string
-)
+type SortingField int
 
 const (
-	COUNT_ROWS_LIMIT              = 1000
-	SortingOrderAsc  SortingOrder = "ASC"
-	SortingOrderDesc SortingOrder = "DESC"
+	SortingFieldUnknown SortingField = iota
+	SortingFieldCreatedAt
+	SortingFieldUpdatedAt
 )
 
+func (sf SortingField) String() string {
+	switch sf {
+	case SortingFieldCreatedAt:
+		return "created_at"
+	case SortingFieldUpdatedAt:
+		return "updated_at"
+	default:
+		return "unknown"
+	}
+}
+
+func SortingFieldFrom(s string) SortingField {
+	switch s {
+	case "created_at":
+		return SortingFieldCreatedAt
+	case "updated_at":
+		return SortingFieldUpdatedAt
+	}
+	return SortingFieldUnknown
+}
+
+type SortingOrder int
+
+const (
+	SortingOrderUnknown SortingOrder = iota
+	SortingOrderAsc
+	SortingOrderDesc
+)
+
+func (so SortingOrder) String() string {
+	switch so {
+	case SortingOrderAsc:
+		return "ASC"
+	case SortingOrderDesc:
+		return "DESC"
+	default:
+		return "unknown"
+	}
+}
+
+func SortingOrderFrom(s string) SortingOrder {
+	switch s {
+	case "ASC":
+		return SortingOrderAsc
+	case "DESC":
+		return SortingOrderDesc
+	}
+	return SortingOrderUnknown
+}
+
 func ValidatePagination(pagination PaginationAndSorting) error {
-	if pagination.Order != SortingOrderAsc && pagination.Order != SortingOrderDesc {
-		return fmt.Errorf("invalid pagination: order must be either ASC or DESC: %w", BadParameterError)
+	if pagination.Order == SortingOrderUnknown {
+		return errors.Wrapf(BadParameterError, "invalid pagination: order must be either ASC or DESC, received %s", pagination.Order)
+	}
+	if pagination.Sorting == SortingFieldUnknown {
+		return errors.Wrapf(BadParameterError, "invalid pagination: sorting must be either created_at or updated_at, received %s", pagination.Sorting)
 	}
 	if pagination.Limit <= 0 {
-		return fmt.Errorf("invalid pagination: limit must be greater than 0: %w", BadParameterError)
+		return errors.Wrapf(BadParameterError, "invalid pagination: limit must be greater than 0, received %d", pagination.Limit)
 	}
 	return nil
+}
+
+type PaginationDefaults struct {
+	Limit  int
+	SortBy SortingField
+	Order  SortingOrder
+}
+
+func WithPaginationDefaults(pagination PaginationAndSorting, defaults PaginationDefaults) PaginationAndSorting {
+	if pagination.Sorting == SortingFieldUnknown {
+		pagination.Sorting = defaults.SortBy
+	}
+
+	if pagination.Order == SortingOrderUnknown {
+		pagination.Order = defaults.Order
+	}
+
+	if pagination.Limit == 0 {
+		pagination.Limit = defaults.Limit
+	}
+
+	return pagination
 }

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -266,9 +266,9 @@ func applyCasesPagination(query squirrel.SelectBuilder, p models.PaginationAndSo
 	args := []any{offsetField, offsetField, p.OffsetId}
 
 	if p.Order == models.SortingOrderDesc {
-		query = query.Where(squirrel.Expr(queryConditionBefore, args...))
+		query = query.Where(queryConditionBefore, args...)
 	} else {
-		query = query.Where(squirrel.Expr(queryConditionAfter, args...))
+		query = query.Where(queryConditionAfter, args...)
 	}
 
 	return query, nil

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -216,7 +216,7 @@ func casesCoreQueryWithRank(pagination models.PaginationAndSorting) squirrel.Sel
 
 	// When fetching the previous page, we want the "last xx cases", so we need to reverse the order of the query,
 	// select the xx items, then reverse again to put them back in the right order
-	if pagination.OffsetId != "" && pagination.Previous {
+	if pagination.OffsetId != "" { // && pagination.Previous {
 		query = query.OrderBy(fmt.Sprintf("c.%s %s, c.id %s", pagination.Sorting,
 			models.ReverseOrder(pagination.Order), models.ReverseOrder(pagination.Order)))
 	} else {
@@ -260,21 +260,21 @@ func applyCasesPagination(query squirrel.SelectBuilder, p models.PaginationAndSo
 	queryConditionBefore := fmt.Sprintf("s.%s < ? OR (s.%s = ? AND s.id < ?)", p.Sorting, p.Sorting)
 	queryConditionAfter := fmt.Sprintf("s.%s > ? OR (s.%s = ? AND s.id > ?)", p.Sorting, p.Sorting)
 	args := []any{offsetField, offsetField, p.OffsetId}
-	if p.Next {
-		if p.Order == "DESC" {
-			query = query.Where(queryConditionBefore, args...)
-		} else {
-			query = query.Where(queryConditionAfter, args...)
-		}
+	// if p.Next {
+	if p.Order == "DESC" {
+		query = query.Where(queryConditionBefore, args...)
+	} else {
+		query = query.Where(queryConditionAfter, args...)
 	}
+	// }
 
-	if p.Previous {
-		if p.Order == "DESC" {
-			query = query.Where(queryConditionAfter, args...)
-		} else {
-			query = query.Where(queryConditionBefore, args...)
-		}
-	}
+	// if p.Previous {
+	// 	if p.Order == "DESC" {
+	// 		query = query.Where(queryConditionAfter, args...)
+	// 	} else {
+	// 		query = query.Where(queryConditionBefore, args...)
+	// 	}
+	// }
 
 	return query, nil
 }

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -47,20 +47,14 @@ func (repo *MarbleDbRepository) ListOrganizationCases(
 	if err != nil {
 		return []models.CaseWithRank{}, err
 	}
-	queryWithJoinedFields := selectCasesWithJoinedFields(paginatedSubquery, pagination, true)
-
-	count, err := countCases(ctx, exec, filters)
-	if err != nil {
-		return []models.CaseWithRank{}, errors.Wrap(err, "Error counting cases")
-	}
+	queryWithJoinedFields := selectCasesWithJoinedFields(paginatedSubquery, pagination)
 
 	return SqlToListOfRow(ctx, exec, queryWithJoinedFields, func(row pgx.CollectableRow) (models.CaseWithRank, error) {
 		db, err := pgx.RowToStructByPos[dbmodels.DBPaginatedCases](row)
 		if err != nil {
 			return models.CaseWithRank{}, err
 		}
-
-		return dbmodels.AdaptCaseWithRank(db.DBCaseWithContributorsAndTags, db.RankNumber, count)
+		return dbmodels.AdaptCaseWithRank(db.DBCaseWithContributorsAndTags, db.RankNumber)
 	})
 }
 
@@ -69,13 +63,30 @@ func (repo *MarbleDbRepository) GetCaseById(ctx context.Context, exec Executor, 
 		return models.Case{}, err
 	}
 
+	query := NewQueryBuilder().
+		Select(columnsNames("c", dbmodels.SelectCaseColumn)...).
+		Column(
+			fmt.Sprintf(
+				"(SELECT array_agg(row(%s) ORDER BY cc.created_at) AS contributors FROM %s AS cc WHERE cc.case_id=c.id)",
+				strings.Join(columnsNames("cc", dbmodels.SelectCaseContributorColumn), ","),
+				dbmodels.TABLE_CASE_CONTRIBUTORS,
+			),
+		).
+		Column(
+			fmt.Sprintf(
+				"(SELECT array_agg(row(%s) ORDER BY ct.created_at) AS tags FROM %s AS ct WHERE ct.case_id=c.id AND ct.deleted_at IS NULL)",
+				strings.Join(columnsNames("ct", dbmodels.SelectCaseTagColumn), ","),
+				dbmodels.TABLE_CASE_TAGS,
+			),
+		).
+		Column(fmt.Sprintf("(SELECT count(distinct d.id) FROM %s AS d WHERE d.case_id = c.id AND d.org_id=c.org_id) AS decisions_count", dbmodels.TABLE_DECISIONS)).
+		From(dbmodels.TABLE_CASES + " AS c").
+		Where(squirrel.Eq{"c.id": caseId})
+
 	return SqlToModel(
 		ctx,
 		exec,
-		selectCasesWithJoinedFields(squirrel.SelectBuilder(NewQueryBuilder()), models.PaginationAndSorting{
-			Sorting: models.CasesSortingCreatedAt,
-		}, false).
-			Where(squirrel.Eq{"c.id": caseId}),
+		query,
 		dbmodels.AdaptCaseWithContributorsAndTags,
 	)
 }
@@ -209,20 +220,11 @@ func casesWithRankColumns() []string {
 func casesCoreQueryWithRank(pagination models.PaginationAndSorting) squirrel.SelectBuilder {
 	orderCondition := fmt.Sprintf("c.%s %s, c.id %s", pagination.Sorting, pagination.Order, pagination.Order)
 
-	query := squirrel.StatementBuilder.
+	return squirrel.StatementBuilder.
 		Select(dbmodels.SelectCaseColumn...).
 		Column(fmt.Sprintf("RANK() OVER (ORDER BY %s) as rank_number", orderCondition)).
-		From(dbmodels.TABLE_CASES + " AS c")
-
-	// When fetching the previous page, we want the "last xx cases", so we need to reverse the order of the query,
-	// select the xx items, then reverse again to put them back in the right order
-	if pagination.OffsetId != "" { // && pagination.Previous {
-		query = query.OrderBy(fmt.Sprintf("c.%s %s, c.id %s", pagination.Sorting,
-			models.ReverseOrder(pagination.Order), models.ReverseOrder(pagination.Order)))
-	} else {
-		query = query.OrderBy(orderCondition)
-	}
-	return query
+		From(dbmodels.TABLE_CASES + " AS c").
+		OrderBy(orderCondition)
 }
 
 func applyCaseFilters(query squirrel.SelectBuilder, filters models.CaseFilters) squirrel.SelectBuilder {
@@ -260,80 +262,18 @@ func applyCasesPagination(query squirrel.SelectBuilder, p models.PaginationAndSo
 	queryConditionBefore := fmt.Sprintf("s.%s < ? OR (s.%s = ? AND s.id < ?)", p.Sorting, p.Sorting)
 	queryConditionAfter := fmt.Sprintf("s.%s > ? OR (s.%s = ? AND s.id > ?)", p.Sorting, p.Sorting)
 	args := []any{offsetField, offsetField, p.OffsetId}
-	// if p.Next {
+
 	if p.Order == "DESC" {
 		query = query.Where(queryConditionBefore, args...)
 	} else {
 		query = query.Where(queryConditionAfter, args...)
 	}
-	// }
-
-	// if p.Previous {
-	// 	if p.Order == "DESC" {
-	// 		query = query.Where(queryConditionAfter, args...)
-	// 	} else {
-	// 		query = query.Where(queryConditionBefore, args...)
-	// 	}
-	// }
 
 	return query, nil
 }
 
-func countCases(ctx context.Context, exec Executor, filters models.CaseFilters) (int, error) {
-	subquery := NewQueryBuilder().
-		Select("*").
-		From(fmt.Sprintf("%s AS c", dbmodels.TABLE_CASES)).
-		Limit(models.COUNT_ROWS_LIMIT)
-	subquery = applyCaseFilters(subquery, filters)
-	query := NewQueryBuilder().
-		Select("COUNT(*)").
-		FromSelect(subquery, "s")
-
-	sql, args, err := query.ToSql()
-	if err != nil {
-		return 0, err
-	}
-
-	var count int
-	err = exec.QueryRow(ctx, sql, args...).Scan(&count)
-	return count, err
-}
-
-/*
-The most complex end query is like (case DESC, previous with offset)
-
-SELECT
-
-	c.id, c.created_at, c.inbox_id, c.name, c.org_id, c.status,
-	(SELECT array_agg(row(cc.id,cc.case_id,cc.user_id,cc.created_at) ORDER BY cc.created_at) as contributors FROM case_contributors WHERE cc.case_id=c.id),
-	(SELECT array_agg(row(ct.id,ct.case_id,ct.tag_id,ct.created_at,ct.deleted_at) ORDER BY ct.created_at) as tags FROM case_tags WHERE ct.case_id=c.id AND ct.deleted_at IS NULL),
-	count(distinct d.id) as decisions_count,
-	rank_number
-
-FROM (
-
-	SELECT
-		s.id, s.created_at, s.inbox_id, s.name, s.org_id, s.status, rank_number
-	FROM (
-		SELECT
-			id, created_at, inbox_id, name, org_id, status,
-			RANK() OVER (ORDER BY c.created_at DESC, c.id DESC) as rank_number
-		FROM cases AS c
-		WHERE c.org_id = $1
-			AND c.inbox_id IN ($2,$3,$4,$5,$6,$7)
-		ORDER BY c.created_at ASC, c.id ASC
-	) AS s
-	WHERE s.created_at > $8
-		OR (s.created_at = $9 AND s.id > $10)
-	LIMIT 25
-
-) AS c
-LEFT JOIN decisions AS d ON d.case_id = c.id
-GROUP BY c.id, c.created_at, c.inbox_id, c.name, c.org_id, c.status, rank_number
-ORDER BY c.created_at DESC, c.id DESC
-*/
-func selectCasesWithJoinedFields(query squirrel.SelectBuilder, p models.PaginationAndSorting, fromSubquery bool) squirrel.SelectBuilder {
-	q := squirrel.StatementBuilder.
+func selectCasesWithJoinedFields(query squirrel.SelectBuilder, p models.PaginationAndSorting) squirrel.SelectBuilder {
+	return squirrel.StatementBuilder.
 		Select(columnsNames("c", dbmodels.SelectCaseColumn)...).
 		Column(
 			fmt.Sprintf(
@@ -349,18 +289,9 @@ func selectCasesWithJoinedFields(query squirrel.SelectBuilder, p models.Paginati
 				dbmodels.TABLE_CASE_TAGS,
 			),
 		).
-		Column(fmt.Sprintf("(SELECT count(distinct d.id) FROM %s AS d WHERE d.case_id = c.id AND d.org_id=c.org_id) AS decisions_count", dbmodels.TABLE_DECISIONS))
-	if fromSubquery {
-		q = q.Column("rank_number")
-	}
-
-	if fromSubquery {
-		q = q.FromSelect(query, "c")
-	} else {
-		q = q.From(dbmodels.TABLE_CASES + " AS c")
-	}
-
-	return q.
+		Column(fmt.Sprintf("(SELECT count(distinct d.id) FROM %s AS d WHERE d.case_id = c.id AND d.org_id=c.org_id) AS decisions_count", dbmodels.TABLE_DECISIONS)).
+		Column("rank_number").
+		FromSelect(query, "c").
 		OrderBy(fmt.Sprintf("c.%s %s, c.id %s", p.Sorting, p.Order, p.Order)).
 		PlaceholderFormat(squirrel.Dollar)
 }

--- a/repositories/dbmodels/db_case.go
+++ b/repositories/dbmodels/db_case.go
@@ -67,7 +67,7 @@ func AdaptCaseWithContributorsAndTags(db DBCaseWithContributorsAndTags) (models.
 	return caseModel, nil
 }
 
-func AdaptCaseWithRank(db DBCaseWithContributorsAndTags, rankNumber int, total int) (models.CaseWithRank, error) {
+func AdaptCaseWithRank(db DBCaseWithContributorsAndTags, rankNumber int) (models.CaseWithRank, error) {
 	c, err := AdaptCaseWithContributorsAndTags(db)
 	if err != nil {
 		return models.CaseWithRank{}, err
@@ -75,6 +75,5 @@ func AdaptCaseWithRank(db DBCaseWithContributorsAndTags, rankNumber int, total i
 	return models.CaseWithRank{
 		Case:       c,
 		RankNumber: rankNumber,
-		TotalCount: models.TotalCount{Value: total, IsMaxCount: total == models.COUNT_ROWS_LIMIT},
 	}, nil
 }

--- a/repositories/dbmodels/db_decision.go
+++ b/repositories/dbmodels/db_decision.go
@@ -103,11 +103,10 @@ func AdaptDecisionWithRuleExecutions(db DbDecision, ruleExecutions []models.Rule
 	return models.DecisionWithRuleExecutions{Decision: decision, RuleExecutions: ruleExecutions}
 }
 
-func AdaptDecisionWithRank(db DbDecision, decisionCase *models.Case, rankNumber, total int) models.DecisionWithRank {
+func AdaptDecisionWithRank(db DbDecision, decisionCase *models.Case, rankNumber int) models.DecisionWithRank {
 	decision := AdaptDecision(db, decisionCase)
 	return models.DecisionWithRank{
 		Decision:   decision,
 		RankNumber: rankNumber,
-		TotalCount: models.TotalCount{Value: total, IsMaxCount: total == models.COUNT_ROWS_LIMIT},
 	}
 }

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -370,7 +370,7 @@ func selectDecisionsWithRank(p models.PaginationAndSorting) squirrel.SelectBuild
 
 	// When fetching the previous page, we want the "last xx decisions", so we need to reverse the order of the query,
 	// select the xx items, then reverse again to put them back in the right order
-	if p.OffsetId != "" && p.Previous {
+	if p.OffsetId != "" { // && p.Previous {
 		query = query.OrderBy(fmt.Sprintf("d.%s %s, d.id %s", p.Sorting,
 			models.ReverseOrder(p.Order), models.ReverseOrder(p.Order)))
 	} else {
@@ -406,20 +406,20 @@ func applyDecisionPagination(query squirrel.SelectBuilder, p models.PaginationAn
 	queryConditionAfter := fmt.Sprintf("%s > ? OR (%s = ? AND id > ?)", p.Sorting, p.Sorting)
 
 	args := []any{offsetField, offsetField, p.OffsetId}
-	if p.Next {
-		if p.Order == "DESC" {
-			query = query.Where(queryConditionBefore, args...)
-		} else {
-			query = query.Where(queryConditionAfter, args...)
-		}
+	// if p.Next {
+	if p.Order == "DESC" {
+		query = query.Where(queryConditionBefore, args...)
+	} else {
+		query = query.Where(queryConditionAfter, args...)
 	}
-	if p.Previous {
-		if p.Order == "DESC" {
-			query = query.Where(queryConditionAfter, args...)
-		} else {
-			query = query.Where(queryConditionBefore, args...)
-		}
-	}
+	// }
+	// if p.Previous {
+	// 	if p.Order == "DESC" {
+	// 		query = query.Where(queryConditionAfter, args...)
+	// 	} else {
+	// 		query = query.Where(queryConditionBefore, args...)
+	// 	}
+	// }
 
 	return query, nil
 }

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -279,7 +279,7 @@ func (repo *MarbleDbRepository) DecisionsOfOrganization(
 	query := selectDecisionsWithJoinedFields(paginatedQuery, orderCond)
 
 	decision, err := SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (models.Decision, error) {
-		db, err := pgx.RowToStructByPos[dbmodels.DBPaginatedDecisions](row)
+		db, err := pgx.RowToStructByPos[dbmodels.DbJoinDecisionAndCase](row)
 		if err != nil {
 			return models.Decision{}, err
 		}

--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -159,8 +159,6 @@ paths:
             enum:
               - created_at
         - $ref: "#/components/parameters/offset_id"
-        - $ref: "#/components/parameters/previous"
-        - $ref: "#/components/parameters/next"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/order"
       responses:
@@ -291,20 +289,6 @@ components:
       schema:
         type: string
         format: uuid
-    next:
-      in: query
-      name: next
-      description: Next page
-      required: false
-      schema:
-        type: boolean
-    previous:
-      in: query
-      name: previous
-      description: Previous page
-      required: false
-      schema:
-        type: boolean
     limit:
       in: query
       name: limit
@@ -572,21 +556,12 @@ components:
       required:
         - end_index
         - start_index
-        - total_count
+        - has_next_page
       properties:
         end_index:
           type: integer
         start_index:
           type: integer
-        total_count:
-          $ref: "#/components/schemas/pagination_count"
-    pagination_count:
-      type: object
-      required:
-        - is_max_count
-        - value
-      properties:
-        is_max_count:
+        has_next_page:
           type: boolean
-        value:
-          type: integer
+    


### PR DESCRIPTION
## Context
Loosely inspired from https://github.com/checkmarble/marble-backend/pull/764, and prerequisite for https://github.com/checkmarble/marble-frontend/pull/617.

## Contains
- refactoring of the pagination model & dto (to better enforce at a higher level "now raw user input makes it into a sql query"
- the cases, decision list endpoints no longer return a total count (**breaking change**)
- the cases, decision list endpoints pagination input no longer accepts a `previous` or `next` (boolean) query params input when passing an `offset_id`. Instead, "`next`" type pagination is used by default (**breaking change**)
- the public endpoint for decisions no longer returns the `start_index`,`end_index` for a given page of items (**breaking change**)
- the list case and decision endpoints return a `has_next_page` field (boolean), to indicate to the client if there is a next page to retrieve. This is implemented by retrieving `limit+1` items at the usecase level, returning `limit` items to the client and the flag depends on the presence of a `+1` item.

## Doc
- https://docs.checkmarble.com/reference/get_decisions has been updated

Sorry it's a bit massive and hard to read, as you can see below... I struggled with the github security bot.