### PR TITLE
rework evaluate scenario deps injection

### DIFF
--- a/repositories/decision_phantoms_repository.go
+++ b/repositories/decision_phantoms_repository.go
@@ -15,19 +15,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-type DecisionPhantomUsecaseRepository interface {
-	StorePhantomDecision(
-		ctx context.Context,
-		exec Executor,
-		decision models.PhantomDecision,
-		organizationId string,
-		testRunId string,
-		newPhantomDecisionId string,
-		scenarioVersion int) error
-
-	GetTestRunIterationIdByScenarioId(ctx context.Context, exec Executor, scenarioID string) (*string, error)
-}
-
 func (repo *MarbleDbRepository) StorePhantomDecision(
 	ctx context.Context,
 	exec Executor,

--- a/usecases/ast_eval/evaluate_ast_expression.go
+++ b/usecases/ast_eval/evaluate_ast_expression.go
@@ -13,7 +13,7 @@ type EvaluateAstExpression struct {
 	AstEvaluationEnvironmentFactory AstEvaluationEnvironmentFactory
 }
 
-func (evaluator *EvaluateAstExpression) EvaluateAstExpression(
+func (evaluator EvaluateAstExpression) EvaluateAstExpression(
 	ctx context.Context,
 	cache *EvaluationCache,
 	ruleAstExpression ast.Node,

--- a/usecases/decision_workflows/decision_workflows.go
+++ b/usecases/decision_workflows/decision_workflows.go
@@ -51,7 +51,7 @@ type webhookEventCreator interface {
 
 type CaseNameEvaluator interface {
 	EvalCaseName(ctx context.Context, params evaluate_scenario.ScenarioEvaluationParameters,
-		repositories evaluate_scenario.ScenarioEvaluationRepositories, scenario models.Scenario) (string, error)
+		scenario models.Scenario) (string, error)
 }
 
 type DecisionsWorkflows struct {
@@ -80,7 +80,6 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 	tx repositories.Transaction,
 	scenario models.Scenario,
 	decision models.DecisionWithRuleExecutions,
-	repositories evaluate_scenario.ScenarioEvaluationRepositories,
 	params evaluate_scenario.ScenarioEvaluationParameters,
 	webhookEventId string,
 ) (addedToCase bool, err error) {
@@ -92,7 +91,7 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 	}
 
 	if scenario.DecisionToCaseWorkflowType == models.WorkflowCreateCase {
-		caseName, err := d.caseNameEvaluator.EvalCaseName(ctx, params, repositories, scenario)
+		caseName, err := d.caseNameEvaluator.EvalCaseName(ctx, params, scenario)
 		if err != nil {
 			return false, errors.Wrap(err, "error creating case for decision")
 		}
@@ -121,7 +120,7 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 		}
 
 		if !added {
-			caseName, err := d.caseNameEvaluator.EvalCaseName(ctx, params, repositories, scenario)
+			caseName, err := d.caseNameEvaluator.EvalCaseName(ctx, params, scenario)
 			if err != nil {
 				return false, errors.Wrap(err, "error creating case for decision")
 			}

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -7,10 +7,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func evaluateSanctionCheck(
+func (e ScenarioEvaluator) evaluateSanctionCheck(
 	ctx context.Context,
-	evaluator EvaluateAstExpression,
-	executor EvalSanctionCheckUsecase,
 	iteration models.ScenarioIteration,
 	params ScenarioEvaluationParameters,
 	dataAccessor DataAccessor,
@@ -24,7 +22,7 @@ func evaluateSanctionCheck(
 		return
 	}
 
-	triggerEvaluation, err := evaluator.EvaluateAstExpression(
+	triggerEvaluation, err := e.evaluateAstExpression.EvaluateAstExpression(
 		ctx,
 		nil,
 		iteration.SanctionCheckConfig.TriggerRule,
@@ -44,7 +42,7 @@ func evaluateSanctionCheck(
 	}
 
 	// Then, actually perform the sanction check
-	nameFilterAny, err := evaluator.EvaluateAstExpression(
+	nameFilterAny, err := e.evaluateAstExpression.EvaluateAstExpression(
 		ctx,
 		nil,
 		iteration.SanctionCheckConfig.Query.Name,
@@ -66,7 +64,7 @@ func evaluateSanctionCheck(
 		},
 	}
 
-	result, err := executor.Execute(ctx, params.Scenario.OrganizationId, query)
+	result, err := e.evalSanctionCheckUsecase.Execute(ctx, params.Scenario.OrganizationId, query)
 	if err != nil {
 		sanctionCheckErr = errors.Wrap(err, "could not perform sanction check")
 		return

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -4,13 +4,12 @@ import (
 	"context"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/usecases/ast_eval"
 	"github.com/cockroachdb/errors"
 )
 
 func evaluateSanctionCheck(
 	ctx context.Context,
-	evaluator ast_eval.EvaluateAstExpression,
+	evaluator EvaluateAstExpression,
 	executor EvalSanctionCheckUsecase,
 	iteration models.ScenarioIteration,
 	params ScenarioEvaluationParameters,

--- a/usecases/scheduled_execution/async_scheduled_exec_status_job.go
+++ b/usecases/scheduled_execution/async_scheduled_exec_status_job.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
-	"github.com/checkmarble/marble-backend/usecases/ast_eval"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
-	"github.com/checkmarble/marble-backend/usecases/scenarios"
 	"github.com/checkmarble/marble-backend/utils"
 
 	"github.com/riverqueue/river"
@@ -28,47 +26,17 @@ const (
 type AsyncScheduledExecWorker struct {
 	river.WorkerDefaults[models.ScheduledExecStatusSyncArgs]
 
-	repository                     asyncDecisionWorkerRepository
-	executorFactory                executor_factory.ExecutorFactory
-	scenarioPublicationsRepository repositories.ScenarioPublicationRepository
-	dataModelRepository            repositories.DataModelRepository
-	ingestedDataReadRepository     repositories.IngestedDataReadRepository
-	evaluateAstExpression          ast_eval.EvaluateAstExpression
-	decisionRepository             repositories.DecisionRepository
-	decisionWorkflows              decisionWorkflowsUsecase
-	webhookEventsSender            webhookEventsUsecase
-	snoozesReader                  snoozesForDecisionReader
-	scenarioFetcher                scenarios.ScenarioFetcher
-	sanctionCheckConfigRepository  repositories.EvalSanctionCheckConfigRepository
+	repository      asyncDecisionWorkerRepository
+	executorFactory executor_factory.ExecutorFactory
 }
 
 func NewAsyncScheduledExecWorker(
 	repository asyncDecisionWorkerRepository,
 	executorFactory executor_factory.ExecutorFactory,
-	scenarioPublicationsRepository repositories.ScenarioPublicationRepository,
-	dataModelRepository repositories.DataModelRepository,
-	ingestedDataReadRepository repositories.IngestedDataReadRepository,
-	evaluateAstExpression ast_eval.EvaluateAstExpression,
-	decisionRepository repositories.DecisionRepository,
-	decisionWorkflows decisionWorkflowsUsecase,
-	webhookEventsSender webhookEventsUsecase,
-	snoozesReader snoozesForDecisionReader,
-	scenarioFetcher scenarios.ScenarioFetcher,
-	sanctionCheckConfigRepository repositories.EvalSanctionCheckConfigRepository,
 ) AsyncScheduledExecWorker {
 	return AsyncScheduledExecWorker{
-		repository:                     repository,
-		executorFactory:                executorFactory,
-		scenarioPublicationsRepository: scenarioPublicationsRepository,
-		dataModelRepository:            dataModelRepository,
-		ingestedDataReadRepository:     ingestedDataReadRepository,
-		evaluateAstExpression:          evaluateAstExpression,
-		decisionRepository:             decisionRepository,
-		decisionWorkflows:              decisionWorkflows,
-		webhookEventsSender:            webhookEventsSender,
-		snoozesReader:                  snoozesReader,
-		scenarioFetcher:                scenarioFetcher,
-		sanctionCheckConfigRepository:  sanctionCheckConfigRepository,
+		repository:      repository,
+		executorFactory: executorFactory,
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -96,23 +96,18 @@ func (usecases *UsecasesWithCreds) NewEnforceTagSecurity() security.EnforceSecur
 
 func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 	return DecisionUsecase{
-		enforceSecurity:               usecases.NewEnforceDecisionSecurity(),
-		enforceSecurityScenario:       usecases.NewEnforceScenarioSecurity(),
-		executorFactory:               usecases.NewExecutorFactory(),
-		transactionFactory:            usecases.NewTransactionFactory(),
-		ingestedDataReadRepository:    usecases.Repositories.IngestedDataReadRepository,
-		dataModelRepository:           usecases.Repositories.DataModelRepository,
-		repository:                    &usecases.Repositories.MarbleDbRepository,
-		sanctionCheckConfigRepository: &usecases.Repositories.MarbleDbRepository,
-		sanctionCheckUsecase:          usecases.NewSanctionCheckUsecase(),
-		evaluateAstExpression:         usecases.NewEvaluateAstExpression(),
-		decisionWorkflows:             usecases.NewDecisionWorkflows(),
-		webhookEventsSender:           usecases.NewWebhookEventsUsecase(),
-		snoozesReader:                 &usecases.Repositories.MarbleDbRepository,
-		phantomUseCase:                usecases.NewPhantomDecisionUseCase(),
-		scenarioTestRunRepository:     &usecases.Repositories.MarbleDbRepository,
-		featureAccessReader:           usecases.NewFeatureAccessReader(),
-		scenarioEvaluator:             usecases.NewScenarioEvaluator(),
+		enforceSecurity:           usecases.NewEnforceDecisionSecurity(),
+		enforceSecurityScenario:   usecases.NewEnforceScenarioSecurity(),
+		executorFactory:           usecases.NewExecutorFactory(),
+		transactionFactory:        usecases.NewTransactionFactory(),
+		dataModelRepository:       usecases.Repositories.DataModelRepository,
+		repository:                &usecases.Repositories.MarbleDbRepository,
+		sanctionCheckRepository:   &usecases.Repositories.MarbleDbRepository,
+		decisionWorkflows:         usecases.NewDecisionWorkflows(),
+		webhookEventsSender:       usecases.NewWebhookEventsUsecase(),
+		phantomUseCase:            usecases.NewPhantomDecisionUseCase(),
+		scenarioTestRunRepository: &usecases.Repositories.MarbleDbRepository,
+		scenarioEvaluator:         usecases.NewScenarioEvaluator(),
 	}
 }
 
@@ -120,20 +115,25 @@ func (usecases *UsecasesWithCreds) NewPhantomDecisionUseCase() decision_phantom.
 	return decision_phantom.NewPhantomDecisionUseCase(
 		usecases.NewEnforcePhantomDecisionSecurity(),
 		usecases.NewExecutorFactory(),
-		usecases.Repositories.IngestedDataReadRepository,
-		&usecases.Repositories.MarbleDbRepository,
-		usecases.NewEvaluateAstExpression(),
-		&usecases.Repositories.MarbleDbRepository,
-		&usecases.Repositories.MarbleDbRepository,
-		&usecases.Repositories.MarbleDbRepository,
-		&usecases.Repositories.MarbleDbRepository,
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewScenarioEvaluator(),
 	)
 }
 
 func (usecases *UsecasesWithCreds) NewScenarioEvaluator() evaluate_scenario.ScenarioEvaluator {
-	return evaluate_scenario.NewScenarioEvaluator()
+	return evaluate_scenario.NewScenarioEvaluator(
+		&usecases.Repositories.MarbleDbRepository,
+		&usecases.Repositories.MarbleDbRepository,
+		usecases.NewSanctionCheckUsecase(),
+		&usecases.Repositories.MarbleDbRepository,
+		&usecases.Repositories.MarbleDbRepository,
+		&usecases.Repositories.MarbleDbRepository,
+		usecases.NewExecutorFactory(),
+		usecases.Repositories.IngestedDataReadRepository,
+		usecases.NewEvaluateAstExpression(),
+		&usecases.Repositories.MarbleDbRepository,
+		usecases.NewFeatureAccessReader(),
+	)
 }
 
 func (usecases *UsecasesWithCreds) NewSanctionCheckUsecase() SanctionCheckUsecase {
@@ -485,21 +485,16 @@ func (usecases UsecasesWithCreds) NewAsyncDecisionWorker() *scheduled_execution.
 	w := scheduled_execution.NewAsyncDecisionWorker(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
-		usecases.Repositories.ScenarioPublicationRepository,
 		usecases.Repositories.DataModelRepository,
 		usecases.Repositories.IngestedDataReadRepository,
-		usecases.NewEvaluateAstExpression(),
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewTransactionFactory(),
 		usecases.NewDecisionWorkflows(),
 		usecases.NewWebhookEventsUsecase(),
-		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewScenarioFetcher(),
-		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewPhantomDecisionUseCase(),
-		usecases.NewFeatureAccessReader(),
-		usecases.NewSanctionCheckUsecase(),
 		usecases.NewScenarioEvaluator(),
+		&usecases.Repositories.MarbleDbRepository,
 	)
 	return &w
 }
@@ -508,16 +503,6 @@ func (usecases UsecasesWithCreds) NewNewAsyncScheduledExecWorker() *scheduled_ex
 	w := scheduled_execution.NewAsyncScheduledExecWorker(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
-		usecases.Repositories.ScenarioPublicationRepository,
-		usecases.Repositories.DataModelRepository,
-		usecases.Repositories.IngestedDataReadRepository,
-		usecases.NewEvaluateAstExpression(),
-		&usecases.Repositories.MarbleDbRepository,
-		usecases.NewDecisionWorkflows(),
-		usecases.NewWebhookEventsUsecase(),
-		&usecases.Repositories.MarbleDbRepository,
-		usecases.NewScenarioFetcher(),
-		&usecases.Repositories.MarbleDbRepository,
 	)
 	return &w
 }


### PR DESCRIPTION
Continued from https://github.com/checkmarble/marble-backend/pull/817 - dependency injection to the EvaluateScenario method(s) was becoming really cumbersome & error prone because "static" dependencies where passed around as function params rather than being injected from the usecase factory

One small change in actual code logic (added missing storing of sanction check in two places which I pointed out in comments), otherwise it's all just reshuffling injected dependencies and removing some unused dependencies