### PR TITLE
Use correct end date for test run depending on org set timezone.

### DIFF
--- a/api/handle_scenario_test_run.go
+++ b/api/handle_scenario_test_run.go
@@ -23,8 +23,15 @@ func handleCreateScenarioTestRun(uc usecases.Usecases) func(c *gin.Context) {
 			c.Status(http.StatusBadRequest)
 			return
 		}
+
+		orgUsecase := usecasesWithCreds(ctx, uc).NewOrganizationUseCase()
+		org, err := orgUsecase.GetOrganization(c.Request.Context(), organizationId)
+		if presentError(ctx, c, err) {
+			return
+		}
+
 		usecase := usecasesWithCreds(ctx, uc).NewScenarioTestRunUseCase()
-		input, err := dto.AdaptCreateScenarioTestRunBody(data)
+		input, err := dto.AdaptCreateScenarioTestRunBody(data, org.DefaultScenarioTimezone)
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/dto/scenario_testrun.go
+++ b/dto/scenario_testrun.go
@@ -37,7 +37,19 @@ type CreateScenarioTestRunBody struct {
 	EndDate         time.Time `json:"end_date"`
 }
 
-func AdaptCreateScenarioTestRunBody(dto CreateScenarioTestRunBody) (models.ScenarioTestRunInput, error) {
+func AdaptCreateScenarioTestRunBody(dto CreateScenarioTestRunBody, tzName *string) (models.ScenarioTestRunInput, error) {
+	tz := time.UTC
+
+	if tzName != nil {
+		orgTz, err := time.LoadLocation(*tzName)
+		if err == nil {
+			tz = orgTz
+		}
+	}
+
+	// Adapt the browser-locale-dependent timestamp sent by the frontend to the end of day relative to the organization's timezone.
+	dto.EndDate = time.Date(dto.EndDate.Year(), dto.EndDate.Month(), dto.EndDate.Day(), 23, 59, 59, 999999999, tz)
+
 	return models.ScenarioTestRunInput{
 		ScenarioId:         dto.ScenarioId,
 		EndDate:            dto.EndDate,


### PR DESCRIPTION
Creating a test run had two issues related to the end date selection:

* The end date would always be at the start of the selected day, where instinctively, you would think that selecting an end date of "Feb 27th" would still allow the test run to continue on the 27th.
* The frontend sends us a time relative to the browser's locale, which may or may not be the same as the organization's set timezone. The "end of day" calculation must therefore be performed in the org's timezone, but from the selected date (the user's intent).

This PR sets the end date and time for a test run as the end of the selected day in the organization's timezone.