### PR TITLE
Improve example env file to act as proper documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,12 @@
 # REQUIRED SETTINGS
 #
 
-ENV=development # MUST be set to 'production' when not testing. In which case HTTPS will be assumed.
+# MUST be set to 'production' when not testing. In which case HTTPS will be assumed.
+ENV=development
 PORT=8080
 
-MARBLE_APP_HOST="localhost:3000" # Set this to the domain and port used by your users to access Marble's frontend.
+# Set this to the domain and port used by your users to access Marble's frontend.
+MARBLE_APP_HOST="localhost:3000"
 
 # Set your license key here if you have one in order to access premium features.
 LICENSE_KEY=
@@ -24,7 +26,8 @@ PG_HOSTNAME=localhost
 PG_PORT=5432
 PG_USER=postgres
 PG_PASSWORD=marble
-PG_SSL_MODE=prefer # For production, this SHOULD be set to 'require'
+# For production, this SHOULD be set to 'require'
+PG_SSL_MODE=prefer
 
 # Change the three settings below to create your initial organization and users.
 # The user must also have a matching account in the authentication store used (in Firebase, for example).
@@ -78,8 +81,10 @@ CONVOY_PROJECT_ID=
 # TUNING
 #
 
-REQUEST_LOGGING_LEVEL=all # 'liveness' to only log health check probes
-LOGGING_FORMAT=text # 'text', 'json' or 'gcp'
+# 'liveness' to only log health check probes
+REQUEST_LOGGING_LEVEL=all
+# 'text', 'json' or 'gcp'
+LOGGING_FORMAT=text
 
 # You can customize the default timeout durations by uncommenting the following settings. Provided values are defaults.
 # BATCH_TIMEOUT_SECOND=55
@@ -98,7 +103,8 @@ LOGGING_FORMAT=text # 'text', 'json' or 'gcp'
 # CLOUD_RUN_PROBE_PORT=9000
 
 # Configure various external integrations.
-ENABLE_GCP_TRACING=false # Send traces to Google Cloud Platform (see https://cloud.google.com/trace/docs/setup/go-ot). Requires Application Default Credentials.
+# Send traces to Google Cloud Platform (see https://cloud.google.com/trace/docs/setup/go-ot). Requires Application Default Credentials.
+ENABLE_GCP_TRACING=false 
 SEGMENT_WRITE_KEY=UgkImFmHmBZAWh5fxIKBY3QtvlcBrhqQ
 SENTRY_DSN=
 

--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # REQUIRED SETTINGS
 #
 
-ENV=development # MUST be set to 'production' when not testing.
+ENV=development # MUST be set to 'production' when not testing. In which case HTTPS will be assumed.
 PORT=8080
 
 MARBLE_APP_HOST="localhost:3000" # Set this to the domain and port used by your users to access Marble's frontend.
@@ -35,6 +35,7 @@ CREATE_ORG_ADMIN_EMAIL=jbe@zorg.com
 # Configure the ID of your Firebase project for authentication and the path to the service account's JSON private key file.
 #  - The 'Project ID' can be found in the 'General' section of your Firebase project's settings page.
 #  - The private key must be generated in the 'Service accounts' tab by clicking 'Generate new private key'
+# If using the Firebase emulator, this should match the emulator's project ID.
 GOOGLE_CLOUD_PROJECT="firebase-project-id"
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/private/key.json
 
@@ -63,13 +64,12 @@ TRANSFER_CHECK_ENRICHMENT_BUCKET_URL="file://./tempFiles/transfercheck-bucket?cr
 
 # Configure the connection details to your Metabase instance.
 #  - To retrieve the JWT signing key, go to your Metabase admin panel, in 'Settings', then 'Embedding', and click 'Manage' under 'Static embedding'
-#  - TODO: Doc on how to deploy the dashboards?
 METABASE_SITE_URL="https://your_subdomain.metabaseapp.com"
 METABASE_JWT_SIGNING_KEY="dummy"
 METABASE_GLOBAL_DASHBOARD_ID=123
 
 # Set up connection details to Convoy to enable webhooks sending.
-# TODO: explain how to get those values.
+# You can get your project ID and API key from your project settings page in Convoy's dashboard, in the "Secrets" section.
 CONVOY_API_URL= 
 CONVOY_API_KEY=
 CONVOY_PROJECT_ID=
@@ -89,11 +89,6 @@ LOGGING_FORMAT=text # 'text', 'json' or 'gcp'
 #
 # OPTIONAL SETTINGS
 #
-
-# TODO: Remove those? They do not seem to be destined to be read/changed by users.
-# MARBLE_BACKOFFICE_HOST="localhost:3003"
-# CREATE_GLOBAL_ADMIN_EMAIL=admin@checkmarble.com
-# CLIENT_DB_CONFIG_FILE=""
 
 # Uncomment this line if you are using the Firebase emulator for testing.
 # FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"

