### PR TITLE
fix: batch exec with sanction was failing because a usecase config was missing

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -175,6 +175,7 @@ func RunTaskQueue(apiVersion string) error {
 		usecases.WithFailedWebhooksRetryPageSize(workerConfig.failedWebhooksRetryPageSize),
 		usecases.WithLicense(license),
 		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
+		usecases.WithOpensanctions(openSanctionsConfig.IsSet()),
 	)
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, uc)
 	river.AddWorker(workers, adminUc.NewAsyncDecisionWorker())


### PR DESCRIPTION
The repository for sanction checks was configured, but not the usecase.
Clearly a QA issue here, though I wonder if the repository/usecase configuration is becoming too complex/coupled in a hidden way.