### PR TITLE
Change version extraction to GitHub Actions output

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -22,7 +22,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -41,13 +43,17 @@ jobs:
           registry: europe-west1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
+      
+      - name: Extract version from tag
+        id: version
+        run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           push: true
           build-args: |
-            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+            MARBLE_VERSION=${{ steps.version.outputs.MARBLE_VERSION }}
           tags: ${{ env.IMAGE }}
 
       - name: "Set up Cloud SDK"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM golang:1.23 as build
 
+ARG MARBLE_VERSION=dev
+
 WORKDIR /go/src/app
 COPY . .
 
 RUN go get
 
-RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.apiVersion=$(git describe --tags)'"
+RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.apiVersion=${MARBLE_VERSION}'"
 
 FROM alpine:3.19
 


### PR DESCRIPTION
BuiltKit only does a shallow clone, even when asked to copy the git directory, which means we cannot use tags to determine Marble's version.

This adds a previous step to export the version to an output, that is used as a build arg.