### PR TITLE
Pascal/mar 734 return information on missing configuration in feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,9 @@ TRANSFER_CHECK_ENRICHMENT_BUCKET_URL="file://./tempFiles/transfercheck-bucket?cr
 
 # Configure the connection details to your Metabase instance.
 #  - To retrieve the JWT signing key, go to your Metabase admin panel, in 'Settings', then 'Embedding', and click 'Manage' under 'Static embedding'
-METABASE_SITE_URL="https://your_subdomain.metabaseapp.com"
-METABASE_JWT_SIGNING_KEY="dummy"
-METABASE_GLOBAL_DASHBOARD_ID=123
+METABASE_SITE_URL=
+METABASE_JWT_SIGNING_KEY=
+METABASE_GLOBAL_DASHBOARD_ID=
 
 # Set up connection details to Convoy to enable webhooks sending.
 # You can get your project ID and API key from your project settings page in Convoy's dashboard, in the "Secrets" section.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -94,6 +94,7 @@ func RunServer(apiVersion string) error {
 		loggingFormat                    string
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
+		firebaseEmulatorHost             string
 	}{
 		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", 0),
 		caseManagerBucket:                utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
@@ -103,6 +104,7 @@ func RunServer(apiVersion string) error {
 		loggingFormat:                    utils.GetEnv("LOGGING_FORMAT", "text"),
 		sentryDsn:                        utils.GetEnv("SENTRY_DSN", ""),
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
+		firebaseEmulatorHost:             utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
 	}
 
 	logger := utils.NewLogger(serverConfig.loggingFormat)
@@ -156,6 +158,9 @@ func RunServer(apiVersion string) error {
 		usecases.WithCaseManagerBucketUrl(serverConfig.caseManagerBucket),
 		usecases.WithLicense(license),
 		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
+		usecases.WithMetabase(metabaseConfig.SiteUrl),
+		usecases.WithOpensanctions(openSanctionsConfig.IsSet()),
+		usecases.WithTestMode(serverConfig.firebaseEmulatorHost != ""),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/infra/opensanctions.go
+++ b/infra/opensanctions.go
@@ -80,6 +80,10 @@ func (os OpenSanctions) Host() string {
 	return OPEN_SANCTIONS_API_HOST
 }
 
+func (os OpenSanctions) IsSet() bool {
+	return os.IsSelfHosted() || os.Credentials() != ""
+}
+
 func (os OpenSanctions) AuthMethod() OpenSanctionsAuthMethod {
 	return os.authMethod
 }

--- a/models/feature_access.go
+++ b/models/feature_access.go
@@ -6,6 +6,7 @@ const (
 	Restricted FeatureAccess = iota
 	Allowed
 	Test
+	MissingConfiguration
 	UnknownFeatureAccess
 )
 
@@ -20,6 +21,8 @@ func (f FeatureAccess) String() string {
 		return "restricted"
 	case Test:
 		return "test"
+	case MissingConfiguration:
+		return "missing_configuration"
 	}
 	return "unknown"
 }
@@ -33,6 +36,8 @@ func FeatureAccessFrom(s string) FeatureAccess {
 		return Restricted
 	case "test":
 		return Test
+	case "missing_configuration":
+		return MissingConfiguration
 	}
 	return UnknownFeatureAccess
 }