--- a/.env.example
+++ b/.env.example
@@ -1,98 +1,111 @@
-ENV=development
-# port the servers listens on
+#
+# REQUIRED SETTINGS
+#
+
+ENV=development # MUST be set to 'production' when not testing.
 PORT=8080
-# port used by cloud run to probe container health when running the worker on Cloud Run
-CLOUD_RUN_PROBE_PORT=9000
 
-# Env variables for endpoints timeout (values are the default ones)
-# BATCH_TIMEOUT_SECOND=55
-# DECISION_TIMEOUT_SECOND=10
-# DEFAULT_TIMEOUT_SECOND=5
+MARBLE_APP_HOST="localhost:3000" # Set this to the domain and port used by your users to access Marble's frontend.
 
-# Use one of AUTHENTICATION_JWT_SIGNING_KEY or AUTHENTICATION_JWT_SIGNING_KEY_FILE:
-#    (AUTHENTICATION_JWT_SIGNING_KEY_FILE is recommended due to encoding issues with multiline env variables)
-# Expects a PKCS#1 or PKCS#8 PEM encoded private RSA key
-# Replace me in a production environment
+# Set your license key here if you have one in order to access premium features.
+LICENSE_KEY=
+
+# RSA private key, in PEM format, used for for signing authentication tokens. MUST be changed for production.
+# We recommend using AUTHENTICATION_JWT_SIGNING_KEY_FILE to point to a private key on disk.
+# To generate a private key, use `openssl genrsa -out /path/to/private/key.pem 4096`.
 AUTHENTICATION_JWT_SIGNING_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAs+6r50m7qqLHHy7CvfmJPnAi+t/tubi7DPSM2jvA1etT1jEX\nrwbFbmooOu9LTgmjmxOq01p+XwkW1f7iPZViKrf7dEDEuqmpqYG9jPX4G/7xFcci\nGn1iSOiNx9awIKSYZa1wodlMCRM081DGqFNDMf1PScWIyM40nIwaGqLZht4HcOAq\nLbKDa15bxubBqZ9o/YnE1KmyBfq1tTnk0KzAb12Axt0xN4qB2zktsV/LLds+szMk\n/gRHjann1+fCZvxw1JzzRPtgeHLLYzn4ks3mwzy67RO3q/663KPZCsuYhlNCsMqp\n/HAbrF5PaihqzCZqLTDoIXXciCFFgwtLwm951wIDAQABAoIBAQCpb60tJX+1VYeQ\n06XK43rb8xjdiZUA+PYbYwZoUzBpwSq3Xo9g4E12hjzQEpqlJ+qKk+CfGm457AM3\nDMfbGhrRA2Oku4EGDdKYrnXikZVMN6yqx1RUAZJV+bfZYU+Fzbk8tjCEGG3DdfS8\n02nfBFkYb+MEIyGFhriAWmYSgxu4JTN0XRTyPqBytoSLqVCFbv0/yV2oJQDaXW08\nWAA8JtWhzqxACbFnPYe0hYUnrCA71t0v1P/N5uB4kKxI0tulGtW84noSyWA2LSdn\nJlKQW5WsyeMulGBMnIpj/OQJtQErupoITsh1TNi+6ffGgmuMCT1za70DHXVq9Ihu\nkpKBe0wRAoGBAOSarLfNvsS2lTH/8zPyhWBddCS5CfQAeUFLD5xWhQ7/6SenYzYY\n+oiiH2uL7d8grkobX5QLVvJ5ZXziYWoKgJe3SlrvRuNJZCAxvuynUCahhCT+chwW\nGz7ihXh3bGD0gtO6iogGBfrAkvRQnorkdSmVEZd1PsJV/lXp8LKgxJ91AoGBAMl+\ny/6NbzVHt9oQsrVrG/sCAOlqlfTt5KW6pI1WC4LoKBaGe+hy4emZ0G/M2feAJEPR\n92QrPRkVF5bVCjalJj42/7gQIl6r+DQ4+08gLB1MSpWua2M3UtEi/2gsMcQff/wg\n6kmNZObW5Jcnqpp6u72zQTQwF4H29XucV/Yw93abAoGADGvfIKmcSQIGv03CADuY\nRbEuQ2SOhuSTshmLApqs5jC/kXkF6gWXb18nx+c1iJ80+S/dlKS9F7XC7vM6CdIC\nRLwf3SsNNgJh32H0ltVMhJzYGk59EsuctWEHkZEjoW0HwstrBZMWNhbKpV3QD4n0\nV8sSxqEHRPX5ON/aRUp5BJUCgYEAlsymr2P6js2V80X7+Xqn/juJoyd6A0znioEd\nFgoHo3lMR09u/JC+Mq5DKOkPWAQ3H+rMU9NobpUyilf2xN7kuDtBNugcUO4zXCIp\nMxbI7URjrZJUHHUTLiIbNEOfG0DX8EJSFaoUkg7SFa5CKEsipt65Ne2oKkRBhLmF\nu2L6UXECgYBH1bpi0R6j7lIADtZtIJII/TezQbp+VK2R9qoNgkTnHoDjkRVR7v3m\n75wReMvTy1h0Qx/ROtStZz8d5uQuhdeJvbQPQR8KGFUFZDmVWxU+y15WI2H39FMA\nMireKxzCfGGtTsZnhDqYl9NuRPcAGYt5jvoERXlz7b69rkqQUrfy+Q==\n-----END RSA PRIVATE KEY-----"
