### PR TITLE
patch (upsert) endpoint for data ingestion

### DIFF
--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -44,13 +44,17 @@ func handleListDecisions(uc usecases.Usecases, marbleAppHost string) func(c *gin
 
 		var filters dto.DecisionFilters
 		if err := c.ShouldBind(&filters); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 
 		var paginationAndSortingDto dto.PaginationAndSorting
 		if err := c.ShouldBind(&paginationAndSortingDto); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 		paginationAndSorting := models.WithPaginationDefaults(
@@ -77,13 +81,17 @@ func handleListDecisionsInternal(uc usecases.Usecases, marbleAppHost string) fun
 
 		var filters dto.DecisionFilters
 		if err := c.ShouldBind(&filters); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 
 		var paginationAndSortingDto dto.PaginationAndSorting
 		if err := c.ShouldBind(&paginationAndSortingDto); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 		paginationAndSorting := models.WithPaginationDefaults(
@@ -109,7 +117,9 @@ func handlePostDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.
 
 		var requestData dto.CreateDecisionWithScenarioBody
 		if err := c.ShouldBindJSON(&requestData); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 
@@ -165,7 +175,9 @@ func handlePostAllDecisions(uc usecases.Usecases, marbleAppHost string) func(c *
 
 		var requestData dto.CreateDecisionBody
 		if err := c.ShouldBindJSON(&requestData); err != nil {
-			c.Status(http.StatusBadRequest)
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: err.Error(),
+			})
 			return
 		}
 

--- a/api/handle_decision.go
+++ b/api/handle_decision.go
@@ -130,7 +130,7 @@ func handlePostDecision(uc usecases.Usecases, marbleAppHost string) func(c *gin.
 			},
 		)
 
-		if returnExpectedDecisionError(c, err) || presentError(ctx, c, err) {
+		if presentIngestionValidationError(c, err) || returnExpectedDecisionError(c, err) || presentError(ctx, c, err) {
 			return
 		}
 		c.JSON(http.StatusOK, dto.NewDecisionWithRuleDto(decision, marbleAppHost, false))
@@ -178,7 +178,7 @@ func handlePostAllDecisions(uc usecases.Usecases, marbleAppHost string) func(c *
 				TriggerObjectTable: requestData.ObjectType,
 			},
 		)
-		if presentError(ctx, c, err) {
+		if presentIngestionValidationError(c, err) || returnExpectedDecisionError(c, err) || presentError(ctx, c, err) {
 			return
 		}
 		c.JSON(http.StatusOK, dto.AdaptDecisionsWithMetadataDto(decisions, marbleAppHost, nbSkipped, false))

--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -62,7 +62,14 @@ func handleIngestionPartialUpsert(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestionUseCase()
 		nb, err := usecase.IngestObject(ctx, organizationId, objectType, objectBody, payload_parser.WithAllowPatch())
-		if presentError(ctx, c, err) {
+		var validationError models.IngestionValidationErrorsSingle
+		if errors.As(err, &validationError) {
+			c.JSON(http.StatusBadRequest, dto.APIErrorResponse{
+				Message: "Input validation error",
+				Details: validationError,
+			})
+			return
+		} else if presentError(ctx, c, err) {
 			return
 		}
 		if nb == 0 {

--- a/api/handle_ingestion.go
+++ b/api/handle_ingestion.go
@@ -13,6 +13,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/usecases/payload_parser"
 	"github.com/checkmarble/marble-backend/utils"
 )
 
@@ -33,6 +34,34 @@ func handleIngestion(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestionUseCase()
 		nb, err := usecase.IngestObject(ctx, organizationId, objectType, objectBody)
+		if presentError(ctx, c, err) {
+			return
+		}
+		if nb == 0 {
+			c.Status(http.StatusOK)
+			return
+		}
+		c.Status(http.StatusCreated)
+	}
+}
+
+func handleIngestionPartialUpsert(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		objectType := c.Param("object_type")
+		objectBody, err := io.ReadAll(c.Request.Body)
+		if err != nil {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
+			return
+		}
+
+		usecase := usecasesWithCreds(ctx, uc).NewIngestionUseCase()
+		nb, err := usecase.IngestObject(ctx, organizationId, objectType, objectBody, payload_parser.WithAllowPatch())
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/routes.go
+++ b/api/routes.go
@@ -48,6 +48,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth Aut
 	router.POST("/decisions/:decision_id/snooze", tom, handleSnoozeDecision(uc))
 
 	router.POST("/ingestion/:object_type", tom, handleIngestion(uc))
+	router.PATCH("/ingestion/:object_type", tom, handleIngestionPartialUpsert(uc))
 	router.POST("/ingestion/:object_type/multiple", tom, handleIngestionMultiple(uc))
 	router.POST("/ingestion/:object_type/batch", timeoutMiddleware(conf.BatchTimeout), handlePostCsvIngestion(uc))
 	router.GET("/ingestion/:object_type/upload-logs", tom, handleListUploadLogs(uc))

--- a/api/routes.go
+++ b/api/routes.go
@@ -50,6 +50,8 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth Aut
 	router.POST("/ingestion/:object_type", tom, handleIngestion(uc))
 	router.PATCH("/ingestion/:object_type", tom, handleIngestionPartialUpsert(uc))
 	router.POST("/ingestion/:object_type/multiple", tom, handleIngestionMultiple(uc))
+	router.PATCH("/ingestion/:object_type/multiple", tom,
+		handleIngestionMultiplePartialUpsert(uc))
 	router.POST("/ingestion/:object_type/batch", timeoutMiddleware(conf.BatchTimeout), handlePostCsvIngestion(uc))
 	router.GET("/ingestion/:object_type/upload-logs", tom, handleListUploadLogs(uc))
 	router.GET("/ingestion/:object_type/:object_id", tom, handleGetIngestedObject(uc))

--- a/dto/api_error.go
+++ b/dto/api_error.go
@@ -23,6 +23,10 @@ const (
 	// decision related
 	TriggerConditionNotMatched ErrorCode = "trigger_condition_not_matched"
 
+	// ingestion related
+	SchemaMismatchError ErrorCode = "data_does_not_match_schema"
+	InvalidJSON         ErrorCode = "invalid_json"
+
 	// general
 	UnknownUser ErrorCode = "unknown_user"
 )

--- a/dto/api_error.go
+++ b/dto/api_error.go
@@ -1,8 +1,11 @@
 package dto
 
+import "encoding/json"
+
 type APIErrorResponse struct {
-	Message   string    `json:"message"`
-	ErrorCode ErrorCode `json:"error_code"`
+	Message   string         `json:"message"`
+	Details   json.Marshaler `json:"details,omitempty"`
+	ErrorCode ErrorCode      `json:"error_code"`
 }
 
 type ErrorCode string

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -591,12 +591,10 @@ func createAndTestDecision(
 	expectedScore int,
 ) models.DecisionWithRuleExecutions {
 	parser := payload_parser.NewParser()
-	transactionPayload, validationErrors, err :=
-		parser.ParsePayload(table, transactionPayloadJson)
+	transactionPayload, err := parser.ParsePayload(table, transactionPayloadJson)
 	if err != nil {
 		assert.FailNow(t, "Could not parse payload", err)
 	}
-	assert.Empty(t, validationErrors, "Expected no validation errors, got %v", validationErrors)
 
 	decision, err := decisionUsecase.CreateDecision(
 		ctx,

--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -176,3 +176,8 @@ func (e *EnforceSecurity) WriteDataModelIndexes(organizationId string) error {
 	args := e.Called(organizationId)
 	return args.Error(0)
 }
+
+func (e *EnforceSecurity) CanIngest(orgId string) error {
+	args := e.Called(orgId)
+	return args.Error(0)
+}

--- a/models/payload.go
+++ b/models/payload.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"encoding/json"
+)
+
 type DbFieldReadParams struct {
 	TriggerTableName string
 	Path             []string
@@ -8,7 +12,33 @@ type DbFieldReadParams struct {
 	ClientObject     ClientObject
 }
 
+type MissingField struct {
+	Field          Field
+	ErrorIfMissing string
+}
+
 type ClientObject struct {
 	TableName string
 	Data      map[string]any
+
+	// MissingFieldsToLookup is a list of fields that are missing from the payload but exist in the data model.
+	// It is used in the context of partial updates to fetch the missing fields from the database.
+	// It is not related to whether the field is actually required in the data model or not.
+	MissingFieldsToLookup []MissingField
+}
+
+// expects format {"field_name": "error message", ...}
+type IngestionValidationErrorsSingle map[string]string
+
+func (err IngestionValidationErrorsSingle) Error() string {
+	encoded, _ := json.Marshal(err)
+	return string(encoded)
+}
+
+// expects format {"object_id": {"field_name": "error message"}, ...}
+type IngestionValidationErrorsMultiple map[string]map[string]string
+
+func (err IngestionValidationErrorsMultiple) Error() string {
+	encoded, _ := json.Marshal(err)
+	return string(encoded)
 }

--- a/models/payload.go
+++ b/models/payload.go
@@ -49,26 +49,26 @@ func (err IngestionValidationErrorsSingle) Is(target error) bool {
 }
 
 // expects format {"object_id": {"field_name": "error message"}, ...}
-type IngestionValidationErrorsMultiple map[string]map[string]string
+type IngestionValidationErrors map[string]IngestionValidationErrorsSingle
 
-func (err IngestionValidationErrorsMultiple) Error() string {
+func (err IngestionValidationErrors) Error() string {
 	encoded, _ := json.Marshal(err)
 	return string(encoded)
 }
 
-func (err IngestionValidationErrorsMultiple) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]map[string]string(err))
+func (err IngestionValidationErrors) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]IngestionValidationErrorsSingle(err))
 }
 
-func (err IngestionValidationErrorsMultiple) Is(target error) bool {
+func (err IngestionValidationErrors) Is(target error) bool {
 	if target == BadParameterError {
 		return true
 	}
-	t, ok := target.(IngestionValidationErrorsMultiple)
+	t, ok := target.(IngestionValidationErrors)
 	return ok && reflect.DeepEqual(err, t)
 }
 
-func (err IngestionValidationErrorsMultiple) GetSomeItem() (string, map[string]string) {
+func (err IngestionValidationErrors) GetSomeItem() (string, IngestionValidationErrorsSingle) {
 	for k, v := range err {
 		return k, v
 	}

--- a/models/payload.go
+++ b/models/payload.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+	"reflect"
 )
 
 type DbFieldReadParams struct {
@@ -39,6 +40,14 @@ func (err IngestionValidationErrorsSingle) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]string(err))
 }
 
+func (err IngestionValidationErrorsSingle) Is(target error) bool {
+	if target == BadParameterError {
+		return true
+	}
+	t, ok := target.(IngestionValidationErrorsSingle)
+	return ok && reflect.DeepEqual(err, t)
+}
+
 // expects format {"object_id": {"field_name": "error message"}, ...}
 type IngestionValidationErrorsMultiple map[string]map[string]string
 
@@ -49,4 +58,19 @@ func (err IngestionValidationErrorsMultiple) Error() string {
 
 func (err IngestionValidationErrorsMultiple) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]map[string]string(err))
+}
+
+func (err IngestionValidationErrorsMultiple) Is(target error) bool {
+	if target == BadParameterError {
+		return true
+	}
+	t, ok := target.(IngestionValidationErrorsMultiple)
+	return ok && reflect.DeepEqual(err, t)
+}
+
+func (err IngestionValidationErrorsMultiple) GetSomeItem() (string, map[string]string) {
+	for k, v := range err {
+		return k, v
+	}
+	return "", nil
 }

