### PR TITLE
Handle null index_version for OpenSanctions datasets.

### DIFF
--- a/api/handle_sanction_checks.go
+++ b/api/handle_sanction_checks.go
@@ -19,8 +19,11 @@ func handleSanctionCheckDatasetFreshness(uc usecases.Usecases) func(c *gin.Conte
 		uc := usecasesWithCreds(ctx, uc).NewSanctionCheckUsecase()
 
 		dataset, err := uc.CheckDatasetFreshness(ctx)
+		if err != nil {
+			utils.LoggerFromContext(ctx).WarnContext(ctx,
+				"could not check OpenSanctions dataset freshness", "error", err.Error())
 
-		if presentError(ctx, c, err) {
+			c.JSON(http.StatusOK, dto.CreateOpenSanctionsFreshnessFallback())
 			return
 		}
 

--- a/dto/sanction_check_dataset_dto.go
+++ b/dto/sanction_check_dataset_dto.go
@@ -69,3 +69,9 @@ func AdaptSanctionCheckDataset(model models.OpenSanctionsDatasetFreshness) OpenS
 		UpToDate: model.UpToDate,
 	}
 }
+
+func CreateOpenSanctionsFreshnessFallback() OpenSanctionsDatasetFreshness {
+	return OpenSanctionsDatasetFreshness{
+		UpToDate: true,
+	}
+}

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -102,8 +102,12 @@ type TimeProvider func() time.Time
 // The local dataset is always considered up to date if its version matches
 // that of its upstream counterpart.
 func (dataset *OpenSanctionsDatasetFreshness) CheckIsUpToDate(tp TimeProvider) error {
+	if dataset == nil {
+		return errors.New("trying to check freshness on a nil dataset")
+	}
+
 	if dataset.Upstream.Version == dataset.Version {
-		(*dataset).UpToDate = true
+		dataset.UpToDate = true
 		return nil
 	}
 
@@ -115,18 +119,18 @@ func (dataset *OpenSanctionsDatasetFreshness) CheckIsUpToDate(tp TimeProvider) e
 	tickAfterLastUpdate, _ := gronx.NextTickAfter(dataset.Upstream.Schedule, dataset.LastExport, false)
 
 	if tickAfterLastUpdate.Add(OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY).Before(dataset.Upstream.LastExport) {
-		(*dataset).UpToDate = false
+		dataset.UpToDate = false
 		return nil
 	}
 
 	tickAfterLastChange, _ := gronx.NextTickAfter(dataset.Upstream.Schedule, dataset.Upstream.LastExport, false)
 
 	if tp().After(tickAfterLastChange.Add(OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY)) {
-		(*dataset).UpToDate = false
+		dataset.UpToDate = false
 		return nil
 	}
 
-	(*dataset).UpToDate = true
+	dataset.UpToDate = true
 
 	return nil
 }

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -174,7 +174,7 @@ func (repo OpenSanctionsRepository) GetLatestLocalDataset(ctx context.Context) (
 
 	dataset.Upstream = upstream
 	if err := dataset.CheckIsUpToDate(time.Now); err != nil {
-		return models.OpenSanctionsDatasetFreshness{}, nil
+		return models.OpenSanctionsDatasetFreshness{}, err
 	}
 
 	return dataset, nil


### PR DESCRIPTION
Before merging this, we need to understand tghe semantic behind `index_version`, should we say that we are up to date iof it is null or out of date?