### PR TITLE
reshuffle code on webhooks sending: don't accumulate unsent webhook e…

### DIFF
--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -99,7 +99,9 @@ func RunBatchIngestion() error {
 	)
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithIngestionBucketUrl(jobConfig.ingestionBucketUrl),
-		usecases.WithLicense(license))
+		usecases.WithLicense(license),
+		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
+	)
 
 	err = jobs.IngestDataFromCsv(ctx, uc)
 	if err != nil {

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -111,7 +111,10 @@ func RunScheduledExecuter() error {
 		repositories.WithTracerProvider(telemetryRessources.TracerProvider),
 	)
 
-	uc := usecases.NewUsecases(repositories, usecases.WithLicense(license))
+	uc := usecases.NewUsecases(repositories,
+		usecases.WithLicense(license),
+		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
+	)
 
 	err = jobs.ExecuteAllScheduledScenarios(ctx, uc)
 	if err != nil {

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -89,7 +89,9 @@ func RunSendPendingWebhookEvents() error {
 		))
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithFailedWebhooksRetryPageSize(jobConfig.failedWebhooksRetryPageSize),
-		usecases.WithLicense(license))
+		usecases.WithLicense(license),
+		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
+	)
 
 	err = jobs.SendPendingWebhookEvents(ctx, uc)
 	if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -142,6 +142,7 @@ func RunServer() error {
 		usecases.WithIngestionBucketUrl(serverConfig.ingestionBucketUrl),
 		usecases.WithCaseManagerBucketUrl(serverConfig.caseManagerBucket),
 		usecases.WithLicense(license),
+		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -150,6 +150,7 @@ func RunTaskQueue() error {
 		usecases.WithIngestionBucketUrl(workerConfig.ingestionBucketUrl),
 		usecases.WithFailedWebhooksRetryPageSize(workerConfig.failedWebhooksRetryPageSize),
 		usecases.WithLicense(license),
+		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
 	)
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, uc)
 	river.AddWorker(workers, adminUc.NewAsyncDecisionWorker())

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -18,6 +18,8 @@ const (
 	Success WebhookEventDeliveryStatus = "success"
 	// The event delivery previously failed and the automatic retries have kicked in
 	Retry WebhookEventDeliveryStatus = "retry"
+	// The webhooks feature is available in the license, or no convoy server has been set up
+	Skipped WebhookEventDeliveryStatus = "skipped"
 )
 
 type WebhookEventType string

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -22,6 +22,7 @@ type Usecases struct {
 	ingestionBucketUrl          string
 	caseManagerBucketUrl        string
 	failedWebhooksRetryPageSize int
+	hasConvoyServerSetup        bool
 	license                     models.LicenseValidation
 }
 
@@ -57,12 +58,21 @@ func WithBatchIngestionMaxSize(size int) Option {
 	}
 }
 
+func WithConvoyServer(url string) Option {
+	return func(o *options) {
+		if url != "" {
+			o.hasConvoyServerSetup = true
+		}
+	}
+}
+
 type options struct {
 	batchIngestionMaxSize       int
 	ingestionBucketUrl          string
 	caseManagerBucketUrl        string
 	failedWebhooksRetryPageSize int
 	license                     models.LicenseValidation
+	hasConvoyServerSetup        bool
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -410,6 +410,7 @@ func (usecases *UsecasesWithCreds) NewWebhookEventsUsecase() WebhookEventsUsecas
 		usecases.Repositories.MarbleDbRepository,
 		usecases.Usecases.failedWebhooksRetryPageSize,
 		usecases.Usecases.license.Webhooks,
+		usecases.Usecases.hasConvoyServerSetup,
 	)
 }
 


### PR DESCRIPTION
## Problem statement
For self-hosted customers with a license that includes webhooks, but that don't have a convoy set up, the webhook events are just accumulating in the backlog and are being tentatively retried infinitely.

See [shared slack conv](https://checkmarble.slack.com/archives/C07CY8GK3U4/p1733995434581829)

## Proposed resolutions
- the webhooks sending usecases also receives the presence/absence of a convoy server as input - it is noop if no license or no convoy server is set up
- if for any reason a webhook event has been created, but no webhooks license or convoy server is available at the time it's retried, its status is changed to "skipped" (new option, along "scheduled", "success", "retry" currently available)

## Backward compatibility
For self-hosted customers like Pixpay who currently don't have webhooks set up, no new webhook_events will be created if convoy is not configured, and old ones will be marked as "skipped" and no longer retried batch by batch

## Long term perspective
We still need to move the whole "webhooks sending" into a task queue of its own, but this is an independent evolution.