--- a/models/payload.go
+++ b/models/payload.go
@@ -35,10 +35,18 @@ func (err IngestionValidationErrorsSingle) Error() string {
 	return string(encoded)
 }
 
+func (err IngestionValidationErrorsSingle) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string(err))
+}
+
 // expects format {"object_id": {"field_name": "error message"}, ...}
 type IngestionValidationErrorsMultiple map[string]map[string]string
 
 func (err IngestionValidationErrorsMultiple) Error() string {
 	encoded, _ := json.Marshal(err)
 	return string(encoded)
+}
+
+func (err IngestionValidationErrorsMultiple) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]map[string]string(err))
 }

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -141,8 +141,12 @@ func (repo *IngestionRepositoryImpl) loadPreviouslyIngestedObjects(
 		for i, columnName := range columnNames {
 			objectAsMap[columnName] = values[i]
 		}
+		id, ok := objectAsMap["id"].([16]byte)
+		if !ok {
+			return nil, fmt.Errorf("error while converting ID to UUID")
+		}
 		output = append(output, ingestedObject{
-			id:        objectAsMap["id"].(string),
+			id:        uuid.UUID(id).String(),
 			objectId:  objectAsMap["object_id"].(string),
 			updatedAt: objectAsMap["updated_at"].(time.Time),
 			data:      objectAsMap,

--- a/repositories/ingestion_repository.go
+++ b/repositories/ingestion_repository.go
@@ -35,7 +35,7 @@ func (repo *IngestionRepositoryImpl) IngestObjects(
 		return 0, err
 	}
 
-	payloadsToInsert, obsoleteIngestedObjectIds, validationErrors := repo.comparePayloadsToIngestedObjects(
+	payloadsToInsert, obsoleteIngestedObjectIds, validationErrors := compareAndMergePayloadsWithIngestedObjects(
 		mostRecentPayloads,
 		previouslyIngestedObjects,
 	)
@@ -165,10 +165,10 @@ func (repo *IngestionRepositoryImpl) loadPreviouslyIngestedObjects(
 // - a list of complete payloads that should be inserted, obtained by merging the payloads with the missing fields from the previously ingested objects
 // - a list of IDs of objects that should be marked as obsolete
 // - a map of validation errors for each payload (if any required missing fields are also missing in the ingested objects)
-func (repo *IngestionRepositoryImpl) comparePayloadsToIngestedObjects(
+func compareAndMergePayloadsWithIngestedObjects(
 	payloads []models.ClientObject,
 	previouslyIngestedObjects []ingestedObject,
-) ([]models.ClientObject, []string, models.IngestionValidationErrorsMultiple) {
+) ([]models.ClientObject, []string, models.IngestionValidationErrors) {
 	previouslyIngestedMap := make(map[string]ingestedObject)
 	for _, obj := range previouslyIngestedObjects {
 		previouslyIngestedMap[obj.objectId] = obj
@@ -176,7 +176,7 @@ func (repo *IngestionRepositoryImpl) comparePayloadsToIngestedObjects(
 
 	payloadsToInsert := make([]models.ClientObject, 0, len(payloads))
 	obsoleteIngestedObjectIds := make([]string, 0, len(previouslyIngestedMap))
-	validationErrors := make(models.IngestionValidationErrorsMultiple, len(payloads))
+	validationErrors := make(models.IngestionValidationErrors, len(payloads))
 
 	for _, payload := range payloads {
 		objectId, updatedAt := objectIdAndUpdatedAtFromPayload(payload)

--- a/repositories/ingestion_repository_test.go
+++ b/repositories/ingestion_repository_test.go
@@ -1,0 +1,184 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCompareAndMergePayloadsWithIngestedObjects(t *testing.T) {
+	testTime := time.Now()
+	tests := []struct {
+		name                      string
+		payloads                  []models.ClientObject
+		previouslyIngestedObjects []ingestedObject
+		expectedPayloadsToInsert  []models.ClientObject
+		expectedObsoleteIds       []string
+		expectedValidationErrors  models.IngestionValidationErrors
+	}{
+		{
+			name: "New payloads with no previously ingested objects",
+			payloads: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+				},
+			},
+			previouslyIngestedObjects: []ingestedObject{},
+			expectedPayloadsToInsert: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+				},
+			},
+			expectedObsoleteIds:      []string{},
+			expectedValidationErrors: models.IngestionValidationErrors{},
+		},
+		{
+			name: "Payloads with previously ingested objects",
+			payloads: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+				},
+			},
+			previouslyIngestedObjects: []ingestedObject{
+				{
+					id:        "1",
+					objectId:  "1",
+					updatedAt: testTime.Add(-time.Hour),
+					data:      map[string]any{"object_id": "1", "updated_at": testTime.Add(-time.Hour)},
+				},
+			},
+			expectedPayloadsToInsert: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+				},
+			},
+			expectedObsoleteIds:      []string{"1"},
+			expectedValidationErrors: models.IngestionValidationErrors{},
+		},
+		{
+			name: "Payloads with missing required fields, previously ingested",
+			payloads: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+					MissingFieldsToLookup: []models.MissingField{
+						{
+							Field: models.Field{
+								Name:     "required_field",
+								Nullable: false,
+							},
+							ErrorIfMissing: "required_field is missing",
+						},
+					},
+				},
+			},
+			previouslyIngestedObjects: []ingestedObject{
+				{
+					id:        "1",
+					objectId:  "1",
+					updatedAt: testTime.Add(-time.Hour),
+					data:      map[string]any{"object_id": "1", "updated_at": testTime.Add(-time.Hour), "required_field": "present"},
+				},
+			},
+			expectedPayloadsToInsert: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":      "1",
+						"updated_at":     testTime,
+						"required_field": "present",
+					},
+					MissingFieldsToLookup: []models.MissingField{
+						{
+							Field: models.Field{
+								Name:     "required_field",
+								Nullable: false,
+							},
+							ErrorIfMissing: "required_field is missing",
+						},
+					},
+				},
+			},
+			expectedObsoleteIds:      []string{"1"},
+			expectedValidationErrors: models.IngestionValidationErrors{},
+		},
+		{
+			name: "Payloads with missing required fields, not previously ingested",
+			payloads: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":  "1",
+						"updated_at": testTime,
+					},
+					MissingFieldsToLookup: []models.MissingField{
+						{
+							Field: models.Field{
+								Name:     "required_field",
+								Nullable: false,
+							},
+							ErrorIfMissing: "required_field is missing",
+						},
+					},
+				},
+			},
+			previouslyIngestedObjects: []ingestedObject{
+				{
+					id:        "1",
+					objectId:  "1",
+					updatedAt: testTime.Add(-time.Hour),
+					data:      map[string]any{"object_id": "1", "updated_at": testTime.Add(-time.Hour)},
+				},
+			},
+			expectedPayloadsToInsert: []models.ClientObject{
+				{
+					Data: map[string]any{
+						"object_id":      "1",
+						"updated_at":     testTime,
+						"required_field": nil,
+					},
+					MissingFieldsToLookup: []models.MissingField{
+						{
+							Field: models.Field{
+								Name:     "required_field",
+								Nullable: false,
+							},
+							ErrorIfMissing: "required_field is missing",
+						},
+					},
+				},
+			},
+			expectedObsoleteIds: []string{"1"},
+			expectedValidationErrors: models.IngestionValidationErrors{
+				"1": {
+					"required_field": "required_field is missing",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payloadsToInsert, obsoleteIds, validationErrors :=
+				compareAndMergePayloadsWithIngestedObjects(tt.payloads, tt.previouslyIngestedObjects)
+
+			assert.Equal(t, tt.expectedPayloadsToInsert, payloadsToInsert)
+			assert.Equal(t, tt.expectedObsoleteIds, obsoleteIds)
+			assert.Equal(t, tt.expectedValidationErrors, validationErrors)
+		})
+	}
+}

