### PR TITLE
sanction check in error status can be refined

### DIFF
--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -49,6 +49,10 @@ func (scs SanctionCheckStatus) IsReviewable() bool {
 	return scs == SanctionStatusInReview
 }
 
+func (scs SanctionCheckStatus) IsRefinable() bool {
+	return scs == SanctionStatusInReview || scs == SanctionStatusError
+}
+
 type SanctionCheckMatchStatus int
 
 const (

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -725,9 +725,9 @@ func (uc SanctionCheckUsecase) enforceCanRefineSanctionCheck(
 			errors.Wrap(models.NotFoundError, "no active sanction check found for this decision")
 	}
 
-	if !sanctionCheck.Status.IsReviewable() {
+	if !sanctionCheck.Status.IsRefinable() {
 		return models.Decision{}, *sanctionCheck,
-			errors.Wrap(models.NotFoundError, "this sanction is not pending review")
+			errors.Wrap(models.NotFoundError, "this sanction is not pending review or error")
 	}
 
 	decision, err := uc.enforceCanReadOrUpdateCase(ctx, sanctionCheck.DecisionId)


### PR DESCRIPTION
See slack conv: https://checkmarble.slack.com/archives/C04J8MPJJHY/p1739981694748709.
Currently the frontend seems to allow to refine (basically redo) a sanction check that was in error status, but it is forbidden by the backend, resulting in an error displayed in the case manager.
The rationale is that late is better than never to perform a sanction check properly if it was originally an error. As of now, the only error case being that only empty inputs have been sent to the OS API.