### PR TITLE
fixes on watermark logic

### DIFF
--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -492,7 +492,7 @@ components:
         review_status:
           description: Review status of the decision (if outcome=block_and_review).
           type: string
-          enum: [pending, approve, rejecte]
+          enum: [pending, approve, reject]
         rules:
           description: Rules executed to take the decision.
           type: array

--- a/specs/public_api.yaml
+++ b/specs/public_api.yaml
@@ -492,7 +492,7 @@ components:
         review_status:
           description: Review status of the decision (if outcome=block_and_review).
           type: string
-          enum: [pending, approve, reject]
+          enum: [pending, approve, decline]
         rules:
           description: Rules executed to take the decision.
           type: array


### PR DESCRIPTION
The final release is going to be for tomorrow in the end.
There was a bit of a logic error related to the fact that the watermark is on the summaries, that no summaries are updated if no decisions exist in the window between [then, windowBound], where the code remains stuck (and a test run would remain unsummarized forever).
I fixed it by adding a "bump all watermarks after writing the summaries" step.
It was a bit of a pain to debug, because the issue would appear in a way that is very dependent on how the decisions on the scenarios are distributed in time.