### PR TITLE
wip: try postgres 16 on marble

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 services:
   db:
     container_name: postgres
-    # image: postgres:15
-    # image: europe-west1-docker.pkg.dev/marble-infra/marble/postgresql-db:latest
     image: postgres:16
     shm_size: 1g
     restart: always
@@ -14,46 +12,46 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres-db2:/data/postgres
+      - postgres-db:/data/postgres
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 1s
       retries: 5
-  # elasticsearch:
-  #   container_name: es
-  #   image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
-  #   ports:
-  #     - "9200:9200"
-  #   environment:
-  #     - node.name=es
-  #     - cluster.name=marble-es
-  #     - discovery.type=single-node
-  #     - bootstrap.memory_lock=true
-  #     - xpack.security.enabled=false
-  #     - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
-  #   ulimits:
-  #     memlock:
-  #       soft: -1
-  #       hard: -1
-  #   volumes:
-  #     - es:/usr/share/elasticsearch/data
-  # yente:
-  #   container_name: yente
-  #   image: ghcr.io/opensanctions/yente:4.2.1
-  #   depends_on:
-  #     - elasticsearch
-  #   ports:
-  #     - "8000:8000"
-  #   volumes:
-  #     - ./contrib/yente-datasets.yml:/app/manifests/default.yml
-  #   environment:
-  #     YENTE_INDEX_TYPE: elasticsearch
-  #     YENTE_INDEX_URL: "http://es:9200"
-  #     YENTE_UPDATE_TOKEN: ""
+  elasticsearch:
+    container_name: es
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
+    ports:
+      - "9200:9200"
+    environment:
+      - node.name=es
+      - cluster.name=marble-es
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es:/usr/share/elasticsearch/data
+  yente:
+    container_name: yente
+    image: ghcr.io/opensanctions/yente:4.2.1
+    depends_on:
+      - elasticsearch
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./contrib/yente-datasets.yml:/app/manifests/default.yml
+    environment:
+      YENTE_INDEX_TYPE: elasticsearch
+      YENTE_INDEX_URL: "http://es:9200"
+      YENTE_UPDATE_TOKEN: ""
 
 volumes:
-  postgres-db2:
+  postgres-db:
     driver: local
   es:
     driver: local


### PR DESCRIPTION
In my case at least, I wasn't able to just reuse the same volume.
It might just be that I had an error because I was using the pg_cron extension that is not present in the basic postgres16 image however, I needed to remove it anyway to run my test.
Procedure I followed: (Following https://thomasbandt.com/postgres-docker-major-version-upgrade)

```
docker exec -it  postgres pg_dumpall -U postgres > ./upgrade_backup.sql
./pg_extract.sh upgrade_backup.sql marble >> upgrade_backup_marble.sql
```
Where the script contains 
```bash
#!/bin/bash
[ $# -lt 2 ] && { echo "Usage: $0 <postgresql dump> <dbname>"; exit 1; }
sed  "/connect.*$2/,\$!d" $1 | sed "/PostgreSQL database dump complete/,\$d"
```

then
```
docker compose down
// -> modify postgres version in docker compose & change volume
docker compose up -d
cat ./upgrade_backup_marble.sql | docker exec -i postgres  psql -U postgres
```
Will not try to run with this locally for a few days.