### PR TITLE
feat: make ast validation without type show no type error

### DIFF
--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -141,13 +141,13 @@ func validateScenarioAst(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		expectedReturnType := "bool"
+		expectedReturnType := make([]string, 0, 1)
 		if input.ExpectedReturnType != "" {
-			expectedReturnType = input.ExpectedReturnType
+			expectedReturnType[0] = input.ExpectedReturnType
 		}
 
 		usecase := usecasesWithCreds(ctx, uc).NewScenarioUsecase()
-		astValidation, err := usecase.ValidateScenarioAst(ctx, scenarioId, &astNode, expectedReturnType)
+		astValidation, err := usecase.ValidateScenarioAst(ctx, scenarioId, &astNode, expectedReturnType...)
 
 		if presentError(ctx, c, err) {
 			return

--- a/usecases/scenario_usecase.go
+++ b/usecases/scenario_usecase.go
@@ -149,7 +149,7 @@ func validateScenarioUpdate(scenario models.Scenario, input models.UpdateScenari
 }
 
 func (usecase *ScenarioUsecase) ValidateScenarioAst(ctx context.Context,
-	scenarioId string, astNode *ast.Node, expectedReturnType string,
+	scenarioId string, astNode *ast.Node, expectedReturnType ...string,
 ) (validation ast.NodeEvaluation, err error) {
 	scenario, err := usecase.scenarioFetcher.FetchScenario(ctx,
 		usecase.executorFactory.NewExecutor(), scenarioId)
@@ -161,7 +161,7 @@ func (usecase *ScenarioUsecase) ValidateScenarioAst(ctx context.Context,
 		return validation, err
 	}
 
-	validation, err = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType)
+	validation, err = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType...)
 
 	return validation, err
 }


### PR DESCRIPTION
- /validate-ast was testing against bool if no expectedType, now it won't type check the returnValue

Frontend PR: https://github.com/checkmarble/marble-frontend/pull/697