### PR TITLE
AST: Allow children of commutative nodes to be reordered cost-wise.

### DIFF
--- a/models/ast/ast_aggregator.go
+++ b/models/ast/ast_aggregator.go
@@ -16,4 +16,5 @@ var FuncAggregatorAttributes = FuncAttributes{
 	DebugName:      "FUNC_AGGREGATOR",
 	AstName:        "Aggregator",
 	NamedArguments: []string{"tableName", "fieldName", "aggregator", "filters", "label"},
+	Cost:           50,
 }

--- a/models/ast/ast_custom_list_attr.go
+++ b/models/ast/ast_custom_list_attr.go
@@ -12,6 +12,7 @@ var AttributeFuncCustomListAccess = struct {
 		NamedArguments: []string{
 			"customListId",
 		},
+		Cost: 30,
 	},
 	ArgumentCustomListId: "customListId",
 }

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -177,6 +177,7 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 	FUNC_PAYLOAD: {
 		DebugName: "FUNC_PAYLOAD",
 		AstName:   "Payload",
+		Cost:      30,
 	},
 	FUNC_DB_ACCESS:          AttributeFuncDbAccess.FuncAttributes,
 	FUNC_CUSTOM_LIST_ACCESS: AttributeFuncCustomListAccess.FuncAttributes,
@@ -289,6 +290,7 @@ var AttributeFuncDbAccess = struct {
 		NamedArguments: []string{
 			"tableName", "fieldName", "path",
 		},
+		Cost: 30,
 	},
 	ArgumentTableName: "tableName",
 	ArgumentFieldName: "fieldName",

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -86,6 +86,11 @@ type FuncAttributes struct {
 	// considering for every one of them if evaluation should continue or not. For the result value of one child, the
 	// function returns whether evaluation of subsequent children should continue (true) or not (false).
 	LazyChildEvaluation func(NodeEvaluation) bool
+	// Commutative indicates this function can treat its children as a commutative list of arguments, and that
+	// they can be reordered without changing the outcome of the function.
+	Commutative bool
+	// Cost modelizes the computation cost of a given node, the default being zero.
+	Cost int
 }
 
 // If number of arguments -1 the function can take any number of arguments
@@ -143,14 +148,16 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 		AstName:   "Not",
 	},
 	FUNC_AND: {
-		DebugName: "FUNC_AND",
-		AstName:   "And",
+		DebugName:   "FUNC_AND",
+		AstName:     "And",
+		Commutative: true,
 		// Boolean AND returns false if any child node evaluates to false
 		LazyChildEvaluation: shortCircuitIfFalse,
 	},
 	FUNC_OR: {
-		DebugName: "FUNC_OR",
-		AstName:   "Or",
+		DebugName:   "FUNC_OR",
+		AstName:     "Or",
+		Commutative: true,
 		// Boolean OR returns true if any child nodes evluates to true
 		LazyChildEvaluation: shortCircuitIfTrue,
 	},

--- a/models/ast/ast_node.go
+++ b/models/ast/ast_node.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Node struct {
+	Index int
+
 	// A node is a constant xOR a function
 	Function Function
 	Constant any
@@ -48,4 +50,21 @@ func (node Node) ReadConstantNamedChildString(name string) (string, error) {
 		return "", errors.New(fmt.Sprintf("\"%s\" constant is not a string: takes value %v", name, child.Constant))
 	}
 	return value, nil
+}
+
+// Cost calculates the weights of an AST subtree to reorder, when the parent is commutative,
+// nodes to prioritize faster ones.
+func (node Node) Cost() int {
+	selfCost := 0
+	childCost := 0
+
+	if attrs, err := node.Function.Attributes(); err == nil {
+		selfCost = attrs.Cost
+	}
+
+	for _, ch := range node.Children {
+		childCost += ch.Cost()
+	}
+
+	return selfCost + childCost
 }

--- a/models/ast/ast_node.go
+++ b/models/ast/ast_node.go
@@ -65,6 +65,9 @@ func (node Node) Cost() int {
 	for _, ch := range node.Children {
 		childCost += ch.Cost()
 	}
+	for _, ch := range node.NamedChildren {
+		childCost += ch.Cost()
+	}
 
 	return selfCost + childCost
 }

