### PR TITLE
Pascal/mar 725 enforce license keys feature access permissions to setup the

### DIFF
--- a/dto/scenario_iterations.go
+++ b/dto/scenario_iterations.go
@@ -36,7 +36,6 @@ type ScenarioIterationBodyDto struct {
 }
 
 type SanctionCheckConfig struct {
-	Enabled       *bool                     `json:"enabled"`
 	Datasets      []string                  `json:"datasets,omitempty"`
 	ForceOutcome  *string                   `json:"force_outcome,omitempty"`
 	ScoreModifier *int                      `json:"score_modifier,omitempty"`
@@ -105,7 +104,6 @@ func AdaptScenarioIterationWithBodyDto(si models.ScenarioIteration) (ScenarioIte
 		}
 
 		body.SanctionCheckConfig = &SanctionCheckConfig{
-			Enabled:       &si.SanctionCheckConfig.Enabled,
 			Datasets:      si.SanctionCheckConfig.Datasets,
 			ForceOutcome:  nil,
 			ScoreModifier: &si.SanctionCheckConfig.Outcome.ScoreModifier,
@@ -167,7 +165,6 @@ func AdaptUpdateScenarioIterationInput(input UpdateScenarioIterationBody, iterat
 
 	if input.Body.SanctionCheckConfig != nil {
 		updateScenarioIterationInput.Body.SanctionCheckConfig = &models.UpdateSanctionCheckConfigInput{
-			Enabled:     input.Body.SanctionCheckConfig.Enabled,
 			Datasets:    input.Body.SanctionCheckConfig.Datasets,
 			TriggerRule: nil,
 			Outcome: models.UpdateSanctionCheckOutcomeInput{

--- a/mocks/feature_access_reader.go
+++ b/mocks/feature_access_reader.go
@@ -1,0 +1,19 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/mock"
+)
+
+type FeatureAccessReader struct {
+	mock.Mock
+}
+
+func (r *FeatureAccessReader) GetOrganizationFeatureAccess(ctx context.Context,
+	organizationId string,
+) (models.OrganizationFeatureAccess, error) {
+	args := r.Called(ctx, organizationId)
+	return args.Get(0).(models.OrganizationFeatureAccess), args.Error(1)
+}

--- a/mocks/sanction_check_config_repository.go
+++ b/mocks/sanction_check_config_repository.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/stretchr/testify/mock"
+)
+
+type SanctionCheckConfigRepository struct {
+	mock.Mock
+}
+
+func (r *SanctionCheckConfigRepository) GetSanctionCheckConfig(
+	ctx context.Context,
+	exec repositories.Executor,
+	scenarioIterationId string,
+) (*models.SanctionCheckConfig, error) {
+	args := r.Called(ctx, exec, scenarioIterationId)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.SanctionCheckConfig), args.Error(1)
+}
+
+func (r *SanctionCheckConfigRepository) UpdateSanctionCheckConfig(
+	ctx context.Context,
+	exec repositories.Executor,
+	scenarioIterationId string,
+	sanctionCheckConfig models.UpdateSanctionCheckConfigInput,
+) (models.SanctionCheckConfig, error) {
+	args := r.Called(ctx, exec, scenarioIterationId, sanctionCheckConfig)
+	return args.Get(0).(models.SanctionCheckConfig), args.Error(1)
+}

--- a/models/feature_access.go
+++ b/models/feature_access.go
@@ -36,3 +36,7 @@ func FeatureAccessFrom(s string) FeatureAccess {
 	}
 	return UnknownFeatureAccess
 }
+
+func (f FeatureAccess) IsAllowed() bool {
+	return f == Allowed || f == Test
+}

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -55,6 +55,7 @@ type UpdateScenarioIterationBody struct {
 }
 
 type SanctionCheckConfig struct {
+	// TODO: Do we really need the "enabled" field ?
 	Enabled     bool
 	Datasets    []string
 	TriggerRule ast.Node

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -55,8 +55,6 @@ type UpdateScenarioIterationBody struct {
 }
 
 type SanctionCheckConfig struct {
-	// TODO: Do we really need the "enabled" field ?
-	Enabled     bool
 	Datasets    []string
 	TriggerRule ast.Node
 	Query       SanctionCheckConfigQuery
@@ -69,7 +67,6 @@ type SanctionCheckOutcome struct {
 }
 
 type UpdateSanctionCheckConfigInput struct {
-	Enabled     *bool
 	Datasets    []string
 	TriggerRule *ast.Node
 	Query       *SanctionCheckConfigQuery

--- a/repositories/dbmodels/db_sanction_check_config.go
+++ b/repositories/dbmodels/db_sanction_check_config.go
@@ -16,7 +16,6 @@ const TABLE_SANCTION_CHECK_CONFIGS = "sanction_check_configs"
 type DBSanctionCheckConfigs struct {
 	Id                  string                     `db:"id"`
 	ScenarioIterationId string                     `db:"scenario_iteration_id"`
-	Enabled             bool                       `db:"enabled"`
 	Datasets            []string                   `db:"datasets"`
 	TriggerRule         []byte                     `db:"trigger_rule"`
 	Query               DBSanctionCheckConfigQuery `db:"query"`
@@ -54,7 +53,6 @@ func AdaptSanctionCheckConfig(db DBSanctionCheckConfigs) (models.SanctionCheckCo
 	}
 
 	scc := models.SanctionCheckConfig{
-		Enabled:     db.Enabled,
 		Datasets:    db.Datasets,
 		TriggerRule: *triggerRuleAst,
 		Query:       query,

--- a/repositories/eval_scenario_testrun.go
+++ b/repositories/eval_scenario_testrun.go
@@ -11,7 +11,7 @@ type EvalScenarioRepository interface {
 }
 
 type EvalSanctionCheckConfigRepository interface {
-	GetSanctionCheckConfig(ctx context.Context, exec Executor, scenarioIterationId string) (models.SanctionCheckConfig, error)
+	GetSanctionCheckConfig(ctx context.Context, exec Executor, scenarioIterationId string) (*models.SanctionCheckConfig, error)
 }
 
 type EvalTestRunScenarioRepository interface {

--- a/repositories/migrations/20250203205500_sanction_check_config_drop_enabled.sql
+++ b/repositories/migrations/20250203205500_sanction_check_config_drop_enabled.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE sanction_check_configs
+DROP COLUMN enabled;
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sanction_check_configs
+ADD COLUMN enabled BOOLEAN NOT NULL DEFAULT TRUE;
+
+-- +goose StatementEnd

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -94,10 +94,7 @@ func (repo OpenSanctionsRepository) GetLatestLocalDataset(ctx context.Context) (
 	return dataset, nil
 }
 
-func (repo OpenSanctionsRepository) Search(ctx context.Context,
-	cfg models.SanctionCheckConfig,
-	query models.OpenSanctionsQuery,
-) (models.SanctionCheckWithMatches, error) {
+func (repo OpenSanctionsRepository) Search(ctx context.Context, query models.OpenSanctionsQuery) (models.SanctionCheckWithMatches, error) {
 	req, rawQuery, err := repo.searchRequest(ctx, query)
 	if err != nil {
 		return models.SanctionCheckWithMatches{}, err

--- a/repositories/opensanctions_repository_test.go
+++ b/repositories/opensanctions_repository_test.go
@@ -30,6 +30,7 @@ func TestOpenSanctionsSelfHostedApi(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("https://yente.local", "", "")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -40,7 +41,7 @@ func TestOpenSanctionsSelfHostedApi(t *testing.T) {
 		Post("/match/sanctions").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -52,6 +53,7 @@ func TestOpenSanctionsSelfHostedAndApiKey(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("https://yente.local", "", "abcdef")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -63,7 +65,7 @@ func TestOpenSanctionsSelfHostedAndApiKey(t *testing.T) {
 		MatchParam("api_key", "abcdef").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -75,6 +77,7 @@ func TestOpenSanctionsSaaSAndApiKey(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("", "", "abcdef")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -86,7 +89,7 @@ func TestOpenSanctionsSaaSAndApiKey(t *testing.T) {
 		MatchParam("api_key", "abcdef").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -98,6 +101,7 @@ func TestOpenSanctionsSelfHostedAndBearerToken(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("https://yente.local", "bearer", "abcdef")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -109,7 +113,7 @@ func TestOpenSanctionsSelfHostedAndBearerToken(t *testing.T) {
 		MatchHeader("authorization", "Bearer abcdef").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -121,6 +125,7 @@ func TestOpenSanctionsSelfHostedAndBasicAuth(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("https://yente.local", "basic", "abcdef:helloworld")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -132,7 +137,7 @@ func TestOpenSanctionsSelfHostedAndBasicAuth(t *testing.T) {
 		MatchHeader("authorization", "Basic YWJjZGVmOmhlbGxvd29ybGQ=").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -144,6 +149,7 @@ func TestOpenSanctionsError(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("", "", "")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -154,7 +160,7 @@ func TestOpenSanctionsError(t *testing.T) {
 		Post("/match/sanctions").
 		Reply(http.StatusBadRequest)
 
-	_, err := repo.Search(context.TODO(), cfg, query)
+	_, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.Error(t, err)
@@ -166,6 +172,7 @@ func TestOpenSanctionsSuccessfulPartialResponse(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("", "", "")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -179,7 +186,7 @@ func TestOpenSanctionsSuccessfulPartialResponse(t *testing.T) {
 		Reply(http.StatusOK).
 		BodyString(string(body))
 
-	matches, err := repo.Search(context.TODO(), cfg, query)
+	matches, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.NoError(t, err)
@@ -194,6 +201,7 @@ func TestOpenSanctionsSuccessfulFullResponse(t *testing.T) {
 	repo := getMockedOpenSanctionsRepository("", "", "")
 	cfg := models.SanctionCheckConfig{}
 	query := models.OpenSanctionsQuery{
+		Config: cfg,
 		Queries: models.OpenSanctionCheckFilter{
 			"name": []string{"bob"},
 		},
@@ -207,7 +215,7 @@ func TestOpenSanctionsSuccessfulFullResponse(t *testing.T) {
 		Reply(http.StatusOK).
 		BodyString(string(body))
 
-	matches, err := repo.Search(context.TODO(), cfg, query)
+	matches, err := repo.Search(context.TODO(), query)
 
 	assert.False(t, gock.HasUnmatchedRequest())
 	assert.NoError(t, err)

--- a/repositories/sanction_check_config_repository.go
+++ b/repositories/sanction_check_config_repository.go
@@ -13,18 +13,21 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func (repo *MarbleDbRepository) GetSanctionCheckConfig(ctx context.Context, exec Executor,
+func (repo *MarbleDbRepository) GetSanctionCheckConfig(
+	ctx context.Context,
+	exec Executor,
 	scenarioIterationId string,
-) (models.SanctionCheckConfig, error) {
+) (*models.SanctionCheckConfig, error) {
 	if err := validateMarbleDbExecutor(exec); err != nil {
-		return models.SanctionCheckConfig{}, err
+		return nil, err
 	}
 
 	sql := NewQueryBuilder().
-		Select("*").From(dbmodels.TABLE_SANCTION_CHECK_CONFIGS).
+		Select(dbmodels.SanctionCheckConfigColumnList...).
+		From(dbmodels.TABLE_SANCTION_CHECK_CONFIGS).
 		Where(squirrel.Eq{"scenario_iteration_id": scenarioIterationId})
 
-	return SqlToModel(ctx, exec, sql, dbmodels.AdaptSanctionCheckConfig)
+	return SqlToOptionalModel(ctx, exec, sql, dbmodels.AdaptSanctionCheckConfig)
 }
 
 func (repo *MarbleDbRepository) UpdateSanctionCheckConfig(ctx context.Context, exec Executor,

--- a/repositories/sanction_check_config_repository.go
+++ b/repositories/sanction_check_config_repository.go
@@ -60,10 +60,9 @@ func (repo *MarbleDbRepository) UpdateSanctionCheckConfig(ctx context.Context, e
 
 	sql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_SANCTION_CHECK_CONFIGS).
-		Columns("scenario_iteration_id", "enabled", "datasets", "forced_outcome", "score_modifier", "trigger_rule", "query").
+		Columns("scenario_iteration_id", "datasets", "forced_outcome", "score_modifier", "trigger_rule", "query").
 		Values(
 			scenarioIterationId,
-			utils.Or(cfg.Enabled, true),
 			cfg.Datasets,
 			cfg.Outcome.ForceOutcome.MaybeString(),
 			utils.Or(cfg.Outcome.ScoreModifier, 0),
@@ -73,9 +72,6 @@ func (repo *MarbleDbRepository) UpdateSanctionCheckConfig(ctx context.Context, e
 
 	updateFields := make([]string, 0, 4)
 
-	if cfg.Enabled != nil {
-		updateFields = append(updateFields, "enabled = EXCLUDED.enabled")
-	}
 	if cfg.Datasets != nil {
 		updateFields = append(updateFields, "datasets = EXCLUDED.datasets")
 	}

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -76,6 +76,13 @@ type DecisionUsecaseRepository interface {
 	GetCaseById(ctx context.Context, exec repositories.Executor, caseId string) (models.Case, error)
 }
 
+type decisionUsecaseFeatureAccessReader interface {
+	GetOrganizationFeatureAccess(
+		ctx context.Context,
+		organizationId string,
+	) (models.OrganizationFeatureAccess, error)
+}
+
 type decisionWorkflowsUsecase interface {
 	AutomaticDecisionToCase(
 		ctx context.Context,
@@ -113,6 +120,7 @@ type DecisionUsecase struct {
 	webhookEventsSender           webhookEventsUsecase
 	phantomUseCase                decision_phantom.PhantomDecisionUsecase
 	snoozesReader                 snoozesForDecisionReader
+	featureAccessReader           decisionUsecaseFeatureAccessReader
 }
 
 func (usecase *DecisionUsecase) GetDecision(ctx context.Context, decisionId string) (models.DecisionWithRuleExecutions, error) {

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -417,6 +417,7 @@ func (usecase *DecisionUsecase) CreateDecision(
 		IngestedDataReadRepository:        usecase.ingestedDataReadRepository,
 		EvaluateAstExpression:             usecase.evaluateAstExpression,
 		SnoozeReader:                      usecase.snoozesReader,
+		FeatureAccessReader:               usecase.featureAccessReader,
 	}
 
 	scenarioExecution, err := evaluate_scenario.EvalScenario(ctx, evaluationParameters, evaluationRepositories)
@@ -575,10 +576,12 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 	evaluationRepositories := evaluate_scenario.ScenarioEvaluationRepositories{
 		EvalScenarioRepository:            usecase.repository,
 		EvalSanctionCheckConfigRepository: usecase.sanctionCheckConfigRepository,
+		EvalSanctionCheckUsecase:          usecase.sanctionCheckUsecase,
 		ExecutorFactory:                   usecase.executorFactory,
 		IngestedDataReadRepository:        usecase.ingestedDataReadRepository,
 		EvaluateAstExpression:             usecase.evaluateAstExpression,
 		SnoozeReader:                      usecase.snoozesReader,
+		FeatureAccessReader:               usecase.featureAccessReader,
 	}
 
 	type decisionAndScenario struct {

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -8,57 +8,72 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func evaluateSanctionCheck(ctx context.Context,
-	evaluator ast_eval.EvaluateAstExpression, executor EvalSanctionCheckUsecase,
-	iteration models.ScenarioIteration, params ScenarioEvaluationParameters, dataAccessor DataAccessor,
-) (sanctionCheck *models.SanctionCheckWithMatches, performed bool, sanctionCheckErr error) {
-	if iteration.SanctionCheckConfig != nil && iteration.SanctionCheckConfig.Enabled {
-		triggerEvaluation, err := evaluator.EvaluateAstExpression(
-			ctx,
-			nil,
-			iteration.SanctionCheckConfig.TriggerRule,
-			params.Scenario.OrganizationId,
-			dataAccessor.ClientObject,
-			params.DataModel,
-		)
-		if err != nil {
-			sanctionCheckErr = errors.Wrap(err, "could not execute sanction check trigger rule")
-			return
-		}
-		if _, ok := triggerEvaluation.ReturnValue.(bool); !ok {
-			sanctionCheckErr = errors.New("sanction check trigger rule did not evaluate to a boolean")
-		}
-
-		if triggerEvaluation.ReturnValue == true {
-			nameFilterAny, err := evaluator.EvaluateAstExpression(ctx, nil,
-				iteration.SanctionCheckConfig.Query.Name, iteration.OrganizationId,
-				dataAccessor.ClientObject, dataAccessor.DataModel)
-			if err != nil {
-				return nil, true, err
-			}
-			nameFilter, ok := nameFilterAny.ReturnValue.(string)
-			if !ok {
-				return nil, true, errors.New("name filter name query did not return a string")
-			}
-
-			query := models.OpenSanctionsQuery{
-				Config: *iteration.SanctionCheckConfig,
-				Queries: models.OpenSanctionCheckFilter{
-					"name": []string{nameFilter},
-				},
-			}
-
-			result, err := executor.Execute(ctx,
-				params.Scenario.OrganizationId, *iteration.SanctionCheckConfig, query)
-			if err != nil {
-				sanctionCheckErr = errors.Wrap(err, "could not perform sanction check")
-				return
-			}
-
-			sanctionCheck = &result
-			performed = true
-		}
+func evaluateSanctionCheck(
+	ctx context.Context,
+	evaluator ast_eval.EvaluateAstExpression,
+	executor EvalSanctionCheckUsecase,
+	iteration models.ScenarioIteration,
+	params ScenarioEvaluationParameters,
+	dataAccessor DataAccessor,
+) (
+	sanctionCheck *models.SanctionCheckWithMatches,
+	performed bool,
+	sanctionCheckErr error,
+) {
+	// First, check if the sanction check should be performed
+	if iteration.SanctionCheckConfig == nil || !iteration.SanctionCheckConfig.Enabled {
+		return
 	}
 
+	triggerEvaluation, err := evaluator.EvaluateAstExpression(
+		ctx,
+		nil,
+		iteration.SanctionCheckConfig.TriggerRule,
+		params.Scenario.OrganizationId,
+		dataAccessor.ClientObject,
+		params.DataModel,
+	)
+	if err != nil {
+		sanctionCheckErr = errors.Wrap(err, "could not execute sanction check trigger rule")
+		return
+	}
+	passed, ok := triggerEvaluation.ReturnValue.(bool)
+	if !ok {
+		sanctionCheckErr = errors.New("sanction check trigger rule did not evaluate to a boolean")
+	} else if !passed {
+		return
+	}
+
+	// Then, actually perform the sanction check
+	nameFilterAny, err := evaluator.EvaluateAstExpression(
+		ctx,
+		nil,
+		iteration.SanctionCheckConfig.Query.Name,
+		iteration.OrganizationId,
+		dataAccessor.ClientObject,
+		dataAccessor.DataModel)
+	if err != nil {
+		return nil, true, err
+	}
+	nameFilter, ok := nameFilterAny.ReturnValue.(string)
+	if !ok {
+		return nil, true, errors.New("name filter name query did not return a string")
+	}
+
+	query := models.OpenSanctionsQuery{
+		Config: *iteration.SanctionCheckConfig,
+		Queries: models.OpenSanctionCheckFilter{
+			"name": []string{nameFilter},
+		},
+	}
+
+	result, err := executor.Execute(ctx, params.Scenario.OrganizationId, query)
+	if err != nil {
+		sanctionCheckErr = errors.Wrap(err, "could not perform sanction check")
+		return
+	}
+
+	sanctionCheck = &result
+	performed = true
 	return
 }

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -21,7 +21,7 @@ func evaluateSanctionCheck(
 	sanctionCheckErr error,
 ) {
 	// First, check if the sanction check should be performed
-	if iteration.SanctionCheckConfig == nil || !iteration.SanctionCheckConfig.Enabled {
+	if iteration.SanctionCheckConfig == nil {
 		return
 	}
 

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -57,7 +57,6 @@ func TestSanctionCheckSkippedWhenTriggerRuleFalse(t *testing.T) {
 
 	iteration := models.ScenarioIteration{
 		SanctionCheckConfig: &models.SanctionCheckConfig{
-			Enabled:     true,
 			TriggerRule: ast.Node{Constant: false},
 		},
 	}
@@ -74,7 +73,6 @@ func TestSanctionCheckErrorWhenNameQueryNotString(t *testing.T) {
 
 	iteration := models.ScenarioIteration{
 		SanctionCheckConfig: &models.SanctionCheckConfig{
-			Enabled:     true,
 			TriggerRule: ast.Node{Constant: true},
 			Query: models.SanctionCheckConfigQuery{
 				Name: ast.Node{Constant: 12},
@@ -94,7 +92,6 @@ func TestSanctionCheckCalledWhenNameFilterConstant(t *testing.T) {
 
 	iteration := models.ScenarioIteration{
 		SanctionCheckConfig: &models.SanctionCheckConfig{
-			Enabled:     true,
 			TriggerRule: ast.Node{Constant: true},
 			Query: models.SanctionCheckConfigQuery{
 				Name: ast.Node{Constant: "constant string"},
@@ -123,7 +120,6 @@ func TestSanctionCheckCalledWhenNameFilterConcat(t *testing.T) {
 
 	iteration := models.ScenarioIteration{
 		SanctionCheckConfig: &models.SanctionCheckConfig{
-			Enabled:     true,
 			TriggerRule: ast.Node{Constant: true},
 			Query: models.SanctionCheckConfigQuery{
 				Name: ast.Node{

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -15,13 +15,15 @@ type mockSanctionCheckExecutor struct {
 	*mock.Mock
 }
 
-func (m mockSanctionCheckExecutor) Execute(ctx context.Context, orgId string,
-	cfg models.SanctionCheckConfig, query models.OpenSanctionsQuery,
+func (m mockSanctionCheckExecutor) Execute(
+	ctx context.Context,
+	orgId string,
+	query models.OpenSanctionsQuery,
 ) (models.SanctionCheckWithMatches, error) {
 	// We are not mocking returned data here, only that the function was called
 	// with the appropriate arguments, so we always expect this to be called.
-	m.On("Execute", context.TODO(), orgId, cfg, query)
-	m.Called(ctx, orgId, cfg, query)
+	m.On("Execute", context.TODO(), orgId, query)
+	m.Called(ctx, orgId, query)
 
 	return models.SanctionCheckWithMatches{}, nil
 }
@@ -110,8 +112,7 @@ func TestSanctionCheckCalledWhenNameFilterConstant(t *testing.T) {
 	_, performed, err := evaluateSanctionCheck(context.TODO(), eval, exec, iteration,
 		ScenarioEvaluationParameters{}, DataAccessor{})
 
-	exec.Mock.AssertCalled(t, "Execute", context.TODO(), "",
-		*iteration.SanctionCheckConfig, expectedQuery)
+	exec.Mock.AssertCalled(t, "Execute", context.TODO(), "", expectedQuery)
 
 	assert.True(t, performed)
 	assert.NoError(t, err)
@@ -147,8 +148,7 @@ func TestSanctionCheckCalledWhenNameFilterConcat(t *testing.T) {
 	_, performed, err := evaluateSanctionCheck(context.TODO(), eval, exec, iteration,
 		ScenarioEvaluationParameters{}, DataAccessor{})
 
-	exec.Mock.AssertCalled(t, "Execute", context.TODO(), "",
-		*iteration.SanctionCheckConfig, expectedQuery)
+	exec.Mock.AssertCalled(t, "Execute", context.TODO(), "", expectedQuery)
 
 	assert.True(t, performed)
 	assert.NoError(t, err)

--- a/usecases/feature_access/feature_access_reader.go
+++ b/usecases/feature_access/feature_access_reader.go
@@ -1,0 +1,57 @@
+package feature_access
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/security"
+)
+
+type FeatureAccessReaderOrgRepository interface {
+	GetOrganizationFeatureAccess(
+		ctx context.Context,
+		executor repositories.Executor,
+		organizationId string,
+	) (models.DbStoredOrganizationFeatureAccess, error)
+}
+
+type FeatureAccessReader struct {
+	enforceSecurity security.EnforceSecurityOrganization
+	orgRepo         FeatureAccessReaderOrgRepository
+	executorFactory executor_factory.ExecutorFactory
+	license         models.LicenseValidation
+}
+
+func NewFeatureAccessReader(
+	enforceSecurity security.EnforceSecurityOrganization,
+	orgRepo FeatureAccessReaderOrgRepository,
+	executorFactory executor_factory.ExecutorFactory,
+	license models.LicenseValidation,
+) FeatureAccessReader {
+	return FeatureAccessReader{
+		enforceSecurity: enforceSecurity,
+		orgRepo:         orgRepo,
+		executorFactory: executorFactory,
+		license:         license,
+	}
+}
+
+func (f FeatureAccessReader) GetOrganizationFeatureAccess(
+	ctx context.Context,
+	organizationId string,
+) (models.OrganizationFeatureAccess, error) {
+	if err := f.enforceSecurity.ReadOrganization(organizationId); err != nil {
+		return models.OrganizationFeatureAccess{}, err
+	}
+
+	dbStoredFeatureAccess, err := f.orgRepo.GetOrganizationFeatureAccess(ctx,
+		f.executorFactory.NewExecutor(), organizationId)
+	if err != nil {
+		return models.OrganizationFeatureAccess{}, err
+	}
+
+	return dbStoredFeatureAccess.MergeWithLicenseEntitlement(
+		&f.license.LicenseEntitlements), nil
+}

--- a/usecases/sanction_check_config_usecase.go
+++ b/usecases/sanction_check_config_usecase.go
@@ -8,7 +8,7 @@ import (
 )
 
 type SanctionCheckConfigRepository interface {
-	GetSanctionCheckConfig(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (models.SanctionCheckConfig, error)
+	GetSanctionCheckConfig(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (*models.SanctionCheckConfig, error)
 	UpdateSanctionCheckConfig(ctx context.Context, exec repositories.Executor,
 		scenarioIterationId string, sanctionCheckConfig models.UpdateSanctionCheckConfigInput) (models.SanctionCheckConfig, error)
 }

--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -312,7 +312,6 @@ func (usecase *ScenarioIterationUsecase) CreateDraftFromScenarioIteration(
 
 			if sanctionCheckConfig != nil {
 				newSanctionCheckConfig := models.UpdateSanctionCheckConfigInput{
-					Enabled:     &sanctionCheckConfig.Enabled,
 					Datasets:    sanctionCheckConfig.Datasets,
 					TriggerRule: &sanctionCheckConfig.TriggerRule,
 					Outcome: models.UpdateSanctionCheckOutcomeInput{

--- a/usecases/scenario_publication_usecase_test.go
+++ b/usecases/scenario_publication_usecase_test.go
@@ -27,6 +27,7 @@ type ScenarioPublicationUsecaseTestSuite struct {
 	transaction                    *mocks.Transaction
 	transactionFactory             *mocks.TransactionFactory
 	clientDbIndexEditor            *mocks.ClientDbIndexEditor
+	featureAccessReader            *mocks.FeatureAccessReader
 
 	organizationId                string
 	scenarioId                    string
@@ -54,6 +55,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) SetupTest() {
 	suite.transaction = new(mocks.Transaction)
 	suite.transactionFactory = &mocks.TransactionFactory{TxMock: suite.transaction}
 	suite.clientDbIndexEditor = new(mocks.ClientDbIndexEditor)
+	suite.featureAccessReader = new(mocks.FeatureAccessReader)
 
 	suite.organizationId = "organizationId"
 	suite.scenarioId = "scenarioId"
@@ -144,15 +146,16 @@ func (suite *ScenarioPublicationUsecaseTestSuite) SetupTest() {
 }
 
 func (suite *ScenarioPublicationUsecaseTestSuite) makeUsecase() *ScenarioPublicationUsecase {
-	return &ScenarioPublicationUsecase{
-		enforceSecurity:                suite.enforceSecurity,
-		executorFactory:                suite.executorFactory,
-		scenarioFetcher:                suite.scenarioFetcher,
-		scenarioPublicationsRepository: suite.scenarioPublicationsRepository,
-		scenarioPublisher:              suite.scenarioPublisher,
-		transactionFactory:             suite.transactionFactory,
-		clientDbIndexEditor:            suite.clientDbIndexEditor,
-	}
+	return NewScenarioPublicationUsecase(
+		suite.transactionFactory,
+		suite.executorFactory,
+		suite.scenarioPublicationsRepository,
+		suite.enforceSecurity,
+		suite.scenarioFetcher,
+		suite.scenarioPublisher,
+		suite.clientDbIndexEditor,
+		suite.featureAccessReader,
+	)
 }
 
 func (suite *ScenarioPublicationUsecaseTestSuite) AssertExpectations() {

--- a/usecases/scenarios/scenario_and_iteration.go
+++ b/usecases/scenarios/scenario_and_iteration.go
@@ -2,7 +2,6 @@ package scenarios
 
 import (
 	"context"
-	"errors"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
@@ -13,7 +12,7 @@ type ScenarioFetcherRepository interface {
 	GetScenarioIteration(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (
 		models.ScenarioIteration, error,
 	)
-	GetSanctionCheckConfig(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (models.SanctionCheckConfig, error)
+	GetSanctionCheckConfig(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (*models.SanctionCheckConfig, error)
 }
 
 type ScenarioFetcher struct {
@@ -29,12 +28,10 @@ func (fetcher ScenarioFetcher) FetchScenarioAndIteration(ctx context.Context,
 	}
 
 	sanctionCheckConfig, err := fetcher.Repository.GetSanctionCheckConfig(ctx, exec, iterationId)
-	switch {
-	case err == nil:
-		result.Iteration.SanctionCheckConfig = &sanctionCheckConfig
-	case !errors.Is(err, models.NotFoundError):
+	if err != nil {
 		return models.ScenarioAndIteration{}, err
 	}
+	result.Iteration.SanctionCheckConfig = sanctionCheckConfig
 
 	result.Scenario, err = fetcher.Repository.GetScenarioById(ctx, exec, result.Iteration.ScenarioId)
 	if err != nil {

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -196,16 +196,17 @@ func (usecases *UsecasesWithCreds) NewCustomListUseCase() CustomListUseCase {
 	}
 }
 
-func (usecases *UsecasesWithCreds) NewScenarioPublicationUsecase() ScenarioPublicationUsecase {
-	return ScenarioPublicationUsecase{
-		transactionFactory:             usecases.NewTransactionFactory(),
-		executorFactory:                usecases.NewExecutorFactory(),
-		scenarioPublicationsRepository: usecases.Repositories.ScenarioPublicationRepository,
-		enforceSecurity:                usecases.NewEnforceScenarioSecurity(),
-		scenarioFetcher:                usecases.NewScenarioFetcher(),
-		scenarioPublisher:              usecases.NewScenarioPublisher(),
-		clientDbIndexEditor:            usecases.NewClientDbIndexEditor(),
-	}
+func (usecases *UsecasesWithCreds) NewScenarioPublicationUsecase() *ScenarioPublicationUsecase {
+	return NewScenarioPublicationUsecase(
+		usecases.NewTransactionFactory(),
+		usecases.NewExecutorFactory(),
+		usecases.Repositories.ScenarioPublicationRepository,
+		usecases.NewEnforceScenarioSecurity(),
+		usecases.NewScenarioFetcher(),
+		usecases.NewScenarioPublisher(),
+		usecases.NewClientDbIndexEditor(),
+		usecases.NewFeatureAccessReader(),
+	)
 }
 
 func (usecases *UsecasesWithCreds) NewClientDbIndexEditor() clientDbIndexEditor {
@@ -485,6 +486,8 @@ func (usecases UsecasesWithCreds) NewAsyncDecisionWorker() *scheduled_execution.
 			&usecases.Repositories.MarbleDbRepository, &usecases.Repositories.MarbleDbRepository,
 			&usecases.Repositories.MarbleDbRepository, &usecases.Repositories.MarbleDbRepository,
 			&usecases.Repositories.MarbleDbRepository),
+		usecases.NewFeatureAccessReader(),
+		usecases.NewSanctionCheckUsecase(),
 	)
 	return &w
 }
@@ -514,4 +517,17 @@ func (usecases UsecasesWithCreds) NewFeatureAccessReader() feature_access.Featur
 		usecases.NewExecutorFactory(),
 		usecases.Usecases.license,
 	)
+}
+
+func (usecases *UsecasesWithCreds) NewScenarioTestRunUseCase() ScenarioTestRunUsecase {
+	return ScenarioTestRunUsecase{
+		transactionFactory:            usecases.NewTransactionFactory(),
+		executorFactory:               usecases.NewExecutorFactory(),
+		enforceSecurity:               usecases.NewEnforceTestRunScenarioSecurity(),
+		repository:                    &usecases.Repositories.MarbleDbRepository,
+		clientDbIndexEditor:           usecases.NewClientDbIndexEditor(),
+		scenarioRepository:            &usecases.Repositories.MarbleDbRepository,
+		featureAccessReader:           usecases.NewFeatureAccessReader(),
+		sanctionCheckConfigRepository: &usecases.Repositories.MarbleDbRepository,
+	}
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -4,6 +4,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases/decision_phantom"
 	"github.com/checkmarble/marble-backend/usecases/decision_workflows"
+	"github.com/checkmarble/marble-backend/usecases/feature_access"
 	"github.com/checkmarble/marble-backend/usecases/inboxes"
 	"github.com/checkmarble/marble-backend/usecases/indexes"
 	"github.com/checkmarble/marble-backend/usecases/scheduled_execution"
@@ -115,6 +116,7 @@ func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 			&usecases.Repositories.MarbleDbRepository, &usecases.Repositories.MarbleDbRepository,
 			&usecases.Repositories.MarbleDbRepository),
 		scenarioTestRunRepository: &usecases.Repositories.MarbleDbRepository,
+		featureAccessReader:       usecases.NewFeatureAccessReader(),
 	}
 }
 
@@ -226,7 +228,7 @@ func (usecases *UsecasesWithCreds) NewOrganizationUseCase() OrganizationUseCase 
 		usecases.NewOrganizationCreator(),
 		usecases.Repositories.OrganizationSchemaRepository,
 		usecases.NewExecutorFactory(),
-		usecases.Usecases.license,
+		usecases.NewFeatureAccessReader(),
 	)
 }
 
@@ -503,4 +505,13 @@ func (usecases UsecasesWithCreds) NewNewAsyncScheduledExecWorker() *scheduled_ex
 		&usecases.Repositories.MarbleDbRepository,
 	)
 	return &w
+}
+
+func (usecases UsecasesWithCreds) NewFeatureAccessReader() feature_access.FeatureAccessReader {
+	return feature_access.NewFeatureAccessReader(
+		usecases.NewEnforceOrganizationSecurity(),
+		usecases.Repositories.OrganizationRepository,
+		usecases.NewExecutorFactory(),
+		usecases.Usecases.license,
+	)
 }


### PR DESCRIPTION
## Content
### small refactoring in the first commit
- GetSanctionCheckConfig by scenario iteration id returns a pointer to a sanction check config, because there may not be a sanction check on the iteration
- remove some function parameters that were effectively passed in a duplicate way
- de-indent some code in usecases/evaluate_scenario/evaluate_sanction_check.go (TBH this one is a matter of taste, I like to try and keep code not over indented to keep the flow more readable, but I'm happy to discuss it and revert it)

### Actual aim of the PR
- create a feature access class that we can reuse everywhere we need to check feature accesses before doing things in the backend

