### PR TITLE
Pascal/mar 726 enforce limitations on what actions can be taken on a

### DIFF
--- a/api/handle_sanction_checks.go
+++ b/api/handle_sanction_checks.go
@@ -37,13 +37,13 @@ func handleListSanctionChecks(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		uc := usecasesWithCreds(ctx, uc).NewSanctionCheckUsecase()
-		sanctionCheck, err := uc.GetSanctionCheck(ctx, decisionId)
+		sanctionChecks, err := uc.ListSanctionChecks(ctx, decisionId)
 
 		if presentError(ctx, c, err) {
 			return
 		}
 
-		c.JSON(http.StatusOK, dto.AdaptSanctionCheckDto(sanctionCheck))
+		c.JSON(http.StatusOK, pure_utils.Map(sanctionChecks, dto.AdaptSanctionCheckDto))
 	}
 }
 

--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -33,7 +33,7 @@ type SanctionCheckRequestDto struct {
 	Query     json.RawMessage `json:"query"`
 }
 
-func AdaptSanctionCheckDto(m models.SanctionCheck) SanctionCheckDto {
+func AdaptSanctionCheckDto(m models.SanctionCheckWithMatches) SanctionCheckDto {
 	sanctionCheck := SanctionCheckDto{
 		Id: m.Id,
 		Request: SanctionCheckRequestDto{

--- a/models/decision.go
+++ b/models/decision.go
@@ -50,7 +50,7 @@ type DecisionCore struct {
 type DecisionWithRuleExecutions struct {
 	Decision
 	RuleExecutions         []RuleExecution
-	SanctionCheckExecution *SanctionCheck
+	SanctionCheckExecution *SanctionCheckWithMatches
 }
 
 type DecisionsByVersionByOutcome struct {
@@ -74,7 +74,7 @@ type ScenarioExecution struct {
 	PivotId                *string
 	PivotValue             *string
 	RuleExecutions         []RuleExecution
-	SanctionCheckExecution *SanctionCheck
+	SanctionCheckExecution *SanctionCheckWithMatches
 	Score                  int
 	Outcome                Outcome
 	OrganizationId         string

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -50,6 +50,10 @@ func (scs SanctionCheckStatus) String() string {
 	return "unknown"
 }
 
+func (scs SanctionCheckStatus) IsReviewable() bool {
+	return scs == SanctionStatusInReview
+}
+
 type SanctionCheckMatchStatus int
 
 const (
@@ -101,14 +105,25 @@ type SanctionCheck struct {
 	IsArchived  bool
 	RequestedBy *string
 	Partial     bool
-	Count       int
-	Matches     []SanctionCheckMatch
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
 }
 
-func (sc SanctionCheck) IsReviewable() bool {
-	return sc.Status == SanctionStatusInReview
+type SanctionCheckWithMatches struct {
+	Id          string
+	DecisionId  string
+	Status      SanctionCheckStatus
+	Datasets    []string
+	Query       json.RawMessage
+	OrgConfig   OrganizationOpenSanctionsConfig
+	IsManual    bool
+	IsArchived  bool
+	RequestedBy *string
+	Partial     bool
+	Count       int
+	Matches     []SanctionCheckMatch
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type SanctionCheckMatch struct {

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -110,20 +110,9 @@ type SanctionCheck struct {
 }
 
 type SanctionCheckWithMatches struct {
-	Id          string
-	DecisionId  string
-	Status      SanctionCheckStatus
-	Datasets    []string
-	Query       json.RawMessage
-	OrgConfig   OrganizationOpenSanctionsConfig
-	IsManual    bool
-	IsArchived  bool
-	RequestedBy *string
-	Partial     bool
-	Count       int
-	Matches     []SanctionCheckMatch
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	SanctionCheck
+	Matches []SanctionCheckMatch
+	Count   int
 }
 
 type SanctionCheckMatch struct {

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -98,6 +98,7 @@ type SanctionCheck struct {
 	Query       json.RawMessage
 	OrgConfig   OrganizationOpenSanctionsConfig
 	IsManual    bool
+	IsArchived  bool
 	RequestedBy *string
 	Partial     bool
 	Count       int

--- a/repositories/dbmodels/db_sanction_check.go
+++ b/repositories/dbmodels/db_sanction_check.go
@@ -33,17 +33,38 @@ func AdaptSanctionCheck(dto DBSanctionCheck) (models.SanctionCheck, error) {
 		MatchThreshold: dto.SearchThreshold,
 	}
 
+	return models.SanctionCheck{
+		Id:          dto.Id,
+		DecisionId:  dto.DecisionId,
+		Datasets:    dto.SearchDatasets,
+		Query:       dto.SearchInput,
+		OrgConfig:   cfg,
+		Partial:     dto.IsPartial,
+		Status:      models.SanctionCheckStatusFrom(dto.Status),
+		IsManual:    dto.IsManual,
+		IsArchived:  dto.IsArchived,
+		RequestedBy: dto.RequestedBy,
+		CreatedAt:   dto.CreatedAt,
+		UpdatedAt:   dto.UpdatedAt,
+	}, nil
+}
+
+func AdaptSanctionCheckWithMatches(dto DBSanctionCheck) (models.SanctionCheckWithMatches, error) {
+	cfg := models.OrganizationOpenSanctionsConfig{
+		MatchThreshold: dto.SearchThreshold,
+	}
+
 	matches := make([]models.SanctionCheckMatch, 0, len(dto.Matches))
 	for _, match := range dto.Matches {
 		m, err := AdaptSanctionCheckMatch(match)
 		if err != nil {
-			return models.SanctionCheck{}, err
+			return models.SanctionCheckWithMatches{}, err
 		}
 
 		matches = append(matches, m)
 	}
 
-	return models.SanctionCheck{
+	return models.SanctionCheckWithMatches{
 		Id:          dto.Id,
 		DecisionId:  dto.DecisionId,
 		Datasets:    dto.SearchDatasets,

--- a/repositories/dbmodels/db_sanction_check.go
+++ b/repositories/dbmodels/db_sanction_check.go
@@ -13,23 +13,34 @@ const TABLE_SANCTION_CHECKS = "sanction_checks"
 var SelectSanctionChecksColumn = utils.ColumnList[DBSanctionCheck]()
 
 type DBSanctionCheck struct {
-	Id              string          `db:"id"`
-	DecisionId      string          `db:"decision_id"`
-	Status          string          `db:"status"`
-	SearchInput     json.RawMessage `db:"search_input"`
-	SearchDatasets  []string        `db:"search_datasets"`
-	SearchThreshold *int            `db:"search_threshold"`
-	IsManual        bool            `db:"is_manual"`
-	RequestedBy     *string         `db:"requested_by"`
-	IsPartial       bool            `db:"is_partial"`
-	IsArchived      bool            `db:"is_archived"`
-	CreatedAt       time.Time       `db:"created_at"`
-	UpdatedAt       time.Time       `db:"updated_at"`
+	Id              string                 `db:"id"`
+	DecisionId      string                 `db:"decision_id"`
+	Status          string                 `db:"status"`
+	SearchInput     json.RawMessage        `db:"search_input"`
+	SearchDatasets  []string               `db:"search_datasets"`
+	SearchThreshold *int                   `db:"search_threshold"`
+	IsManual        bool                   `db:"is_manual"`
+	RequestedBy     *string                `db:"requested_by"`
+	IsPartial       bool                   `db:"is_partial"`
+	IsArchived      bool                   `db:"is_archived"`
+	CreatedAt       time.Time              `db:"created_at"`
+	UpdatedAt       time.Time              `db:"updated_at"`
+	Matches         []DBSanctionCheckMatch `db:"matches"`
 }
 
 func AdaptSanctionCheck(dto DBSanctionCheck) (models.SanctionCheck, error) {
 	cfg := models.OrganizationOpenSanctionsConfig{
 		MatchThreshold: dto.SearchThreshold,
+	}
+
+	matches := make([]models.SanctionCheckMatch, 0, len(dto.Matches))
+	for _, match := range dto.Matches {
+		m, err := AdaptSanctionCheckMatch(match)
+		if err != nil {
+			return models.SanctionCheck{}, err
+		}
+
+		matches = append(matches, m)
 	}
 
 	return models.SanctionCheck{
@@ -41,6 +52,11 @@ func AdaptSanctionCheck(dto DBSanctionCheck) (models.SanctionCheck, error) {
 		Partial:     dto.IsPartial,
 		Status:      models.SanctionCheckStatusFrom(dto.Status),
 		IsManual:    dto.IsManual,
+		IsArchived:  dto.IsArchived,
 		RequestedBy: dto.RequestedBy,
+		CreatedAt:   dto.CreatedAt,
+		UpdatedAt:   dto.UpdatedAt,
+		Matches:     matches,
+		Count:       len(matches),
 	}, nil
 }

--- a/repositories/dbmodels/db_sanction_check.go
+++ b/repositories/dbmodels/db_sanction_check.go
@@ -65,19 +65,21 @@ func AdaptSanctionCheckWithMatches(dto DBSanctionCheck) (models.SanctionCheckWit
 	}
 
 	return models.SanctionCheckWithMatches{
-		Id:          dto.Id,
-		DecisionId:  dto.DecisionId,
-		Datasets:    dto.SearchDatasets,
-		Query:       dto.SearchInput,
-		OrgConfig:   cfg,
-		Partial:     dto.IsPartial,
-		Status:      models.SanctionCheckStatusFrom(dto.Status),
-		IsManual:    dto.IsManual,
-		IsArchived:  dto.IsArchived,
-		RequestedBy: dto.RequestedBy,
-		CreatedAt:   dto.CreatedAt,
-		UpdatedAt:   dto.UpdatedAt,
-		Matches:     matches,
-		Count:       len(matches),
+		SanctionCheck: models.SanctionCheck{
+			Id:          dto.Id,
+			DecisionId:  dto.DecisionId,
+			Datasets:    dto.SearchDatasets,
+			Query:       dto.SearchInput,
+			OrgConfig:   cfg,
+			Partial:     dto.IsPartial,
+			Status:      models.SanctionCheckStatusFrom(dto.Status),
+			IsManual:    dto.IsManual,
+			IsArchived:  dto.IsArchived,
+			RequestedBy: dto.RequestedBy,
+			CreatedAt:   dto.CreatedAt,
+			UpdatedAt:   dto.UpdatedAt,
+		},
+		Matches: matches,
+		Count:   len(matches),
 	}, nil
 }

--- a/repositories/httpmodels/http_opensanctions_result.go
+++ b/repositories/httpmodels/http_opensanctions_result.go
@@ -27,7 +27,7 @@ type HTTPOpenSanctionResultResult struct {
 	} `json:"properties"`
 }
 
-func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsResult) (models.SanctionCheck, error) {
+func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsResult) (models.SanctionCheckWithMatches, error) {
 	partial := false
 	matches := make(map[string]models.SanctionCheckMatch)
 	matchToQueryId := make(map[string][]string)
@@ -41,7 +41,7 @@ func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsRes
 			var parsed HTTPOpenSanctionResultResult
 
 			if err := json.NewDecoder(bytes.NewReader(match)).Decode(&parsed); err != nil {
-				return models.SanctionCheck{}, err
+				return models.SanctionCheckWithMatches{}, err
 			}
 
 			if _, ok := matches[parsed.Id]; !ok {
@@ -64,7 +64,7 @@ func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsRes
 		}
 	}
 
-	output := models.SanctionCheck{
+	output := models.SanctionCheckWithMatches{
 		Query:   query,
 		Partial: partial,
 		Count:   len(matches),

--- a/repositories/httpmodels/http_opensanctions_result.go
+++ b/repositories/httpmodels/http_opensanctions_result.go
@@ -65,8 +65,10 @@ func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsRes
 	}
 
 	output := models.SanctionCheckWithMatches{
-		Query:   query,
-		Partial: partial,
+		SanctionCheck: models.SanctionCheck{
+			Query:   query,
+			Partial: partial,
+		},
 		Count:   len(matches),
 		Matches: slices.Collect(maps.Values(matches)),
 	}

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -96,10 +96,10 @@ func (repo OpenSanctionsRepository) GetLatestLocalDataset(ctx context.Context) (
 func (repo OpenSanctionsRepository) Search(ctx context.Context,
 	cfg models.SanctionCheckConfig,
 	query models.OpenSanctionsQuery,
-) (models.SanctionCheck, error) {
+) (models.SanctionCheckWithMatches, error) {
 	req, rawQuery, err := repo.searchRequest(ctx, query)
 	if err != nil {
-		return models.SanctionCheck{}, err
+		return models.SanctionCheckWithMatches{}, err
 	}
 
 	utils.LoggerFromContext(ctx).InfoContext(ctx, "sending sanction check query")
@@ -107,12 +107,12 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context,
 
 	resp, err := repo.opensanctions.Client().Do(req)
 	if err != nil {
-		return models.SanctionCheck{},
+		return models.SanctionCheckWithMatches{},
 			errors.Wrap(err, "could not perform sanction check")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return models.SanctionCheck{}, fmt.Errorf(
+		return models.SanctionCheckWithMatches{}, fmt.Errorf(
 			"sanction check API returned status %d", resp.StatusCode)
 	}
 
@@ -121,7 +121,7 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context,
 	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(&matches); err != nil {
-		return models.SanctionCheck{}, errors.Wrap(err,
+		return models.SanctionCheckWithMatches{}, errors.Wrap(err,
 			"could not parse sanction check response")
 	}
 

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -51,7 +51,7 @@ type CaseUseCaseRepository interface {
 }
 
 type CaseUsecaseSanctionCheckRepository interface {
-	GetActiveSanctionCheckForDecision(context.Context, repositories.Executor, string) (models.SanctionCheck, error)
+	GetActiveSanctionCheckForDecision(context.Context, repositories.Executor, string) (*models.SanctionCheck, error)
 }
 
 type webhookEventsUsecase interface {
@@ -1017,7 +1017,7 @@ func (usecase *CaseUseCase) ReviewCaseDecisions(
 		if err != nil {
 			return models.Case{}, errors.Wrap(err, "could not retrieve sanction check")
 		}
-		if sanctionCheck.Status != models.SanctionStatusNoHit {
+		if sanctionCheck != nil && sanctionCheck.Status != models.SanctionStatusNoHit {
 			return models.Case{}, errors.Wrap(models.BadParameterError,
 				"cannot approve a decision with possible sanction hits")
 		}

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -51,7 +51,8 @@ type CaseUseCaseRepository interface {
 }
 
 type CaseUsecaseSanctionCheckRepository interface {
-	GetActiveSanctionCheckForDecision(context.Context, repositories.Executor, string) (*models.SanctionCheck, error)
+	GetActiveSanctionCheckForDecision(context.Context, repositories.Executor, string) (
+		*models.SanctionCheckWithMatches, error)
 }
 
 type webhookEventsUsecase interface {

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -9,7 +9,7 @@ import (
 
 func evaluateSanctionCheck(ctx context.Context, repositories ScenarioEvaluationRepositories,
 	iteration models.ScenarioIteration, params ScenarioEvaluationParameters, dataAccessor DataAccessor,
-) (sanctionCheck *models.SanctionCheck, performed bool, sanctionCheckErr error) {
+) (sanctionCheck *models.SanctionCheckWithMatches, performed bool, sanctionCheckErr error) {
 	if iteration.SanctionCheckConfig != nil && iteration.SanctionCheckConfig.Enabled {
 		triggerEvaluation, err := repositories.EvaluateAstExpression.EvaluateAstExpression(
 			ctx,

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -34,7 +34,7 @@ type ScenarioEvaluationParameters struct {
 
 type EvalSanctionCheckUsecase interface {
 	Execute(context.Context, string, models.SanctionCheckConfig,
-		models.OpenSanctionsQuery) (models.SanctionCheck, error)
+		models.OpenSanctionsQuery) (models.SanctionCheckWithMatches, error)
 }
 
 type SnoozesForDecisionReader interface {

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -103,7 +103,7 @@ func (uc SanctionCheckUsecase) ListSanctionChecks(ctx context.Context, decisionI
 		return nil, errors.Wrap(models.NotFoundError, "requested decision does not exist")
 	}
 
-	if err := uc.enforceSecurityDecision.ReadDecision(decisions[0]); err != nil {
+	if _, err = uc.enforceCanReadOrUpdateCase(ctx, decisions[0].DecisionId); err != nil {
 		return nil, err
 	}
 

--- a/usecases/sanction_check_usecase_test.go
+++ b/usecases/sanction_check_usecase_test.go
@@ -32,7 +32,7 @@ func buildSanctionCheckUsecaseMock() (SanctionCheckUsecase, executor_factory.Exe
 	return uc, exec
 }
 
-func TestGetSanctionCheckOnDecision(t *testing.T) {
+func TestListSanctionChecksOnDecision(t *testing.T) {
 	uc, exec := buildSanctionCheckUsecaseMock()
 	mockSc, mockScRow := utils.FakeStruct[dbmodels.DBSanctionCheck](
 		ops.WithRandomMapAndSliceMinSize(1))

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -301,15 +301,16 @@ func (usecases *UsecasesWithCreds) NewInboxReader() inboxes.InboxReader {
 
 func (usecases *UsecasesWithCreds) NewCaseUseCase() *CaseUseCase {
 	return &CaseUseCase{
-		enforceSecurity:      usecases.NewEnforceCaseSecurity(),
-		transactionFactory:   usecases.NewTransactionFactory(),
-		executorFactory:      usecases.NewExecutorFactory(),
-		repository:           &usecases.Repositories.MarbleDbRepository,
-		decisionRepository:   &usecases.Repositories.MarbleDbRepository,
-		inboxReader:          usecases.NewInboxReader(),
-		caseManagerBucketUrl: usecases.caseManagerBucketUrl,
-		blobRepository:       usecases.Repositories.BlobRepository,
-		webhookEventsUsecase: usecases.NewWebhookEventsUsecase(),
+		enforceSecurity:         usecases.NewEnforceCaseSecurity(),
+		transactionFactory:      usecases.NewTransactionFactory(),
+		executorFactory:         usecases.NewExecutorFactory(),
+		repository:              &usecases.Repositories.MarbleDbRepository,
+		decisionRepository:      &usecases.Repositories.MarbleDbRepository,
+		inboxReader:             usecases.NewInboxReader(),
+		caseManagerBucketUrl:    usecases.caseManagerBucketUrl,
+		blobRepository:          usecases.Repositories.BlobRepository,
+		webhookEventsUsecase:    usecases.NewWebhookEventsUsecase(),
+		sanctionCheckRepository: &usecases.Repositories.MarbleDbRepository,
 	}
 }
 

--- a/utils/testing.go
+++ b/utils/testing.go
@@ -4,9 +4,10 @@ import (
 	"reflect"
 
 	"github.com/go-faker/faker/v4"
+	"github.com/go-faker/faker/v4/pkg/options"
 )
 
-func FakeStruct[T any]() (T, []any) {
+func FakeStruct[T any](opt ...options.OptionFunc) (T, []any) {
 	var object T
 
 	_ = faker.FakeData(&object)
@@ -14,7 +15,7 @@ func FakeStruct[T any]() (T, []any) {
 	return object, StructToMockRow(object)
 }
 
-func FakeStructs[T any](n int) ([]T, [][]any) {
+func FakeStructs[T any](n int, opt ...options.OptionFunc) ([]T, [][]any) {
 	objects := make([]T, n)
 	rows := make([][]any, n)
 


### PR DESCRIPTION
## business logic content
- implement restrictions on what can be done on a decision (changing its review status) depending on the presence of a sanction check

## refactoring
- the repo method that retrieves the sanction check for a decision now returns an optional value (a pointer), because there may be none
- repo methods that read sanction checks now do a join with matches in order to return a full "SanctionCheckWithMatches" model (otherwise it was hard to know if a given SanctionCheck model instance has the matches attached or not