### PR TITLE
feat: make trigger condition optional

### DIFF
--- a/repositories/scenario_iterations_write.go
+++ b/repositories/scenario_iterations_write.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 
@@ -131,13 +132,17 @@ func (repo *MarbleDbRepository) UpdateScenarioIteration(ctx context.Context, exe
 		countUpdate++
 	}
 	if scenarioIteration.Body.TriggerConditionAstExpression != nil {
-		triggerCondition, err := dbmodels.SerializeFormulaAstExpression(
-			scenarioIteration.Body.TriggerConditionAstExpression)
-		if err != nil {
-			return models.ScenarioIteration{}, fmt.Errorf(
-				"unable to marshal trigger condition ast expression: %w", err)
+		if scenarioIteration.Body.TriggerConditionAstExpression.Function != ast.FUNC_UNDEFINED {
+			triggerCondition, err := dbmodels.SerializeFormulaAstExpression(
+				scenarioIteration.Body.TriggerConditionAstExpression)
+			if err != nil {
+				return models.ScenarioIteration{}, fmt.Errorf(
+					"unable to marshal trigger condition ast expression: %w", err)
+			}
+			sql = sql.Set("trigger_condition_ast_expression", triggerCondition)
+		} else {
+			sql = sql.Set("trigger_condition_ast_expression", nil)
 		}
-		sql = sql.Set("trigger_condition_ast_expression", triggerCondition)
 		countUpdate++
 	}
 	if countUpdate == 0 {

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -138,17 +138,20 @@ func (e ScenarioEvaluator) processScenarioIteration(ctx context.Context, params 
 
 	// Evaluate the trigger
 
-	errEval := e.evalScenarioTrigger(
-		ctx,
-		cache,
-		*iteration.TriggerConditionAstExpression,
-		dataAccessor.organizationId,
-		dataAccessor.ClientObject,
-		params.DataModel,
-	)
-	if errEval != nil {
-		return models.ScenarioExecution{}, errEval
+	if iteration.TriggerConditionAstExpression != nil {
+		errEval := e.evalScenarioTrigger(
+			ctx,
+			cache,
+			*iteration.TriggerConditionAstExpression,
+			dataAccessor.organizationId,
+			dataAccessor.ClientObject,
+			params.DataModel,
+		)
+		if errEval != nil {
+			return models.ScenarioExecution{}, errEval
+		}
 	}
+
 	var pivotValue *string
 	var errPv error
 	if params.Pivot != nil {

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -87,13 +87,7 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 
 	// validate trigger
 	trigger := iteration.TriggerConditionAstExpression
-	if trigger == nil {
-		result.Trigger.Errors = append(result.Trigger.Errors, models.ScenarioValidationError{
-			Error: errors.Wrap(models.BadParameterError,
-				"scenario iteration has no trigger condition ast expression"),
-			Code: models.TriggerConditionRequired,
-		})
-	} else {
+	if trigger != nil {
 		result.Trigger.TriggerEvaluation, _ = ast_eval.EvaluateAst(ctx, nil, dryRunEnvironment, *trigger)
 		if _, ok := result.Trigger.TriggerEvaluation.ReturnValue.(bool); !ok {
 			result.Trigger.Errors = append(result.Trigger.Errors, models.ScenarioValidationError{


### PR DESCRIPTION
This PR makes scenario trigger condition optional by:
- Setting the `trigger_condition_ast_expression` field to NULL when patching scenario iteration if the trigger is an undefined node
- Skipping trigger execution while evaluating scenario if the trigger is nil
- Getting rid of validation scenario error when trigger is nil