### PR TITLE
Implement sanction check whitelists.

### DIFF
--- a/dto/sanction_check_config_dto.go
+++ b/dto/sanction_check_config_dto.go
@@ -7,14 +7,15 @@ import (
 )
 
 type SanctionCheckConfig struct {
-	Name          *string                   `json:"name"`
-	Description   *string                   `json:"description"`
-	RuleGroup     *string                   `json:"rule_group,omitempty"`
-	Datasets      []string                  `json:"datasets,omitempty"`
-	ForceOutcome  *string                   `json:"force_outcome,omitempty"`
-	ScoreModifier *int                      `json:"score_modifier,omitempty"`
-	TriggerRule   *NodeDto                  `json:"trigger_rule"`
-	Query         *SanctionCheckConfigQuery `json:"query"`
+	Name                     *string                   `json:"name"`
+	Description              *string                   `json:"description"`
+	RuleGroup                *string                   `json:"rule_group,omitempty"`
+	Datasets                 []string                  `json:"datasets,omitempty"`
+	ForceOutcome             *string                   `json:"force_outcome,omitempty"`
+	ScoreModifier            *int                      `json:"score_modifier,omitempty"`
+	TriggerRule              *NodeDto                  `json:"trigger_rule"`
+	Query                    *SanctionCheckConfigQuery `json:"query"`
+	CounterpartyIdExpression *NodeDto                  `json:"counterparty_id_expression"`
 }
 
 func AdaptSanctionCheckConfig(model models.SanctionCheckConfig) (SanctionCheckConfig, error) {
@@ -43,6 +44,15 @@ func AdaptSanctionCheckConfig(model models.SanctionCheckConfig) (SanctionCheckCo
 		}
 
 		config.Query = &query
+	}
+
+	if model.CounterpartyIdExpression != nil {
+		counterpartyIdExpr, err := AdaptNodeDto(*model.CounterpartyIdExpression)
+		if err != nil {
+			return SanctionCheckConfig{}, err
+		}
+
+		config.CounterpartyIdExpression = &counterpartyIdExpr
 	}
 
 	return config, nil
@@ -81,6 +91,19 @@ func AdaptSanctionCheckConfigInputDto(dto SanctionCheckConfig) (models.UpdateSan
 
 		config.Query = &query
 	}
+
+	if dto.CounterpartyIdExpression != nil {
+		counterpartyIdExpr, err := AdaptASTNode(*dto.CounterpartyIdExpression)
+		if err != nil {
+			return models.UpdateSanctionCheckConfigInput{}, errors.Wrap(
+				models.BadParameterError,
+				"invalid query",
+			)
+		}
+
+		config.CounterpartyIdExpression = &counterpartyIdExpr
+	}
+
 	if dto.ForceOutcome != nil {
 		config.Outcome.ForceOutcome = utils.Ptr(models.ForcedOutcomeFrom(*dto.ForceOutcome))
 	}

--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -73,6 +73,7 @@ type SanctionCheckMatchDto struct {
 	Status     string                         `json:"status"`
 	ReviewedBy *string                        `json:"reviewer_id,omitempty"` //nolint:tagliatelle
 	Datasets   []string                       `json:"datasets"`
+	ObjectId   *string                        `json:"object_id"`
 	Payload    json.RawMessage                `json:"payload"`
 	Comments   []SanctionCheckMatchCommentDto `json:"comments"`
 }
@@ -86,6 +87,7 @@ func AdaptSanctionCheckMatchDto(m models.SanctionCheckMatch) SanctionCheckMatchD
 		QueryIds:   m.QueryIds,
 		Datasets:   make([]string, 0),
 		Payload:    m.Payload,
+		ObjectId:   m.ObjectId,
 		Comments:   pure_utils.Map(m.Comments, AdaptSanctionCheckMatchCommentDto),
 	}
 

