### PR TITLE
Handle timezone-less RFC3339 datetimes

### DIFF
--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -597,6 +597,8 @@ func parseStringValuesToMap(headers []string, values []string, table models.Tabl
 				result[fieldName] = val.UTC()
 			} else if val, err = time.Parse("2006-01-02 15:04:05.9", value); err == nil {
 				result[fieldName] = val.UTC()
+			} else if val, err = time.Parse("2006-01-02T15:04:05.9", value); err == nil {
+				result[fieldName] = val.UTC()
 			} else {
 				return nil, fmt.Errorf("error parsing timestamp %s for field %s: %w", value, fieldName, err)
 			}

--- a/usecases/ingestion_usecase_test.go
+++ b/usecases/ingestion_usecase_test.go
@@ -39,29 +39,43 @@ func TestParseStringValuesToMap(t *testing.T) {
 		values  []string
 	}
 
+	refTime := time.Date(2023, 4, 10, 14, 30, 0, 0, time.UTC)
+
 	OKcases := []testCase{
 		{
 			name:    "valid case with all fields present",
 			columns: []string{"object_id", "updated_at", "value", "status"},
-			values:  []string{"1", "2020-01-01T00:00:00Z", "1.0", "OK"},
+			values:  []string{"1", "2023-04-10T14:30:00Z", "1.0", "OK"},
 		},
 		{
 			name:    "valid case with empty status and null value",
 			columns: []string{"object_id", "updated_at", "value", "status"},
-			values:  []string{"1", "2020-01-01T00:00:00Z", "", ""},
+			values:  []string{"1", "2023-04-10T14:30:00Z", "", ""},
 		},
 		{
-			name:    "error case with the other format updated_at (missing T & Z)",
+			name:    "valid case with the other format updated_at (missing T & Z)",
 			columns: []string{"object_id", "updated_at", "value", "status"},
-			values:  []string{"1234", "2023-01-01 00:00:00", "", ""},
+			values:  []string{"1234", "2023-04-10 14:30:00", "", ""},
+		},
+		{
+			name:    "valid case with custom RFC3339 format without time zone",
+			columns: []string{"object_id", "updated_at", "value", "status"},
+			values:  []string{"1234", "2023-04-10T14:30:00", "", ""},
+		},
+		{
+			name:    "valid case with RFC3339 with time zone offset",
+			columns: []string{"object_id", "updated_at", "value", "status"},
+			values:  []string{"1234", "2023-04-10T17:00:00+02:30", "", ""},
 		},
 	}
 
 	for _, c := range OKcases {
-		_, err := parseStringValuesToMap(c.columns, c.values, table)
+		result, err := parseStringValuesToMap(c.columns, c.values, table)
 		if err != nil {
 			t.Errorf("Error parsing string values to map: %v", err)
 		}
+
+		assert.WithinDuration(t, refTime, result["updated_at"].(time.Time), 0)
 	}
 
 	ErrCases := []testCase{

--- a/usecases/payload_parser/payload.go
+++ b/usecases/payload_parser/payload.go
@@ -118,6 +118,9 @@ func NewParser(opts ...ParserOpt) *Parser {
 			if t, err := time.Parse("2006-01-02 15:04:05.9", result.String()); err == nil {
 				return t.UTC(), nil
 			}
+			if t, err := time.Parse("2006-01-02T15:04:05", result.String()); err == nil {
+				return t.UTC(), nil
+			}
 			return nil, fmt.Errorf("%w: expected format \"YYYY-MM-DD hh:mm:ss[+optional decimals]\" or \"YYYY-MM-DDThh:mm:ss[+optional decimals]Z\", got \"%s\"", errIsInvalidTimestamp, result.String())
 		},
 		models.Int: func(result gjson.Result) (any, error) {

--- a/usecases/payload_parser/payload_test.go
+++ b/usecases/payload_parser/payload_test.go
@@ -219,6 +219,35 @@ func TestParser_ParsePayload(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "nullable missing field with object_id and updated_at with timezone-less RFC3339 datetime",
+			table: models.Table{
+				Name: "transactions",
+				Fields: map[string]models.Field{
+					"nullable": {
+						DataType: models.String,
+						Nullable: true,
+					},
+					"object_id": {
+						DataType: models.String,
+						Nullable: false,
+					},
+					"updated_at": {
+						DataType: models.Timestamp,
+						Nullable: false,
+					},
+				},
+			},
+			input: []byte(`{"object_id": "id", "updated_at": "2023-10-19T00:00:00"}`),
+			want: models.ClientObject{
+				TableName: "transactions",
+				Data: map[string]any{
+					"object_id": "id",
+					// input is in UTC+3, but the output is in UTC
+					"updated_at": time.Date(2023, time.October, 19, 0, 0, 0, 0, time.UTC),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds a new format supported in payloads and ingested data, which is the same format as `time.RFC3339` but without timezone information. The parsing still assumes the datetime is represented as UTC.

Also added tests that check the times parsed from ingestion.