### PR TITLE
Fix permissions on list sanction checks

### DIFF
--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -131,8 +131,14 @@ func (uc SanctionCheckUsecase) ListSanctionChecks(ctx context.Context, decisionI
 		return nil, errors.Wrap(models.NotFoundError, "requested decision does not exist")
 	}
 
-	if _, err = uc.enforceCanReadOrUpdateCase(ctx, decisions[0].DecisionId); err != nil {
-		return nil, err
+	if decisions[0].Case == nil {
+		if err := uc.enforceSecurityDecision.ReadDecision(decisions[0]); err != nil {
+			return nil, err
+		}
+	} else {
+		if _, err = uc.enforceCanReadOrUpdateCase(ctx, decisions[0].DecisionId); err != nil {
+			return nil, err
+		}
 	}
 
 	scs, err := uc.repository.GetSanctionChecksForDecision(ctx, exec, decisions[0].DecisionId)


### PR DESCRIPTION
The only security enforcement we had on listing sanction checks was to check whether the user had permission to read or update the case. This fell flat when a decision was not yet added to a case.

This conditions the case permission checking on whether the decision is in a case, or otherwise checks that the user can read the decision. 