### PR TITLE
fix: test runs phantom decisions were not created on the /decisions/all endpoint

### DIFF
--- a/usecases/scheduled_execution/async_decision_job.go
+++ b/usecases/scheduled_execution/async_decision_job.go
@@ -288,6 +288,11 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 		Pivot:             pivot,
 	}
 
+	// Note: Statistics on test runs when using batch scenarios may still be slightly off, because the batch execution does a partial
+	// precomputation of the filters from the trigger condition, based on the live version of the scenario.
+	// The cleaner solution would be to do a parallel execution in batch of the test run, but even then it would be extremely tiresome to
+	// protect against all edge cases if part of one or the other job fails to run for unexpected reasons.
+	// We probably want to live with this for the time being.
 	executeTestRun := func(se *models.ScenarioExecution) {
 		evaluationParameters.TargetIterationId = nil
 		if se != nil {


### PR DESCRIPTION
## Object
Corrects one of the last "big" causes of data mismatch between test run and live scenario.

The remaining ones are (but smaller magnitude - probably, at least in the nominal case):
- batch exec trigger condition precompute (see comment added inline)
- test run decisions are run in a gorouting, liable to error or timeout - we could do them in a task queue in the future it this proves too much of a problem

## Comments on implementation
I tried two versions, one with a closure and the other with a dedicated private method in the usecase. The second is more DRY I guess but it takes an uncomfortable number of input params. Probably still better, I guess.
Most of the logic is still replicated where we do the async decisions for batch exec.