### PR TITLE
fix bug on decision/all endpoint

### DIFF
--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -601,15 +601,15 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 		defer span.End()
 		triggerPassed, scenarioExecution, err :=
 			usecase.scenarioEvaluator.EvalScenario(ctx, evaluationParameters)
-		if err != nil {
+		switch {
+		case err != nil:
 			return nil, 0, errors.Wrap(err, "error evaluating scenario in CreateAllDecisions")
-		} else if !triggerPassed {
+		case !triggerPassed:
 			nbSkipped++
+		default:
+			decision := models.AdaptScenarExecToDecision(scenarioExecution, payload, nil)
+			items = append(items, decisionAndScenario{decision: decision, scenario: scenario})
 		}
-
-		decision := models.AdaptScenarExecToDecision(scenarioExecution, payload, nil)
-		items = append(items, decisionAndScenario{decision: decision, scenario: scenario})
-
 	}
 
 	ctx, span2 := tracer.Start(ctx, "DecisionUsecase.CreateAllDecisions - store decisions")

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -369,6 +369,8 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 	}
 
 	setToFailed := func(numRowsIngested int) {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+		defer cancel()
 		_, err := usecase.uploadLogRepository.UpdateUploadLogStatus(
 			ctx,
 			exec,


### PR DESCRIPTION
- Corrects an error on logic in the POST /decisions/all endpoint introduced in v0.38
- smuggled inside this PR too: small fix so that an ingestion job that times out (or context canceled for another reason) does not fail to update the batch ingestion's status