### PR TITLE
chore: try to optimize for covering index for PATCH/POST ingestion

### DIFF
--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -369,7 +369,7 @@ func setupScenarioAndPublish(
 	// Wait for a potential 'index_creation' task to be created. If it is, we wait for both 'index_creation'
 	// and 'index_creation_status' to be completed before continuing.
 	if IfTaskIsCreated(ctx, riverClient, time.Second, "index_creation") {
-		WaitUntilAllTasksDone(t, ctx, riverClient, 5*time.Second, "index_creation", "index_creation_status")
+		WaitUntilAllTasksDone(t, ctx, riverClient, 10*time.Second, "index_creation", "index_creation_status")
 	}
 
 	scenarioPublications, err := scenarioPublicationUsecase.ExecuteScenarioPublicationAction(

--- a/usecases/ingestion_usecase_test.go
+++ b/usecases/ingestion_usecase_test.go
@@ -172,10 +172,10 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nomina
 	rowId := utils.ByteUuid(rowIdStr)
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there is a previous version for this object
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id  FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
 		WithArgs("Infinity", "1").
-		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
-			AddRow("1", "OK", updAt, 1.0, rowId))
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "updated_at", "id"}).
+			AddRow("1", updAt, rowId))
 	// update the previous version
 	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2)`)).
 		WithArgs("now()", rowIdStr).
@@ -207,7 +207,7 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nomina
 
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there is no previous version for this object
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
 		WithArgs("Infinity", "1").
 		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
 	// insert the new version
@@ -244,9 +244,9 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nomina
 
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there is no previous version for this object
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
 		WithArgs("Infinity", "1").
-		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "updated_at", "id"}))
 	// insert the new version
 	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5)`)).
 		WithArgs("1", "OK", updAt, 1.0, anyUuid{}).
@@ -279,10 +279,10 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObject_nomina
 	rowId := utils.ByteUuid(rowIdStr)
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there is a previous version for this object
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2)`)).
 		WithArgs("Infinity", "1").
-		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
-			AddRow("1", "OK", updAt.Add(time.Hour), 1.0, rowId))
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "updated_at", "id"}).
+			AddRow("1", updAt.Add(time.Hour), rowId))
 
 	suite.dataModelRepository.On("BatchInsertEnumValues", mock.MatchedBy(matchContext),
 		mock.MatchedBy(matchExec), models.EnumValues{}, suite.dataModel.Tables["transactions"]).
@@ -374,9 +374,9 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_nomin
 
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there is no previous version for these objects
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
 		WithArgs("Infinity", "1", "2").
-		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}))
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "updated_at", "id"}))
 	// insert the new versions
 	suite.executorFactory.Mock.ExpectExec(escapeSql(`INSERT INTO "test"."transactions" (object_id,status,updated_at,value,id) VALUES ($1,$2,$3,$4,$5),($6,$7,$8,$9,$10)`)).
 		WithArgs(
@@ -411,11 +411,11 @@ func (suite *IngestionUsecaseTestSuite) TestIngestionUsecase_IngestObjects_with_
 	rowId2 := utils.ByteUuid(rowIdStr2)
 	updAt, _ := time.Parse(time.RFC3339, "2020-01-01T00:00:00Z")
 	// there are previous versions for these objects
-	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, status, updated_at, value, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
+	suite.executorFactory.Mock.ExpectQuery(escapeSql(`SELECT object_id, updated_at, id FROM "test"."transactions" WHERE "test"."transactions".valid_until = $1 AND object_id IN ($2,$3)`)).
 		WithArgs("Infinity", "1", "2").
-		WillReturnRows(pgxmock.NewRows([]string{"object_id", "status", "updated_at", "value", "id"}).
-			AddRow("1", "OK", updAt, 1.0, rowId1).
-			AddRow("2", "OK", updAt, 2.0, rowId2))
+		WillReturnRows(pgxmock.NewRows([]string{"object_id", "updated_at", "id"}).
+			AddRow("1", updAt, rowId1).
+			AddRow("2", updAt, rowId2))
 	// update the previous versions
 	suite.executorFactory.Mock.ExpectExec(escapeSql(`UPDATE "test"."transactions" SET valid_until = $1 WHERE id IN ($2,$3)`)).
 		WithArgs("now()", rowIdStr1, rowIdStr2).


### PR DESCRIPTION
Borrowing from the explanation comment in the PR:
```
// Try to only load the fields that are actually missing from the payloads (in the case of a partial update).
// The same method is used for the POST and PATCH endpoints, but if no fields are missing then there is a
// covering index on the object_id and updated_at columns that can be used.
// This makes the POST endpoint possibly faster to respond than the PATCH endpoint for ingestion (when there
// is data present and some payload have missing fields).
```

The PR that allowed partial payload ingestion (PATCH endpoints for ingestion) made changes that caused every ingestion call to always go read data from the base table (client data table), even though a covering index exists that is sufficient in many cases.