--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -43,6 +43,10 @@ paths:
           description: The object was successfully ingested.
         400:
           description: The provided object is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while ingesting the object.
   /ingestion/{object_type}/multiple:
@@ -74,6 +78,10 @@ paths:
           description: The object was successfully ingested.
         400:
           description: One of the provided object is invalid (with respect to the data model), or too many objects have been sent.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while ingesting the object.
   /decisions:
@@ -98,6 +106,10 @@ paths:
                 $ref: "#/components/schemas/decision"
         400:
           description: The input is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while taking a decision.
     get:
@@ -179,6 +191,10 @@ paths:
                           $ref: "#/components/schemas/decision"
         400:
           description: The input is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while taking a decision.
   /decisions/all:
@@ -213,6 +229,10 @@ paths:
                         $ref: "#/components/schemas/decisions_count_metadata"
         400:
           description: The input is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while creating the decisions
   /decisions/{decision_id}:
@@ -239,6 +259,10 @@ paths:
                 $ref: "#/components/schemas/decision"
         400:
           description: The input is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         500:
           description: An error happened while taking a decision.
   /scheduled-executions:
@@ -270,6 +294,12 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/scheduled_execution"
+        400:
+          description: The input is invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorDto'
         401:
           description: Unauthorized
         500:
@@ -551,6 +581,15 @@ components:
           type: integer
         message:
           type: string
