### PR TITLE
Test Run Summaries: only process missing data by slices of 6 hours an…

### DIFF
--- a/models/scenario_testrun.go
+++ b/models/scenario_testrun.go
@@ -54,6 +54,9 @@ type ScenarioTestRun struct {
 	// processing results when the test run ends), or we would miss results, so we continue processing until
 	// we reach a watermark later than the test run end date, then we set this boolean to true.
 	Summarized bool
+	// This is used a an idempotency key to make concurrent runs of the test run summary job do not produce incorrect results.
+	// Please do not update outside of this.
+	UpdatedAt time.Time
 }
 
 type ScenarioTestRunWithSummary struct {

--- a/repositories/dbmodels/db_scenario_testrun.go
+++ b/repositories/dbmodels/db_scenario_testrun.go
@@ -15,6 +15,7 @@ type DBScenarioTestRun struct {
 	ExpiresAt               time.Time `db:"expires_at"`
 	Status                  string    `db:"status"`
 	Summarized              bool      `db:"summarized"`
+	UpdatedAt               time.Time `db:"updated_at"`
 }
 
 type DBScenarioTestRunWitInfo struct {
@@ -24,7 +25,7 @@ type DBScenarioTestRunWitInfo struct {
 }
 
 type DBScenarioTestRunWithSummary struct {
-	DBScenarioTestRun
+	DBScenarioTestRunWitInfo
 
 	Summary []DbScenarioTestRunSummary `db:"summaries"`
 }
@@ -42,6 +43,7 @@ func AdaptScenarioTestrun(db DBScenarioTestRun) (models.ScenarioTestRun, error) 
 		ExpiresAt:               db.ExpiresAt,
 		Status:                  models.ScenarioTestStatusFrom(db.Status),
 		Summarized:              db.Summarized,
+		UpdatedAt:               db.UpdatedAt,
 	}, nil
 }
 
@@ -56,6 +58,7 @@ func AdaptScenarioTestrunWithInfo(db DBScenarioTestRunWitInfo) (models.ScenarioT
 		ScenarioId:              db.ScenarioId,
 		Status:                  models.ScenarioTestStatusFrom(db.Status),
 		Summarized:              db.Summarized,
+		UpdatedAt:               db.UpdatedAt,
 	}, nil
 }
 
@@ -70,7 +73,7 @@ func AdaptScenarioTestrunWithSummary(db DBScenarioTestRunWithSummary) (models.Sc
 		summaries[idx] = summary
 	}
 
-	testRun, err := AdaptScenarioTestrun(db.DBScenarioTestRun)
+	testRun, err := AdaptScenarioTestrunWithInfo(db.DBScenarioTestRunWitInfo)
 	if err != nil {
 		return models.ScenarioTestRunWithSummary{}, err
 	}

--- a/repositories/migrations/20250306160800_add_updated_time_to_test_runs.sql
+++ b/repositories/migrations/20250306160800_add_updated_time_to_test_runs.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+-- +goose StatementBegin
+
+alter table scenario_test_run
+    add column updated_at timestamp with time zone null default now();
+
+update scenario_test_run
+set updated_at = now();
+
+alter table scenario_test_run
+    alter column updated_at set not null;
+
+-- +goose StatementEnd
+
+-- +goose Down
+
+alter table scenario_test_run
+    drop column updated_at;

--- a/usecases/scheduled_execution/test_run_summary_job.go
+++ b/usecases/scheduled_execution/test_run_summary_job.go
@@ -58,7 +58,7 @@ type RulesRepository interface {
 		testRunId string, stat models.RuleExecutionStat, newWatermark time.Time,
 	) error
 	SetTestRunAsSummarized(ctx context.Context, exec repositories.Executor, testRunId string) error
-	ReadLatestUpdatedAt(ctx context.Context, exec repositories.Executor, testRunId string) (*time.Time, error)
+	ReadLatestUpdatedAt(ctx context.Context, exec repositories.Executor, testRunId string) (time.Time, error)
 	TouchLatestUpdatedAt(ctx context.Context, exec repositories.Executor, testRunId string) error
 }
 


### PR DESCRIPTION
…d mark a test run as summarized when the latest right bound of processed time is after the expiration (or when downed manually).