### PR TITLE
Pascal/fix batch exec trigger condition pre calc

### DIFF
--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -107,6 +107,12 @@ func (usecase *RunScheduledExecution) ExecuteAllScheduledScenarios(ctx context.C
 	executionErrorChan := make(chan error, len(pendingScheduledExecutions))
 
 	startScheduledExecution := func(scheduledExecution models.ScheduledExecution) {
+		defer func() {
+			if r := recover(); r != nil {
+				err := fmt.Errorf("panic in ExecuteAllScheduledScenarios: %v", r)
+				utils.LogAndReportSentryError(ctx, err)
+			}
+		}()
 		defer waitGroup.Done()
 		ctx = utils.StoreLoggerInContext(
 			ctx,

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -180,10 +180,13 @@ func (usecase *RunScheduledExecution) insertAsyncDecisionTasks(
 	if err != nil {
 		return err
 	}
-	filters := selectFiltersFromTriggerAstRootAnd(
-		*liveVersion.TriggerConditionAstExpression,
-		models.TableIdentifier{Table: scenario.TriggerObjectType, Schema: db.DatabaseSchema().Schema},
-	)
+	var filters []models.Filter
+	if liveVersion.TriggerConditionAstExpression != nil {
+		filters = selectFiltersFromTriggerAstRootAnd(
+			*liveVersion.TriggerConditionAstExpression,
+			models.TableIdentifier{Table: scenario.TriggerObjectType, Schema: db.DatabaseSchema().Schema},
+		)
+	}
 
 	objectIds, err := usecase.ingestedDataReadRepository.ListAllObjectIdsFromTable(ctx, db, scenario.TriggerObjectType, filters...)
 	if err != nil {


### PR DESCRIPTION
## Post mortem
There was a panic due to a nil pointer dereference, in the part of the codebase that reads objects to select for a batch execution.
There is a kind of uncomfortable coupling between different parts of the product, through the "trigger condition" feature.

## Action plan
Unrelated to this particular feature, but in the future I'd like to replace all raw goroutine executions by a small "middleware" wrapper with panic recovery and logging.