+        details: {}
+    ErrorDto:
+      type: object
+      properties:
+        error_code:
+          type: integer
+        message:
+          type: string
+        details: {}
     pagination:
       type: object
       required:

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -678,7 +678,6 @@ func (usecase DecisionUsecase) validatePayload(
 	clientObject *models.ClientObject,
 	rawPayload json.RawMessage,
 ) (payload models.ClientObject, dataModel models.DataModel, err error) {
-	logger := utils.LoggerFromContext(ctx)
 	exec := usecase.executorFactory.NewExecutor()
 
 	if clientObject == nil && len(rawPayload) == 0 {
@@ -710,18 +709,10 @@ func (usecase DecisionUsecase) validatePayload(
 	}
 
 	parser := payload_parser.NewParser()
-	payload, validationErrors, err := parser.ParsePayload(table, rawPayload)
+	payload, err = parser.ParsePayload(table, rawPayload)
 	if err != nil {
-		err = errors.Wrap(
-			models.BadParameterError,
-			fmt.Sprintf("Error while validating payload in validatePayload: %v", err),
-		)
+		err = errors.Wrap(err, "error parsing payload in decision usecase validate payload")
 		return
-	}
-	if len(validationErrors) > 0 {
-		encoded, _ := json.Marshal(validationErrors)
-		logger.InfoContext(ctx, fmt.Sprintf("Validation errors on POST all decisions: %s", string(encoded)))
-		err = errors.Wrap(models.BadParameterError, string(encoded))
 	}
 
 	return

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -49,6 +49,7 @@ func (usecase *IngestionUseCase) IngestObject(
 	organizationId string,
 	objectType string,
 	objectBody json.RawMessage,
+	parserOpts ...payload_parser.ParserOpt,
 ) (int, error) {
 	logger := utils.LoggerFromContext(ctx)
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
@@ -78,7 +79,7 @@ func (usecase *IngestionUseCase) IngestObject(
 		)
 	}
 
-	parser := payload_parser.NewParser()
+	parser := payload_parser.NewParser(parserOpts...)
 	payload, validationErrors, err := parser.ParsePayload(table, objectBody)
 	if err != nil {
 		return 0, errors.Wrapf(

--- a/usecases/ingestion_usecase_test.go
+++ b/usecases/ingestion_usecase_test.go
@@ -1,9 +1,22 @@
 package usecases
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/payload_parser"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 func TestParseStringValuesToMap(t *testing.T) {
@@ -79,4 +92,403 @@ func TestParseStringValuesToMap(t *testing.T) {
 			t.Errorf("Expected error parsing string values to map: %v", err)
 		}
 	}
+}
+
+type IngestionUsecaseTestSuite struct {
+	suite.Suite
+	enforceSecurity     *mocks.EnforceSecurity
+	executorFactory     executor_factory.ExecutorFactoryStub
+	transactionFactory  executor_factory.TransactionFactoryStub
+	dataModelRepository *mocks.DataModelRepository
+
+	organizationId string
+	dataModel      models.DataModel
+
+	ctx context.Context
+}
+
+func (suite *IngestionUsecaseTestSuite) makeUsecase() *IngestionUseCase {
+	return &IngestionUseCase{
+		transactionFactory:    suite.transactionFactory,
+		executorFactory:       suite.executorFactory,
+		enforceSecurity:       suite.enforceSecurity,
+		ingestionRepository:   &repositories.IngestionRepositoryImpl{},
+		dataModelRepository:   suite.dataModelRepository,
+		batchIngestionMaxSize: 100,
+	}
+}
+
+func (suite *IngestionUsecaseTestSuite) SetupTest() {
+	suite.enforceSecurity = new(mocks.EnforceSecurity)
+	suite.executorFactory = executor_factory.NewExecutorFactoryStub()
+	suite.transactionFactory = executor_factory.NewTransactionFactoryStub(suite.executorFactory)
+	suite.dataModelRepository = new(mocks.DataModelRepository)
+
+	suite.organizationId = "org_id"
+	suite.dataModel = models.DataModel{
+		Tables: map[string]models.Table{
+			"transactions": {
+				Name: "transactions",
+				Fields: map[string]models.Field{
+					"object_id": {
+						DataType: models.String, Nullable: false, Name: "object_id",
+					},
+					"updated_at": {DataType: models.Timestamp, Nullable: false, Name: "updated_at"},
+					"value":      {DataType: models.Float, Nullable: true, Name: "value"},
+					"status":     {DataType: models.String, Nullable: false, Name: "status"},
+				},
+				LinksToSingle: nil,
+			},
+		},
+	}
+
+	suite.ctx = utils.StoreOpenTelemetryTracerInContext(
+		utils.StoreLoggerInContext(context.TODO(), utils.NewLogger("text")),
+		&noop.Tracer{})
+}
+
+func (suite *IngestionUsecaseTestSuite) AssertExpectations() {
+	t := suite.T()
+	asserts := assert.New(t)
+	// Wait here so we are sure to gather the async call to dataModelRepository.BatchInsertEnumValues
+	time.Sleep(50 * time.Millisecond)
+	asserts.NoError(suite.executorFactory.Mock.ExpectationsWereMet(),
+		"ExecutorFactory expectations were not met")
+	suite.dataModelRepository.AssertExpectations(t)
+	suite.dataModelRepository.AssertExpectations(t)
+	suite.enforceSecurity.AssertExpectations(t)
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nominal_with_previous_version() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	rowIdStr := "17c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId := utils.ByteUuid(rowIdStr)
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is a previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
+			AddRow("1", "OK", updAt, 1.0, rowId))
+	// update the previous version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2)`)).
+		WithArgs("now()", rowIdStr).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// insert the new version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}`))
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting object")
+	asserts.Equal(1, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nominal_no_previous_version() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is no previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+	// insert the new version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}`))
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting object")
+	asserts.Equal(1, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nominal_no_previous_version_and_enum() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	// update the basic data model to include an enum, and use this copy just in this test
+	dataModel := suite.dataModel.Copy()
+	table := dataModel.Tables["transactions"]
+	field := table.Fields["status"]
+	field.IsEnum = true
+	table.Fields["status"] = field
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(dataModel, nil)
+
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is no previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+	// insert the new version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	values := make(models.EnumValues)
+	values["status"] = map[any]struct{}{"OK": {}}
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), values, dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}`))
+
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting object")
+	asserts.Equal(1, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nominal_with_more_recent_previous_version() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	rowIdStr := "17c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId := utils.ByteUuid(rowIdStr)
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is a previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
+			AddRow("1", "OK", updAt.Add(time.Hour), 1.0, rowId))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}`))
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting object")
+	asserts.Equal(0, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nominal_with_previous_version_and_partial_insert() {
+	// "status" is missing in the payload, but it can be read from a previous version of the object
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	rowIdStr := "17c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId := utils.ByteUuid(rowIdStr)
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is a previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
+			AddRow("1", "OK", updAt, 1.0, rowId))
+	// update the previous version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2)`)).
+		WithArgs("now()", rowIdStr).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// insert the new version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z"}`), payload_parser.WithAllowPatch())
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting object")
+	asserts.Equal(1, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_without_previous_version_and_partial_insert() {
+	// "status" is missing in the payload, and it can not be read from a previous version of the object
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is a previous version for this object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+		WithArgs("Infinity", "1").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+	// insert the new version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	_, err := uc.IngestObject(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z"}`), payload_parser.WithAllowPatch())
+	asserts := assert.New(t)
+	asserts.ErrorAs(err, &models.IngestionValidationErrors{}, "Error ingesting object")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_nominal() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is no previous version for these objects
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
+		WithArgs("Infinity", "1", "2").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+	// insert the new versions
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10)`)).
+		WithArgs(
+			"1", "OK", updAt, 1.0, anyUuid{},
+			"2", "OK", updAt, 2.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 2))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObjects(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`[{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}, {"object_id": "2", "updated_at": "2020-01-01T00:00:00Z", "value": 2.0, "status": "OK"}]`))
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting objects")
+	asserts.Equal(2, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_with_previous_versions() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	rowIdStr1 := "17c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId1 := utils.ByteUuid(rowIdStr1)
+	rowIdStr2 := "27c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId2 := utils.ByteUuid(rowIdStr2)
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there are previous versions for these objects
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
+		WithArgs("Infinity", "1", "2").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
+			AddRow("1", "OK", updAt, 1.0, rowId1).
+			AddRow("2", "OK", updAt, 2.0, rowId2))
+	// update the previous versions
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2,$3)`)).
+		WithArgs("now()", rowIdStr1, rowIdStr2).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+	// insert the new versions
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10)`)).
+		WithArgs(
+			"1", "OK", updAt, 1.0, anyUuid{},
+			"2", "OK", updAt, 2.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 2))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObjects(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`[{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}, {"object_id": "2", "updated_at": "2020-01-01T00:00:00Z", "value": 2.0, "status": "OK"}]`))
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting objects")
+	asserts.Equal(2, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_with_partial_insert() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	rowIdStr1 := "17c5805e-eb8f-48f1-afd4-10ad5494954b"
+	rowId1 := utils.ByteUuid(rowIdStr1)
+	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
+	// there is a previous version for one object
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
+		WithArgs("Infinity", "1", "2").
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
+			AddRow("1", "OK", updAt, 1.0, rowId1))
+	// update the previous version
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2)`)).
+		WithArgs("now()", rowIdStr1).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// insert the new versions
+	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10)`)).
+		WithArgs("1", "OK", updAt, 1.0, anyUuid{}, "2", "OK", updAt, 2.0, anyUuid{}).
+		WillReturnResult(pgxmock.NewResult("INSERT", 2))
+
+	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
+		Return(nil)
+
+	nb, err := uc.IngestObjects(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`[{"object_id": "1", "updated_at": "2020-01-01T00:00:00Z"}, {"object_id": "2", "updated_at": "2020-01-01T00:00:00Z", "value": 2.0, "status": "OK"}]`), payload_parser.WithAllowPatch())
+	asserts := assert.New(t)
+	asserts.NoError(err, "Error ingesting objects")
+	asserts.Equal(2, nb, "Number of rows affected")
+}
+
+func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_with_validation_errors() {
+	t := suite.T()
+	uc := suite.makeUsecase()
+
+	suite.enforceSecurity.On("CanIngest", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel", mock.MatchedBy(matchContext),
+		mock.MatchedBy(matchExec), suite.organizationId, false).
+		Return(suite.dataModel, nil)
+
+	_, err := uc.IngestObjects(suite.ctx, suite.organizationId, "transactions",
+		json.RawMessage(`[{"object_id": "", "updated_at": "2020-01-01T00:00:00Z", "value": 1.0, "status": "OK"}, {"object_id": "2", "updated_at": "2020-01-01T00:00:00Z", "value": 2.0, "status": "OK"}]`))
+	asserts := assert.New(t)
+	asserts.ErrorAs(err, &models.IngestionValidationErrors{}, "Error ingesting objects")
+}
+
+func TestIngestionUsecase(t *testing.T) {
+	suite.Run(t, new(IngestionUsecaseTestSuite))
 }

--- a/usecases/payload_parser/payload_test.go
+++ b/usecases/payload_parser/payload_test.go
@@ -1,6 +1,7 @@
 package payload_parser
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -42,7 +43,7 @@ func TestParser_ParsePayload(t *testing.T) {
 		name       string
 		table      models.Table
 		input      []byte
-		wantErrors models.IngestionValidationErrorsMultiple
+		wantErrors models.IngestionValidationErrors
 		want       models.ClientObject
 		err        error
 	}{
@@ -75,7 +76,7 @@ func TestParser_ParsePayload(t *testing.T) {
 			name:  "empty json",
 			table: table,
 			input: []byte(`{}`),
-			wantErrors: models.IngestionValidationErrorsMultiple{"": map[string]string{
+			wantErrors: models.IngestionValidationErrors{"": models.IngestionValidationErrorsSingle{
 				"string":     errIsNotNullable.Error(),
 				"integer":    errIsNotNullable.Error(),
 				"float":      errIsNotNullable.Error(),
@@ -83,6 +84,18 @@ func TestParser_ParsePayload(t *testing.T) {
 				"boolean":    errIsNotNullable.Error(),
 				"object_id":  errIsNotNullable.Error(),
 				"updated_at": errIsNotNullable.Error(),
+			}},
+		},
+		{
+			name:  "missing fields other than object_id and updated_at",
+			table: table,
+			input: []byte(`{"object_id": "1", "updated_at": "2023-10-19 17:33:22"}`),
+			wantErrors: models.IngestionValidationErrors{"1": models.IngestionValidationErrorsSingle{
+				"string":    errIsNotNullable.Error(),
+				"integer":   errIsNotNullable.Error(),
+				"float":     errIsNotNullable.Error(),
+				"timestamp": errIsNotNullable.Error(),
+				"boolean":   errIsNotNullable.Error(),
 			}},
 		},
 		{
@@ -100,7 +113,7 @@ func TestParser_ParsePayload(t *testing.T) {
 				"timestamp": "not a timestamp",
 				"boolean": "true"
 			}`),