--- a/models/organization_feature_access_test.go
+++ b/models/organization_feature_access_test.go
@@ -1,0 +1,163 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeWithLicenseEntitlement(t *testing.T) {
+	tests := []struct {
+		name            string
+		dbFeatureAccess DbStoredOrganizationFeatureAccess
+		license         LicenseEntitlements
+		config          FeaturesConfiguration
+		testMode        bool
+		expected        OrganizationFeatureAccess
+	}{
+		{
+			name: "All features allowed by license and configuration",
+			dbFeatureAccess: DbStoredOrganizationFeatureAccess{
+				Id:             "1",
+				OrganizationId: "org1",
+				TestRun:        Allowed,
+				Sanctions:      Allowed,
+			},
+			license: LicenseEntitlements{
+				Analytics:   true,
+				Webhooks:    true,
+				Workflows:   true,
+				RuleSnoozes: true,
+				UserRoles:   true,
+				TestRun:     true,
+				Sanctions:   true,
+			},
+			config: FeaturesConfiguration{
+				Webhooks:  true,
+				Sanctions: true,
+				Analytics: true,
+			},
+			expected: OrganizationFeatureAccess{
+				Id:             "1",
+				OrganizationId: "org1",
+				TestRun:        Allowed,
+				Sanctions:      Allowed,
+				Analytics:      Allowed,
+				Webhooks:       Allowed,
+				Workflows:      Allowed,
+				RuleSnoozes:    Allowed,
+				Roles:          Allowed,
+			},
+		},
+		{
+			name: "Some features restricted by license",
+			dbFeatureAccess: DbStoredOrganizationFeatureAccess{
+				Id:             "2",
+				OrganizationId: "org2",
+				TestRun:        Allowed,
+				Sanctions:      Allowed,
+			},
+			license: LicenseEntitlements{
+				Analytics:   false,
+				Webhooks:    true,
+				Workflows:   true,
+				RuleSnoozes: true,
+				UserRoles:   true,
+				TestRun:     false,
+				Sanctions:   false,
+			},
+			config: FeaturesConfiguration{
+				Webhooks:  true,
+				Sanctions: true,
+				Analytics: true,
+			},
+			expected: OrganizationFeatureAccess{
+				Id:             "2",
+				OrganizationId: "org2",
+				TestRun:        Restricted,
+				Sanctions:      Restricted,
+				Analytics:      Restricted,
+				Webhooks:       Allowed,
+				Workflows:      Allowed,
+				RuleSnoozes:    Allowed,
+				Roles:          Allowed,
+			},
+		},
+		{
+			name: "Some features restricted by configuration",
+			dbFeatureAccess: DbStoredOrganizationFeatureAccess{
+				Id:             "3",
+				OrganizationId: "org3",
+				TestRun:        Allowed,
+				Sanctions:      Allowed,
+			},
+			license: LicenseEntitlements{
+				Analytics:   true,
+				Webhooks:    true,
+				Workflows:   true,
+				RuleSnoozes: true,
+				UserRoles:   true,
+				TestRun:     true,
+				Sanctions:   true,
+			},
+			config: FeaturesConfiguration{
+				Webhooks:  false,
+				Sanctions: false,
+				Analytics: false,
+			},
+			expected: OrganizationFeatureAccess{
+				Id:             "3",
+				OrganizationId: "org3",
+				TestRun:        Allowed,
+				Sanctions:      MissingConfiguration,
+				Analytics:      MissingConfiguration,
+				Webhooks:       MissingConfiguration,
+				Workflows:      Allowed,
+				RuleSnoozes:    Allowed,
+				Roles:          Allowed,
+			},
+		},
+		{
+			name: "Test mode enabled",
+			dbFeatureAccess: DbStoredOrganizationFeatureAccess{
+				Id:             "4",
+				OrganizationId: "org4",
+				TestRun:        Restricted,
+				Sanctions:      Allowed,
+			},
+			license: LicenseEntitlements{
+				Analytics:   false,
+				Webhooks:    false,
+				Workflows:   false,
+				RuleSnoozes: true,
+				UserRoles:   true,
+				TestRun:     false,
+				Sanctions:   true,
+			},
+			config: FeaturesConfiguration{
+				Webhooks:  false,
+				Sanctions: true,
+				Analytics: false,
+			},
+			testMode: true,
+			expected: OrganizationFeatureAccess{
+				Id:             "4",
+				OrganizationId: "org4",
+				TestRun:        Test,
+				Sanctions:      Allowed,
+				Analytics:      MissingConfiguration,
+				Webhooks:       MissingConfiguration,
+				Workflows:      Test,
+				RuleSnoozes:    Allowed,
+				Roles:          Allowed,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.dbFeatureAccess.MergeWithLicenseEntitlement(tt.license, tt.config, tt.testMode)
+			assert.Equal(t, tt.expected, result, tt.name)
+		})
+	}
+}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -24,6 +24,9 @@ type Usecases struct {
 	caseManagerBucketUrl        string
 	failedWebhooksRetryPageSize int
 	hasConvoyServerSetup        bool
+	hasMetabaseSetup            bool
+	hasOpensanctionsSetup       bool
+	hasTestMode                 bool
 	license                     models.LicenseValidation
 }
 
@@ -73,6 +76,28 @@ func WithConvoyServer(url string) Option {
 	}
 }
 
+func WithMetabase(url string) Option {
+	return func(o *options) {
+		if url != "" {
+			o.hasMetabaseSetup = true
+		}
+	}
+}
+
+func WithOpensanctions(isSet bool) Option {
+	return func(o *options) {
+		if isSet {
+			o.hasOpensanctionsSetup = true
+		}
+	}
+}
+
+func WithTestMode(activated bool) Option {
+	return func(o *options) {
+		o.hasTestMode = true
+	}
+}
+
 type options struct {
 	apiVersion                  string
 	batchIngestionMaxSize       int
@@ -81,6 +106,9 @@ type options struct {
 	failedWebhooksRetryPageSize int
 	license                     models.LicenseValidation
 	hasConvoyServerSetup        bool
+	hasMetabaseSetup            bool
+	hasOpensanctionsSetup       bool
+	hasTestMode                 bool
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -95,6 +123,10 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		caseManagerBucketUrl:        o.caseManagerBucketUrl,
 		failedWebhooksRetryPageSize: o.failedWebhooksRetryPageSize,
 		license:                     o.license,
+		hasConvoyServerSetup:        o.hasConvoyServerSetup,
+		hasMetabaseSetup:            o.hasMetabaseSetup,
+		hasOpensanctionsSetup:       o.hasOpensanctionsSetup,
+		hasTestMode:                 o.hasTestMode,
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -529,6 +529,10 @@ func (usecases UsecasesWithCreds) NewFeatureAccessReader() feature_access.Featur
 		usecases.Repositories.OrganizationRepository,
 		usecases.NewExecutorFactory(),
 		usecases.Usecases.license,
+		usecases.Usecases.hasConvoyServerSetup,
+		usecases.Usecases.hasMetabaseSetup,
+		usecases.Usecases.hasOpensanctionsSetup,
+		usecases.Usecases.hasTestMode,
 	)
 }
 


### PR DESCRIPTION
- feature access has a new option "missing_configuration" for a feature that is accessible but that has missing dependencies (computed from checking if the minimal required environment variables are set, not by checking that the variables are valid end to end)
- return "test" instead of "restricted" for all features if test mode is enabled, AKA if the firebase emulator host is set

Related Frontend PR https://github.com/checkmarble/marble-frontend/pull/715