### PR TITLE
Adapt non-matchable object types to multiple queries in refines.

### DIFF
--- a/models/opensanctions_test.go
+++ b/models/opensanctions_test.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpenSanctionsAbstractTypeMapping(t *testing.T) {
+	tts := []struct {
+		kind         string
+		outputLength int
+		outputs      []string
+	}{
+		{"Vehicle", 2, []string{"Airplane", "Vessel"}},
+	}
+
+	for _, tt := range tts {
+		req := SanctionCheckRefineRequest{Type: tt.kind, Query: OpenSanctionCheckFilter{
+			"name": []string{"value"},
+		}}
+
+		queries := AdaptRefineRequestToMatchable(req)
+		types := pure_utils.Map(queries, func(q OpenSanctionsCheckQuery) string {
+			return q.Type
+		})
+
+		assert.Len(t, queries, tt.outputLength)
+
+		for _, c := range tt.outputs {
+			assert.Contains(t, types, c)
+		}
+
+		valuesEqual := true
+
+		for _, q := range queries {
+			assert.Len(t, q.Filters["name"], 1)
+			if q.Filters["name"][0] != "value" {
+				valuesEqual = false
+			}
+		}
+
+		assert.True(t, valuesEqual)
+	}
+}

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -204,7 +204,7 @@ func (uc SanctionCheckUsecase) Execute(
 func (uc SanctionCheckUsecase) Refine(ctx context.Context, refine models.SanctionCheckRefineRequest,
 	requestedBy models.UserId,
 ) (models.SanctionCheckWithMatches, error) {
-	decision, _, err := uc.enforceCanRefineSanctionCheck(ctx, refine.DecisionId)
+	decision, sc, err := uc.enforceCanRefineSanctionCheck(ctx, refine.DecisionId)
 	if err != nil {
 		return models.SanctionCheckWithMatches{}, err
 	}
@@ -217,13 +217,9 @@ func (uc SanctionCheckUsecase) Refine(ctx context.Context, refine models.Sanctio
 
 	query := models.OpenSanctionsQuery{
 		IsRefinement: true,
+		OrgConfig:    sc.OrgConfig,
 		Config:       *scc,
-		Queries: []models.OpenSanctionsCheckQuery{
-			{
-				Type:    refine.Type,
-				Filters: refine.Query,
-			},
-		},
+		Queries:      models.AdaptRefineRequestToMatchable(refine),
 	}
 
 	sanctionCheck, err := uc.Execute(ctx, decision.OrganizationId, query)
@@ -281,12 +277,7 @@ func (uc SanctionCheckUsecase) Search(ctx context.Context, refine models.Sanctio
 		IsRefinement: true,
 		OrgConfig:    sc.OrgConfig,
 		Config:       *scc,
-		Queries: []models.OpenSanctionsCheckQuery{
-			{
-				Type:    refine.Type,
-				Filters: refine.Query,
-			},
-		},
+		Queries:      models.AdaptRefineRequestToMatchable(refine),
 	}
 
 	sanctionCheck, err := uc.Execute(ctx, decision.OrganizationId, query)


### PR DESCRIPTION
This builds on the feat/sanctions/name-recognition branch (to take advantage of the multi-query model).

OpenSanctions does not let us match on `Vehicle` (and other "abstract" object types) directly. If we want ot refine on those, we need to normalize the queries by duplicating the requests accordingly.