-			wantErrors: models.IngestionValidationErrorsMultiple{"": map[string]string{
+			wantErrors: models.IngestionValidationErrors{"": models.IngestionValidationErrorsSingle{
 				"string":     errIsInvalidString.Error(),
 				"integer":    "is not a valid integer: expected an integer, got \"string\"",
 				"float":      "is not a valid float: expected a float, got \"string\"",
@@ -143,7 +156,7 @@ func TestParser_ParsePayload(t *testing.T) {
 					"nullable": nil,
 				},
 			},
-			wantErrors: models.IngestionValidationErrorsMultiple{"": map[string]string{
+			wantErrors: models.IngestionValidationErrors{"": models.IngestionValidationErrorsSingle{
 				"object_id": errIsNotNullable.Error(),
 			}},
 		},
@@ -212,19 +225,24 @@ func TestParser_ParsePayload(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := NewParser()
 
-			out, errors, err := p.ParsePayload(tt.table, tt.input)
-			if err != nil {
+			out, err := p.ParsePayload(tt.table, tt.input)
+			var validationErrors models.IngestionValidationErrors
+			var otherErr error
+			if !errors.As(err, &validationErrors) {
+				otherErr = err
+			}
+			if otherErr != nil {
 				assert.Error(t, tt.err)
-				assert.ErrorIs(t, err, tt.err, "error is the expected error")
+				assert.ErrorIs(t, otherErr, tt.err, "error is the expected error")
 			}
 			if tt.err != nil {
-				assert.ErrorIs(t, err, tt.err, "expected this specific error")
+				assert.ErrorIs(t, otherErr, tt.err, "expected this specific error")
 			} else if len(tt.wantErrors) > 0 {
-				assert.NoError(t, err, "expected no global error")
-				assert.Equal(t, tt.wantErrors, errors, "expected those validation errors")
+				assert.NoError(t, otherErr, "expected no global error")
+				assert.Equal(t, tt.wantErrors, validationErrors, "expected those validation errors")
 			} else if len(tt.want.Data) > 0 {
-				assert.NoError(t, err, "excepted no global error")
-				assert.Empty(t, errors, "expected no validation errors")
+				assert.NoError(t, otherErr, "excepted no global error")
+				assert.Empty(t, validationErrors, "expected no validation errors")
 				assert.Equal(t, tt.want.Data, out.Data, "expected this client object")
 			} else {
 				t.Error("test case is not well defined")

--- a/usecases/testing_helpers.go
+++ b/usecases/testing_helpers.go
@@ -1,0 +1,41 @@
+package usecases
+
+import (
+	"context"
+	"strings"
+
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/google/uuid"
+)
+
+func pipe[T any](fns ...func(t T) T) func(T) T {
+	return func(t T) T {
+		for _, fn := range fns {
+			t = fn(t)
+		}
+		return t
+	}
+}
+
+func escapeSql(str string) string {
+	// replace all (,),$ by the escaped equivalent
+	return pipe(
+		func(s string) string { return strings.ReplaceAll(s, "(", "\\(") },
+		func(s string) string { return strings.ReplaceAll(s, ")", "\\)") },
+		func(s string) string { return strings.ReplaceAll(s, "$", "\\$") },
+	)(str)
+}
+
+type anyUuid struct{}
+
+func (a anyUuid) Match(v any) bool {
+	str, ok := v.(string)
+	if !ok {
+		return false
+	}
+	_, err := uuid.Parse(str)
+	return err == nil
+}
+
+func matchContext(ctx context.Context) bool     { return true }
+func matchExec(exec repositories.Executor) bool { return true }

--- a/utils/uuid.go
+++ b/utils/uuid.go
@@ -14,3 +14,7 @@ func ValidateUuid(uuidParam string) error {
 	}
 	return err
 }
+
+func ByteUuid(str string) [16]byte {
+	return [16]byte(uuid.MustParse(str))
+}


### PR DESCRIPTION
## Summary of changes
### new patch upsert endpoint
Two new endpoints for ingestion, using the same path but with PATCH method. They allow the customer to send a partial object, and reuse missing values from a previously ingested version of the object. If some of the missing values are required and are not present in the previous version, or if it is the first time this object id is ingested, we get an error, otherwise a new version is ingested.

For instance suppose the data model is as such
```
object_id    required
updated_at   required
req          required
value        optional
```

If we receive 
```json
{
   "object_id": "1",
   "udpated_at": "2022-...",
   "req": "ok"
}
```
we will look up a previous version with object_id "1" and update it by keeping the same `"value"`, or create a new object if no previous version exists.

If we receive 
```json
{
   "object_id": "1",
   "udpated_at": "2022-..."
}
```
we will look up a previous version with object_id "1" and return a validation error if there is none.

⚠️  "object_id" and "updated_at" are "hard required", no matter previous versions => we need them for the actual logic of looking up previous versions and comparing them

NB: same change applied on the decisions endpoint

⚠️  the ingestion by CSVs still requires full payloads, and I rather intend to keep it like this

#### performance considerations
The PATCH endpoints should be expected to be slightly slower to respond than the currently existing POST endpoints, because they can no longer use a covering index for looking up the previous versions of the objects.

### refactor and improve payload validation logic
I reworked a bit the structure of the validation logic, and especially the error message we send back to the customer if a bad/incomplete payload is received (including after lookup of previous values with the new endpoints' logic). 

#### before
```json
{
    "message": "{\"object_id\":\"is not nullable\",\"test\":\"is not a valid string\"}: bad parameter",
    "error_code": ""
}
```

#### after
```json
{
    "message": "Input validation error",
    "details": {
        "updated_at": "is not nullable"
    },
    "error_code": "data_does_not_match_schema"
}
```

or in the case of the `/multiple` endpoint
```json
{
    "message": "Input validation error",
    "details": {
        "e345cdd3-eed9-4362-99b7-d63accebe112": {
            "test": "is not a valid string",
            "updated_at": "is not nullable"
        }
    },
    "error_code": "data_does_not_match_schema"
}
```
Nb: we now return the errors for every object received in the payload, as a nested object with the object_id as key. Objects that are sent without an object_id (or with null or empty string in it) will all be grouped under the empty string key.


## Implementation discussion
Nothing really exciting to say, except that there were some awkward choices related to the fact that in the payload parsing, the fields `object_id` and `updated_at` (that are not necessarily present in the data model object as per the model, though they are in practice always expected there as per the data model creation logic) are effectively "more required" than the others. Some business logic related to this is leaking from the parser lib to the usecase to the repo, and I couldn't find an elegant way around it. Nothing too bad, but it means there are a few gotchas in the code.