### PR TITLE
Ordering of sanction check matches.

### DIFF
--- a/repositories/sanction_check_repository.go
+++ b/repositories/sanction_check_repository.go
@@ -67,7 +67,7 @@ func (*MarbleDbRepository) GetSanctionCheckWithoutMatches(ctx context.Context, e
 func selectSanctionChecksWithMatches() squirrel.SelectBuilder {
 	return NewQueryBuilder().
 		Select(columnsNames("sc", dbmodels.SelectSanctionChecksColumn)...).
-		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s)) FILTER (WHERE scm.id IS NOT NULL) AS matches",
+		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s) ORDER BY array_position(array['confirmed_hit', 'pending', 'no_hit', 'skipped'], scm.status), scm.payload->>'score' DESC) FILTER (WHERE scm.id IS NOT NULL) AS matches",
 			strings.Join(columnsNames("scm", dbmodels.SelectSanctionCheckMatchesColumn), ","))).
 		From(dbmodels.TABLE_SANCTION_CHECKS + " AS sc").
 		LeftJoin(dbmodels.TABLE_SANCTION_CHECK_MATCHES + " AS scm ON sc.id = scm.sanction_check_id").

--- a/usecases/sanction_check_usecase_test.go
+++ b/usecases/sanction_check_usecase_test.go
@@ -64,15 +64,15 @@ func TestListSanctionChecksOnDecision(t *testing.T) {
 		}),
 	)
 
-	exec.Mock.ExpectQuery(`
+	exec.Mock.ExpectQuery(escapeSql(`
 		SELECT
 			sc.id, sc.decision_id, sc.status, sc.search_input, sc.search_datasets, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.whitelisted_entities, sc.error_codes, sc.created_at, sc.updated_at,
-			ARRAY_AGG\(ROW\(scm.id,scm.sanction_check_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.counterparty_id,scm.payload,scm.reviewed_by,scm.created_at,scm.updated_at\)\) FILTER \(WHERE scm.id IS NOT NULL\) AS matches
+			ARRAY_AGG(ROW(scm.id,scm.sanction_check_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.counterparty_id,scm.payload,scm.reviewed_by,scm.created_at,scm.updated_at) ORDER BY array_position(.+, scm.status), scm.payload->>'score' DESC) FILTER (WHERE scm.id IS NOT NULL) AS matches
 		FROM sanction_checks AS sc
 		LEFT JOIN sanction_check_matches AS scm ON sc.id = scm.sanction_check_id
-		WHERE sc.decision_id = \$1 AND sc.is_archived = \$2
+		WHERE sc.decision_id = $1 AND sc.is_archived = $2
 		GROUP BY sc.id
-	`).
+	`)).
 		WithArgs("decisionid", false).
 		WillReturnRows(
 			pgxmock.NewRows(dbmodels.SelectSanctionChecksWithMatchesColumn).


### PR DESCRIPTION
They are now ordered according to the following criteria:

 - Confirmed hit first, then pending, then no match, then skipped
 - Within those groups, higher scores are returned first
