### PR TITLE
fix bug impacting index creation for test run

### DIFF
--- a/repositories/pg_indexes/pg_indexes.go
+++ b/repositories/pg_indexes/pg_indexes.go
@@ -57,7 +57,7 @@ func (pgIndex PGIndex) AdaptConcreteIndex() models.ConcreteIndex {
 	idx := parseCreateIndexStatement(pgIndex.Definition)
 
 	idx.TableName = pgIndex.TableName
-	idx.IndexName = pgIndex.Name
+	idx = idx.WithName(pgIndex.Name)
 	return idx
 }
 


### PR DESCRIPTION
See linear for the details on the bug that triggered the ticket.
The fix was a bit trickier than I initially thought, because of how the ConcreteModel index was also used as a dto implicitly when serializing the job a rgs.
Also takes care of https://linear.app/marble-eu/issue/MAR-802/review-placement-of-index-name-logic-following-incident-on-index following the incident yesterday.