### PR TITLE
Add async match enrichement 

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -182,6 +182,7 @@ func RunTaskQueue(apiVersion string) error {
 	river.AddWorker(workers, adminUc.NewIndexCreationStatusWorker())
 	river.AddWorker(workers, adminUc.NewIndexCleanupWorker())
 	river.AddWorker(workers, adminUc.NewTestRunSummaryWorker())
+	river.AddWorker(workers, adminUc.NewMatchEnrichmentWorker())
 
 	if err := riverClient.Start(ctx); err != nil {
 		utils.LogAndReportSentryError(ctx, err)

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -52,3 +52,12 @@ func (m *TaskQueueRepository) EnqueueCreateIndexTask(
 	args := m.Called(ctx, organizationId, indices)
 	return args.Error(0)
 }
+
+func (m *TaskQueueRepository) EnqueueMatchEnrichmentTask(
+	ctx context.Context,
+	organizationId string,
+	sanctionCheckId string,
+) error {
+	args := m.Called(ctx, organizationId, sanctionCheckId)
+	return args.Error(0)
+}

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -42,3 +42,10 @@ type TestRunSummaryArgs struct {
 }
 
 func (TestRunSummaryArgs) Kind() string { return "test_run_summary" }
+
+type MatchEnrichmentArgs struct {
+	OrgId           string `json:"org_id"`
+	SanctionCheckId string `json:"sanction_check_id"`
+}
+
+func (MatchEnrichmentArgs) Kind() string { return "match_enrichment" }

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -40,6 +40,10 @@ type openSanctionsRequestQuery struct {
 	Properties models.OpenSanctionCheckFilter `json:"properties"`
 }
 
+func (repo OpenSanctionsRepository) IsSelfHosted(ctx context.Context) bool {
+	return repo.opensanctions.IsSelfHosted()
+}
+
 func (repo OpenSanctionsRepository) IsConfigured(ctx context.Context) (bool, error) {
 	if ok, err := repo.opensanctions.IsConfigured(); !ok {
 		return false, models.MissingRequirementError{

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -460,7 +460,11 @@ func (usecase *DecisionUsecase) CreateDecision(
 			}
 
 			if usecase.openSanctionsRepository.IsSelfHosted(ctx) {
-				_ = usecase.taskQueueRepository.EnqueueMatchEnrichmentTask(ctx, input.OrganizationId, sc.Id)
+				if err := usecase.taskQueueRepository.EnqueueMatchEnrichmentTask(
+					ctx, input.OrganizationId, sc.Id); err != nil {
+					utils.LogAndReportSentryError(ctx, errors.Wrap(err,
+						"could not enqueue sanction check for refinement"))
+				}
 			}
 		}
 
@@ -640,7 +644,11 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 				}
 
 				if usecase.openSanctionsRepository.IsSelfHosted(ctx) {
-					_ = usecase.taskQueueRepository.EnqueueMatchEnrichmentTask(ctx, input.OrganizationId, sc.Id)
+					if err := usecase.taskQueueRepository.EnqueueMatchEnrichmentTask(
+						ctx, input.OrganizationId, sc.Id); err != nil {
+						utils.LogAndReportSentryError(ctx, errors.Wrap(err,
+							"could not enqueue sanction check for refinement"))
+					}
 				}
 			}
 

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -267,8 +267,11 @@ func (uc SanctionCheckUsecase) Refine(ctx context.Context, refine models.Sanctio
 		}
 
 		if uc.openSanctionsProvider.IsSelfHosted(ctx) {
-			_ = uc.taskQueueRepository.EnqueueMatchEnrichmentTask(ctx,
-				decision.OrganizationId, sanctionCheck.Id)
+			if err := uc.taskQueueRepository.EnqueueMatchEnrichmentTask(ctx,
+				decision.OrganizationId, sanctionCheck.Id); err != nil {
+				utils.LogAndReportSentryError(ctx, errors.Wrap(err,
+					"could not enqueue sanction check for refinement"))
+			}
 		}
 
 		if err := uc.repository.CopySanctionCheckFiles(ctx, tx, oldSanctionCheck.Id, sanctionCheck.Id); err != nil {

--- a/usecases/scheduled_execution/match_enrichment_job.go
+++ b/usecases/scheduled_execution/match_enrichment_job.go
@@ -1,0 +1,60 @@
+package scheduled_execution
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/cockroachdb/errors"
+	"github.com/riverqueue/river"
+)
+
+type SanctionCheckRepository interface {
+	GetSanctionCheck(ctx context.Context, exec repositories.Executor, id string) (models.SanctionCheckWithMatches, error)
+}
+
+type SanctionCheckUsecase interface {
+	EnrichMatchWithoutAuthorization(ctx context.Context, matchId string) (models.SanctionCheckMatch, error)
+}
+
+type MatchEnrichmentWorker struct {
+	river.WorkerDefaults[models.MatchEnrichmentArgs]
+
+	executorFactory      executor_factory.ExecutorFactory
+	sanctionCheckUsecase SanctionCheckUsecase
+	repository           SanctionCheckRepository
+}
+
+func NewMatchEnrichmentWorker(
+	executorFactory executor_factory.ExecutorFactory,
+	sanctionCheckUsecase SanctionCheckUsecase,
+	repository SanctionCheckRepository,
+) MatchEnrichmentWorker {
+	return MatchEnrichmentWorker{
+		executorFactory:      executorFactory,
+		sanctionCheckUsecase: sanctionCheckUsecase,
+		repository:           repository,
+	}
+}
+
+func (w *MatchEnrichmentWorker) Work(ctx context.Context, job *river.Job[models.MatchEnrichmentArgs]) error {
+	var errs error
+
+	scc, err := w.repository.GetSanctionCheck(ctx, w.executorFactory.NewExecutor(), job.Args.SanctionCheckId)
+	if err != nil {
+		return err
+	}
+
+	for _, match := range scc.Matches {
+		if match.Enriched {
+			continue
+		}
+
+		if _, err := w.sanctionCheckUsecase.EnrichMatchWithoutAuthorization(ctx, match.Id); err != nil {
+			errs = errors.Join(errs, err)
+		}
+	}
+
+	return errs
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -109,6 +109,8 @@ func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 		scenarioTestRunRepository: &usecases.Repositories.MarbleDbRepository,
 		scenarioEvaluator:         usecases.NewScenarioEvaluator(),
 		featureAccessReader:       usecases.NewFeatureAccessReader(),
+		openSanctionsRepository:   usecases.Repositories.OpenSanctionsRepository,
+		taskQueueRepository:       usecases.Repositories.TaskQueueRepository,
 	}
 }
 
@@ -151,6 +153,7 @@ func (usecases *UsecasesWithCreds) NewSanctionCheckUsecase() SanctionCheckUsecas
 		scenarioFetcher:               usecases.NewScenarioFetcher(),
 		openSanctionsProvider:         usecases.Repositories.OpenSanctionsRepository,
 		sanctionCheckConfigRepository: &usecases.Repositories.MarbleDbRepository,
+		taskQueueRepository:           usecases.Repositories.TaskQueueRepository,
 		repository:                    &usecases.Repositories.MarbleDbRepository,
 		blobRepository:                usecases.Repositories.BlobRepository,
 		blobBucketUrl:                 usecases.caseManagerBucketUrl,
@@ -544,6 +547,15 @@ func (usecases UsecasesWithCreds) NewTestRunSummaryWorker() *scheduled_execution
 	w := scheduled_execution.NewTestRunSummaryWorker(
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
+		&usecases.Repositories.MarbleDbRepository,
+	)
+	return &w
+}
+
+func (usecases UsecasesWithCreds) NewMatchEnrichmentWorker() *scheduled_execution.MatchEnrichmentWorker {
+	w := scheduled_execution.NewMatchEnrichmentWorker(
+		usecases.NewExecutorFactory(),
+		usecases.NewSanctionCheckUsecase(),
 		&usecases.Repositories.MarbleDbRepository,
 	)
 	return &w


### PR DESCRIPTION
This also fixes an issue with overall enrichment where we replaced the payload completely (hence losing attributes specific to the search, e.g. `score`).