### PR TITLE
Thomas/custom list values by csv

### DIFF
--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -157,7 +157,7 @@ func handleGetCsvCustomListValues(uc usecases.Usecases) func(c *gin.Context) {
 		customListID := c.Param("list_id")
 
 		usecase := usecasesWithCreds(ctx, uc).NewCustomListUseCase()
-		customListName, err := usecase.WriteCustomListValuesToCSV(ctx, customListID, c.Writer)
+		customListName, err := usecase.ReadCustomListValuesToCSV(ctx, customListID, c.Writer)
 		if presentError(ctx, c, err) {
 			logger.ErrorContext(ctx, "error writing values to a list to CSV: \n"+err.Error())
 			return
@@ -208,13 +208,6 @@ func handlePostCustomListValue(uc usecases.Usecases) func(c *gin.Context) {
 func handlePostCsvCustomListValues(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		logger := utils.LoggerFromContext(ctx)
-
-		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
-		if presentError(ctx, c, err) {
-			return
-		}
-		logger = logger.With(slog.String("organizationId", organizationId))
 
 		customListID := c.Param("list_id")
 
@@ -230,7 +223,6 @@ func handlePostCsvCustomListValues(uc usecases.Usecases) func(c *gin.Context) {
 		usecase := usecasesWithCreds(ctx, uc).NewCustomListUseCase()
 		err = usecase.ReplaceCustomListValuesFromCSV(ctx, customListID, fileReader)
 		if presentError(ctx, c, err) {
-			logger.ErrorContext(ctx, "error replacing values to a list from CSV: \n"+err.Error())
 			return
 		}
 		c.Status(http.StatusCreated)

--- a/api/handle_custom_list.go
+++ b/api/handle_custom_list.go
@@ -221,11 +221,13 @@ func handlePostCsvCustomListValues(uc usecases.Usecases) func(c *gin.Context) {
 		fileReader := csv.NewReader(pure_utils.NewReaderWithoutBom(file))
 
 		usecase := usecasesWithCreds(ctx, uc).NewCustomListUseCase()
-		err = usecase.ReplaceCustomListValuesFromCSV(ctx, customListID, fileReader)
+		results, err := usecase.ReplaceCustomListValuesFromCSV(ctx, customListID, fileReader)
 		if presentError(ctx, c, err) {
 			return
 		}
-		c.Status(http.StatusCreated)
+		c.JSON(http.StatusCreated, gin.H{
+			"results": dto.AdaptBatchInsertCustomListValueResultsDto(results),
+		})
 	}
 }
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -109,6 +109,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth Aut
 	router.PATCH("/custom-lists/:list_id", tom, handlePatchCustomList(uc))
 	router.DELETE("/custom-lists/:list_id", tom, handleDeleteCustomList(uc))
 	router.POST("/custom-lists/:list_id/values", tom, handlePostCustomListValue(uc))
+	router.POST("/custom-lists/:list_id/values/batch", timeoutMiddleware(conf.BatchTimeout), handlePostCsvCustomListValues(uc))
 	router.DELETE("/custom-lists/:list_id/values/:value_id", tom, handleDeleteCustomListValue(uc))
 
 	router.GET("/editor/:scenario_id/identifiers", tom, handleGetEditorIdentifiers(uc))

--- a/api/routes.go
+++ b/api/routes.go
@@ -108,6 +108,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth Aut
 	router.GET("/custom-lists/:list_id", tom, handleGetCustomListWithValues(uc))
 	router.PATCH("/custom-lists/:list_id", tom, handlePatchCustomList(uc))
 	router.DELETE("/custom-lists/:list_id", tom, handleDeleteCustomList(uc))
+	router.GET("/custom-lists/:list_id/values", tom, handleGetCsvCustomListValues(uc))
 	router.POST("/custom-lists/:list_id/values", tom, handlePostCustomListValue(uc))
 	router.POST("/custom-lists/:list_id/values/batch", timeoutMiddleware(conf.BatchTimeout), handlePostCsvCustomListValues(uc))
 	router.DELETE("/custom-lists/:list_id/values/:value_id", tom, handleDeleteCustomListValue(uc))

--- a/api/routes.go
+++ b/api/routes.go
@@ -110,7 +110,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth Aut
 	router.DELETE("/custom-lists/:list_id", tom, handleDeleteCustomList(uc))
 	router.GET("/custom-lists/:list_id/values", tom, handleGetCsvCustomListValues(uc))
 	router.POST("/custom-lists/:list_id/values", tom, handlePostCustomListValue(uc))
-	router.POST("/custom-lists/:list_id/values/batch", timeoutMiddleware(conf.BatchTimeout), handlePostCsvCustomListValues(uc))
+	router.POST("/custom-lists/:list_id/values/batch", tom, handlePostCsvCustomListValues(uc))
 	router.DELETE("/custom-lists/:list_id/values/:value_id", tom, handleDeleteCustomListValue(uc))
 
 	router.GET("/editor/:scenario_id/identifiers", tom, handleGetEditorIdentifiers(uc))

--- a/dto/custom_list_dto.go
+++ b/dto/custom_list_dto.go
@@ -66,3 +66,17 @@ type UpdateCustomListBodyDto struct {
 type CreateCustomListValueBodyDto struct {
 	Value string `json:"value"`
 }
+
+type BatchInsertCustomListValueResultsDto struct {
+	TotalExisting int `json:"total_existing"`
+	TotalDeleted  int `json:"total_deleted"`
+	TotalCreated  int `json:"total_created"`
+}
+
+func AdaptBatchInsertCustomListValueResultsDto(listValue models.BatchInsertCustomListValueResults) BatchInsertCustomListValueResultsDto {
+	return BatchInsertCustomListValueResultsDto{
+		TotalExisting: listValue.TotalExisting,
+		TotalDeleted:  listValue.TotalDeleted,
+		TotalCreated:  listValue.TotalCreated,
+	}
+}

--- a/mocks/custom_list_repository.go
+++ b/mocks/custom_list_repository.go
@@ -24,7 +24,7 @@ func (cl *CustomListRepository) GetCustomListById(ctx context.Context, exec repo
 }
 
 func (cl *CustomListRepository) GetCustomListValues(ctx context.Context, exec repositories.Executor,
-	getCustomList models.GetCustomListValuesInput,
+	getCustomList models.GetCustomListValuesInput, forUpdate ...bool,
 ) ([]models.CustomListValue, error) {
 	args := cl.Called(exec, getCustomList)
 	return args.Get(0).([]models.CustomListValue), args.Error(1)
@@ -65,6 +65,17 @@ func (cl *CustomListRepository) AddCustomListValue(
 	return args.Error(0)
 }
 
+func (cl *CustomListRepository) BatchInsertCustomListValues(
+	ctx context.Context,
+	exec repositories.Executor,
+	customListId string,
+	customListValues []models.BatchInsertCustomListValue,
+	userId *models.UserId,
+) error {
+	args := cl.Called(ctx, exec, customListId, customListValues, userId)
+	return args.Error(0)
+}
+
 func (cl *CustomListRepository) DeleteCustomListValue(
 	ctx context.Context,
 	exec repositories.Executor,
@@ -72,5 +83,16 @@ func (cl *CustomListRepository) DeleteCustomListValue(
 	userId *models.UserId,
 ) error {
 	args := cl.Called(ctx, exec, deleteCustomListValue, userId)
+	return args.Error(0)
+}
+
+func (cl *CustomListRepository) BatchDeleteCustomListValues(
+	ctx context.Context,
+	exec repositories.Executor,
+	customListId string,
+	deleteCustomListValueIds []string,
+	userId *models.UserId,
+) error {
+	args := cl.Called(ctx, exec, customListId, deleteCustomListValueIds, userId)
 	return args.Error(0)
 }

--- a/models/custom_list.go
+++ b/models/custom_list.go
@@ -50,3 +50,9 @@ type BatchInsertCustomListValue struct {
 	Id    string
 	Value string
 }
+
+type BatchInsertCustomListValueResults struct {
+	TotalExisting int
+	TotalDeleted  int
+	TotalCreated  int
+}

--- a/models/custom_list.go
+++ b/models/custom_list.go
@@ -45,3 +45,8 @@ type DeleteCustomListValueInput struct {
 	Id           string
 	CustomListId string
 }
+
+type BatchInsertCustomListValue struct {
+	Id    string
+	Value string
+}

--- a/models/events.go
+++ b/models/events.go
@@ -14,6 +14,7 @@ const (
 	AnalyticsListUpdated                AnalyticsEvent = "Updated a List"
 	AnalyticsListDeleted                AnalyticsEvent = "Deleted a List"
 	AnalyticsListValueCreated           AnalyticsEvent = "Created a List Value"
+	AnalyticsListValuesReplaced         AnalyticsEvent = "Replaced List Values by CSV"
 	AnalyticsListValueDeleted           AnalyticsEvent = "Deleted a List Value"
 	AnalyticsCaseCreated                AnalyticsEvent = "Created a Case"
 	AnalyticsCaseUpdated                AnalyticsEvent = "Updated a Case"

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -189,29 +189,33 @@ func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 }
 
 func (usecase *CustomListUseCase) ReadCustomListValuesToCSV(ctx context.Context, customListID string, w io.Writer) (string, error) {
-	customList, err := usecase.GetCustomListById(ctx, customListID)
+	exec := usecase.executorFactory.NewExecutor()
+	customList, err := usecase.CustomListRepository.GetCustomListById(ctx, exec, customListID)
 	if err != nil {
 		return "", err
 	}
-	customListValues, err := usecase.CustomListRepository.GetCustomListValues(ctx,
-		usecase.executorFactory.NewExecutor(), models.GetCustomListValuesInput{Id: customListID})
+	if err := usecase.enforceSecurity.ReadCustomList(customList); err != nil {
+		return "", err
+	}
+
+	customListValues, err := usecase.CustomListRepository.GetCustomListValues(ctx, exec, models.GetCustomListValuesInput{
+		Id: customListID,
+	})
 	if err != nil {
 		return "", err
 	}
 
 	csvWriter := csv.NewWriter(w)
-
-	// Write header
-	if err := csvWriter.Write(customListValuesCSVHeader); err != nil {
-		return "", err
-	}
-
-	// Write values
 	for _, customListValue := range customListValues {
 		if err := csvWriter.Write([]string{customListValue.Value}); err != nil {
 			return "", err
 		}
 	}
+	csvWriter.Flush()
+	if err = csvWriter.Error(); err != nil {
+		return "", err
+	}
+
 	return customList.Name, nil
 }
 


### PR DESCRIPTION
Add two endpoints to handle list by csv:
- downlaod a csv with current list values
- upload a csv with new list values (it will delete existing ones that are not inside the csv, and create only new values)

What is missing:
- 10000 max list values limit
- uniqueness of data