-# Or alternatively (set me and create a file if you want to use a file)
-AUTHENTICATION_JWT_SIGNING_KEY_FILE=""
+# AUTHENTICATION_JWT_SIGNING_KEY_FILE="/path/to/private/key.pem"
 
-# Env variables for the postgresql database
-PG_CONNECTION_STRING=
-# Set the connection params by passing a connection string above (more flexible) or by setting the variables below
+# Configure your PostgreSQL database connection information, either by providing a DSN using this form:
+# PG_CONNECTION_STRING='postgres://postgres:marble@localhost:5432/marble?sslmode=prefer'
+
+# Or by setting each piece of information in those variables:
 PG_HOSTNAME=localhost
 PG_PORT=5432
 PG_USER=postgres
 PG_PASSWORD=marble
-# only recommended for local development - use "require" for production
-PG_SSL_MODE=prefer
+PG_SSL_MODE=prefer # For production, this SHOULD be set to 'require'
 
-# pointing to the file with the configuration for the client dbs
-CLIENT_DB_CONFIG_FILE=""
+# Change the three settings below to create your initial organization and users.
+# The user must also have a matching account in the authentication store used (in Firebase, for example).
+# Subsequent users will be able to be created from the application.
+CREATE_ORG_NAME=Zorg
+CREATE_ORG_ADMIN_EMAIL=jbe@zorg.com
 
-MARBLE_APP_HOST="localhost:3000"
-MARBLE_BACKOFFICE_HOST="localhost:3003"
+# Configure the ID of your Firebase project for authentication and the path to the service account's JSON private key file.
+#  - The 'Project ID' can be found in the 'General' section of your Firebase project's settings page.
+#  - The private key must be generated in the 'Service accounts' tab by clicking 'Generate new private key'
+GOOGLE_CLOUD_PROJECT="firebase-project-id"
+GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/private/key.json
 
-# Used by the firebase sdk to validate the id tokens
-FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
-
-# Used:
-# - by the firebase sdk to validate the id tokens
-# - by the opentelemetry tracing agent to send traces to the collector
-GOOGLE_CLOUD_PROJECT="tokyo-country-381508"
-
-# Used by the GCS SDK to authenticate
-GOOGLE_APPLICATION_CREDENTIALS=
-
-# Enable to activate GCP tracing
-# If activated, you MUST have GCP application default credentials set up - see https://cloud.google.com/trace/docs/setup/go-ot
-# Will send error logs (but the app will still run) if an unexisting project is specified in GOOGLE_CLOUD_PROJECT or 
-# if the runner does not have the correct permissions to use tracing on the project
-ENABLE_GCP_TRACING=false
-
-# 'liveness' (only log liveness requests) || 'all' (log all requests) || any other value for no request logs
-REQUEST_LOGGING_LEVEL=all
-# 'json' || 'text' || 'gcp'
-LOGGING_FORMAT=text
-
-# Configure the document storage backend
-# The options are
-# - "file://{path}?create_dir=true"
-#    - for LOCAL TEST only, not fully compatible with all features - create_dir not required if the folder exists)
-#    - see https://pkg.go.dev/gocloud.dev/blob/fileblob#URLOpener for details on the format
-# - "gs://{bucket_name}"
-# - "s3://{bucket_name}"
-# - "azblob://{bucket_name}"
-# See https://gocloud.dev/howto/blob/ for details.
-# Using a Google Cloud Storage (gs://) bucket backend additionally requires that a service account key be present in the file pointed 
-# to by GOOGLE_APPLICATION_CREDENTIALS. This is because with GCS, a private key from a service account key must be present to return signed urls.
-# In all cases, credentials discovery is done automatically according to each provider's usual practices (env variables, 
-# credentials file, metadata server...)
+# Configure the document blob storage backend.
+# The example values MUST be changed for anything but a local test environment since the file provider does not support all features.
+#
+# Several blob storage implementations are supported:
+#  - 'file://{path}?create_dir=true' (see https://pkg.go.dev/gocloud.dev/blob/fileblob#URLOpener)
+#  - 'gs://{bucket_name}' for Google Cloud Storage
+#  - 's3://{bucket_name}' for AWS S3 or any S3-compatible platform (Minio, ...)
+#  - 'azblob://{bucket_name}' for Azure Blob Storage
+#
+# Depending on the used cloud provider, the idiomatic way to discover credentials will be used, such as:
+#  - GOOGLE_APPLICATION_CREDENTIALS or Application Default Credentials for Google Cloud Platform
+#  - AWS_DEFAULT_REGION, AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or default profile for Amazon Web Services
+#  - AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY or equivalent for Azure
+#
+# If you are using Minio, you should use the S3 provider with some options set, depending on your setup, for example:
+#  - s3://marble?awssdk=v1&endpoint=https://minio.local&s3ForcePathStyle=true
+# When testing Marble, you can add the 'requireSSL=false' query parameter to connect in cleartext.
+#
+# See https://gocloud.dev/howto/blob/ for more details.
 INGESTION_BUCKET_URL="file://./tempFiles/data-ingestion-bucket?create_dir=true"
 CASE_MANAGER_BUCKET_URL="file://./tempFiles/case-manager-bucket?create_dir=true"
 TRANSFER_CHECK_ENRICHMENT_BUCKET_URL="file://./tempFiles/transfercheck-bucket?create_dir=true"
 
