### PR TITLE
Sanctions check scenario validation

### DIFF
--- a/dto/sanction_check_config_dto.go
+++ b/dto/sanction_check_config_dto.go
@@ -113,21 +113,27 @@ func AdaptSanctionCheckConfigInputDto(dto SanctionCheckConfig) (models.UpdateSan
 }
 
 type SanctionCheckConfigQuery struct {
-	Name  NodeDto  `json:"name"`
+	Name  *NodeDto `json:"name"`
 	Label *NodeDto `json:"label"`
 }
 
 func AdaptSanctionCheckConfigQuery(model models.SanctionCheckConfigQuery) (SanctionCheckConfigQuery, error) {
-	nameAst, err := AdaptNodeDto(model.Name)
-	if err != nil {
-		return SanctionCheckConfigQuery{}, err
-	}
-
 	dto := SanctionCheckConfigQuery{
-		Name: nameAst,
+		Name: &NodeDto{
+			Name: "Undefined",
+		},
 		Label: &NodeDto{
 			Name: "Undefined",
 		},
+	}
+
+	if model.Name != nil {
+		nameAst, err := AdaptNodeDto(*model.Name)
+		if err != nil {
+			return SanctionCheckConfigQuery{}, err
+		}
+
+		dto.Name = &nameAst
 	}
 
 	if model.Label != nil && model.Label.Function != ast.FUNC_UNDEFINED {
@@ -143,13 +149,18 @@ func AdaptSanctionCheckConfigQuery(model models.SanctionCheckConfigQuery) (Sanct
 }
 
 func AdaptSanctionCheckConfigQueryDto(dto SanctionCheckConfigQuery) (models.SanctionCheckConfigQuery, error) {
-	nameAst, err := AdaptASTNode(dto.Name)
-	if err != nil {
-		return models.SanctionCheckConfigQuery{}, err
+	model := models.SanctionCheckConfigQuery{
+		Name:  &ast.Node{Function: ast.FUNC_UNDEFINED},
+		Label: &ast.Node{Function: ast.FUNC_UNDEFINED},
 	}
 
-	model := models.SanctionCheckConfigQuery{
-		Name: nameAst,
+	if dto.Name != nil {
+		nameAst, err := AdaptASTNode(*dto.Name)
+		if err != nil {
+			return models.SanctionCheckConfigQuery{}, err
+		}
+
+		model.Name = &nameAst
 	}
 
 	if dto.Label != nil {

--- a/dto/scenario_validation_dto.go
+++ b/dto/scenario_validation_dto.go
@@ -39,7 +39,9 @@ type decisionValidationDto struct {
 
 type sanctionCheckConfigValidationDto struct {
 	Trigger                  triggerValidationDto `json:"trigger"`
-	NameFilter               ruleValidationDto    `json:"name_filter"`
+	Query                    ruleValidationDto    `json:"query"`
+	QueryName                ruleValidationDto    `json:"query_name"`
+	QueryLabel               ruleValidationDto    `json:"query_label"`
 	CounterpartyIdExpression ruleValidationDto    `json:"counterparty_id_expression"`
 }
 
@@ -70,9 +72,17 @@ func AdaptScenarioValidationDto(s models.ScenarioValidation) ScenarioValidationD
 				Errors:            pure_utils.Map(s.SanctionCheck.TriggerRule.Errors, AdaptScenarioValidationErrorDto),
 				TriggerEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.TriggerRule.TriggerEvaluation),
 			},
-			NameFilter: ruleValidationDto{
-				Errors:         pure_utils.Map(s.SanctionCheck.NameFilter.Errors, AdaptScenarioValidationErrorDto),
-				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.NameFilter.RuleEvaluation),
+			Query: ruleValidationDto{
+				Errors:         pure_utils.Map(s.SanctionCheck.Query.Errors, AdaptScenarioValidationErrorDto),
+				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.Query.RuleEvaluation),
+			},
+			QueryName: ruleValidationDto{
+				Errors:         pure_utils.Map(s.SanctionCheck.QueryName.Errors, AdaptScenarioValidationErrorDto),
+				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.QueryName.RuleEvaluation),
+			},
+			QueryLabel: ruleValidationDto{
+				Errors:         pure_utils.Map(s.SanctionCheck.QueryLabel.Errors, AdaptScenarioValidationErrorDto),
+				RuleEvaluation: ast.AdaptNodeEvaluationDto(s.SanctionCheck.QueryLabel.RuleEvaluation),
 			},
 			CounterpartyIdExpression: ruleValidationDto{
 				Errors:         pure_utils.Map(s.SanctionCheck.CounterpartyIdExpression.Errors, AdaptScenarioValidationErrorDto),

--- a/infra/opensanctions.go
+++ b/infra/opensanctions.go
@@ -58,6 +58,16 @@ func (os OpenSanctions) Client() *http.Client {
 	return os.client
 }
 
+func (os OpenSanctions) IsConfigured() bool {
+	if !os.IsSelfHosted() && len(os.credentials) > 0 {
+		return true
+	}
+	if os.IsSelfHosted() && len(os.host) > 0 {
+		return true
+	}
+	return false
+}
+
 func (os OpenSanctions) IsSelfHosted() bool {
 	return len(os.host) > 0
 }

--- a/models/errors.go
+++ b/models/errors.go
@@ -22,6 +22,9 @@ var (
 
 	// ConflictError is rendered with the http status code 409
 	ConflictError = errors.New("duplicate value")
+
+	// MissingRequirement means this features required infrastructure or configuration that was not provided
+	MissingRequirement = errors.New("missing requirement")
 )
 
 // Authentication related errors

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -102,7 +102,7 @@ type UpdateSanctionCheckConfigInput struct {
 }
 
 type SanctionCheckConfigQuery struct {
-	Name  ast.Node
+	Name  *ast.Node
 	Label *ast.Node
 }
 

--- a/models/scenario_validation.go
+++ b/models/scenario_validation.go
@@ -76,7 +76,9 @@ type decisionValidation struct {
 
 type sanctionCheckConfigValidation struct {
 	TriggerRule              triggerValidation
-	NameFilter               RuleValidation
+	Query                    RuleValidation
+	QueryName                RuleValidation
+	QueryLabel               RuleValidation
 	CounterpartyIdExpression RuleValidation
 }
 

--- a/repositories/dbmodels/db_sanction_check_config.go
+++ b/repositories/dbmodels/db_sanction_check_config.go
@@ -34,8 +34,8 @@ type DBSanctionCheckConfigQuery struct {
 }
 
 type DBSanctionCheckConfigQueryInput struct {
-	Name  dto.NodeDto `json:"name"`
-	Label dto.NodeDto `json:"label"`
+	Name  *dto.NodeDto `json:"name"`
+	Label *dto.NodeDto `json:"label"`
 }
 
 var SanctionCheckConfigColumnList = utils.ColumnList[DBSanctionCheckConfigs]()
@@ -89,18 +89,22 @@ func AdaptSanctionCheckConfig(db DBSanctionCheckConfigs) (models.SanctionCheckCo
 }
 
 func AdaptSanctionCheckConfigQuery(db DBSanctionCheckConfigQuery) (models.SanctionCheckConfigQuery, error) {
-	nameAst, err := AdaptSerializedAstExpression(db.Name)
-	if err != nil {
-		return models.SanctionCheckConfigQuery{}, err
-	}
-	labelAst, err := AdaptSerializedAstExpression(db.Label)
-	if err != nil {
-		return models.SanctionCheckConfigQuery{}, err
+	model := models.SanctionCheckConfigQuery{}
+
+	if db.Name != nil {
+		nameAst, err := AdaptSerializedAstExpression(db.Name)
+		if err != nil {
+			return models.SanctionCheckConfigQuery{}, err
+		}
+		model.Name = nameAst
 	}
 
-	model := models.SanctionCheckConfigQuery{
-		Name:  *nameAst,
-		Label: labelAst,
+	if db.Label != nil {
+		labelAst, err := AdaptSerializedAstExpression(db.Label)
+		if err != nil {
+			return models.SanctionCheckConfigQuery{}, err
+		}
+		model.Label = labelAst
 	}
 
 	return model, nil

--- a/repositories/name_recognition_repository.go
+++ b/repositories/name_recognition_repository.go
@@ -26,6 +26,10 @@ type NameRecognitionMatch struct {
 	Text string `json:"text"`
 }
 
+func (repo NameRecognitionRepository) IsConfigured() bool {
+	return repo.NameRecognitionProvider != nil && repo.NameRecognitionProvider.ApiUrl != ""
+}
+
 func (repo NameRecognitionRepository) PerformNameRecognition(ctx context.Context, input string) ([]httpmodels.HTTPNameRecognitionMatch, error) {
 	if repo.NameRecognitionProvider == nil {
 		return []httpmodels.HTTPNameRecognitionMatch{}, nil

--- a/repositories/sanction_check_config_repository.go
+++ b/repositories/sanction_check_config_repository.go
@@ -51,13 +51,14 @@ func (repo *MarbleDbRepository) UpsertSanctionCheckConfig(ctx context.Context, e
 	var query *dbmodels.DBSanctionCheckConfigQueryInput
 
 	if cfg.Query != nil {
-		ser, err := dto.AdaptNodeDto(cfg.Query.Name)
-		if err != nil {
-			return models.SanctionCheckConfig{}, err
-		}
+		query = &dbmodels.DBSanctionCheckConfigQueryInput{}
 
-		query = &dbmodels.DBSanctionCheckConfigQueryInput{
-			Name: ser,
+		if cfg.Query.Name != nil {
+			ser, err := dto.AdaptNodeDto(*cfg.Query.Name)
+			if err != nil {
+				return models.SanctionCheckConfig{}, err
+			}
+			query.Name = &ser
 		}
 
 		if cfg.Query.Label != nil {
@@ -65,7 +66,7 @@ func (repo *MarbleDbRepository) UpsertSanctionCheckConfig(ctx context.Context, e
 			if err != nil {
 				return models.SanctionCheckConfig{}, err
 			}
-			query.Label = ser
+			query.Label = &ser
 		}
 	}
 

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -45,9 +45,11 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 
 	queries := []models.OpenSanctionsCheckQuery{}
 
-	queries, err = e.evaluateSanctionCheckName(ctx, queries, iteration, dataAccessor)
-	if err != nil {
-		return nil, true, err
+	if iteration.SanctionCheckConfig.Query.Name != nil {
+		queries, err = e.evaluateSanctionCheckName(ctx, queries, iteration, dataAccessor)
+		if err != nil {
+			return nil, true, err
+		}
 	}
 
 	if e.nameRecognizer != nil && iteration.SanctionCheckConfig.Query.Label != nil {
@@ -125,7 +127,7 @@ func (e ScenarioEvaluator) evaluateSanctionCheckName(ctx context.Context, querie
 	iteration models.ScenarioIteration, dataAccessor DataAccessor,
 ) ([]models.OpenSanctionsCheckQuery, error) {
 	nameFilterAny, err := e.evaluateAstExpression.EvaluateAstExpression(ctx, nil,
-		iteration.SanctionCheckConfig.Query.Name, iteration.OrganizationId,
+		*iteration.SanctionCheckConfig.Query.Name, iteration.OrganizationId,
 		dataAccessor.ClientObject, dataAccessor.DataModel)
 	if err != nil {
 		return queries, err

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -116,7 +116,7 @@ func TestSanctionCheckErrorWhenNameQueryNotString(t *testing.T) {
 		SanctionCheckConfig: &models.SanctionCheckConfig{
 			TriggerRule: &ast.Node{Constant: true},
 			Query: &models.SanctionCheckConfigQuery{
-				Name: ast.Node{Constant: 12},
+				Name: &ast.Node{Constant: 12},
 			},
 		},
 	}
@@ -135,7 +135,7 @@ func TestSanctionCheckCalledWhenNameFilterConstant(t *testing.T) {
 		SanctionCheckConfig: &models.SanctionCheckConfig{
 			TriggerRule: &ast.Node{Constant: true},
 			Query: &models.SanctionCheckConfigQuery{
-				Name: ast.Node{Constant: "constant string"},
+				Name: &ast.Node{Constant: "constant string"},
 			},
 		},
 	}
@@ -168,7 +168,7 @@ func TestSanctionCheckCalledWhenNameFilterConcat(t *testing.T) {
 		SanctionCheckConfig: &models.SanctionCheckConfig{
 			TriggerRule: &ast.Node{Constant: true},
 			Query: &models.SanctionCheckConfigQuery{
-				Name: ast.Node{
+				Name: &ast.Node{
 					Function:      ast.FUNC_STRING_CONCAT,
 					NamedChildren: map[string]ast.Node{"with_separator": {Constant: true}},
 					Children: []ast.Node{
@@ -217,7 +217,7 @@ func TestSanctionCheckCalledWithNameRecognizedLabel(t *testing.T) {
 		SanctionCheckConfig: &models.SanctionCheckConfig{
 			TriggerRule: &ast.Node{Constant: true},
 			Query: &models.SanctionCheckConfigQuery{
-				Name:  ast.Node{Constant: "bob gross"},
+				Name:  &ast.Node{Constant: "bob gross"},
 				Label: &ast.Node{Constant: "dinner with joe finnigan"},
 			},
 		},

--- a/usecases/evaluate_scenario/evaluate_sanction_check_test.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check_test.go
@@ -16,6 +16,12 @@ type mockSanctionCheckExecutor struct {
 	*mock.Mock
 }
 
+func (m mockSanctionCheckExecutor) IsConfigured() bool {
+	args := m.Called()
+
+	return args.Bool(0)
+}
+
 func (m mockSanctionCheckExecutor) Execute(
 	ctx context.Context,
 	orgId string,
@@ -209,6 +215,7 @@ func TestSanctionCheckCalledWithNameRecognizedLabel(t *testing.T) {
 	}
 
 	eval, exec := getSanctionCheckEvaluator()
+	exec.Mock.On("IsConfigured").Return(true)
 	exec.Mock.
 		On("PerformNameRecognition", mock.Anything, "dinner with joe finnigan").
 		Return(names, nil)
@@ -242,6 +249,41 @@ func TestSanctionCheckCalledWithNameRecognizedLabel(t *testing.T) {
 				Type: "Organization",
 				Filters: models.OpenSanctionCheckFilter{
 					"name": []string{"acme inc."},
+				},
+			},
+		},
+	}
+
+	_, performed, err := eval.evaluateSanctionCheck(context.TODO(), iteration,
+		ScenarioEvaluationParameters{}, DataAccessor{})
+
+	exec.Mock.AssertCalled(t, "Execute", context.TODO(), "", expectedQuery)
+
+	assert.True(t, performed)
+	assert.NoError(t, err)
+}
+
+func TestSanctionCheckCalledWithNameRecognitionDisabled(t *testing.T) {
+	eval, exec := getSanctionCheckEvaluator()
+	exec.Mock.On("IsConfigured").Return(false)
+
+	iteration := models.ScenarioIteration{
+		SanctionCheckConfig: &models.SanctionCheckConfig{
+			TriggerRule: &ast.Node{Constant: true},
+			Query: &models.SanctionCheckConfigQuery{
+				Name:  &ast.Node{Constant: "bob gross"},
+				Label: &ast.Node{Constant: "dinner with joe finnigan"},
+			},
+		},
+	}
+
+	expectedQuery := models.OpenSanctionsQuery{
+		Config: *iteration.SanctionCheckConfig,
+		Queries: []models.OpenSanctionsCheckQuery{
+			{
+				Type: "Thing",
+				Filters: models.OpenSanctionCheckFilter{
+					"name": []string{"bob gross", "dinner with joe finnigan"},
 				},
 			},
 		},

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -42,6 +42,7 @@ type EvalSanctionCheckUsecase interface {
 }
 
 type EvalNameRecognitionRepository interface {
+	IsConfigured() bool
 	PerformNameRecognition(context.Context, string) ([]httpmodels.HTTPNameRecognitionMatch, error)
 }
 

--- a/usecases/sanction_check_config_usecase.go
+++ b/usecases/sanction_check_config_usecase.go
@@ -39,7 +39,8 @@ func (uc SanctionCheckUsecase) ConfigureSanctionCheck(ctx context.Context,
 	}
 
 	if scCfg.Query != nil {
-		if scCfg.Query.Name.Function != ast.FUNC_STRING_CONCAT {
+		if scCfg.Query.Name != nil && scCfg.Query.Name.Function != ast.FUNC_UNDEFINED &&
+			scCfg.Query.Name.Function != ast.FUNC_STRING_CONCAT {
 			return models.SanctionCheckConfig{}, errors.New(
 				"query name filter must be a StringConcat")
 		}

--- a/usecases/scenario_publication_usecase_test.go
+++ b/usecases/scenario_publication_usecase_test.go
@@ -155,6 +155,7 @@ func (suite *ScenarioPublicationUsecaseTestSuite) makeUsecase() *ScenarioPublica
 		suite.scenarioPublisher,
 		suite.clientDbIndexEditor,
 		suite.featureAccessReader,
+		nil,
 	)
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -230,6 +230,7 @@ func (usecases *UsecasesWithCreds) NewScenarioPublicationUsecase() *ScenarioPubl
 		usecases.NewScenarioPublisher(),
 		usecases.NewClientDbIndexEditor(),
 		usecases.NewFeatureAccessReader(),
+		usecases.Repositories.OpenSanctionsRepository,
 	)
 }
 


### PR DESCRIPTION
Scenario should fail validation if:
* One of `query/name` or  `query/label` returns a non-string value (validation names `query_name` and `query_label`)
* Both `query/name` and `query/label` are unspecified (validation name `query`)

Scenario publishing should fail if:
* The Open Sanctions API is unreachable

Also added the logic for not executing name recognition if it is not configured. In that case, the configured label will be inserted into the main request as a `Thing`.

This also prevents scenario publishing if the OpenSanctions API is either not-configured or does not respond to healthchecks.