### PR TITLE
Initial (pre-refinements) sanction check endpoint

### DIFF
--- a/api/handle_sanction_checks.go
+++ b/api/handle_sanction_checks.go
@@ -47,6 +47,7 @@ func handleListSanctionChecks(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		decisionId := c.Query("decision_id")
+		initialOnly := c.Query("initial_only") == "1"
 
 		if decisionId == "" {
 			c.Status(http.StatusBadRequest)
@@ -54,7 +55,7 @@ func handleListSanctionChecks(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		uc := usecasesWithCreds(ctx, uc).NewSanctionCheckUsecase()
-		sanctionChecks, err := uc.ListSanctionChecks(ctx, decisionId)
+		sanctionChecks, err := uc.ListSanctionChecks(ctx, decisionId, initialOnly)
 
 		if presentError(ctx, c, err) {
 			return

--- a/repositories/sanction_check_repository.go
+++ b/repositories/sanction_check_repository.go
@@ -29,13 +29,22 @@ func (*MarbleDbRepository) GetSanctionChecksForDecision(
 	ctx context.Context,
 	exec Executor,
 	decisionId string,
+	initialOnly bool,
 ) ([]models.SanctionCheckWithMatches, error) {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return nil, err
 	}
 
+	filters := squirrel.Eq{"sc.decision_id": decisionId}
+
+	if initialOnly {
+		filters["sc.is_manual"] = false
+	} else {
+		filters["sc.is_archived"] = false
+	}
+
 	sql := selectSanctionChecksWithMatches().
-		Where(squirrel.Eq{"sc.decision_id": decisionId, "sc.is_archived": false})
+		Where(filters)
 
 	return SqlToListOfModels(ctx, exec, sql, dbmodels.AdaptSanctionCheckWithMatches)
 }

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -48,7 +48,7 @@ type SanctionCheckInboxReader interface {
 type SanctionCheckRepository interface {
 	GetActiveSanctionCheckForDecision(context.Context, repositories.Executor, string) (
 		*models.SanctionCheckWithMatches, error)
-	GetSanctionChecksForDecision(ctx context.Context, exec repositories.Executor, decisionId string) (
+	GetSanctionChecksForDecision(ctx context.Context, exec repositories.Executor, decisionId string, initialOnly bool) (
 		[]models.SanctionCheckWithMatches, error)
 	GetSanctionCheck(context.Context, repositories.Executor, string) (models.SanctionCheckWithMatches, error)
 	GetSanctionCheckWithoutMatches(context.Context, repositories.Executor, string) (models.SanctionCheck, error)
@@ -128,7 +128,9 @@ func (uc SanctionCheckUsecase) GetDatasetCatalog(ctx context.Context) (models.Op
 	return uc.openSanctionsProvider.GetCatalog(ctx)
 }
 
-func (uc SanctionCheckUsecase) ListSanctionChecks(ctx context.Context, decisionId string) ([]models.SanctionCheckWithMatches, error) {
+func (uc SanctionCheckUsecase) ListSanctionChecks(ctx context.Context, decisionId string,
+	initialOnly bool,
+) ([]models.SanctionCheckWithMatches, error) {
 	exec := uc.executorFactory.NewExecutor()
 	decisions, err := uc.externalRepository.DecisionsById(ctx, exec, []string{decisionId})
 	if err != nil {
@@ -148,7 +150,7 @@ func (uc SanctionCheckUsecase) ListSanctionChecks(ctx context.Context, decisionI
 		}
 	}
 
-	scs, err := uc.repository.GetSanctionChecksForDecision(ctx, exec, decisions[0].DecisionId)
+	scs, err := uc.repository.GetSanctionChecksForDecision(ctx, exec, decisions[0].DecisionId, initialOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/sanction_check_usecase_test.go
+++ b/usecases/sanction_check_usecase_test.go
@@ -94,7 +94,7 @@ func TestListSanctionChecksOnDecision(t *testing.T) {
 				AddRows(mockCommentsRows...),
 		)
 
-	scs, err := uc.ListSanctionChecks(context.TODO(), "decisionid")
+	scs, err := uc.ListSanctionChecks(context.TODO(), "decisionid", false)
 
 	assert.NoError(t, exec.Mock.ExpectationsWereMet())
 	assert.NoError(t, err)


### PR DESCRIPTION
Adds an endpoint to retrieve, if applicable, the initial sanction check for a decision, before refinements.

To be discussed if it is a separate endpoint or a parameter on the existing one.