### PR TITLE
Create standard response for requirement misconfiguration.

### DIFF
--- a/api/present_error.go
+++ b/api/present_error.go
@@ -58,7 +58,7 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 				},
 			}
 
-			c.JSON(http.StatusInternalServerError, errorResponse)
+			c.JSON(http.StatusNotImplemented, errorResponse)
 		}
 
 	case errors.Is(err, context.DeadlineExceeded):

--- a/dto/api_error.go
+++ b/dto/api_error.go
@@ -28,5 +28,20 @@ const (
 	InvalidJSON         ErrorCode = "invalid_json"
 
 	// general
-	UnknownUser ErrorCode = "unknown_user"
+	UnknownUser        ErrorCode = "unknown_user"
+	MissingRequirement ErrorCode = "missing_requirement"
 )
+
+type RequirementErrorDto struct {
+	Requirement string `json:"requirement"`
+	Reason      string `json:"reason"`
+	Error       string `json:"error"`
+}
+
+func (err RequirementErrorDto) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{
+		"requirement": err.Requirement,
+		"reason":      err.Reason,
+		"error":       err.Error,
+	})
+}

--- a/infra/opensanctions.go
+++ b/infra/opensanctions.go
@@ -1,6 +1,9 @@
 package infra
 
-import "net/http"
+import (
+	"fmt"
+	"net/http"
+)
 
 const (
 	OPEN_SANCTIONS_API_HOST = "https://api.opensanctions.org"
@@ -58,14 +61,11 @@ func (os OpenSanctions) Client() *http.Client {
 	return os.client
 }
 
-func (os OpenSanctions) IsConfigured() bool {
-	if !os.IsSelfHosted() && len(os.credentials) > 0 {
-		return true
+func (os OpenSanctions) IsConfigured() (bool, error) {
+	if !os.IsSelfHosted() && len(os.credentials) == 0 {
+		return false, fmt.Errorf("missing API key for SaaS Open Sanctions configuration")
 	}
-	if os.IsSelfHosted() && len(os.host) > 0 {
-		return true
-	}
-	return false
+	return true, nil
 }
 
 func (os OpenSanctions) IsSelfHosted() bool {

--- a/models/errors.go
+++ b/models/errors.go
@@ -69,3 +69,32 @@ type FieldValidationError map[string]string
 func (e FieldValidationError) Error() string {
 	return fmt.Sprintf("%v", map[string]string(e))
 }
+
+type (
+	RequirementError       string
+	RequirementErrorReason string
+)
+
+const (
+	REQUIREMENT_OPEN_SANCTIONS RequirementError = "open_sanctions"
+
+	REQUIREMENT_REASON_MISSING_CONFIGURATION = "missing_configuration"
+	REQUIREMENT_REASON_INVALID_CONFIGURATION = "invalid_configuration"
+	REQUIREMENT_REASON_HEALTHCHECK_FAILED    = "healthcheck_failed"
+)
+
+type MissingRequirementError struct {
+	Requirement RequirementError
+	Reason      RequirementErrorReason
+	Err         error
+}
+
+func (err MissingRequirementError) Error() string {
+	return string(err.Requirement)
+}
+
+func (e MissingRequirementError) Is(target error) bool {
+	var req MissingRequirementError
+
+	return errors.As(target, &req)
+}

--- a/usecases/scenario_publications_usecase.go
+++ b/usecases/scenario_publications_usecase.go
@@ -163,8 +163,7 @@ func (usecase *ScenarioPublicationUsecase) ExecuteScenarioPublicationAction(
 				}
 
 				if isConfigured, err := usecase.sanctionCheckRequirements.IsConfigured(ctx); !isConfigured {
-					return nil, errors.Join(models.MissingRequirement,
-						errors.Wrap(err, "OpenSanctions API is not configured or not working"))
+					return nil, err
 				}
 			}
 


### PR DESCRIPTION
To be discussed, it might be interesting to settle on a common status code / error payload to inform the frontend that some preconditions failed on the backend, especially as far as third-party services are concerned.

Those errors could indicate that a specific class of error happened when trying to use a certain third-party service.

In this PR, the error looks like this:

```json
{
    "message": "A required configuration was missing or invalid",
    "details": {
        "error": "missing API key for SaaS Open Sanctions configuration",
        "reason": "missing_configuration",
        "requirement": "open_sanctions"
    },
    "error_code": "missing_requirement"
}
```

Where both `details.requirement` and `details.reason` are enum variants:

```go
type (
	RequirementError       string
	RequirementErrorReason string
)

const (
	REQUIREMENT_OPEN_SANCTIONS RequirementError = "open_sanctions"

	REQUIREMENT_REASON_MISSING_CONFIGURATION = "missing_configuration"
	REQUIREMENT_REASON_INVALID_CONFIGURATION = "invalid_configuration"
	REQUIREMENT_REASON_HEALTHCHECK_FAILED    = "healthcheck_failed"
)
```

Those will be extended to cover more third-parties are maybe more reason for the requirement failure, but they should be standardized so the frontend can generate legible error messages indicating the source of the failure.

All of this is to be discussed.