### PR TITLE
fix: fix errors management for ast validation

### DIFF
--- a/api/handle_scenarios.go
+++ b/api/handle_scenarios.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
-	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
@@ -154,7 +153,7 @@ func validateScenarioAst(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, gin.H{
-			"ast_validation": ast.AdaptNodeEvaluationDto(astValidation),
+			"ast_validation": dto.AdaptAstValidationDto(astValidation),
 		})
 	}
 }

--- a/dto/ast_validation_dto.go
+++ b/dto/ast_validation_dto.go
@@ -1,0 +1,19 @@
+package dto
+
+import (
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
+)
+
+type AstValidationDto struct {
+	Errors     []ScenarioValidationErrorDto `json:"errors"`
+	Evaluation ast.NodeEvaluationDto        `json:"evaluation"`
+}
+
+func AdaptAstValidationDto(s models.AstValidation) AstValidationDto {
+	return AstValidationDto{
+		Errors:     pure_utils.Map(s.Errors, AdaptScenarioValidationErrorDto),
+		Evaluation: ast.AdaptNodeEvaluationDto(s.Evaluation),
+	}
+}

--- a/models/ast_validation.go
+++ b/models/ast_validation.go
@@ -1,0 +1,14 @@
+package models
+
+import "github.com/checkmarble/marble-backend/models/ast"
+
+type AstValidation struct {
+	Errors     []ScenarioValidationError
+	Evaluation ast.NodeEvaluation
+}
+
+func NewAstValidation() AstValidation {
+	return AstValidation{
+		Errors: make([]ScenarioValidationError, 0),
+	}
+}

--- a/models/scenario_validation.go
+++ b/models/scenario_validation.go
@@ -15,6 +15,7 @@ const (
 	// Ast output
 	FormulaMustReturnBoolean
 	FormulaMustReturnString
+	FormulaIncorrectReturnType
 	// Decision
 	ScoreThresholdMissing
 	ScoreThresholdsMismatch
@@ -35,6 +36,8 @@ func (e ScenarioValidationErrorCode) String() string {
 		return "FORMULA_MUST_RETURN_BOOLEAN"
 	case FormulaMustReturnString:
 		return "FORMULA_MUST_RETURN_STRING"
+	case FormulaIncorrectReturnType:
+		return "FORMULA_INCORRECT_RETURN_TYPE"
 	case ScoreThresholdMissing:
 		return "SCORE_THRESHOLD_MISSING"
 	case ScoreThresholdsMismatch:

--- a/usecases/scenario_usecase.go
+++ b/usecases/scenario_usecase.go
@@ -94,8 +94,14 @@ func (usecase *ScenarioUsecase) UpdateScenario(
 					return models.Scenario{}, err
 				}
 				if len(validation.Errors) > 0 || len(validation.Evaluation.FlattenErrors()) > 0 {
-					return models.Scenario{}, errors.Join(
-						validation.Evaluation.FlattenErrors()...)
+					errs := append(
+						validation.Evaluation.FlattenErrors(),
+						pure_utils.Map(
+							validation.Errors, func(err models.ScenarioValidationError) error {
+								return err.Error
+							})...,
+					)
+					return models.Scenario{}, errors.Join(errs...)
 				}
 			}
 
@@ -162,9 +168,9 @@ func (usecase *ScenarioUsecase) ValidateScenarioAst(ctx context.Context,
 		return validation, err
 	}
 
-	validation, err = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType...), nil
+	validation = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType...)
 
-	return validation, err
+	return validation, nil
 }
 
 func (usecase *ScenarioUsecase) CreateScenario(

--- a/usecases/scenario_usecase.go
+++ b/usecases/scenario_usecase.go
@@ -93,8 +93,9 @@ func (usecase *ScenarioUsecase) UpdateScenario(
 				if err != nil {
 					return models.Scenario{}, err
 				}
-				if len(validation.FlattenErrors()) > 0 {
-					return models.Scenario{}, errors.Join(validation.FlattenErrors()...)
+				if len(validation.Errors) > 0 || len(validation.Evaluation.FlattenErrors()) > 0 {
+					return models.Scenario{}, errors.Join(
+						validation.Evaluation.FlattenErrors()...)
 				}
 			}
 
@@ -150,7 +151,7 @@ func validateScenarioUpdate(scenario models.Scenario, input models.UpdateScenari
 
 func (usecase *ScenarioUsecase) ValidateScenarioAst(ctx context.Context,
 	scenarioId string, astNode *ast.Node, expectedReturnType ...string,
-) (validation ast.NodeEvaluation, err error) {
+) (validation models.AstValidation, err error) {
 	scenario, err := usecase.scenarioFetcher.FetchScenario(ctx,
 		usecase.executorFactory.NewExecutor(), scenarioId)
 	if err != nil {
@@ -161,7 +162,7 @@ func (usecase *ScenarioUsecase) ValidateScenarioAst(ctx context.Context,
 		return validation, err
 	}
 
-	validation, err = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType...)
+	validation, err = usecase.validateScenarioAst.Validate(ctx, scenario, astNode, expectedReturnType...), nil
 
 	return validation, err
 }


### PR DESCRIPTION
AST Validation was only return an evaluation and formula validation error were mixed with evaluation errors. Rework it to be like other validation processes (trigger, rules and sanction)

Frontend PR: https://github.com/checkmarble/marble-frontend/pull/746