### PR TITLE
AST: Lazy evaluate boolean child nodes.

### DIFF
--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -529,11 +529,11 @@ func createDecisions(
 		assert.Nil(t, ruleExecution.Error, "Expected error to be nil, got \"%s\"", ruleExecution.Error)
 	}
 
-	// Create a decision [APPROVE] with a division by zero
+	// Create a decision [DECLINE] with a division by zero
 	transactionPayloadJson = []byte(`{
 		"object_id": "{transaction_id}",
 		"updated_at": "2020-01-01T00:00:00Z",
-		"account_id": "{account_id_approve}",
+		"account_id": "{account_id_decline}",
 		"amount": 0
 	}`)
 	approveDivisionByZeroDecision := createAndTestDecision(ctx, t, transactionPayloadJson, table,

--- a/pure_utils/map.go
+++ b/pure_utils/map.go
@@ -50,3 +50,37 @@ func MapValuesErr[Key comparable, T any, U any](src map[Key]T, f func(T) (U, err
 	}
 	return result, nil
 }
+
+// MapWhile maps over items in a slice and produces a slice of items of another type.
+// Contrary to regular Map(), the callbacks returns a second boolean value to indicate if the operation
+// should continue. It stops whenever the callback returns false.
+func MapWhile[T, U any](src []T, f func(T) (U, bool)) []U {
+	us := make([]U, 0, len(src))
+	for i := range src {
+		item, next := f(src[i])
+
+		us = append(us, item)
+
+		if !next {
+			break
+		}
+	}
+	return us
+}
+
+// MapValuesWhile maps over a map's values in a slice and produces a slice of items of another type.
+// Contrary to regular MapValues(), the callbacks returns a second boolean value to indicate if the operation
+// should continue. It stops whenever the callback returns false.
+func MapValuesWhile[Key comparable, T any, U any](src map[Key]T, f func(T) (U, bool)) map[Key]U {
+	result := make(map[Key]U, len(src))
+	for key, value := range src {
+		item, next := f(value)
+
+		result[key] = item
+
+		if !next {
+			break
+		}
+	}
+	return result
+}

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -10,7 +10,8 @@ import (
 )
 
 type AstEvaluationEnvironment struct {
-	availableFunctions map[ast.Function]evaluate.Evaluator
+	availableFunctions     map[ast.Function]evaluate.Evaluator
+	disableCircuitBreaking bool
 }
 
 func (environment *AstEvaluationEnvironment) AddEvaluator(function ast.Function, evaluator evaluate.Evaluator) {
@@ -25,6 +26,12 @@ func (environment *AstEvaluationEnvironment) GetEvaluator(function ast.Function)
 		return funcClass, nil
 	}
 	return nil, errors.New(fmt.Sprintf("function '%s' is not available", function.DebugString()))
+}
+
+func (environment AstEvaluationEnvironment) WithoutCircuitBreaking() AstEvaluationEnvironment {
+	environment.disableCircuitBreaking = true
+
+	return environment
 }
 
 func NewAstEvaluationEnvironment() AstEvaluationEnvironment {

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -227,6 +227,8 @@ func (validator *AstValidatorImpl) MakeDryRunEnvironment(ctx context.Context,
 		ClientObject:                  clientObject,
 		DataModel:                     dataModel,
 		DatabaseAccessReturnFakeValue: true,
-	})
+	}).
+		WithoutCircuitBreaking()
+
 	return env, nil
 }

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -91,7 +91,7 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 	validator := AstValidatorImpl{
 		DataModelRepository: mdmr,
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
-			return ast_eval.NewAstEvaluationEnvironment()
+			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
 		},
 		ExecutorFactory: executorFactory,
 	}
@@ -183,7 +183,107 @@ func TestValidateScenarioIterationImpl_Validate_notBool(t *testing.T) {
 	validator := AstValidatorImpl{
 		DataModelRepository: mdmr,
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
-			return ast_eval.NewAstEvaluationEnvironment()
+			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
+		},
+		ExecutorFactory: executorFactory,
+	}
+
+	siValidator := ValidateScenarioIterationImpl{
+		AstValidator: &validator,
+	}
+
+	result := siValidator.Validate(ctx, models.ScenarioAndIteration{
+		Scenario:  scenario,
+		Iteration: scenarioIteration,
+	})
+	assert.NotEmpty(t, ScenarioValidationToError(result))
+}
+
+func TestValidationShouldBypassCircuitBreaking(t *testing.T) {
+	ctx := utils.StoreLoggerInContext(context.Background(), utils.NewLogger("text"))
+	scenario := models.Scenario{
+		Id:                uuid.New().String(),
+		OrganizationId:    uuid.New().String(),
+		Name:              "scenario_name",
+		Description:       "description",
+		TriggerObjectType: "object_type",
+		CreatedAt:         time.Now(),
+		LiveVersionID:     utils.Ptr(uuid.New().String()),
+	}
+
+	scenarioIterationID := uuid.New().String()
+	scenarioIteration := models.ScenarioIteration{
+		Id:             scenarioIterationID,
+		OrganizationId: scenario.OrganizationId,
+		ScenarioId:     scenario.Id,
+		Version:        utils.Ptr(1),
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+		TriggerConditionAstExpression: utils.Ptr(ast.Node{
+			Constant: true,
+		}),
+		Rules: []models.Rule{
+			{
+				Id:                  "rule",
+				ScenarioIterationId: scenarioIterationID,
+				OrganizationId:      scenario.OrganizationId,
+				DisplayOrder:        0,
+				Name:                "rule",
+				Description:         "description",
+				FormulaAstExpression: utils.Ptr(ast.Node{
+					Function: ast.FUNC_AND,
+					Constant: nil,
+					Children: []ast.Node{
+						{
+							Function: ast.FUNC_EQUAL,
+							Children: []ast.Node{
+								{Constant: 100},
+								{Constant: 101},
+							},
+						},
+						{
+							Function: ast.FUNC_EQUAL,
+							Children: []ast.Node{
+								{Constant: 100},
+								{Constant: "oplop"},
+							},
+						},
+					},
+				}),
+				ScoreModifier: 10,
+				CreatedAt:     time.Now(),
+			},
+		},
+		ScoreReviewThreshold:         utils.Ptr(100),
+		ScoreBlockAndReviewThreshold: utils.Ptr(1000),
+		ScoreDeclineThreshold:        utils.Ptr(1000),
+		Schedule:                     "schedule",
+	}
+
+	exec := new(mocks.Executor)
+	executorFactory := new(mocks.ExecutorFactory)
+	executorFactory.On("NewExecutor").Once().Return(exec)
+	mdmr := new(mocks.DataModelRepository)
+	mdmr.On("GetDataModel", ctx, exec, scenario.OrganizationId, false).
+		Return(models.DataModel{
+			Version: "version",
+			Tables: map[string]models.Table{
+				"object_type": {
+					Name: "object_type",
+					Fields: map[string]models.Field{
+						"id": {
+							DataType: models.Int,
+						},
+					},
+					LinksToSingle: nil,
+				},
+			},
+		}, nil)
+
+	validator := AstValidatorImpl{
+		DataModelRepository: mdmr,
+		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
+			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
 		},
 		ExecutorFactory: executorFactory,
 	}


### PR DESCRIPTION
This adds circuit breaking to boolean evaluation.

An AND boolean resolves to false if the first operand is false, and an OR boolean resolves to true if the first operand is true. With this, second operands and skipped if they can have no sway on the node's result.

Circuit breaking is disabled when trying to validate a scenario, so all cases are considered.