### PR TITLE
chore(doc): Improve getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,50 +9,67 @@ This repo is the Marble backend implementation:
 
 ### Setup your environment
 
-[Install Go](https://go.dev/doc/install) on your laptop (see the version in go.mod).
+> **Disclaimer**
+>
+> This repository’s README file is intended for internal use by our development team. The documentation provided here is specifically designed for setting up and running the project on macOS.
+>
+> While external contributions and interest are appreciated, please note that we do not officially support setups on other operating systems. If you encounter issues outside of the macOS environment, support may be limited.
+> 
+> For general documentation and user-facing guides, please refer to our main repository: [Marble Documentation](https://github.com/checkmarble/marble/blob/main/README.md).
 
-> NB: To handle different versions, you can look at [Managing Go installations](https://go.dev/doc/manage-install) or use a version manager tool like [asdf](https://github.com/kennyp/asdf-golang)
+[Install mise-en-place](https://mise.jdx.dev/getting-started.html) or alternatively [install Go](https://go.dev/doc/install) manually on your laptop (see the version in go.mod).
 
-Create you own `.env` file based on `.env.example`. You can fill it with your own values but it should work locally with the default values (except for third-party services functionalities).
+Create your own `.env` file based on `.env.example`. You can customize it with your own values, but it should work locally with the default values (except for third-party service functionalities).
 
-#### Setup the DB
+#### Setup the Database and Services
 
-Launch the postgres DB used by the backend:
+Launch the Postgres DB and other services used by the backend:
 
 ```sh
 docker compose up -d
 ```
 
-> NB: it creates a `marble-backend_postgres-db` volume to store PG data.
+> NB: It creates a `marble-backend_postgres-db` volume to store PG data.
 
 #### Firebase emulator suite for local development
 
 Install the [Firebase tools](https://firebase.google.com/docs/emulator-suite):
 
 ```sh
-# Install the Firebase CLI using npm, since the curl script is broken (on 06/09/2024)
-npm install -g firebase-tools
+# Install the Firebase CLI
+curl -sL https://firebase.tools | bash
 
 # Check the version is at least 13.16.0
 firebase --version
+
+# Login to firebase cli
+firebase login
 ```
 
 Then copy the `./contrib/firebase-local-data.example` folder to `./firebase-local-data`. This folder will be used to store the local data of the Firebase emulator. It is ignored by git.
+```
+cp -r ./contrib/firebase-local-data.example ./firebase-local-data
+```
 
-Then start it using (replace `GOOGLE_CLOUD_PROJECT` with the value from your `.env` file):
+Then start it using (replace `[GOOGLE_CLOUD_PROJECT]` with the value from your `.env` file):
 
 ```sh
-firebase --project GOOGLE_CLOUD_PROJECT emulators:start --import=./firebase-local-data --export-on-exit
+firebase --project [GOOGLE_CLOUD_PROJECT] emulators:start --import=./firebase-local-data --export-on-exit
 ```
 
 > NB: The `--import` flag is used to import the local data into the emulator. The `--export-on-exit` flag is used to export the data when the emulator is stopped so you don't lose your changes.
 
 ### Launch the project
 
-Export your `.env` file and run the root of the project:
+Export your `.env` file (e.g. using [direnv](https://direnv.net/) or [mise](https://mise.jdx.dev/)) and run the root of the project:
 
 ```sh
 go run . --migrations --server
+```
+
+alternatively, using mise :
+```sh
+mise exec -- go run . --migrations --server
 ```
 
 > Using VSCode, you can also run the `Migrate and Launch (.env)` task in the "Run and debug" tab. This will load your env file, migrate the DB and start the server.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The application can be run with the following flags:
 
 ## API
 
-The rooting of the application is defined inside `api/routes.go`.
+The routing of the application is defined inside `api/routes.go`.
 
 For further information on the API, you can also refer to the following resources:
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,5 @@
+[tools]
+go = "1.24"
+
+[env]
+_.file = '.env'


### PR DESCRIPTION
- Start the database container only in `docker compose` command.
- Use the default firebase cli install script since it's now fixed.
- Propose the usage of [mise](https://mise.jdx.dev/) to ease the env vars export and create the its config file.