-# Othe dependency configurations
-SEGMENT_WRITE_KEY=UgkImFmHmBZAWh5fxIKBY3QtvlcBrhqQ
-SENTRY_DSN=
-
-# Metabase configuration
+# Configure the connection details to your Metabase instance.
+#  - To retrieve the JWT signing key, go to your Metabase admin panel, in 'Settings', then 'Embedding', and click 'Manage' under 'Static embedding'
+#  - TODO: Doc on how to deploy the dashboards?
 METABASE_SITE_URL="https://your_subdomain.metabaseapp.com"
 METABASE_JWT_SIGNING_KEY="dummy"
 METABASE_GLOBAL_DASHBOARD_ID=123
 
-# Used to create a first default admin user if no user exists
-CREATE_GLOBAL_ADMIN_EMAIL=admin@checkmarble.com
-# Used to create an organization if no organization exists with this name
-CREATE_ORG_NAME=Zorg
-# Used to create a first organization admin if no user exists with this email
-CREATE_ORG_ADMIN_EMAIL=jbe@zorg.com
-
-# Org variables used to connect to convoy for webhooks sending
+# Set up connection details to Convoy to enable webhooks sending.
+# TODO: explain how to get those values.
+CONVOY_API_URL= 
 CONVOY_API_KEY=
-CONVOY_API_URL=
 CONVOY_PROJECT_ID=
 
-# Env variables for license retrieval
-LICENSE_KEY=
+#
+# TUNING
+#
+
+REQUEST_LOGGING_LEVEL=all # 'liveness' to only log health check probes
+LOGGING_FORMAT=text # 'text', 'json' or 'gcp'
+
+# You can customize the default timeout durations by uncommenting the following settings. Provided values are defaults.
+# BATCH_TIMEOUT_SECOND=55
+# DECISION_TIMEOUT_SECOND=10
+# DEFAULT_TIMEOUT_SECOND=5
+
+#
+# OPTIONAL SETTINGS
+#
+
+# TODO: Remove those? They do not seem to be destined to be read/changed by users.
+# MARBLE_BACKOFFICE_HOST="localhost:3003"
+# CREATE_GLOBAL_ADMIN_EMAIL=admin@checkmarble.com
+# CLIENT_DB_CONFIG_FILE=""
+
+# Uncomment this line if you are using the Firebase emulator for testing.
+# FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
+
+# If running the worker process in an environment requiring all processes to respond on an HTTP port, uncomment this setting.
+# For example, Cloud Run requires all services to process liveness checks to keep running.
+# CLOUD_RUN_PROBE_PORT=9000
+
+# Configure various external integrations.
+ENABLE_GCP_TRACING=false # Send traces to Google Cloud Platform (see https://cloud.google.com/trace/docs/setup/go-ot). Requires Application Default Credentials.
+SEGMENT_WRITE_KEY=UgkImFmHmBZAWh5fxIKBY3QtvlcBrhqQ
+SENTRY_DSN=
+
+# Abort and exit if license cannot be validated.
 KILL_IF_READ_LICENSE_ERROR=false


### PR DESCRIPTION
Rationale for changes:

 * File is organized thus:
   * Mandatory settings go at the top
   * Then tuning settings
   * Finally, optional settings most people will not touch
 * Examples are given when value format is not obvious (database DSN or bucket URLs).
 * If requiring external value, explain how to get the value.
 * Internal settings not for end users are removed from the file
 * All settings provide detailed explanation as to what value to set them
 * When settings have alternatives, only one is present, the others are commented out.
 * Try to avoid repeating the settings name as its only explanation.