--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -67,28 +67,28 @@ func AdaptSanctionCheckRefineDto(dto SanctionCheckRefineDto) models.SanctionChec
 }
 
 type SanctionCheckMatchDto struct {
-	Id         string                         `json:"id"`
-	EntityId   string                         `json:"entity_id"`
-	QueryIds   []string                       `json:"query_ids"`
-	Status     string                         `json:"status"`
-	ReviewedBy *string                        `json:"reviewer_id,omitempty"` //nolint:tagliatelle
-	Datasets   []string                       `json:"datasets"`
-	ObjectId   *string                        `json:"object_id"`
-	Payload    json.RawMessage                `json:"payload"`
-	Comments   []SanctionCheckMatchCommentDto `json:"comments"`
+	Id                           string                         `json:"id"`
+	EntityId                     string                         `json:"entity_id"`
+	QueryIds                     []string                       `json:"query_ids"`
+	Status                       string                         `json:"status"`
+	ReviewedBy                   *string                        `json:"reviewer_id,omitempty"` //nolint:tagliatelle
+	Datasets                     []string                       `json:"datasets"`
+	UniqueCounterpartyIdentifier *string                        `json:"unique_counterparty_identifier"`
+	Payload                      json.RawMessage                `json:"payload"`
+	Comments                     []SanctionCheckMatchCommentDto `json:"comments"`
 }
 
 func AdaptSanctionCheckMatchDto(m models.SanctionCheckMatch) SanctionCheckMatchDto {
 	match := SanctionCheckMatchDto{
-		Id:         m.Id,
-		EntityId:   m.EntityId,
-		Status:     m.Status.String(),
-		ReviewedBy: m.ReviewedBy,
-		QueryIds:   m.QueryIds,
-		Datasets:   make([]string, 0),
-		Payload:    m.Payload,
-		ObjectId:   m.ObjectId,
-		Comments:   pure_utils.Map(m.Comments, AdaptSanctionCheckMatchCommentDto),
+		Id:                           m.Id,
+		EntityId:                     m.EntityId,
+		Status:                       m.Status.String(),
+		ReviewedBy:                   m.ReviewedBy,
+		QueryIds:                     m.QueryIds,
+		Datasets:                     make([]string, 0),
+		Payload:                      m.Payload,
+		UniqueCounterpartyIdentifier: m.UniqueCounterpartyIdentifier,
+		Comments:                     pure_utils.Map(m.Comments, AdaptSanctionCheckMatchCommentDto),
 	}
 
 	return match

--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -93,8 +93,9 @@ func AdaptSanctionCheckMatchDto(m models.SanctionCheckMatch) SanctionCheckMatchD
 }
 
 type SanctionCheckMatchUpdateDto struct {
-	Status  string  `json:"status"`
-	Comment *string `json:"comment,omitempty"`
+	Status    string  `json:"status"`
+	Comment   *string `json:"comment,omitempty"`
+	Whitelist bool    `json:"whitelist"`
 }
 
 func AdaptSanctionCheckMatchUpdateInputDto(matchId string, reviewerId models.UserId,
@@ -109,6 +110,7 @@ func AdaptSanctionCheckMatchUpdateInputDto(matchId string, reviewerId models.Use
 		MatchId:    matchId,
 		ReviewerId: reviewerId,
 		Status:     models.SanctionCheckMatchStatusFrom(dto.Status),
+		Whitelist:  dto.Whitelist,
 	}
 
 	if dto.Comment != nil {

--- a/dto/scenario_validation_dto.go
+++ b/dto/scenario_validation_dto.go
@@ -38,8 +38,9 @@ type decisionValidationDto struct {
 }
 
 type sanctionCheckConfigValidationDto struct {
-	Trigger    triggerValidationDto `json:"trigger"`
-	NameFilter ruleValidationDto    `json:"name_filter"`
+	Trigger                  triggerValidationDto `json:"trigger"`
+	NameFilter               ruleValidationDto    `json:"name_filter"`
+	CounterpartyIdExpression ruleValidationDto    `json:"counterparty_id_expression"`
 }
 
 type ScenarioValidationDto struct {
@@ -72,6 +73,10 @@ func AdaptScenarioValidationDto(s models.ScenarioValidation) ScenarioValidationD
 			NameFilter: ruleValidationDto{
 				Errors:         pure_utils.Map(s.SanctionCheck.NameFilter.Errors, AdaptScenarioValidationErrorDto),
 				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.NameFilter.RuleEvaluation),
+			},
+			CounterpartyIdExpression: ruleValidationDto{
+				Errors:         pure_utils.Map(s.SanctionCheck.CounterpartyIdExpression.Errors, AdaptScenarioValidationErrorDto),
+				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.CounterpartyIdExpression.RuleEvaluation),
 			},
 		},
 		Decision: decisionValidationDto{

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -25,11 +25,12 @@ type OpenSanctionsCatalogDataset struct {
 }
 
 type OpenSanctionsQuery struct {
-	IsRefinement bool
-	Type         string
-	Queries      OpenSanctionCheckFilter
-	Config       SanctionCheckConfig
-	OrgConfig    OrganizationOpenSanctionsConfig
+	IsRefinement  bool
+	LimitIncrease int
+	Type          string
+	Queries       OpenSanctionCheckFilter
+	Config        SanctionCheckConfig
+	OrgConfig     OrganizationOpenSanctionsConfig
 }
 
 type OpenSanctionCheckFilter map[string][]string

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -165,6 +165,7 @@ type SanctionCheckMatch struct {
 	EntityId        string
 	Status          SanctionCheckMatchStatus
 	QueryIds        []string
+	ObjectId        *string
 	Payload         []byte
 	ReviewedBy      *string
 	Comments        []SanctionCheckMatchComment
@@ -175,6 +176,7 @@ type SanctionCheckMatchUpdate struct {
 	ReviewerId UserId
 	Status     SanctionCheckMatchStatus
 	Comment    *SanctionCheckMatchComment
+	Whitelist  bool
 }
 
 type SanctionCheckRefineRequest struct {

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -95,19 +95,20 @@ func (scs SanctionCheckMatchStatus) String() string {
 }
 
 type SanctionCheck struct {
-	Id                string
-	DecisionId        string
-	Status            SanctionCheckStatus
-	Datasets          []string
-	SearchInput       json.RawMessage
-	OrgConfig         OrganizationOpenSanctionsConfig
-	IsManual          bool
-	IsArchived        bool
-	InitialHasMatches bool
-	RequestedBy       *string
-	Partial           bool
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	Id                  string
+	DecisionId          string
+	Status              SanctionCheckStatus
+	Datasets            []string
+	SearchInput         json.RawMessage
+	OrgConfig           OrganizationOpenSanctionsConfig
+	IsManual            bool
+	IsArchived          bool
+	InitialHasMatches   bool
+	RequestedBy         *string
+	Partial             bool
+	WhitelistedEntities []string
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 type SanctionCheckWithMatches struct {
@@ -117,9 +118,10 @@ type SanctionCheckWithMatches struct {
 }
 
 type SanctionRawSearchResponseWithMatches struct {
-	SearchInput       json.RawMessage
-	InitialHasMatches bool
-	Partial           bool
+	SearchInput         json.RawMessage
+	InitialHasMatches   bool
+	WhitelistedEntities []string
+	Partial             bool
 
 	Matches []SanctionCheckMatch
 	Count   int
@@ -128,13 +130,14 @@ type SanctionRawSearchResponseWithMatches struct {
 func (s SanctionRawSearchResponseWithMatches) AdaptSanctionCheckFromSearchResponse(query OpenSanctionsQuery) SanctionCheckWithMatches {
 	sanctionCheck := SanctionCheckWithMatches{
 		SanctionCheck: SanctionCheck{
-			Datasets:          query.Config.Datasets,
-			OrgConfig:         query.OrgConfig,
-			SearchInput:       s.SearchInput,
-			Partial:           s.Partial,
-			InitialHasMatches: s.InitialHasMatches,
-			CreatedAt:         time.Now(),
-			UpdatedAt:         time.Now(),
+			Datasets:            query.Config.Datasets,
+			OrgConfig:           query.OrgConfig,
+			SearchInput:         s.SearchInput,
+			Partial:             s.Partial,
+			InitialHasMatches:   s.InitialHasMatches,
+			WhitelistedEntities: s.WhitelistedEntities,
+			CreatedAt:           time.Now(),
+			UpdatedAt:           time.Now(),
 		},
 		Matches: s.Matches,
 		Count:   s.Count,
@@ -202,4 +205,13 @@ type SanctionCheckFileInput struct {
 	BucketName      string
 	FileReference   string
 	FileName        string
+}
+
+type SanctionCheckWhitelist struct {
+	Id             string
+	OrgId          string
+	CounterpartyId string
+	EntityId       string
+	WhitelistedBy  string
+	CreatedAt      time.Time
 }

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -159,16 +159,16 @@ func (s SanctionCheckWithMatches) InitialStatusFromMatches() SanctionCheckStatus
 }
 
 type SanctionCheckMatch struct {
-	Id              string
-	IsMatch         bool
-	SanctionCheckId string
-	EntityId        string
-	Status          SanctionCheckMatchStatus
-	QueryIds        []string
-	ObjectId        *string
-	Payload         []byte
-	ReviewedBy      *string
-	Comments        []SanctionCheckMatchComment
+	Id                           string
+	IsMatch                      bool
+	SanctionCheckId              string
+	EntityId                     string
+	Status                       SanctionCheckMatchStatus
+	QueryIds                     []string
+	UniqueCounterpartyIdentifier *string
+	Payload                      []byte
+	ReviewedBy                   *string
+	Comments                     []SanctionCheckMatchComment
 }
 
 type SanctionCheckMatchUpdate struct {

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -55,13 +55,14 @@ type UpdateScenarioIterationBody struct {
 }
 
 type SanctionCheckConfig struct {
-	Name        string
-	Description string
-	RuleGroup   *string
-	Datasets    []string
-	TriggerRule *ast.Node
-	Query       *SanctionCheckConfigQuery
-	Outcome     SanctionCheckOutcome
+	Name           string
+	Description    string
+	RuleGroup      *string
+	Datasets       []string
+	TriggerRule    *ast.Node
+	Query          *SanctionCheckConfigQuery
+	Outcome        SanctionCheckOutcome
+	WhitelistField *ast.Node
 }
 
 func (scc SanctionCheckConfig) HasSameQuery(other SanctionCheckConfig) bool {

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -55,14 +55,14 @@ type UpdateScenarioIterationBody struct {
 }
 
 type SanctionCheckConfig struct {
-	Name           string
-	Description    string
-	RuleGroup      *string
-	Datasets       []string
-	TriggerRule    *ast.Node
-	Query          *SanctionCheckConfigQuery
-	Outcome        SanctionCheckOutcome
-	WhitelistField *ast.Node
+	Name                     string
+	Description              string
+	RuleGroup                *string
+	Datasets                 []string
+	TriggerRule              *ast.Node
+	Query                    *SanctionCheckConfigQuery
+	Outcome                  SanctionCheckOutcome
+	CounterpartyIdExpression *ast.Node
 }
 
 func (scc SanctionCheckConfig) HasSameQuery(other SanctionCheckConfig) bool {
@@ -91,13 +91,14 @@ func (sco SanctionCheckOutcome) equal(other SanctionCheckOutcome) bool {
 }
 
 type UpdateSanctionCheckConfigInput struct {
-	Name        *string
-	Description *string
-	RuleGroup   *string
-	Datasets    []string
-	TriggerRule *ast.Node
-	Query       *SanctionCheckConfigQuery
-	Outcome     UpdateSanctionCheckOutcomeInput
+	Name                     *string
+	Description              *string
+	RuleGroup                *string
+	Datasets                 []string
+	TriggerRule              *ast.Node
+	Query                    *SanctionCheckConfigQuery
+	CounterpartyIdExpression *ast.Node
+	Outcome                  UpdateSanctionCheckOutcomeInput
 }
 
 type SanctionCheckConfigQuery struct {

--- a/models/scenario_validation.go
+++ b/models/scenario_validation.go
@@ -75,8 +75,9 @@ type decisionValidation struct {
 }
 
 type sanctionCheckConfigValidation struct {
-	TriggerRule triggerValidation
-	NameFilter  RuleValidation
+	TriggerRule              triggerValidation
+	NameFilter               RuleValidation
+	CounterpartyIdExpression RuleValidation
 }
 
 type ScenarioValidation struct {

--- a/repositories/dbmodels/db_sanction_check.go
+++ b/repositories/dbmodels/db_sanction_check.go
@@ -16,20 +16,21 @@ var (
 )
 
 type DBSanctionCheck struct {
-	Id                string          `db:"id"`
-	DecisionId        string          `db:"decision_id"`
-	Status            string          `db:"status"`
-	SearchInput       json.RawMessage `db:"search_input"`
-	SearchDatasets    []string        `db:"search_datasets"`
-	MatchThreshold    int             `db:"match_threshold"`
-	MatchLimit        int             `db:"match_limit"`
-	IsManual          bool            `db:"is_manual"`
-	RequestedBy       *string         `db:"requested_by"`
-	IsPartial         bool            `db:"is_partial"`
-	IsArchived        bool            `db:"is_archived"`
-	InitialHasMatches bool            `db:"initial_has_matches"`
-	CreatedAt         time.Time       `db:"created_at"`
-	UpdatedAt         time.Time       `db:"updated_at"`
+	Id                  string          `db:"id"`
+	DecisionId          string          `db:"decision_id"`
+	Status              string          `db:"status"`
+	SearchInput         json.RawMessage `db:"search_input"`
+	SearchDatasets      []string        `db:"search_datasets"`
+	MatchThreshold      int             `db:"match_threshold"`
+	MatchLimit          int             `db:"match_limit"`
+	IsManual            bool            `db:"is_manual"`
+	RequestedBy         *string         `db:"requested_by"`
+	IsPartial           bool            `db:"is_partial"`
+	IsArchived          bool            `db:"is_archived"`
+	InitialHasMatches   bool            `db:"initial_has_matches"`
+	WhitelistedEntities []string        `db:"whitelisted_entities"`
+	CreatedAt           time.Time       `db:"created_at"`
+	UpdatedAt           time.Time       `db:"updated_at"`
 }
 
 type DBSanctionCheckWithMatches struct {
@@ -44,19 +45,20 @@ func AdaptSanctionCheck(dto DBSanctionCheck) (models.SanctionCheck, error) {
 	}
 
 	return models.SanctionCheck{
-		Id:                dto.Id,
-		DecisionId:        dto.DecisionId,
-		Datasets:          dto.SearchDatasets,
-		SearchInput:       dto.SearchInput,
-		OrgConfig:         cfg,
-		Partial:           dto.IsPartial,
-		Status:            models.SanctionCheckStatusFrom(dto.Status),
-		IsManual:          dto.IsManual,
-		IsArchived:        dto.IsArchived,
-		InitialHasMatches: dto.InitialHasMatches,
-		RequestedBy:       dto.RequestedBy,
-		CreatedAt:         dto.CreatedAt,
-		UpdatedAt:         dto.UpdatedAt,
+		Id:                  dto.Id,
+		DecisionId:          dto.DecisionId,
+		Datasets:            dto.SearchDatasets,
+		SearchInput:         dto.SearchInput,
+		OrgConfig:           cfg,
+		Partial:             dto.IsPartial,
+		Status:              models.SanctionCheckStatusFrom(dto.Status),
+		IsManual:            dto.IsManual,
+		IsArchived:          dto.IsArchived,
+		InitialHasMatches:   dto.InitialHasMatches,
+		WhitelistedEntities: dto.WhitelistedEntities,
+		RequestedBy:         dto.RequestedBy,
+		CreatedAt:           dto.CreatedAt,
+		UpdatedAt:           dto.UpdatedAt,
 	}, nil
 }
 

--- a/repositories/dbmodels/db_sanction_check_config.go
+++ b/repositories/dbmodels/db_sanction_check_config.go
@@ -14,18 +14,18 @@ import (
 const TABLE_SANCTION_CHECK_CONFIGS = "sanction_check_configs"
 
 type DBSanctionCheckConfigs struct {
-	Id                    string                      `db:"id"`
-	ScenarioIterationId   string                      `db:"scenario_iteration_id"`
-	Name                  string                      `db:"name"`
-	Description           string                      `db:"description"`
-	RuleGroup             string                      `db:"rule_group"`
-	Datasets              []string                    `db:"datasets"`
-	TriggerRule           []byte                      `db:"trigger_rule"`
-	Query                 *DBSanctionCheckConfigQuery `db:"query"`
-	ForcedOutcome         *string                     `db:"forced_outcome"`
-	ScoreModifier         int                         `db:"score_modifier"`
-	WhitelistAttributeAst []byte                      `db:"whitelist_field_ast"`
-	UpdatedAt             time.Time                   `db:"updated_at"`
+	Id                  string                      `db:"id"`
+	ScenarioIterationId string                      `db:"scenario_iteration_id"`
+	Name                string                      `db:"name"`
+	Description         string                      `db:"description"`
+	RuleGroup           string                      `db:"rule_group"`
+	Datasets            []string                    `db:"datasets"`
+	TriggerRule         []byte                      `db:"trigger_rule"`
+	Query               *DBSanctionCheckConfigQuery `db:"query"`
+	ForcedOutcome       *string                     `db:"forced_outcome"`
+	ScoreModifier       int                         `db:"score_modifier"`
+	CounterpartyIdExpr  []byte                      `db:"counterparty_id_expression"`
+	UpdatedAt           time.Time                   `db:"updated_at"`
 }
 
 type DBSanctionCheckConfigQuery struct {
@@ -69,14 +69,14 @@ func AdaptSanctionCheckConfig(db DBSanctionCheckConfigs) (models.SanctionCheckCo
 		scc.Query = &query
 	}
 
-	if db.WhitelistAttributeAst != nil {
-		field, err := AdaptSerializedAstExpression(db.WhitelistAttributeAst)
+	if db.CounterpartyIdExpr != nil {
+		field, err := AdaptSerializedAstExpression(db.CounterpartyIdExpr)
 		if err != nil {
 			return models.SanctionCheckConfig{}, errors.Wrap(err,
 				"could not unmarshal whitelist field expression")
 		}
 
-		scc.WhitelistField = field
+		scc.CounterpartyIdExpression = field
 	}
 
 	if db.ForcedOutcome != nil {

--- a/repositories/dbmodels/db_sanction_check_config.go
+++ b/repositories/dbmodels/db_sanction_check_config.go
@@ -14,17 +14,18 @@ import (
 const TABLE_SANCTION_CHECK_CONFIGS = "sanction_check_configs"
 
 type DBSanctionCheckConfigs struct {
-	Id                  string                      `db:"id"`
-	ScenarioIterationId string                      `db:"scenario_iteration_id"`
-	Name                string                      `db:"name"`
-	Description         string                      `db:"description"`
-	RuleGroup           string                      `db:"rule_group"`
-	Datasets            []string                    `db:"datasets"`
-	TriggerRule         []byte                      `db:"trigger_rule"`
-	Query               *DBSanctionCheckConfigQuery `db:"query"`
-	ForcedOutcome       *string                     `db:"forced_outcome"`
-	ScoreModifier       int                         `db:"score_modifier"`
-	UpdatedAt           time.Time                   `db:"updated_at"`
+	Id                    string                      `db:"id"`
+	ScenarioIterationId   string                      `db:"scenario_iteration_id"`
+	Name                  string                      `db:"name"`
+	Description           string                      `db:"description"`
+	RuleGroup             string                      `db:"rule_group"`
+	Datasets              []string                    `db:"datasets"`
+	TriggerRule           []byte                      `db:"trigger_rule"`
+	Query                 *DBSanctionCheckConfigQuery `db:"query"`
+	ForcedOutcome         *string                     `db:"forced_outcome"`
+	ScoreModifier         int                         `db:"score_modifier"`
+	WhitelistAttributeAst []byte                      `db:"whitelist_field_ast"`
+	UpdatedAt             time.Time                   `db:"updated_at"`
 }
 
 type DBSanctionCheckConfigQuery struct {
@@ -66,6 +67,16 @@ func AdaptSanctionCheckConfig(db DBSanctionCheckConfigs) (models.SanctionCheckCo
 		}
 
 		scc.Query = &query
+	}
+
+	if db.WhitelistAttributeAst != nil {
+		field, err := AdaptSerializedAstExpression(db.WhitelistAttributeAst)
+		if err != nil {
+			return models.SanctionCheckConfig{}, errors.Wrap(err,
+				"could not unmarshal whitelist field expression")
+		}
+
+		scc.WhitelistField = field
 	}
 
 	if db.ForcedOutcome != nil {

--- a/repositories/dbmodels/db_sanction_check_match.go
+++ b/repositories/dbmodels/db_sanction_check_match.go
@@ -18,6 +18,7 @@ type DBSanctionCheckMatch struct {
 	OpenSanctionEntityId string          `db:"opensanction_entity_id"`
 	Status               string          `db:"status"`
 	QueryIds             []string        `db:"query_ids"`
+	ObjectId             *string         `db:"object_id"`
 	Payload              json.RawMessage `db:"payload"`
 	ReviewedBy           *string         `db:"reviewed_by"`
 	CreatedAt            time.Time       `db:"created_at"`
@@ -34,6 +35,7 @@ func AdaptSanctionCheckMatch(dto DBSanctionCheckMatch) (models.SanctionCheckMatc
 		Status:          models.SanctionCheckMatchStatusFrom(dto.Status),
 		ReviewedBy:      dto.ReviewedBy,
 		QueryIds:        dto.QueryIds,
+		ObjectId:        dto.ObjectId,
 		Payload:         dto.Payload,
 	}
 

--- a/repositories/dbmodels/db_sanction_check_match.go
+++ b/repositories/dbmodels/db_sanction_check_match.go
@@ -18,7 +18,7 @@ type DBSanctionCheckMatch struct {
 	OpenSanctionEntityId string          `db:"opensanction_entity_id"`
 	Status               string          `db:"status"`
 	QueryIds             []string        `db:"query_ids"`
-	ObjectId             *string         `db:"object_id"`
+	CounterpartyId       *string         `db:"counterparty_id"`
 	Payload              json.RawMessage `db:"payload"`
 	ReviewedBy           *string         `db:"reviewed_by"`
 	CreatedAt            time.Time       `db:"created_at"`
@@ -29,14 +29,14 @@ type DBSanctionCheckMatch struct {
 
 func AdaptSanctionCheckMatch(dto DBSanctionCheckMatch) (models.SanctionCheckMatch, error) {
 	match := models.SanctionCheckMatch{
-		Id:              dto.Id,
-		SanctionCheckId: dto.SanctionCheckId,
-		EntityId:        dto.OpenSanctionEntityId,
-		Status:          models.SanctionCheckMatchStatusFrom(dto.Status),
-		ReviewedBy:      dto.ReviewedBy,
-		QueryIds:        dto.QueryIds,
-		ObjectId:        dto.ObjectId,
-		Payload:         dto.Payload,
+		Id:                           dto.Id,
+		SanctionCheckId:              dto.SanctionCheckId,
+		EntityId:                     dto.OpenSanctionEntityId,
+		Status:                       models.SanctionCheckMatchStatusFrom(dto.Status),
+		ReviewedBy:                   dto.ReviewedBy,
+		QueryIds:                     dto.QueryIds,
+		UniqueCounterpartyIdentifier: dto.CounterpartyId,
+		Payload:                      dto.Payload,
 	}
 
 	return match, nil

--- a/repositories/dbmodels/db_sanction_check_whitelist.go
+++ b/repositories/dbmodels/db_sanction_check_whitelist.go
@@ -1,0 +1,32 @@
+package dbmodels
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+const TABLE_SANCTION_CHECK_WHITELISTS = "sanction_check_whitelists"
+
+type DBSanctionCheckWhitelists struct {
+	Id             string    `db:"id"`
+	OrgId          string    `db:"org_id"`
+	CounterpartyId string    `db:"counterparty_id"`
+	EntityId       string    `db:"entity_id"`
+	WhitelistedBy  string    `db:"whitelisted_by"`
+	CreatedAt      time.Time `db:"created_at"`
+}
+
+var SanctionCheckWhitelistColumnList = utils.ColumnList[DBSanctionCheckWhitelists]()
+
+func AdaptSanctionCheckWhitelist(db DBSanctionCheckWhitelists) (models.SanctionCheckWhitelist, error) {
+	return models.SanctionCheckWhitelist{
+		Id:             db.Id,
+		OrgId:          db.OrgId,
+		CounterpartyId: db.CounterpartyId,
+		EntityId:       db.EntityId,
+		WhitelistedBy:  db.WhitelistedBy,
+		CreatedAt:      db.CreatedAt,
+	}, nil
+}

--- a/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
+++ b/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
@@ -8,6 +8,9 @@ alter table sanction_check_configs
 alter table sanction_checks
     add column whitelisted_entities text[] not null default '{}';
 
+alter table sanction_check_matches
+    add column object_id text;
+
 create table sanction_check_whitelists (
     id uuid default uuid_generate_v4(),
     org_id uuid not null,
@@ -21,7 +24,7 @@ create table sanction_check_whitelists (
     constraint fk_user foreign key (whitelisted_by) references users (id)
 );
 
-create index idx_sanction_check_whitelist on sanction_check_whitelists (org_id, object_id, entity_id);
+create unique index idx_sanction_check_whitelist on sanction_check_whitelists (org_id, object_id, entity_id);
 
 -- +goose StatementEnd
 
@@ -33,6 +36,9 @@ alter table sanction_check_configs
 
 alter table sanction_checks
     drop column whitelisted_entities;
+
+alter table sanction_check_matches
+    drop column object_id;
 
 drop table sanction_check_whitelists;
 

--- a/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
+++ b/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
@@ -14,7 +14,7 @@ alter table sanction_check_matches
 create table sanction_check_whitelists (
     id uuid default uuid_generate_v4(),
     org_id uuid not null,
-    object_id text not null,
+    counterparty_id text not null,
     entity_id text not null,
     whitelisted_by uuid not null,
     created_at timestamp with time zone default now(),
@@ -24,7 +24,7 @@ create table sanction_check_whitelists (
     constraint fk_user foreign key (whitelisted_by) references users (id)
 );
 
-create unique index idx_sanction_check_whitelist on sanction_check_whitelists (org_id, object_id, entity_id);
+create unique index idx_sanction_check_whitelist on sanction_check_whitelists (org_id, counterparty_id, entity_id);
 
 -- +goose StatementEnd
 

--- a/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
+++ b/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+
+alter table sanction_check_configs
+    add column whitelist_field_ast
+    jsonb;
+
+alter table sanction_checks
+    add column whitelisted_entities text[] not null default '{}';
+
+create table sanction_check_whitelists (
+    id uuid default uuid_generate_v4(),
+    org_id uuid not null,
+    object_id text not null,
+    entity_id text not null,
+    whitelisted_by uuid not null,
+    created_at timestamp with time zone default now(),
+
+    primary key (id),
+    constraint fk_organization foreign key (org_id) references organizations (id),
+    constraint fk_user foreign key (whitelisted_by) references users (id)
+);
+
+create index idx_sanction_check_whitelist on sanction_check_whitelists (org_id, object_id, entity_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+alter table sanction_check_configs
+    drop column whitelist_field_ast;
+
+alter table sanction_checks
+    drop column whitelisted_entities;
+
+drop table sanction_check_whitelists;
+
+-- +goose StatementEnd

--- a/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
+++ b/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
@@ -2,7 +2,7 @@
 -- +goose StatementBegin
 
 alter table sanction_check_configs
-    add column whitelist_field_ast
+    add column counterparty_id_expression
     jsonb;
 
 alter table sanction_checks
@@ -32,7 +32,7 @@ create unique index idx_sanction_check_whitelist on sanction_check_whitelists (o
 -- +goose StatementBegin
 
 alter table sanction_check_configs
-    drop column whitelist_field_ast;
+    drop column counterparty_id_expression;
 
 alter table sanction_checks
     drop column whitelisted_entities;

--- a/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
+++ b/repositories/migrations/20250210144400_create_sanctions_whitelist.sql
@@ -9,7 +9,7 @@ alter table sanction_checks
     add column whitelisted_entities text[] not null default '{}';
 
 alter table sanction_check_matches
-    add column object_id text;
+    add column counterparty_id text;
 
 create table sanction_check_whitelists (
     id uuid default uuid_generate_v4(),
@@ -38,7 +38,7 @@ alter table sanction_checks
     drop column whitelisted_entities;
 
 alter table sanction_check_matches
-    drop column object_id;
+    drop column counterparty_id;
 
 drop table sanction_check_whitelists;
 

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -209,7 +209,7 @@ func (repo OpenSanctionsRepository) searchRequest(ctx context.Context,
 
 	requestUrl := fmt.Sprintf("%s/match/sanctions", repo.opensanctions.Host())
 
-	if qs := repo.buildQueryString(query.Config, query.OrgConfig); len(qs) > 0 {
+	if qs := repo.buildQueryString(query.Config, query); len(qs) > 0 {
 		requestUrl = fmt.Sprintf("%s?%s", requestUrl, qs.Encode())
 	}
 
@@ -229,7 +229,7 @@ func (repo OpenSanctionsRepository) searchRequest(ctx context.Context,
 	return req, rawQuery.Bytes(), err
 }
 
-func (repo OpenSanctionsRepository) buildQueryString(cfg models.SanctionCheckConfig, orgCfg models.OrganizationOpenSanctionsConfig) url.Values {
+func (repo OpenSanctionsRepository) buildQueryString(cfg models.SanctionCheckConfig, query models.OpenSanctionsQuery) url.Values {
 	qs := url.Values{}
 
 	if repo.opensanctions.AuthMethod() == infra.OPEN_SANCTIONS_AUTH_SAAS &&
@@ -243,10 +243,10 @@ func (repo OpenSanctionsRepository) buildQueryString(cfg models.SanctionCheckCon
 
 	// Unless determined otherwise, we do not need those results that are *not*
 	// matches. They could still be filtered further down the chain, but we do not need them returned.
-	qs.Set("threshold", fmt.Sprintf("%.1f", float64(orgCfg.MatchThreshold)/100))
-	qs.Set("cutoff", fmt.Sprintf("%.1f", float64(orgCfg.MatchThreshold)/100))
+	qs.Set("threshold", fmt.Sprintf("%.1f", float64(query.OrgConfig.MatchThreshold)/100))
+	qs.Set("cutoff", fmt.Sprintf("%.1f", float64(query.OrgConfig.MatchThreshold)/100))
 
-	qs.Set("limit", fmt.Sprintf("%d", orgCfg.MatchLimit))
+	qs.Set("limit", fmt.Sprintf("%d", query.OrgConfig.MatchLimit+query.LimitIncrease))
 
 	return qs
 }

--- a/repositories/sanction_check_repository.go
+++ b/repositories/sanction_check_repository.go
@@ -173,6 +173,12 @@ func (*MarbleDbRepository) InsertSanctionCheck(
 		return sanctionCheck, err
 	}
 
+	whitelistedEntities := make([]string, 0)
+
+	if sanctionCheck.WhitelistedEntities != nil {
+		whitelistedEntities = sanctionCheck.WhitelistedEntities
+	}
+
 	sql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_SANCTION_CHECKS).Columns(
 		"decision_id",
@@ -195,7 +201,7 @@ func (*MarbleDbRepository) InsertSanctionCheck(
 		sanctionCheck.Partial,
 		sanctionCheck.IsManual,
 		sanctionCheck.InitialHasMatches,
-		sanctionCheck.WhitelistedEntities,
+		whitelistedEntities,
 		sanctionCheck.RequestedBy,
 		sanctionCheck.Status.String(),
 	).Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectSanctionChecksColumn, ",")))

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -90,6 +90,10 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 			return
 		}
 
+		for idx := range result.Matches {
+			result.Matches[idx].ObjectId = &whitelistField
+		}
+
 		result, err = e.evalSanctionCheckUsecase.FilterOutWhitelistedMatches(ctx,
 			params.Scenario.OrganizationId, result, whitelistField)
 		if err != nil {

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -70,6 +70,33 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 		return
 	}
 
+	if iteration.SanctionCheckConfig.WhitelistField != nil {
+		whitelistFieldResult, err := e.evaluateAstExpression.EvaluateAstExpression(
+			ctx,
+			nil,
+			*iteration.SanctionCheckConfig.WhitelistField,
+			params.Scenario.OrganizationId,
+			dataAccessor.ClientObject,
+			params.DataModel,
+		)
+		if err != nil {
+			sanctionCheckErr = errors.Wrap(err, "could not extract object field for whitelist check")
+			return
+		}
+
+		whitelistField, err := whitelistFieldResult.GetStringReturnValue()
+		if err != nil {
+			sanctionCheckErr = errors.Wrap(err, "could not parse object field for white list check as string")
+			return
+		}
+
+		result, err = e.evalSanctionCheckUsecase.FilterOutWhitelistedMatches(ctx,
+			params.Scenario.OrganizationId, result, whitelistField)
+		if err != nil {
+			return
+		}
+	}
+
 	sanctionCheck = &result
 	performed = true
 	return

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -68,11 +68,11 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 		},
 	}
 
-	if iteration.SanctionCheckConfig.WhitelistField != nil {
-		whitelistFieldResult, err := e.evaluateAstExpression.EvaluateAstExpression(
+	if iteration.SanctionCheckConfig.CounterpartyIdExpression != nil {
+		counterpartyIdResult, err := e.evaluateAstExpression.EvaluateAstExpression(
 			ctx,
 			nil,
-			*iteration.SanctionCheckConfig.WhitelistField,
+			*iteration.SanctionCheckConfig.CounterpartyIdExpression,
 			params.Scenario.OrganizationId,
 			dataAccessor.ClientObject,
 			params.DataModel,
@@ -82,14 +82,14 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 			return
 		}
 
-		whitelistField, err := whitelistFieldResult.GetStringReturnValue()
+		counterpartyId, err := counterpartyIdResult.GetStringReturnValue()
 		if err != nil && !errors.Is(err, ast.ErrNullFieldRead) {
 			sanctionCheckErr = errors.Wrap(err, "could not parse object field for white list check as string")
 			return
 		}
 
-		if trimmed := strings.TrimSpace(whitelistField); trimmed != "" {
-			uniqueCounterpartyIdentifier = &whitelistField
+		if trimmed := strings.TrimSpace(counterpartyId); trimmed != "" {
+			uniqueCounterpartyIdentifier = &counterpartyId
 
 			whitelistCount, err := e.evalSanctionCheckUsecase.CountWhitelistsForCounterpartyId(
 				ctx, iteration.OrganizationId, *uniqueCounterpartyIdentifier)

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -28,6 +28,20 @@ func (m mockSanctionCheckExecutor) Execute(
 	return models.SanctionCheckWithMatches{}, nil
 }
 
+func (m mockSanctionCheckExecutor) FilterOutWhitelistedMatches(
+	ctx context.Context,
+	orgId string,
+	sanctionCheck models.SanctionCheckWithMatches,
+	objectId string,
+) (models.SanctionCheckWithMatches, error) {
+	// We are not mocking returned data here, only that the function was called
+	// with the appropriate arguments, so we always expect this to be called.
+	m.On("FilterOutWhitelistedMatches", context.TODO(), orgId, sanctionCheck, objectId)
+	m.Called(ctx, orgId, sanctionCheck, objectId)
+
+	return sanctionCheck, nil
+}
+
 func getSanctionCheckEvaluator() (ScenarioEvaluator, mockSanctionCheckExecutor) {
 	evaluator := ast_eval.EvaluateAstExpression{
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -42,6 +42,19 @@ func (m mockSanctionCheckExecutor) FilterOutWhitelistedMatches(
 	return sanctionCheck, nil
 }
 
+func (m mockSanctionCheckExecutor) CountWhitelistsForCounterpartyId(
+	ctx context.Context,
+	orgId string,
+	counterpartyId string,
+) (int, error) {
+	// We are not mocking returned data here, only that the function was called
+	// with the appropriate arguments, so we always expect this to be called.
+	m.On("CountWhistelistsForCounterparty", context.TODO(), orgId, counterpartyId)
+	m.Called(ctx, orgId, counterpartyId)
+
+	return 0, nil
+}
+
 func getSanctionCheckEvaluator() (ScenarioEvaluator, mockSanctionCheckExecutor) {
 	evaluator := ast_eval.EvaluateAstExpression{
 		AstEvaluationEnvironmentFactory: func(params ast_eval.EvaluationEnvironmentFactoryParams) ast_eval.AstEvaluationEnvironment {

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -32,12 +32,12 @@ func (m mockSanctionCheckExecutor) FilterOutWhitelistedMatches(
 	ctx context.Context,
 	orgId string,
 	sanctionCheck models.SanctionCheckWithMatches,
-	objectId string,
+	counterpartyId string,
 ) (models.SanctionCheckWithMatches, error) {
 	// We are not mocking returned data here, only that the function was called
 	// with the appropriate arguments, so we always expect this to be called.
-	m.On("FilterOutWhitelistedMatches", context.TODO(), orgId, sanctionCheck, objectId)
-	m.Called(ctx, orgId, sanctionCheck, objectId)
+	m.On("FilterOutWhitelistedMatches", context.TODO(), orgId, sanctionCheck, counterpartyId)
+	m.Called(ctx, orgId, sanctionCheck, counterpartyId)
 
 	return sanctionCheck, nil
 }

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -37,6 +37,7 @@ type EvalSanctionCheckUsecase interface {
 	Execute(context.Context, string, models.OpenSanctionsQuery) (models.SanctionCheckWithMatches, error)
 	FilterOutWhitelistedMatches(context.Context, string, models.SanctionCheckWithMatches,
 		string) (models.SanctionCheckWithMatches, error)
+	CountWhitelistsForCounterpartyId(context.Context, string, string) (int, error)
 }
 
 type SnoozesForDecisionReader interface {

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -35,6 +35,8 @@ type ScenarioEvaluationParameters struct {
 
 type EvalSanctionCheckUsecase interface {
 	Execute(context.Context, string, models.OpenSanctionsQuery) (models.SanctionCheckWithMatches, error)
+	FilterOutWhitelistedMatches(context.Context, string, models.SanctionCheckWithMatches,
+		string) (models.SanctionCheckWithMatches, error)
 }
 
 type SnoozesForDecisionReader interface {

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -82,6 +82,8 @@ type SanctionCheckRepository interface {
 		orgId, objectId string, entityId string, reviewerId models.UserId) error
 	IsSanctionCheckMatchWhitelisted(ctx context.Context, exec repositories.Executor,
 		orgId, objectId string, entityId []string) ([]models.SanctionCheckWhitelist, error)
+	CountWhitelistsForCounterpartyId(ctx context.Context, exec repositories.Executor,
+		orgId, counterpartyId string) (int, error)
 }
 
 type SanctionsCheckUsecaseExternalRepository interface {
@@ -330,6 +332,10 @@ func (uc SanctionCheckUsecase) FilterOutWhitelistedMatches(ctx context.Context, 
 	sanctionCheck.Count = len(sanctionCheck.Matches)
 
 	return sanctionCheck, nil
+}
+
+func (uc SanctionCheckUsecase) CountWhitelistsForCounterpartyId(ctx context.Context, orgId, counterpartyId string) (int, error) {
+	return uc.repository.CountWhitelistsForCounterpartyId(ctx, uc.executorFactory.NewExecutor(), orgId, counterpartyId)
 }
 
 func (uc SanctionCheckUsecase) UpdateMatchStatus(

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -79,9 +79,9 @@ type SanctionCheckRepository interface {
 	CopySanctionCheckFiles(ctx context.Context, exec repositories.Executor,
 		sanctionCheckId, newSanctionCheckId string) error
 	AddSanctionCheckMatchWhitelist(ctx context.Context, exec repositories.Executor,
-		orgId, objectId string, entityId string, reviewerId models.UserId) error
+		orgId, counterpartyId string, entityId string, reviewerId models.UserId) error
 	IsSanctionCheckMatchWhitelisted(ctx context.Context, exec repositories.Executor,
-		orgId, objectId string, entityId []string) ([]models.SanctionCheckWhitelist, error)
+		orgId, counterpartyId string, entityId []string) ([]models.SanctionCheckWhitelist, error)
 	CountWhitelistsForCounterpartyId(ctx context.Context, exec repositories.Executor,
 		orgId, counterpartyId string) (int, error)
 }
@@ -290,14 +290,14 @@ func (uc SanctionCheckUsecase) Search(ctx context.Context, refine models.Sanctio
 }
 
 func (uc SanctionCheckUsecase) FilterOutWhitelistedMatches(ctx context.Context, orgId string,
-	sanctionCheck models.SanctionCheckWithMatches, objectId string,
+	sanctionCheck models.SanctionCheckWithMatches, counterpartyId string,
 ) (models.SanctionCheckWithMatches, error) {
 	matchesSet := set.From(pure_utils.Map(sanctionCheck.Matches, func(m models.SanctionCheckMatch) string {
 		return m.EntityId
 	}))
 
 	whitelists, err := uc.repository.IsSanctionCheckMatchWhitelisted(ctx,
-		uc.executorFactory.NewExecutor(), orgId, objectId, matchesSet.Slice())
+		uc.executorFactory.NewExecutor(), orgId, counterpartyId, matchesSet.Slice())
 	if err != nil {
 		return sanctionCheck, err
 	}

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -435,9 +435,10 @@ func (uc SanctionCheckUsecase) UpdateMatchStatus(
 				}
 			}
 
-			if update.Status == models.SanctionMatchStatusNoHit && update.Whitelist && data.match.ObjectId != nil {
+			if update.Status == models.SanctionMatchStatusNoHit && update.Whitelist &&
+				data.match.UniqueCounterpartyIdentifier != nil {
 				if err := uc.repository.AddSanctionCheckMatchWhitelist(ctx, tx,
-					data.decision.OrganizationId, *data.match.ObjectId,
+					data.decision.OrganizationId, *data.match.UniqueCounterpartyIdentifier,
 					data.match.EntityId, update.ReviewerId); err != nil {
 					return errors.Wrap(err, "could not whitelist match")
 				}

--- a/usecases/sanction_check_usecase_test.go
+++ b/usecases/sanction_check_usecase_test.go
@@ -49,7 +49,7 @@ func TestListSanctionChecksOnDecision(t *testing.T) {
 
 	exec.Mock.ExpectQuery(`
 		SELECT
-			sc.id, sc.decision_id, sc.status, sc.search_input, sc.search_datasets, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.created_at, sc.updated_at,
+			sc.id, sc.decision_id, sc.status, sc.search_input, sc.search_datasets, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.whitelisted_entities, sc.created_at, sc.updated_at,
 			ARRAY_AGG\(ROW\(scm.id,scm.sanction_check_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.payload,scm.reviewed_by,scm.created_at,scm.updated_at\)\) FILTER \(WHERE scm.id IS NOT NULL\) AS matches
 		FROM sanction_checks AS sc
 		LEFT JOIN sanction_check_matches AS scm ON sc.id = scm.sanction_check_id
@@ -126,7 +126,7 @@ func TestUpdateMatchStatus(t *testing.T) {
 			AddRow(mockScmRow...),
 		)
 	exec.Mock.
-		ExpectQuery(`SELECT id, decision_id, status, search_input, search_datasets, match_threshold, match_limit, is_manual, requested_by, is_partial, is_archived, initial_has_matches, created_at, updated_at FROM sanction_checks WHERE id = \$1`).
+		ExpectQuery(`SELECT id, decision_id, status, search_input, search_datasets, match_threshold, match_limit, is_manual, requested_by, is_partial, is_archived, initial_has_matches, whitelisted_entities, created_at, updated_at FROM sanction_checks WHERE id = \$1`).
 		WithArgs("sanction_check_id").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionChecksColumn).
 			AddRow(mockScRow...),

--- a/usecases/sanction_check_usecase_test.go
+++ b/usecases/sanction_check_usecase_test.go
@@ -50,7 +50,7 @@ func TestListSanctionChecksOnDecision(t *testing.T) {
 	exec.Mock.ExpectQuery(`
 		SELECT
 			sc.id, sc.decision_id, sc.status, sc.search_input, sc.search_datasets, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.whitelisted_entities, sc.created_at, sc.updated_at,
-			ARRAY_AGG\(ROW\(scm.id,scm.sanction_check_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.object_id,scm.payload,scm.reviewed_by,scm.created_at,scm.updated_at\)\) FILTER \(WHERE scm.id IS NOT NULL\) AS matches
+			ARRAY_AGG\(ROW\(scm.id,scm.sanction_check_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.counterparty_id,scm.payload,scm.reviewed_by,scm.created_at,scm.updated_at\)\) FILTER \(WHERE scm.id IS NOT NULL\) AS matches
 		FROM sanction_checks AS sc
 		LEFT JOIN sanction_check_matches AS scm ON sc.id = scm.sanction_check_id
 		WHERE sc.decision_id = \$1 AND sc.is_archived = \$2
@@ -120,7 +120,7 @@ func TestUpdateMatchStatus(t *testing.T) {
 		}))
 
 	exec.Mock.
-		ExpectQuery(`SELECT id, sanction_check_id, opensanction_entity_id, status, query_ids, object_id, payload, reviewed_by, created_at, updated_at FROM sanction_check_matches WHERE id = \$1`).
+		ExpectQuery(`SELECT id, sanction_check_id, opensanction_entity_id, status, query_ids, counterparty_id, payload, reviewed_by, created_at, updated_at FROM sanction_check_matches WHERE id = \$1`).
 		WithArgs("matchid").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionCheckMatchesColumn).
 			AddRow(mockScmRow...),
@@ -131,20 +131,20 @@ func TestUpdateMatchStatus(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionChecksColumn).
 			AddRow(mockScRow...),
 		)
-	exec.Mock.ExpectQuery(`SELECT id, sanction_check_id, opensanction_entity_id, status, query_ids, object_id, payload, reviewed_by, created_at, updated_at FROM sanction_check_matches WHERE sanction_check_id = \$1`).
+	exec.Mock.ExpectQuery(`SELECT id, sanction_check_id, opensanction_entity_id, status, query_ids, counterparty_id, payload, reviewed_by, created_at, updated_at FROM sanction_check_matches WHERE sanction_check_id = \$1`).
 		WithArgs("sanction_check_id").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionCheckMatchesColumn).
 			AddRow(mockScmRow...).
 			AddRows(mockOtherScmRows...),
 		)
-	exec.Mock.ExpectQuery(`UPDATE sanction_check_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,sanction_check_id,opensanction_entity_id,status,query_ids,object_id,payload,reviewed_by,created_at,updated_at`).
+	exec.Mock.ExpectQuery(`UPDATE sanction_check_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,sanction_check_id,opensanction_entity_id,status,query_ids,counterparty_id,payload,reviewed_by,created_at,updated_at`).
 		WithArgs(models.UserId(""), models.SanctionMatchStatusConfirmedHit, "NOW()", "matchid").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionCheckMatchesColumn).
 			AddRow(mockScmRow...),
 		)
 
 	for i := range 3 {
-		exec.Mock.ExpectQuery(`UPDATE sanction_check_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,sanction_check_id,opensanction_entity_id,status,query_ids,object_id,payload,reviewed_by,created_at,updated_at`).
+		exec.Mock.ExpectQuery(`UPDATE sanction_check_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,sanction_check_id,opensanction_entity_id,status,query_ids,counterparty_id,payload,reviewed_by,created_at,updated_at`).
 			WithArgs(models.UserId(""), models.SanctionMatchStatusSkipped, "NOW()", mockOtherScms[i].Id).
 			WillReturnRows(pgxmock.NewRows(dbmodels.SelectSanctionCheckMatchesColumn).
 				AddRow(mockOtherScmRows[i]...),


### PR DESCRIPTION
A sanction check config can now receive an AST to dynamically select the field uniquely identifying a record.

A sanction check match review can now include a boolean, `whitelist` that will permanently link an Open Sanctions entity ID to the unique identifier selected by the previously defined expression.

Any object/entity that has been whitelisted will not be excluded from a sanction check matches.