### PR TITLE
Filter out returned results that are not matches.

### DIFF
--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -157,6 +157,7 @@ func (s SanctionCheckWithMatches) InitialStatusFromMatches() SanctionCheckStatus
 
 type SanctionCheckMatch struct {
 	Id              string
+	IsMatch         bool
 	SanctionCheckId string
 	EntityId        string
 	Status          SanctionCheckMatchStatus

--- a/repositories/fixtures/opensanctions/response_full.json
+++ b/repositories/fixtures/opensanctions/response_full.json
@@ -8,14 +8,16 @@
                     "schema": "Person",
                     "properties": {
                         "name": ["Bob", "Joe"]
-                    }
+                    },
+                    "match": true
                 },
                 {
                     "id": "UNIQUEID2",
                     "schema": "Business",
                     "properties": {
                         "name": ["ACME Inc."]
-                    }
+                    },
+                    "match": true
                 }
             ],
             "total": {

--- a/repositories/fixtures/opensanctions/response_partial.json
+++ b/repositories/fixtures/opensanctions/response_partial.json
@@ -8,7 +8,8 @@
                     "schema": "Person",
                     "properties": {
                         "name": ["Bob", "Joe"]
-                    }
+                    },
+                    "match": true
                 }
             ],
             "total": {

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -241,7 +241,11 @@ func (repo OpenSanctionsRepository) buildQueryString(cfg models.SanctionCheckCon
 		qs["include_dataset"] = cfg.Datasets
 	}
 
+	// Unless determined otherwise, we do not need those results that are *not*
+	// matches. They could still be filtered further down the chain, but we do not need them returned.
 	qs.Set("threshold", fmt.Sprintf("%.1f", float64(orgCfg.MatchThreshold)/100))
+	qs.Set("cutoff", fmt.Sprintf("%.1f", float64(orgCfg.MatchThreshold)/100))
+
 	qs.Set("limit", fmt.Sprintf("%d", orgCfg.MatchLimit))
 
 	return qs


### PR DESCRIPTION
This implements Open Sanctions queries properly, since the API does return results that are not considered matches (whose score does not meet the `threshold`) if their score is between `cutoff` and `threshold`.

Right now, thus, we do not request the API to return non-matches (by setting the same value for the two parameters). Even though they are not returned, logic to filter them out and determine partial results was amended, in case we change the behavior in the future).