### PR TITLE
use standard postgres 15 image in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: postgres
-    image: europe-west1-docker.pkg.dev/marble-infra/marble/postgresql-db:latest # custom image of postgres 15 with pg_cron extension added
+    image: postgres:15
     shm_size: 1g
     restart: always
     environment:
@@ -14,7 +14,7 @@ services:
     volumes:
       - postgres-db:/data/postgres
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
A fix for issue https://github.com/checkmarble/marble-backend/issues/797.
I previously created a custom image that added pg_cron to postgres, but we no longer use it and my custom image was a pain for users not on arm architecture.