### PR TITLE
Accept a generic search term when refining a sanction check.

### DIFF
--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -56,11 +56,13 @@ func AdaptSanctionCheckDto(m models.SanctionCheckWithMatches) SanctionCheckDto {
 // TODO: accept query.
 type SanctionCheckRefineDto struct {
 	DecisionId string `json:"decision_id"`
+	Term       string `json:"term"`
 }
 
 func AdaptSanctionCheckRefineDto(dto SanctionCheckRefineDto) models.SanctionCheckRefineRequest {
 	return models.SanctionCheckRefineRequest{
 		DecisionId: dto.DecisionId,
+		SearchTerm: dto.Term,
 	}
 }
 

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -134,6 +134,7 @@ type SanctionCheckMatchUpdate struct {
 
 type SanctionCheckRefineRequest struct {
 	DecisionId string
+	SearchTerm string
 }
 
 type SanctionCheckMatchComment struct {

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -163,7 +163,7 @@ func (uc SanctionCheckUsecase) Refine(ctx context.Context, refine models.Sanctio
 		OrgConfig: sc.OrgConfig,
 		Config:    *scc,
 		Queries: models.OpenSanctionCheckFilter{
-			"name": []string{"macron"},
+			"name": []string{refine.SearchTerm},
 		},
 	}
 


### PR DESCRIPTION
Before we merge the work in progress, let's add basic search term for the refinement endpoint before we start implementing the actual per-entity logic.