### PR TITLE
feat: make trigger in sanctioncheck optional

### DIFF
--- a/repositories/sanction_check_config_repository.go
+++ b/repositories/sanction_check_config_repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
@@ -38,7 +39,7 @@ func (repo *MarbleDbRepository) UpsertSanctionCheckConfig(ctx context.Context, e
 	}
 
 	var triggerRule *[]byte
-	if cfg.TriggerRule != nil {
+	if cfg.TriggerRule != nil && cfg.TriggerRule.Function != ast.FUNC_UNDEFINED {
 		astJson, err := dbmodels.SerializeFormulaAstExpression(cfg.TriggerRule)
 		if err != nil {
 			return models.SanctionCheckConfig{}, errors.Wrap(err,

--- a/usecases/evaluate_scenario/evaluate_sanction_check.go
+++ b/usecases/evaluate_scenario/evaluate_sanction_check.go
@@ -27,29 +27,32 @@ func (e ScenarioEvaluator) evaluateSanctionCheck(
 		return
 	}
 
-	triggerEvaluation, err := e.evaluateAstExpression.EvaluateAstExpression(
-		ctx,
-		nil,
-		*iteration.SanctionCheckConfig.TriggerRule,
-		params.Scenario.OrganizationId,
-		dataAccessor.ClientObject,
-		params.DataModel,
-	)
-	if err != nil {
-		sanctionCheckErr = errors.Wrap(err, "could not execute sanction check trigger rule")
-		return
-	}
-	passed, ok := triggerEvaluation.ReturnValue.(bool)
-	if !ok {
-		sanctionCheckErr = errors.New("sanction check trigger rule did not evaluate to a boolean")
-	} else if !passed {
-		return
+	if iteration.SanctionCheckConfig.TriggerRule != nil {
+		triggerEvaluation, err := e.evaluateAstExpression.EvaluateAstExpression(
+			ctx,
+			nil,
+			*iteration.SanctionCheckConfig.TriggerRule,
+			params.Scenario.OrganizationId,
+			dataAccessor.ClientObject,
+			params.DataModel,
+		)
+		if err != nil {
+			sanctionCheckErr = errors.Wrap(err, "could not execute sanction check trigger rule")
+			return
+		}
+		passed, ok := triggerEvaluation.ReturnValue.(bool)
+		if !ok {
+			sanctionCheckErr = errors.New("sanction check trigger rule did not evaluate to a boolean")
+		} else if !passed {
+			return
+		}
 	}
 
 	queries := []models.OpenSanctionsCheckQuery{}
 	emptyFieldRead := 0
 	nbEvaluatedFields := 0
 	emptyInput := false
+	var err error
 
 	if iteration.SanctionCheckConfig.Query.Name != nil {
 		nbEvaluatedFields += 1

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -123,14 +123,7 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 
 	// Validate sanction check trigger and rule
 	if iteration.SanctionCheckConfig != nil {
-		if iteration.SanctionCheckConfig.TriggerRule == nil {
-			result.SanctionCheck.TriggerRule.Errors = append(
-				result.SanctionCheck.TriggerRule.Errors, models.ScenarioValidationError{
-					Error: errors.Wrap(models.BadParameterError,
-						"sanction check does not have a trigger condition"),
-					Code: models.TriggerConditionRequired,
-				})
-		} else {
+		if iteration.SanctionCheckConfig.TriggerRule != nil {
 			triggerRuleEvaluation, _ := ast_eval.EvaluateAst(ctx, nil, dryRunEnvironment,
 				*iteration.SanctionCheckConfig.TriggerRule)
 			if _, ok := triggerRuleEvaluation.ReturnValue.(bool); !ok {


### PR DESCRIPTION
This PR makes the sanction check config trigger rule optional by:
- Setting field in DB as NULL is there's not trigger condition or it is an Undefined AST Node
- Bypassing validation if the trigger is nil
- Not trying to execute the trigger if it's nil when evaluating the sanction check

Frontend PR: https://github.com/checkmarble/marble-frontend/pull/724