--- a/models/ast/ast_node_evaluation.go
+++ b/models/ast/ast_node_evaluation.go
@@ -7,8 +7,9 @@ import (
 )
 
 type NodeEvaluation struct {
-	// Index of the initial node in the AST tree, used to reorder the results as they were.
-	// This should become obsolete when each node has a unique ID.
+	// Index of the initial node winhin its level of the AST tree, used to
+	// reorder the results as they were. This should become obsolete when each
+	// node has a unique ID.
 	Index int
 	// Skipped indicates whether this node was evaluated at all or not. A `true` values means the
 	// engine determined the result of this node would not impact the overall decision's outcome.

--- a/models/ast/ast_node_evaluation.go
+++ b/models/ast/ast_node_evaluation.go
@@ -7,6 +7,13 @@ import (
 )
 
 type NodeEvaluation struct {
+	// Index of the initial node in the AST tree, used to reorder the results as they were.
+	// This should become obsolete when each node has a unique ID.
+	Index int
+	// Skipped indicates whether this node was evaluated at all or not. A `true` values means the
+	// engine determined the result of this node would not impact the overall decision's outcome.
+	Skipped bool
+
 	Function    Function
 	ReturnValue any
 	Errors      []error

--- a/models/ast/ast_node_weight_test.go
+++ b/models/ast/ast_node_weight_test.go
@@ -1,0 +1,26 @@
+package ast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeWeights(t *testing.T) {
+	tts := []struct {
+		n Node
+		c int
+	}{
+		{Node{Function: FUNC_AND, Children: []Node{{Function: FUNC_DB_ACCESS}, {Function: FUNC_PAYLOAD}}}, 60},
+		{Node{Function: FUNC_AND, Children: []Node{{Function: FUNC_DB_ACCESS}, {
+			Function: FUNC_ADD, Children: []Node{{
+				Function: FUNC_AGGREGATOR,
+				Children: []Node{{Function: FUNC_CUSTOM_LIST_ACCESS}, {Function: FUNC_PAYLOAD}},
+			}},
+		}}}, 140},
+	}
+
+	for _, tt := range tts {
+		assert.Equal(t, tt.c, tt.n.Cost())
+	}
+}

--- a/models/ast/node_evaluation_dto.go
+++ b/models/ast/node_evaluation_dto.go
@@ -14,6 +14,7 @@ type NodeEvaluationDto struct {
 	Errors        []EvaluationErrorDto         `json:"errors"`
 	Children      []NodeEvaluationDto          `json:"children,omitempty"`
 	NamedChildren map[string]NodeEvaluationDto `json:"named_children,omitempty"`
+	Skipped       bool                         `json:"skipped"`
 }
 
 func AdaptNodeEvaluationDto(evaluation NodeEvaluation) NodeEvaluationDto {
@@ -29,6 +30,7 @@ func AdaptNodeEvaluationDto(evaluation NodeEvaluation) NodeEvaluationDto {
 		Errors:        pure_utils.Map(evaluation.Errors, AdaptEvaluationErrorDto),
 		Children:      pure_utils.Map(evaluation.Children, AdaptNodeEvaluationDto),
 		NamedChildren: pure_utils.MapValues(evaluation.NamedChildren, AdaptNodeEvaluationDto),
+		Skipped:       evaluation.Skipped,
 	}
 }
 

--- a/usecases/ast_eval/evaluate_ast.go
+++ b/usecases/ast_eval/evaluate_ast.go
@@ -11,6 +11,7 @@ func EvaluateAst(ctx context.Context, environment AstEvaluationEnvironment, node
 	// Early exit for constant, because it should have no children.
 	if node.Function == ast.FUNC_CONSTANT {
 		return ast.NodeEvaluation{
+			Index:       node.Index,
 			Function:    node.Function,
 			ReturnValue: node.Constant,
 			Errors:      []error{},
@@ -37,10 +38,13 @@ func EvaluateAst(ctx context.Context, environment AstEvaluationEnvironment, node
 		return
 	}
 
+	weightedNodes := NewWeightedNodes(environment, node, node.Children)
+
 	// eval each child
 	evaluation := ast.NodeEvaluation{
+		Index:         node.Index,
 		Function:      node.Function,
-		Children:      pure_utils.MapWhile(node.Children, evalChild),
+		Children:      weightedNodes.Reorder(pure_utils.MapWhile(weightedNodes.Sorted(), evalChild)),
 		NamedChildren: pure_utils.MapValuesWhile(node.NamedChildren, evalChild),
 	}
 

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -10,8 +10,9 @@ import (
 )
 
 type AstEvaluationEnvironment struct {
-	availableFunctions     map[ast.Function]evaluate.Evaluator
-	disableCircuitBreaking bool
+	availableFunctions       map[ast.Function]evaluate.Evaluator
+	disableCostOptimizations bool
+	disableCircuitBreaking   bool
 }
 
 func (environment *AstEvaluationEnvironment) AddEvaluator(function ast.Function, evaluator evaluate.Evaluator) {
@@ -28,8 +29,21 @@ func (environment *AstEvaluationEnvironment) GetEvaluator(function ast.Function)
 	return nil, errors.New(fmt.Sprintf("function '%s' is not available", function.DebugString()))
 }
 
+func (environment AstEvaluationEnvironment) WithoutOptimizations() AstEvaluationEnvironment {
+	environment.disableCostOptimizations = true
+	environment.disableCircuitBreaking = true
+
+	return environment
+}
+
 func (environment AstEvaluationEnvironment) WithoutCircuitBreaking() AstEvaluationEnvironment {
 	environment.disableCircuitBreaking = true
+
+	return environment
+}
+
+func (environment AstEvaluationEnvironment) WithoutCostOptimizations() AstEvaluationEnvironment {
+	environment.disableCostOptimizations = true
 
 	return environment
 }

--- a/usecases/ast_eval/weighted_nodes.go
+++ b/usecases/ast_eval/weighted_nodes.go
@@ -1,0 +1,73 @@
+package ast_eval
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+// Weighted nodes manages a flat list of nodes and offers an interface to process
+// them sorted by node cost. A lower-cost node will be executed earlier when the
+// parent is commutative.
+//
+// The parent is passed to the constructor, so that if it is not commutative, this
+// is basically a no-op.
+type WeightedNodes struct {
+	enabled  bool
+	original []ast.Node
+}
+
+func NewWeightedNodes(env AstEvaluationEnvironment, parent ast.Node, nodes []ast.Node) WeightedNodes {
+	enabled := false
+
+	if !env.disableCostOptimizations {
+		if fattrs, err := parent.Function.Attributes(); err == nil {
+			enabled = fattrs.Commutative
+		}
+	}
+
+	if enabled {
+		for idx := range nodes {
+			nodes[idx].Index = idx
+		}
+	}
+
+	return WeightedNodes{
+		enabled:  enabled,
+		original: nodes,
+	}
+}
+
+func (wn WeightedNodes) Sorted() []ast.Node {
+	if !wn.enabled {
+		return wn.original
+	}
+
+	return slices.SortedFunc(slices.Values(wn.original), func(lhs, rhs ast.Node) int {
+		return cmp.Compare(lhs.Cost(), rhs.Cost())
+	})
+}
+
+func (wn WeightedNodes) Reorder(results []ast.NodeEvaluation) []ast.NodeEvaluation {
+	if !wn.enabled {
+		return results
+	}
+
+	output := make([]ast.NodeEvaluation, len(wn.original))
+
+	for idx := range wn.original {
+		output[idx] = ast.NodeEvaluation{
+			Index:       idx,
+			Skipped:     true,
+			ReturnValue: nil,
+		}
+	}
+
+	for _, result := range results {
+		output[result.Index] = result
+		output[result.Index].Skipped = false
+	}
+
+	return output
+}

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -227,8 +227,7 @@ func (validator *AstValidatorImpl) MakeDryRunEnvironment(ctx context.Context,
 		ClientObject:                  clientObject,
 		DataModel:                     dataModel,
 		DatabaseAccessReturnFakeValue: true,
-	}).
-		WithoutCircuitBreaking()
+	}).WithoutOptimizations()
 
 	return env, nil
 }

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -91,7 +91,7 @@ func TestValidateScenarioIterationImpl_Validate(t *testing.T) {
 	validator := AstValidatorImpl{
 		DataModelRepository: mdmr,
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
-			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
+			return ast_eval.NewAstEvaluationEnvironment().WithoutOptimizations()
 		},
 		ExecutorFactory: executorFactory,
 	}
@@ -183,7 +183,7 @@ func TestValidateScenarioIterationImpl_Validate_notBool(t *testing.T) {
 	validator := AstValidatorImpl{
 		DataModelRepository: mdmr,
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
-			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
+			return ast_eval.NewAstEvaluationEnvironment().WithoutOptimizations()
 		},
 		ExecutorFactory: executorFactory,
 	}
@@ -283,7 +283,7 @@ func TestValidationShouldBypassCircuitBreaking(t *testing.T) {
 	validator := AstValidatorImpl{
 		DataModelRepository: mdmr,
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {
-			return ast_eval.NewAstEvaluationEnvironment().WithoutCircuitBreaking()
+			return ast_eval.NewAstEvaluationEnvironment().WithoutOptimizations()
 		},
 		ExecutorFactory: executorFactory,
 	}


### PR DESCRIPTION
This adds several things:

 * Commutative functions are marked as such.
 * AST functions now have an associated cost depending on their computational complexity.
 * Evaluation will now reorder the children of a commutative node to execute the cheapest first.

This would have the benefit, thanks to the lazy evaluation of AST nodes (circuit breaking), to improve overall performance for those scenarii.