### PR TITLE
Move index creation to an asynchronous worker

### DIFF
--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -157,6 +157,8 @@ func TestMain(m *testing.M) {
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, testUsecases)
 	river.AddWorker(workers, adminUc.NewAsyncDecisionWorker())
 	river.AddWorker(workers, adminUc.NewNewAsyncScheduledExecWorker())
+	river.AddWorker(workers, adminUc.NewIndexCreationWorker())
+	river.AddWorker(workers, adminUc.NewIndexCreationStatusWorker())
 
 	if err := riverClient.Start(ctx); err != nil {
 		log.Fatalln("Could not start river client:", err)

--- a/integration_test/river_helpers.go
+++ b/integration_test/river_helpers.go
@@ -1,0 +1,54 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+func IfTaskIsCreated(ctx context.Context, client *river.Client[pgx.Tx], timeout time.Duration, tasks ...string) bool {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+
+		default:
+			jobs, err := client.JobList(ctx, river.NewJobListParams().Kinds(tasks...))
+
+			if err == nil && len(jobs.Jobs) >= len(tasks) {
+				return true
+			}
+
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}
+
+func WaitUntilAllTasksDone(t *testing.T, ctx context.Context, client *river.Client[pgx.Tx], timeout time.Duration, tasks ...string) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		select {
+		case <-ctx.Done():
+			t.Errorf("reached %s timeout while waiting for async tasks %s to complete", timeout, tasks)
+			return
+
+		default:
+			jobs, err := client.JobList(ctx, river.NewJobListParams().Kinds(tasks...).States(rivertype.JobStateCompleted))
+
+			if err == nil && len(jobs.Jobs) >= len(tasks) {
+				return
+			}
+
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+}

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/guregu/null/v5"
+	"github.com/riverqueue/river"
 	"github.com/segmentio/analytics-go/v3"
 	"github.com/stretchr/testify/assert"
 
@@ -100,6 +101,9 @@ func setupOrgAndCreds(ctx context.Context, t *testing.T, orgName string) (models
 	fmt.Println("Created organization", organizationId)
 
 	testAdminUsecase = generateUsecaseWithCredForMarbleAdmin(testUsecases)
+
+	err = riverClient.Queues().Add(organizationId, river.QueueConfig{MaxWorkers: 3})
+	assert.NoError(t, err)
 
 	// Check that there are no users on the organization yet
 	users, err := userUsecase.ListUsers(ctx, &organizationId)
@@ -355,7 +359,7 @@ func setupScenarioAndPublish(
 	if err != nil {
 		assert.FailNow(t, "Could not start publication preparation", err)
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	scenarioPublications, err := scenarioPublicationUsecase.ExecuteScenarioPublicationAction(
 		ctx,
 		organizationId,

--- a/mocks/ingested_data_indexes_repository.go
+++ b/mocks/ingested_data_indexes_repository.go
@@ -89,3 +89,11 @@ func (m *IngestedDataIndexesRepository) DeleteUniqueIndex(
 	args := m.Called(ctx, exec, index)
 	return args.Error(0)
 }
+
+func (m *IngestedDataIndexesRepository) ListIndicesPendingCreation(
+	ctx context.Context,
+	exec repositories.Executor,
+) ([]string, error) {
+	args := m.Called(ctx, exec)
+	return args.Get(0).([]string), args.Error(1)
+}

--- a/mocks/ingested_data_indexes_repository.go
+++ b/mocks/ingested_data_indexes_repository.go
@@ -97,3 +97,20 @@ func (m *IngestedDataIndexesRepository) ListIndicesPendingCreation(
 	args := m.Called(ctx, exec)
 	return args.Get(0).([]string), args.Error(1)
 }
+
+func (m *IngestedDataIndexesRepository) ListInvalidIndices(
+	ctx context.Context,
+	exec repositories.Executor,
+) ([]string, error) {
+	args := m.Called(ctx, exec)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *IngestedDataIndexesRepository) DeleteInvalidIndex(
+	ctx context.Context,
+	exec repositories.Executor,
+	indexName string,
+) error {
+	args := m.Called(ctx, exec)
+	return args.Error(0)
+}

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -1,0 +1,54 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/stretchr/testify/mock"
+)
+
+type TaskQueueRepository struct {
+	mock.Mock
+}
+
+func (m *TaskQueueRepository) EnqueueDecisionTask(
+	ctx context.Context,
+	tx repositories.Transaction,
+	organizationId string,
+	decision models.DecisionToCreate,
+	scenarioIterationId string,
+) error {
+	args := m.Called(ctx, tx, organizationId, decision, scenarioIterationId)
+	return args.Error(0)
+}
+
+func (m *TaskQueueRepository) EnqueueDecisionTaskMany(
+	ctx context.Context,
+	tx repositories.Transaction,
+	organizationId string,
+	decisions []models.DecisionToCreate,
+	scenarioIterationId string,
+) error {
+	args := m.Called(ctx, tx, organizationId, decisions, scenarioIterationId)
+	return args.Error(0)
+}
+
+func (m *TaskQueueRepository) EnqueueScheduledExecStatusTask(
+	ctx context.Context,
+	tx repositories.Transaction,
+	organizationId string,
+	scheduledExecutionId string,
+) error {
+	args := m.Called(ctx, tx, organizationId, scheduledExecutionId)
+	return args.Error(0)
+}
+
+func (m *TaskQueueRepository) EnqueueCreateIndexTask(
+	ctx context.Context,
+	organizationId string,
+	indices []models.ConcreteIndex,
+) error {
+	args := m.Called(ctx, organizationId, indices)
+	return args.Error(0)
+}

--- a/models/concrete_index.go
+++ b/models/concrete_index.go
@@ -17,6 +17,7 @@ type UnicityIndex struct {
 
 type ConcreteIndex struct {
 	TableName string
+	IndexName string
 	Indexed   []string
 	Included  []string
 }

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -16,3 +16,23 @@ type ScheduledExecStatusSyncArgs struct {
 }
 
 func (ScheduledExecStatusSyncArgs) Kind() string { return "scheduled_execution_status_sync" }
+
+type IndexCreationArgs struct {
+	OrgId   string          `json:"org_id"`
+	Indices []ConcreteIndex `json:"indices"`
+}
+
+func (IndexCreationArgs) Kind() string { return "index_creation" }
+
+type IndexCreationStatusArgs struct {
+	OrgId   string          `json:"org_id"`
+	Indices []ConcreteIndex `json:"indices"`
+}
+
+func (IndexCreationStatusArgs) Kind() string { return "index_creation_status" }
+
+type IndexCleanupArgs struct {
+	OrgId string `json:"org_id"`
+}
+
+func (IndexCleanupArgs) Kind() string { return "index_cleanup" }

--- a/repositories/pg_indexes/pg_indexes.go
+++ b/repositories/pg_indexes/pg_indexes.go
@@ -57,6 +57,7 @@ func (pgIndex PGIndex) AdaptConcreteIndex() models.ConcreteIndex {
 	idx := parseCreateIndexStatement(pgIndex.Definition)
 
 	idx.TableName = pgIndex.TableName
+	idx.IndexName = pgIndex.Name
 	return idx
 }
 

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -40,6 +40,11 @@ type TaskQueueRepository interface {
 		organizationId string,
 		scheduledExecutionId string,
 	) error
+	EnqueueCreateIndexTask(
+		ctx context.Context,
+		organizationId string,
+		indices []models.ConcreteIndex,
+	) error
 }
 
 type riverRepository struct {
@@ -140,5 +145,26 @@ func (r riverRepository) EnqueueScheduledExecStatusTask(
 	}
 	logger := utils.LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "Enqueued scheduled execution status update task", "job_id", res.Job.ID)
+	return nil
+}
+
+func (r riverRepository) EnqueueCreateIndexTask(
+	ctx context.Context,
+	organizationId string,
+	indices []models.ConcreteIndex,
+) error {
+	_, err := r.client.Insert(
+		ctx,
+		models.IndexCreationArgs{
+			OrgId:   organizationId,
+			Indices: indices,
+		},
+		&river.InsertOpts{
+			Queue: organizationId,
+		})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/usecases/indexes/index_editor.go
+++ b/usecases/indexes/index_editor.go
@@ -26,6 +26,7 @@ type IngestedDataIndexesRepository interface {
 	CreateUniqueIndexAsync(ctx context.Context, exec repositories.Executor, index models.UnicityIndex) error
 	CreateUniqueIndex(ctx context.Context, exec repositories.Executor, index models.UnicityIndex) error
 	DeleteUniqueIndex(ctx context.Context, exec repositories.Executor, index models.UnicityIndex) error
+	ListIndicesPendingCreation(ctx context.Context, exec repositories.Executor) ([]string, error)
 }
 
 type ScenarioFetcher interface {

--- a/usecases/indexes/index_editor.go
+++ b/usecases/indexes/index_editor.go
@@ -27,6 +27,8 @@ type IngestedDataIndexesRepository interface {
 	CreateUniqueIndex(ctx context.Context, exec repositories.Executor, index models.UnicityIndex) error
 	DeleteUniqueIndex(ctx context.Context, exec repositories.Executor, index models.UnicityIndex) error
 	ListIndicesPendingCreation(ctx context.Context, exec repositories.Executor) ([]string, error)
+	ListInvalidIndices(ctx context.Context, exec repositories.Executor) ([]string, error)
+	DeleteInvalidIndex(ctx context.Context, exec repositories.Executor, indexName string) error
 }
 
 type ScenarioFetcher interface {

--- a/usecases/scheduled_execution/index_cleanup_job.go
+++ b/usecases/scheduled_execution/index_cleanup_job.go
@@ -1,0 +1,51 @@
+package scheduled_execution
+
+import (
+	"context"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/indexes"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/riverqueue/river"
+)
+
+const INDEX_CLEANUP_WORKER_INTERVAL = time.Hour
+
+func NewIndexCleanupPeriodicJob(orgId string) *river.PeriodicJob {
+	return river.NewPeriodicJob(
+		river.PeriodicInterval(10*time.Second),
+		func() (river.JobArgs, *river.InsertOpts) {
+			return models.IndexCleanupArgs{
+					OrgId: orgId,
+				}, &river.InsertOpts{
+					Queue: orgId,
+				}
+		},
+		&river.PeriodicJobOpts{RunOnStart: true},
+	)
+}
+
+type IndexCleanupWorker struct {
+	river.WorkerDefaults[models.IndexCleanupArgs]
+
+	executorFactory executor_factory.ExecutorFactory
+	indexEditor     indexes.IngestedDataIndexesRepository
+}
+
+func NewIndexCleanupWorker(
+	executor_factory executor_factory.ExecutorFactory,
+	indexEditor indexes.IngestedDataIndexesRepository,
+) IndexCleanupWorker {
+	return IndexCleanupWorker{
+		executorFactory: executor_factory,
+		indexEditor:     indexEditor,
+	}
+}
+
+func (w *IndexCleanupWorker) Work(ctx context.Context, job *river.Job[models.IndexCleanupArgs]) error {
+	utils.LoggerFromContext(ctx).DebugContext(ctx, "index cleanup", "org", job.Args.OrgId)
+
+	return nil
+}

--- a/usecases/scheduled_execution/index_creation_job.go
+++ b/usecases/scheduled_execution/index_creation_job.go
@@ -86,7 +86,6 @@ func (w *IndexCreationStatusWorker) Work(ctx context.Context, job *river.Job[mod
 
 	pending, err := w.indexEditor.ListIndicesPendingCreation(ctx, db)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 

--- a/usecases/scheduled_execution/index_creation_job.go
+++ b/usecases/scheduled_execution/index_creation_job.go
@@ -1,0 +1,129 @@
+package scheduled_execution
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/indexes"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+)
+
+type IndexCreationWorker struct {
+	river.WorkerDefaults[models.IndexCreationArgs]
+
+	executorFactory executor_factory.ExecutorFactory
+	indexEditor     indexes.IngestedDataIndexesRepository
+}
+
+func NewIndexCreationWorker(
+	executor_factory executor_factory.ExecutorFactory,
+	indexEditor indexes.IngestedDataIndexesRepository,
+) IndexCreationWorker {
+	return IndexCreationWorker{
+		executorFactory: executor_factory,
+		indexEditor:     indexEditor,
+	}
+}
+
+func (w *IndexCreationWorker) Work(ctx context.Context, job *river.Job[models.IndexCreationArgs]) error {
+	client := river.ClientFromContext[pgx.Tx](ctx)
+
+	utils.LoggerFromContext(ctx).DebugContext(ctx, "worker: creating indices", "indices", job.Args.Indices)
+
+	db, err := w.executorFactory.NewClientDbExecutor(ctx, job.Args.OrgId)
+	if err != nil {
+		return err
+	}
+
+	if err := w.indexEditor.CreateIndexesAsync(ctx, db, job.Args.Indices); err != nil {
+		return err
+	}
+
+	// TODO: there is a race condition where this runs before the index creation starts, detecting them as failed.
+	_, err = client.Insert(
+		ctx,
+		models.IndexCreationStatusArgs{
+			OrgId:   job.Args.OrgId,
+			Indices: job.Args.Indices,
+		},
+		&river.InsertOpts{
+			Priority:    1,
+			ScheduledAt: time.Now(),
+			Queue:       job.Args.OrgId,
+		},
+	)
+
+	return err
+}
+
+type IndexCreationStatusWorker struct {
+	river.WorkerDefaults[models.IndexCreationStatusArgs]
+
+	executorFactory executor_factory.ExecutorFactory
+	indexEditor     indexes.IngestedDataIndexesRepository
+}
+
+func NewIndexCreationStatusWorker(executor_factory executor_factory.ExecutorFactory,
+	indexEditor indexes.IngestedDataIndexesRepository,
+) IndexCreationStatusWorker {
+	return IndexCreationStatusWorker{
+		executorFactory: executor_factory,
+		indexEditor:     indexEditor,
+	}
+}
+
+func (w *IndexCreationStatusWorker) Work(ctx context.Context, job *river.Job[models.IndexCreationStatusArgs]) error {
+	db, err := w.executorFactory.NewClientDbExecutor(ctx, job.Args.OrgId)
+	if err != nil {
+		return err
+	}
+
+	pending, err := w.indexEditor.ListIndicesPendingCreation(ctx, db)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	// If we still have pending indices, we are certain the creation is still underway
+	if len(pending) > 0 {
+		utils.LoggerFromContext(ctx).DebugContext(ctx,
+			"worker: index creation still ongoing", "indices", job.Args.Indices)
+
+		return river.JobSnooze(1 * time.Second)
+	}
+
+	validIndices, err := w.indexEditor.ListAllValidIndexes(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	doneIndices := 0
+
+	// Compare the list of finished indices with the list that was supposed to be created,
+	// if we find all of them, it means the process successfully finished.
+	for _, index := range validIndices {
+		if slices.ContainsFunc(job.Args.Indices, func(i models.ConcreteIndex) bool {
+			return i.TableName == index.TableName && i.IndexName == index.IndexName
+		}) {
+			doneIndices += 1
+		}
+	}
+
+	// If there are less finalized indices than were supposed to be created (and no ongoing
+	// creation), it means an error occured while creating the indices.
+	if doneIndices < len(job.Args.Indices) {
+		return fmt.Errorf("some index creation failed")
+	}
+
+	// Otherwise, we are done.
+	utils.LoggerFromContext(ctx).DebugContext(ctx,
+		"worker: finished creating indices", "indices", job.Args.Indices)
+
+	return nil
+}

--- a/usecases/task_queue.go
+++ b/usecases/task_queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/scheduled_execution"
 	"github.com/checkmarble/marble-backend/utils"
 
 	"github.com/jackc/pgx/v5"
@@ -99,6 +100,8 @@ func (w *TaskQueueWorker) addMissingQueues(ctx context.Context, queues map[strin
 				return err
 			}
 			logger.InfoContext(ctx, fmt.Sprintf("Added queue for organization %s to task queue worker", orgId))
+
+			w.riverClient.PeriodicJobs().Add(scheduled_execution.NewIndexCleanupPeriodicJob(orgId))
 		}
 	}
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -225,6 +225,7 @@ func (usecases *UsecasesWithCreds) NewScenarioPublicationUsecase() *ScenarioPubl
 		usecases.NewTransactionFactory(),
 		usecases.NewExecutorFactory(),
 		usecases.Repositories.ScenarioPublicationRepository,
+		usecases.Repositories.TaskQueueRepository,
 		usecases.NewEnforceScenarioSecurity(),
 		usecases.NewScenarioFetcher(),
 		usecases.NewScenarioPublisher(),
@@ -511,6 +512,30 @@ func (usecases UsecasesWithCreds) NewNewAsyncScheduledExecWorker() *scheduled_ex
 	w := scheduled_execution.NewAsyncScheduledExecWorker(
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
+	)
+	return &w
+}
+
+func (usecases UsecasesWithCreds) NewIndexCreationWorker() *scheduled_execution.IndexCreationWorker {
+	w := scheduled_execution.NewIndexCreationWorker(
+		usecases.NewExecutorFactory(),
+		&usecases.Repositories.ClientDbRepository,
+	)
+	return &w
+}
+
+func (usecases UsecasesWithCreds) NewIndexCreationStatusWorker() *scheduled_execution.IndexCreationStatusWorker {
+	w := scheduled_execution.NewIndexCreationStatusWorker(
+		usecases.NewExecutorFactory(),
+		&usecases.Repositories.ClientDbRepository,
+	)
+	return &w
+}
+
+func (usecases UsecasesWithCreds) NewIndexCleanupWorker() *scheduled_execution.IndexCleanupWorker {
+	w := scheduled_execution.NewIndexCleanupWorker(
+		usecases.NewExecutorFactory(),
+		&usecases.Repositories.ClientDbRepository,
 	)
 	return &w
 }


### PR DESCRIPTION
This is a prototype for using our workers and asynchronous tasks for various aspects of Marble maintenance or operational tasks. Examples of such tasks might include:

* Creation of database indices
* Cleanup of useless or invalid indices
* Notification sending