### PR TITLE
tentative fix: decisions by outcome stats are wrong due to missing filter

### DIFF
--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -87,6 +87,7 @@ func (repo *MarbleDbRepository) DecisionsByOutcomeAndScore(
 	ctx context.Context,
 	exec Executor,
 	organizationId string,
+	scenarioId string,
 	begin, end time.Time,
 ) ([]models.DecisionsByVersionByOutcome, error) {
 	decisionQuery := squirrel.StatementBuilder.
@@ -99,7 +100,8 @@ func (repo *MarbleDbRepository) DecisionsByOutcomeAndScore(
 			"created_at": end,
 		}).
 		Where(squirrel.Eq{
-			"org_id": organizationId,
+			"org_id":      organizationId,
+			"scenario_id": scenarioId,
 		})
 	phantomDecisionQuery := squirrel.StatementBuilder.
 		Select("outcome, scenario_version, score").
@@ -111,7 +113,8 @@ func (repo *MarbleDbRepository) DecisionsByOutcomeAndScore(
 			"created_at": end,
 		}).
 		Where(squirrel.Eq{
-			"org_id": organizationId,
+			"org_id":      organizationId,
+			"scenario_id": scenarioId,
 		})
 	query, err := WithUnionAll(decisionQuery, phantomDecisionQuery)
 	if err != nil {

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -59,21 +59,9 @@ type DecisionUsecaseRepository interface {
 
 	GetScenarioById(ctx context.Context, exec repositories.Executor, scenarioId string) (models.Scenario, error)
 
-	DecisionsByOutcomeAndScore(
-		ctx context.Context,
-		exec repositories.Executor,
-		organizationId string,
-		begin, end time.Time,
-	) ([]models.DecisionsByVersionByOutcome, error)
 	GetSummarizedDecisionStatForTestRun(ctx context.Context, exec repositories.Executor,
 		testRunId string) ([]models.DecisionsByVersionByOutcome, error)
 	ListScenariosOfOrganization(ctx context.Context, exec repositories.Executor, organizationId string) ([]models.Scenario, error)
-
-	GetScenarioIteration(ctx context.Context, exec repositories.Executor, scenarioIterationId string) (
-		models.ScenarioIteration, error,
-	)
-
-	GetCaseById(ctx context.Context, exec repositories.Executor, caseId string) (models.Case, error)
 }
 
 type decisionUsecaseFeatureAccessReader interface {

--- a/usecases/scheduled_execution/test_run_summary_job.go
+++ b/usecases/scheduled_execution/test_run_summary_job.go
@@ -37,8 +37,13 @@ type RulesRepository interface {
 		begin, end time.Time,
 		base string, // "decisions" or "phantom_decisions"
 	) ([]models.RuleExecutionStat, error)
-	DecisionsByOutcomeAndScore(ctx context.Context, exec repositories.Executor, organizationId string,
-		begin, end time.Time) ([]models.DecisionsByVersionByOutcome, error)
+	DecisionsByOutcomeAndScore(
+		ctx context.Context,
+		exec repositories.Executor,
+		organizationId string,
+		scenarioId string,
+		begin, end time.Time,
+	) ([]models.DecisionsByVersionByOutcome, error)
 	SaveTestRunDecisionSummary(ctx context.Context, exec repositories.Executor, testRunId string,
 		stat models.DecisionsByVersionByOutcome, newWatermark time.Time) error
 	SaveTestRunSummary(ctx context.Context, exec repositories.Executor,
@@ -112,7 +117,8 @@ func (w *TestRunSummaryWorker) Work(ctx context.Context, job *river.Job[models.T
 		}
 
 		err := w.transaction_factory.Transaction(ctx, func(tx repositories.Transaction) error {
-			decisionStats, err := w.repository.DecisionsByOutcomeAndScore(ctx, tx, job.Args.OrgId, then, now)
+			decisionStats, err := w.repository.DecisionsByOutcomeAndScore(ctx, tx,
+				job.Args.OrgId, testRun.ScenarioId, then, now)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
As far as I can tell, no change is necessary in in terms of the indexes that the query is expected to use.
We _could_ add an additional index on phantom decisions that also filters on scenario_id - but that can be done later if we see that the query remains slowish.

As a result, currently existing summaries are wrong, so I think i'll (manually) delete them and reset the "summarized" status on existing test runs.