### PR TITLE
BuildKit: keep git directory to extract the version

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -46,6 +46,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
           tags: ${{ env.IMAGE }}
 
       - name: "Set up Cloud SDK"


### PR DESCRIPTION
GitHub Actions uses BuildKit with the Git Context to build container images. By default, it does not keep the `.git` directory in the used working copy. This means that, by default, we cannot use `git` commands to extract the current version of the software.

This adds a BuildKit build argument to keep the directory around.