### PR TITLE
Pascal/refactor error signatures

### DIFF
--- a/dto/decision_dto.go
+++ b/dto/decision_dto.go
@@ -214,7 +214,7 @@ func NewDecisionRuleDto(rule models.RuleExecution, withRuleExecution bool) Decis
 		ScoreModifier: rule.ResultScoreModifier,
 		Result:        rule.Result,
 		RuleId:        rule.Rule.Id,
-		Error:         ErrorDtoFromError(rule.Error),
+		Error:         ErrorDtoFromError(rule.ExecutionError),
 	}
 	if withRuleExecution {
 		out.RuleEvaluation = rule.Evaluation
@@ -222,14 +222,10 @@ func NewDecisionRuleDto(rule models.RuleExecution, withRuleExecution bool) Decis
 	return out
 }
 
-func ErrorDtoFromError(err error) *ErrorDto {
-	if err == nil {
-		return nil
-	}
-
+func ErrorDtoFromError(execErr ast.ExecutionError) *ErrorDto {
 	return &ErrorDto{
-		Code:    int(ast.AdaptExecutionError(err)),
-		Message: err.Error(),
+		Code:    int(execErr),
+		Message: execErr.String(),
 	}
 }
 

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -597,7 +597,7 @@ func createAndTestDecision(
 		assert.FailNow(t, "Could not parse payload", err)
 	}
 
-	decision, err := decisionUsecase.CreateDecision(
+	_, decision, err := decisionUsecase.CreateDecision(
 		ctx,
 		models.CreateDecisionInput{
 			ScenarioId:         scenarioId,

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -493,8 +493,8 @@ func createDecisions(
 		"Expected decision to be Approve, got %s", approveNoNameDecision.Outcome)
 	if assert.NotEmpty(t, approveNoNameDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveNoNameDecision.RuleExecutions, "Check on account name")
-		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
-			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+		assert.Equal(t, ast.NullFieldRead, ruleExecution.ExecutionError,
+			"Expected error to be \"%s\", got \"%s\"", ast.NullFieldRead, ruleExecution.ExecutionError)
 	}
 
 	// Create a decision [APPROVE] without a record in db (no row read)
@@ -510,8 +510,8 @@ func createDecisions(
 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
 	if assert.NotEmpty(t, approveNoRecordDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveNoRecordDecision.RuleExecutions, "Check on account name")
-		assert.ErrorIs(t, ruleExecution.Error, ast.ErrNullFieldRead,
-			"Expected error to be \"%s\", got \"%s\"", ast.ErrNullFieldRead, ruleExecution.Error)
+		assert.Equal(t, ast.NullFieldRead, ruleExecution.ExecutionError,
+			"Expected error to be \"%s\", got \"%s\"", ast.NullFieldRead, ruleExecution.ExecutionError)
 	}
 
 	// Create a decision [APPROVE] without a field in payload (null field read)
@@ -526,7 +526,8 @@ func createDecisions(
 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
 	if assert.NotEmpty(t, approveMissingFieldInPayloadDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveMissingFieldInPayloadDecision.RuleExecutions, "Check on account name")
-		assert.Nil(t, ruleExecution.Error, "Expected error to be nil, got \"%s\"", ruleExecution.Error)
+		assert.Equal(t, ast.NoError, ruleExecution.ExecutionError,
+			"Expected error to be nil, got \"%s\"", ruleExecution.ExecutionError)
 	}
 
 	// Create a decision [DECLINE] with a division by zero
@@ -542,8 +543,8 @@ func createDecisions(
 		"Expected decision to be Approve, got %s", approveNoRecordDecision.Outcome)
 	if assert.NotEmpty(t, approveDivisionByZeroDecision.RuleExecutions) {
 		ruleExecution := findRuleExecutionByName(approveDivisionByZeroDecision.RuleExecutions, "Check on account name")
-		assert.ErrorIs(t, ruleExecution.Error, ast.ErrDivisionByZero,
-			"Expected error to be \"%s\", got \"%s\"", ast.ErrDivisionByZero, ruleExecution.Error)
+		assert.Equal(t, ast.DivisionByZero, ruleExecution.ExecutionError,
+			"Expected error to be \"%s\", got \"%s\"", ast.ErrDivisionByZero, ruleExecution.ExecutionError)
 	}
 
 	// find the rule with higest score

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -611,6 +611,7 @@ func createAndTestDecision(
 		},
 	)
 	if err != nil {
+		fmt.Println(err)
 		assert.FailNow(t, "Could not create decision", err)
 	}
 	assert.Equal(t, expectedScore, decision.Score, "The score should match the expected value")

--- a/models/ast/ast_node_evaluation.go
+++ b/models/ast/ast_node_evaluation.go
@@ -1,10 +1,7 @@
 package ast
 
 import (
-	"fmt"
 	"time"
-
-	"github.com/cockroachdb/errors"
 )
 
 type NodeEvaluation struct {
@@ -46,31 +43,6 @@ func (root NodeEvaluation) FlattenErrors() []error {
 	}
 
 	return errs
-}
-
-func (root NodeEvaluation) GetBoolReturnValue() (bool, error) {
-	if root.ReturnValue == nil {
-		return false, ErrNullFieldRead
-	}
-
-	if returnValue, ok := root.ReturnValue.(bool); ok {
-		return returnValue, nil
-	}
-
-	return false, errors.New(
-		fmt.Sprintf("root ast expression does not return a boolean, '%T' instead", root.ReturnValue))
-}
-
-func (root NodeEvaluation) GetStringReturnValue() (string, error) {
-	if root.ReturnValue == nil {
-		return "", ErrNullFieldRead
-	}
-
-	if returnValue, ok := root.ReturnValue.(string); ok {
-		return returnValue, nil
-	}
-
-	return "", errors.New(fmt.Sprintf("ast expression expected to return a string, got '%T' instead", root.ReturnValue))
 }
 
 func (root *NodeEvaluation) SetCached() {

--- a/models/ast/evaluation_error_dto.go
+++ b/models/ast/evaluation_error_dto.go
@@ -37,10 +37,7 @@ var evaluationErrorDtoMap = []errorAndCode{
 	{ErrFilterTableNotMatch, "FILTERS_TABLE_NOT_MATCH"},
 
 	// Runtime execution related errors
-	{ErrNullFieldRead, "NULL_FIELD_READ"},
-	{ErrNoRowsRead, "NO_ROWS_READ"},
 	{ErrDivisionByZero, "DIVISION_BY_ZERO"},
-	{ErrPayloadFieldNotFound, "PAYLOAD_FIELD_NOT_FOUND"},
 	{ErrRuntimeExpression, "RUNTIME_EXPRESSION_ERROR"}, // must be last, as it is the most generic error (and above runtime errors are wrapped in it)
 }
 

--- a/models/ast/evaluation_errors.go
+++ b/models/ast/evaluation_errors.go
@@ -30,6 +30,7 @@ var (
 	ErrPayloadFieldNotFound = errors.Wrap(ErrRuntimeExpression, "Payload field not found")
 )
 
+// keep only div by zero ?
 var ExecutionAuthorizedErrors = []error{
 	ErrNullFieldRead,
 	ErrNoRowsRead,

--- a/models/ast/evaluation_errors.go
+++ b/models/ast/evaluation_errors.go
@@ -23,26 +23,6 @@ var (
 	ErrFilterTableNotMatch               = errors.New("filters must be applied on the same table")
 
 	// Runtime execution related errors
-	ErrRuntimeExpression    = errors.New("expression runtime error")
-	ErrNullFieldRead        = errors.Wrap(ErrRuntimeExpression, "Null field read")
-	ErrNoRowsRead           = errors.Wrap(ErrRuntimeExpression, "No rows read")
-	ErrDivisionByZero       = errors.Wrap(ErrRuntimeExpression, "Division by zero")
-	ErrPayloadFieldNotFound = errors.Wrap(ErrRuntimeExpression, "Payload field not found")
+	ErrRuntimeExpression = errors.New("expression runtime error")
+	ErrDivisionByZero    = errors.Wrap(ErrRuntimeExpression, "Division by zero")
 )
-
-// keep only div by zero ?
-var ExecutionAuthorizedErrors = []error{
-	ErrNullFieldRead,
-	ErrNoRowsRead,
-	ErrDivisionByZero,
-	ErrPayloadFieldNotFound,
-}
-
-func IsAuthorizedError(err error) bool {
-	for _, authorizedError := range ExecutionAuthorizedErrors {
-		if errors.Is(err, authorizedError) {
-			return true
-		}
-	}
-	return false
-}

--- a/models/decision.go
+++ b/models/decision.go
@@ -91,7 +91,7 @@ type RuleExecutionStat struct {
 
 type RuleExecution struct {
 	DecisionId          string
-	Error               error
+	ExecutionError      ast.ExecutionError
 	Evaluation          *ast.NodeEvaluationDto
 	Outcome             string // enum: hit, no_hit, snoozed, error
 	Result              bool

--- a/models/errors.go
+++ b/models/errors.go
@@ -49,11 +49,11 @@ var (
 		"data preparation service is unavailable: an index is being created in the client db schema")
 
 	// execution
-	ErrScenarioHasNoLiveVersion                         = errors.Wrap(BadParameterError, "scenario has no live version")
-	ErrScenarioTriggerTypeAndTiggerObjectTypeMismatch   = errors.Wrap(BadParameterError, "scenario's trigger_type and provided trigger_object type are different")
-	ErrScenarioTriggerConditionAndTriggerObjectMismatch = errors.Wrap(BadParameterError, "trigger_object does not match the scenario's trigger conditions")
-	ErrInvalidAST                                       = errors.Wrap(BadParameterError, "invalid AST")
-	ErrPanicInScenarioEvalution                         = errors.New("panic during scenario evaluation")
+	ErrScenarioHasNoLiveVersion                       = errors.Wrap(BadParameterError, "scenario has no live version")
+	ErrScenarioTriggerTypeAndTiggerObjectTypeMismatch = errors.Wrap(BadParameterError,
+		"scenario's trigger_type and provided trigger_object type are different")
+	ErrInvalidAST               = errors.Wrap(BadParameterError, "invalid AST")
+	ErrPanicInScenarioEvalution = errors.New("panic during scenario evaluation")
 
 	ErrTestRunAlreadyExist      = errors.Wrap(ConflictError, "there is an already existing testrun for this scenario")
 	ErrNoTestRunFound           = errors.Wrap(NotFoundError, "there is no testrun for this scenario")

--- a/repositories/dbmodels/db_decision_rule.go
+++ b/repositories/dbmodels/db_decision_rule.go
@@ -39,7 +39,7 @@ func AdaptRuleExecution(db DbDecisionRule) (models.RuleExecution, error) {
 	}
 	return models.RuleExecution{
 		DecisionId:          db.DecisionId,
-		Error:               ast.AdaptErrorCodeAsError(db.ErrorCode),
+		ExecutionError:      db.ErrorCode,
 		Evaluation:          evaluation,
 		Outcome:             outcome,
 		Result:              db.Result,

--- a/repositories/decision_phantoms_repository.go
+++ b/repositories/decision_phantoms_repository.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
@@ -95,7 +94,7 @@ func (repo *MarbleDbRepository) StorePhantomDecision(
 				newPhantomDecisionId,
 				ruleExecution.ResultScoreModifier,
 				ruleExecution.Result,
-				ast.AdaptExecutionError(ruleExecution.Error),
+				ruleExecution.ExecutionError,
 				ruleExecution.Rule.Id,
 				ruleExecution.Outcome,
 			)

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 	"github.com/checkmarble/marble-backend/utils"
@@ -610,7 +609,7 @@ func (repo *MarbleDbRepository) StoreDecision(
 				newDecisionId,
 				ruleExecution.ResultScoreModifier,
 				ruleExecution.Result,
-				ast.AdaptExecutionError(ruleExecution.Error),
+				ruleExecution.ExecutionError,
 				ruleExecution.Rule.Id,
 				serializedRuleEvaluation,
 				ruleExecution.Outcome,

--- a/repositories/ingested_data_read_repository_test.go
+++ b/repositories/ingested_data_read_repository_test.go
@@ -51,7 +51,7 @@ func (tx TransactionTest) Exec(ctx context.Context, query string, args ...interf
 func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 	path := []string{utils.DummyTableNameSecond}
 
-	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
+	nullFilter, query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
 		TriggerTableName: utils.DummyTableNameFirst,
 		Path:             path,
 		FieldName:        utils.DummyFieldNameForInt,
@@ -61,6 +61,7 @@ func TestIngestedDataGetDbFieldWithoutJoin(t *testing.T) {
 			Data:      map[string]any{utils.DummyFieldNameId: utils.DummyFieldNameId},
 		},
 	})
+	assert.False(t, nullFilter)
 	assert.Empty(t, err)
 	sql, args, err := query.ToSql()
 	assert.Empty(t, err)
@@ -77,7 +78,7 @@ func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {
 		utils.DummyTableNameThird,
 	}
 
-	query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
+	nullFilter, query, err := createQueryDbForField(TransactionTest{}, models.DbFieldReadParams{
 		TriggerTableName: utils.DummyTableNameFirst,
 		Path:             path,
 		FieldName:        utils.DummyFieldNameForInt,
@@ -87,6 +88,7 @@ func TestIngestedDataGetDbFieldWithJoin(t *testing.T) {
 			Data:      map[string]any{utils.DummyFieldNameId: utils.DummyFieldNameId},
 		},
 	})
+	assert.False(t, nullFilter)
 	assert.Empty(t, err)
 	sql, args, err := query.ToSql()
 	assert.Empty(t, err)

--- a/usecases/ast_eval/evaluate/evaluate_database_access.go
+++ b/usecases/ast_eval/evaluate/evaluate_database_access.go
@@ -48,14 +48,15 @@ func (d DatabaseAccess) Evaluate(ctx context.Context, arguments ast.Arguments) (
 	}
 
 	fieldValue, err := d.getDbField(ctx, tableName, fieldName, pathStringArr)
-	if errors.Is(err, ast.ErrNullFieldRead) {
-		return nil, nil
-	} else if err != nil {
+	if err != nil {
 		errorMsg := fmt.Sprintf("Error reading value in DatabaseAccess: tableName %s, fieldName %s, path %v", tableName, fieldName, path)
 		return MakeEvaluateError(errors.Join(
 			errors.Wrap(ast.ErrDatabaseAccessNotFound, errorMsg),
 			err,
 		))
+	}
+	if fieldValue == nil {
+		return nil, nil
 	}
 
 	fieldValueStr, ok := fieldValue.(string)

--- a/usecases/decision_workflows/decision_workflows.go
+++ b/usecases/decision_workflows/decision_workflows.go
@@ -51,7 +51,7 @@ type webhookEventCreator interface {
 
 type CaseNameEvaluator interface {
 	EvalCaseName(ctx context.Context, params evaluate_scenario.ScenarioEvaluationParameters,
-		scenario models.Scenario) (*string, error)
+		scenario models.Scenario) (string, error)
 }
 
 type DecisionsWorkflows struct {
@@ -161,20 +161,12 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 func automaticCreateCaseAttributes(
 	scenario models.Scenario,
 	decision models.DecisionWithRuleExecutions,
-	name *string,
+	name string,
 ) models.CreateCaseAttributes {
-	// TODO: check this logic
-	var nameWithDefault string
-	if name == nil {
-		nameWithDefault = "default case name"
-	} else {
-		nameWithDefault = *name
-	}
-
 	return models.CreateCaseAttributes{
 		DecisionIds:    []string{decision.DecisionId},
 		InboxId:        *scenario.DecisionToCaseInboxId,
-		Name:           nameWithDefault,
+		Name:           name,
 		OrganizationId: scenario.OrganizationId,
 	}
 }

--- a/usecases/decision_workflows/decision_workflows.go
+++ b/usecases/decision_workflows/decision_workflows.go
@@ -51,7 +51,7 @@ type webhookEventCreator interface {
 
 type CaseNameEvaluator interface {
 	EvalCaseName(ctx context.Context, params evaluate_scenario.ScenarioEvaluationParameters,
-		scenario models.Scenario) (string, error)
+		scenario models.Scenario) (*string, error)
 }
 
 type DecisionsWorkflows struct {
@@ -161,12 +161,20 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 func automaticCreateCaseAttributes(
 	scenario models.Scenario,
 	decision models.DecisionWithRuleExecutions,
-	name string,
+	name *string,
 ) models.CreateCaseAttributes {
+	// TODO: check this logic
+	var nameWithDefault string
+	if name == nil {
+		nameWithDefault = "default case name"
+	} else {
+		nameWithDefault = *name
+	}
+
 	return models.CreateCaseAttributes{
 		DecisionIds:    []string{decision.DecisionId},
 		InboxId:        *scenario.DecisionToCaseInboxId,
-		Name:           name,
+		Name:           nameWithDefault,
 		OrganizationId: scenario.OrganizationId,
 	}
 }

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/cockroachdb/errors"
 )
 
@@ -105,9 +104,9 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 			return
 		}
 
-		counterpartyId, err := counterpartyIdResult.GetStringReturnValue()
-		if err != nil && !errors.Is(err, ast.ErrNullFieldRead) {
-			sanctionCheckErr = errors.Wrap(err, "could not parse object field for white list check as string")
+		counterpartyId, ok := counterpartyIdResult.ReturnValue.(string)
+		if counterpartyIdResult.ReturnValue == nil || !ok {
+			sanctionCheckErr = errors.Wrapf(err, "could not parse object field for white list check as string, read %v", counterpartyIdResult.ReturnValue)
 			return
 		}
 

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -633,9 +633,7 @@ func getPivotValue(ctx context.Context, pivot models.Pivot, dataAccessor DataAcc
 		usefulLinks := pivot.PathLinks[:len(pivot.PathLinks)-1]
 		var err error
 		val, err = dataAccessor.GetDbField(ctx, pivot.BaseTable, usefulLinks, lastLink.ChildFieldName)
-		if errors.Is(err, ast.ErrNullFieldRead) || errors.Is(err, ast.ErrNoRowsRead) {
-			return nil, nil
-		} else if err != nil {
+		if err != nil {
 			return nil, errors.Wrap(err, "error getting pivot value")
 		}
 	}

--- a/usecases/transfer_check_usecase.go
+++ b/usecases/transfer_check_usecase.go
@@ -201,7 +201,7 @@ func (usecase *TransferCheckUsecase) CreateTransfer(
 		}, nil
 	}
 
-	decision, err := usecase.decisionUseCase.CreateDecision(
+	_, decision, err := usecase.decisionUseCase.CreateDecision(
 		ctx,
 		models.CreateDecisionInput{
 			ScenarioId:         scenarioId,
@@ -495,7 +495,7 @@ func (usecase *TransferCheckUsecase) ScoreTransfer(
 		return models.Transfer{}, err
 	}
 
-	decision, err := usecase.decisionUseCase.CreateDecision(
+	_, decision, err := usecase.decisionUseCase.CreateDecision(
 		ctx,
 		models.CreateDecisionInput{
 			ScenarioId: scenarioId,


### PR DESCRIPTION
## Goal
This PR should be entirely ISO in terms of business logic. 
The starting point for me was to remove the `GetBoolReturnValue` and  `GetStringReturnValue` helper methods on the NodeEvaluation type. The reason for this is that they provided no real simplification over repeated code, because they replaced "null check and type assert" logic by "catch sentinel errors everywhere" logic. Namely, the codebase was a mess of `if errors.Is(err, ast. ErrNullFieldRead) {...} else if err != nil {...}`.

Continuing on this path, I completely removed the following sentinel errors from the models/ast package:
- `ErrNullFieldRead`
- `ErrNoRowsRead`
- `ErrPayloadFieldNotFound`
Only `ErrDivisionByZero` remains as a specific error at runtime, because that should be the only error we really encounter.

Note that old rule dtos `ast.ExecutionError` can still return the `NoRowsRead`, `PayloadFieldNotFound` values and that rules can still have the `NullFieldRead` status (if they return a nil not a bool).

In the same logic, the `models.ErrScenarioTriggerConditionAndTriggerObjectMismatch` error, that was possibly returned by EvalScenario and caught higher up the stack for a side effect of "don't create a decision" or "return a 400 error", is dropped in favor of explicitly returning a boolean (for "trigger condition [not] passed")

### implementation details
A nasty piece of code that recreated go error types from (integer) ExecutionError DTOs is replaced, decision rule models now hold a proper ExecutionError rather than an error that can be mapped to it.

## Bug fixes
- fixed a bug, where test run executions where the trigger condition has changed to become more restrictive would create a noisy error log when the trigger condition does not pass.

## Design reflexions
In the end, what this PR attemps to fix is a design that seemed ok at the start but became a horrible mess to memorize, never mind understand.

My take away from it is: using generic sentinel errors to trigger specific side effects at some level of the caller stack is ok in the following cases:
- the returned error is designed to be caught and handled immediately above in the call stack - kind of like io.Reader can return an EOF error that is always handled where the reader is actually read
- the sentinel error is general enough that its use can be relatively universal throughout the codebase, e.g. how we return a 400 at the API level if `errors.Is(err, models.NotFoundErr)`

but the pattern where a very specific sentinel error is returned by a method down the stack to be hopefully caught several layers above and through module boundaries is a big "no".