### PR TITLE
Free-form sanctioned entity search + rule snoozing

### DIFF
--- a/api/handle_snoozes.go
+++ b/api/handle_snoozes.go
@@ -67,7 +67,7 @@ func handleSnoozeDecision(uc usecases.Usecases) func(c *gin.Context) {
 			Duration:       input.Duration,
 			OrganizationId: organizationId,
 			RuleId:         input.RuleId,
-			UserId:         userId,
+			UserId:         &userId,
 		})
 		if presentError(ctx, c, err) {
 			return

--- a/dto/rule_snoozes.go
+++ b/dto/rule_snoozes.go
@@ -11,7 +11,7 @@ type RuleSnooze struct {
 	PivotValue            string    `json:"pivot_value"`
 	StartsAt              time.Time `json:"starts_at"`
 	ExpiresAt             time.Time `json:"ends_at"` //nolint:tagliatelle
-	CreatedByUser         string    `json:"created_by_user"`
+	CreatedByUser         *string   `json:"created_by_user,omitempty"`
 	CreatedFromDecisionId *string   `json:"created_from_decision_id"`
 	CreatedFromRuleId     string    `json:"created_from_rule_id"`
 }

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -578,7 +578,7 @@ func createDecisions(
 		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on
 		OrganizationId: organizationId,
 		RuleId:         ruleId, // snooze a rule (nevermind which one)
-		UserId:         usecasesWithUserCreds.Credentials.ActorIdentity.UserId,
+		UserId:         utils.Ptr(usecasesWithUserCreds.Credentials.ActorIdentity.UserId),
 	})
 	if err != nil {
 		assert.FailNow(t, "Failed to snooze decision", err)

--- a/models/permission.go
+++ b/models/permission.go
@@ -56,6 +56,9 @@ const (
 	TAG_CREATE
 	TAG_UPDATE
 	TAG_DELETE
+	SANCTION_CHECK_WHITELIST_READ
+	SANCTION_CHECK_WHITELIST_WRITE
+	SANCTION_CHECK_FREEFORM_SEARCH
 )
 
 func (r Permission) String() (string, error) {
@@ -109,6 +112,9 @@ func (r Permission) String() (string, error) {
 		"TAG_CREATE",
 		"TAG_UPDATE",
 		"TAG_DELETE",
+		"SANCTION_CHECK_WHITELIST_READ",
+		"SANCTION_CHECK_WHITELIST_WRITE",
+		"SANCTION_CHECK_FREEFORM_SEARCH",
 	}
 	if int(r) > len(permissions)-1 {
 		return "", errors.New("Invalid permission: no string representation has been set")

--- a/models/role_permission.go
+++ b/models/role_permission.go
@@ -50,6 +50,10 @@ var ROLES_PERMISSIOMS = map[Role][]Permission{
 		PHANTOM_DECISION_CREATE, // Necessary because a permission check is embedded in the phantom decision usecase
 		INGESTION,
 		WEBHOOK_EVENT, // Necessary because a permission check is embedded in the webhooks events usecase
+		CASE_READ_WRITE,
+		SANCTION_CHECK_WHITELIST_READ,
+		SANCTION_CHECK_WHITELIST_WRITE,
+		SANCTION_CHECK_FREEFORM_SEARCH,
 	},
 	TRANSFER_CHECK_API_CLIENT: {
 		TRANSFER_READ,

--- a/models/role_permission.go
+++ b/models/role_permission.go
@@ -51,6 +51,8 @@ var ROLES_PERMISSIOMS = map[Role][]Permission{
 		INGESTION,
 		WEBHOOK_EVENT, // Necessary because a permission check is embedded in the webhooks events usecase
 		CASE_READ_WRITE,
+		READ_SNOOZES,
+		CREATE_SNOOZE,
 		SANCTION_CHECK_WHITELIST_READ,
 		SANCTION_CHECK_WHITELIST_WRITE,
 		SANCTION_CHECK_FREEFORM_SEARCH,

--- a/models/rule_snoozes.go
+++ b/models/rule_snoozes.go
@@ -11,7 +11,7 @@ type SnoozeGroup struct {
 type RuleSnooze struct {
 	Id                    string
 	OrganizationId        string
-	CreatedByUser         string
+	CreatedByUser         *string
 	CreatedFromDecisionId *string
 	CreatedFromRuleId     string
 	PivotValue            string
@@ -22,7 +22,7 @@ type RuleSnooze struct {
 
 type RuleSnoozeWithRuleId struct {
 	Id                    string
-	CreatedByUser         string
+	CreatedByUser         *string
 	CreatedFromDecisionId *string
 	CreatedFromRuleId     string
 	PivotValue            string
@@ -70,7 +70,7 @@ func NewSnoozesOfDecision(decisionId string, snoozes []RuleSnooze, iteration Sce
 
 type RuleSnoozeCreateInput struct {
 	Id                    string
-	CreatedByUserId       UserId
+	CreatedByUserId       *UserId
 	CreatedFromDecisionId string
 	CreatedFromRuleId     string
 	ExpiresAt             time.Time
@@ -95,13 +95,13 @@ type SnoozeDecisionInput struct {
 	Duration       string
 	OrganizationId string
 	RuleId         string
-	UserId         UserId
+	UserId         *UserId
 }
 
 type RuleSnoozeCaseEventInput struct {
 	CaseId         string
 	Comment        string
 	RuleSnoozeId   string
-	UserId         string
+	UserId         *string
 	WebhookEventId string
 }

--- a/pubapi/constants.go
+++ b/pubapi/constants.go
@@ -16,6 +16,7 @@ var (
 	ErrFeatureDisabled = errors.New("feature_disabled")
 	ErrNotConfigured   = errors.New("feature_not_configured")
 
+	ErrForbidden           = errors.New("forbidden")
 	ErrNotFound            = errors.New("not_found")
 	ErrInvalidPayload      = errors.New("invalid_payload")
 	ErrUnprocessableEntity = errors.New("unprocessable_entity")

--- a/pubapi/constants.go
+++ b/pubapi/constants.go
@@ -19,5 +19,6 @@ var (
 	ErrForbidden           = errors.New("forbidden")
 	ErrNotFound            = errors.New("not_found")
 	ErrInvalidPayload      = errors.New("invalid_payload")
+	ErrConflict            = errors.New("conflict")
 	ErrUnprocessableEntity = errors.New("unprocessable_entity")
 )

--- a/pubapi/response.go
+++ b/pubapi/response.go
@@ -97,6 +97,10 @@ func (resp baseErrorResponse) WithError(err error) baseErrorResponse {
 
 	default:
 		switch {
+		case errors.Is(err, models.ForbiddenError):
+			resp.Error.status = http.StatusForbidden
+			resp.Error.Code = ErrForbidden.Error()
+
 		case
 			errors.Is(err, models.NotFoundError),
 			errors.Is(err, pgx.ErrNoRows):

--- a/pubapi/response.go
+++ b/pubapi/response.go
@@ -108,6 +108,10 @@ func (resp baseErrorResponse) WithError(err error) baseErrorResponse {
 			resp.Error.status = http.StatusNotFound
 			resp.Error.Code = ErrNotFound.Error()
 
+		case errors.Is(err, models.ConflictError):
+			resp.Error.status = http.StatusConflict
+			resp.Error.Code = ErrConflict.Error()
+
 		case errors.Is(err, ErrFeatureDisabled):
 			resp.Error.status = http.StatusPaymentRequired
 			resp.Error.Code = ErrFeatureDisabled.Error()

--- a/pubapi/tests/specs/v1/v1.go
+++ b/pubapi/tests/specs/v1/v1.go
@@ -1,23 +1,12 @@
 package v1
 
 import (
-	"net/http"
 	"testing"
 
-	api "github.com/checkmarble/marble-backend/pubapi/v1"
 	"github.com/gavv/httpexpect/v2"
 )
 
 func PublicApiV1(t *testing.T, e *httpexpect.Expect) {
-	e.POST("/example").
-		WithJSON(api.ExamplePayload{
-			Age:    22,
-			Email:  "test@example.com",
-			IsNice: "true",
-		}).
-		Expect().
-		Status(http.StatusOK)
-
 	sanctionChecks(t, e)
 	whitelists(t, e)
 }

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -16,6 +16,8 @@ func Routes(r *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usec
 
 		r.POST("/example", handleExampleValidation)
 
+		r.POST("/decisions/:decisionId/snooze", HandleSnoozeRule(uc))
+
 		r.GET("/decisions/:decisionId/sanction-checks", HandleListSanctionChecks(uc))
 
 		r.POST("/sanction-checks/:sanctionCheckId/refine", HandleRefineSanctionCheck(uc, true))

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"net/http"
-
 	"github.com/checkmarble/marble-backend/pubapi"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/gin-gonic/gin"
@@ -14,10 +12,7 @@ func Routes(r *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usec
 	{
 		r := r.Group("/", authMiddleware)
 
-		r.POST("/example", handleExampleValidation)
-
 		r.POST("/decisions/:decisionId/snooze", HandleSnoozeRule(uc))
-
 		r.GET("/decisions/:decisionId/sanction-checks", HandleListSanctionChecks(uc))
 
 		r.POST("/sanction-checks/:sanctionCheckId/refine", HandleRefineSanctionCheck(uc, true))
@@ -35,22 +30,5 @@ func Routes(r *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usec
 }
 
 func handleVersion(c *gin.Context) {
-	pubapi.NewResponse(gin.H{"version": "v1a"}).Serve(c)
-}
-
-type ExamplePayload struct {
-	Age    int    `json:"age" binding:"required,gt=18"`
-	Email  string `json:"email" binding:"required,email"`
-	IsNice string `json:"is_nice" binding:"required,boolean"`
-}
-
-func handleExampleValidation(c *gin.Context) {
-	var payload ExamplePayload
-
-	if err := c.ShouldBindBodyWithJSON(&payload); err != nil {
-		pubapi.NewErrorResponse().WithError(err).Serve(c)
-		return
-	}
-
-	c.Status(http.StatusOK)
+	pubapi.NewResponse(gin.H{"version": "v1beta"}).Serve(c)
 }

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -20,6 +20,7 @@ func Routes(r *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usec
 
 		r.POST("/sanction-checks/:sanctionCheckId/refine", HandleRefineSanctionCheck(uc, true))
 		r.POST("/sanction-checks/:sanctionCheckId/search", HandleRefineSanctionCheck(uc, false))
+		r.POST("/sanction-checks/search", HandleSanctionFreeformSearch(uc))
 
 		r.GET("/sanction-checks/entities/:entityId", HandleGetSanctionCheckEntity(uc))
 		r.POST("/sanction-checks/matches/:matchId",

--- a/pubapi/v1/rule_snoozing.go
+++ b/pubapi/v1/rule_snoozing.go
@@ -1,0 +1,51 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/gin-gonic/gin"
+)
+
+type SnoozeRuleParams struct {
+	RuleId   string `json:"rule_id" binding:"required,uuid"`
+	Duration string `json:"duration" binding:"required"`
+}
+
+func HandleSnoozeRule(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		decisionId, err := pubapi.UuidParam(c, "decisionId")
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		var params SnoozeRuleParams
+
+		if err := c.ShouldBindBodyWithJSON(&params); err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		creds, _ := utils.CredentialsFromCtx(c.Request.Context())
+		uc := pubapi.UsecasesWithCreds(c.Request.Context(), uc)
+		ruleSnoozeUsecase := uc.NewRuleSnoozeUsecase()
+
+		snooze := models.SnoozeDecisionInput{
+			OrganizationId: creds.OrganizationId,
+			DecisionId:     decisionId.String(),
+			RuleId:         params.RuleId,
+			Duration:       params.Duration,
+		}
+
+		if _, err = ruleSnoozeUsecase.SnoozeDecision(c.Request.Context(), snooze); err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		c.Status(http.StatusCreated)
+	}
+}

--- a/pubapi/v1/rule_snoozing.go
+++ b/pubapi/v1/rule_snoozing.go
@@ -17,6 +17,12 @@ type SnoozeRuleParams struct {
 
 func HandleSnoozeRule(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
 		decisionId, err := pubapi.UuidParam(c, "decisionId")
 		if err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
@@ -30,12 +36,11 @@ func HandleSnoozeRule(uc usecases.Usecases) gin.HandlerFunc {
 			return
 		}
 
-		creds, _ := utils.CredentialsFromCtx(c.Request.Context())
 		uc := pubapi.UsecasesWithCreds(c.Request.Context(), uc)
 		ruleSnoozeUsecase := uc.NewRuleSnoozeUsecase()
 
 		snooze := models.SnoozeDecisionInput{
-			OrganizationId: creds.OrganizationId,
+			OrganizationId: orgId,
 			DecisionId:     decisionId.String(),
 			RuleId:         params.RuleId,
 			Duration:       params.Duration,

--- a/pubapi/v1/rule_snoozing.go
+++ b/pubapi/v1/rule_snoozing.go
@@ -41,7 +41,7 @@ func HandleSnoozeRule(uc usecases.Usecases) gin.HandlerFunc {
 			Duration:       params.Duration,
 		}
 
-		if _, err = ruleSnoozeUsecase.SnoozeDecision(c.Request.Context(), snooze); err != nil {
+		if _, err = ruleSnoozeUsecase.SnoozeDecisionWithoutCase(c.Request.Context(), snooze); err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
 			return
 		}

--- a/pubapi/v1/sanction_checks.go
+++ b/pubapi/v1/sanction_checks.go
@@ -159,6 +159,12 @@ func HandleRefineSanctionCheck(uc usecases.Usecases, write bool) gin.HandlerFunc
 
 func HandleSanctionFreeformSearch(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
 		var params gdto.RefineQueryDto
 
 		if err := c.ShouldBindBodyWithJSON(&params); err != nil {
@@ -174,7 +180,6 @@ func HandleSanctionFreeformSearch(uc usecases.Usecases) gin.HandlerFunc {
 		}
 
 		uc := pubapi.UsecasesWithCreds(c.Request.Context(), uc)
-		creds, _ := utils.CredentialsFromCtx(c.Request.Context())
 		sanctionCheckUsecase := uc.NewSanctionCheckUsecase()
 
 		refineQuery := models.SanctionCheckRefineRequest{
@@ -183,7 +188,7 @@ func HandleSanctionFreeformSearch(uc usecases.Usecases) gin.HandlerFunc {
 		}
 
 		sanctionCheck, err := sanctionCheckUsecase.FreeformSearch(c.Request.Context(),
-			creds.OrganizationId, models.SanctionCheckConfig{}, refineQuery)
+			orgId, models.SanctionCheckConfig{}, refineQuery)
 		if err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
 			return
@@ -225,7 +230,11 @@ type AddWhitelistParams struct {
 func HandleAddWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		creds, _ := utils.CredentialsFromCtx(ctx)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
 
 		var params AddWhitelistParams
 
@@ -237,7 +246,7 @@ func HandleAddWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 		uc := pubapi.UsecasesWithCreds(ctx, uc)
 		sanctionCheckUsecase := uc.NewSanctionCheckUsecase()
 
-		if err := sanctionCheckUsecase.CreateWhitelist(ctx, nil, creds.OrganizationId,
+		if err := sanctionCheckUsecase.CreateWhitelist(ctx, nil, orgId,
 			params.Counterparty, params.EntityId, nil); err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
 			return
@@ -255,7 +264,11 @@ type DeleteWhitelistParams struct {
 func HandleDeleteWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		creds, _ := utils.CredentialsFromCtx(ctx)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
 
 		var params DeleteWhitelistParams
 
@@ -267,7 +280,7 @@ func HandleDeleteWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 		uc := pubapi.UsecasesWithCreds(ctx, uc)
 		sanctionCheckUsecase := uc.NewSanctionCheckUsecase()
 
-		if err := sanctionCheckUsecase.DeleteWhitelist(ctx, nil, creds.OrganizationId,
+		if err := sanctionCheckUsecase.DeleteWhitelist(ctx, nil, orgId,
 			params.Counterparty, params.EntityId, nil); err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
 			return
@@ -285,7 +298,11 @@ type SearchWhitelistParams struct {
 func HandleSearchWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
-		creds, _ := utils.CredentialsFromCtx(ctx)
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			pubapi.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
 
 		var params SearchWhitelistParams
 
@@ -306,7 +323,7 @@ func HandleSearchWhitelist(uc usecases.Usecases) gin.HandlerFunc {
 		sanctionCheckUsecase := uc.NewSanctionCheckUsecase()
 
 		whitelists, err := sanctionCheckUsecase.SearchWhitelist(ctx, nil,
-			creds.OrganizationId, params.Counterparty, params.EntityId, nil)
+			orgId, params.Counterparty, params.EntityId, nil)
 		if err != nil {
 			pubapi.NewErrorResponse().WithError(err).Serve(c)
 			return

--- a/pubapi/validator.go
+++ b/pubapi/validator.go
@@ -71,6 +71,8 @@ func AdaptFieldValidationError(fe validator.FieldError) string {
 				strings.ReplaceAll(fe.Param(), " ", ", "))
 		case "excluded_unless":
 			return fmt.Sprintf("cannot be provided unless %s", fe.Param())
+		case "uuid":
+			return "should be a UUID"
 		}
 
 		return "is invalid"

--- a/repositories/dbmodels/db_rule_snooze.go
+++ b/repositories/dbmodels/db_rule_snooze.go
@@ -31,7 +31,7 @@ var SelectRuleSnoozesColumn = utils.ColumnList[DBRuleSnooze]()
 
 type DBRuleSnooze struct {
 	Id                    string    `db:"id"`
-	CreatedByUser         string    `db:"created_by_user"`
+	CreatedByUser         *string   `db:"created_by_user"`
 	CreatedFromDecisionId *string   `db:"created_from_decision_id"`
 	CreatedFromRuleId     string    `db:"created_from_rule_id"`
 	SnoozeGroupId         string    `db:"snooze_group_id"`

--- a/repositories/migrations/20250321221500_set_snooze_user_nullable.sql
+++ b/repositories/migrations/20250321221500_set_snooze_user_nullable.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+alter table rule_snoozes
+    alter column created_by_user drop not null;
+
+-- +goose Down
+
+alter table rule_snoozes
+    alter column created_by_user set not null;

--- a/specs/v1_public_api.yaml
+++ b/specs/v1_public_api.yaml
@@ -10,9 +10,58 @@ x-readme:
 servers:
   - url: "https://api.checkmarble.com/v1beta"
 tags:
+  - name: Decisions
+    description: Routes for decisions
   - name: Sanction Checks
     description: Routes for sanction checks
 paths:
+  /decisions/{decisionId}/snooze:
+    post:
+      operationId: snoozeRule
+      tags: ["Decisions"]
+      security:
+        - BearerTokenAuth: []
+        - ApiKeyAuth: []
+      summary: Snooze a rule
+      description: |
+        Snooze a rule for a pivot value.
+
+        Snooze a rule for the provided duration, for the pivot value the decision pertains to. The given decision must be part of a case for its rules to be snoozed.
+      parameters:
+        - name: decisionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ["rule_id", "duration"]
+              properties:
+                rule_id:
+                  type: string
+                  format: uuid
+                duration:
+                  description: |
+                    Duration for which the snooze will take effect.
+
+                    Must use Go's [`time.ParseDuration`](https://pkg.go.dev/time#example-ParseDuration) syntax (e.g. "1h", "10h30m", etc.).
+
+                    Maximum value is 180 days ("4320h").
+                  type: string
+                  format: duration
+      responses:
+        201:
+          description: Rule was successfully snoozed
+
+        400: { $ref: '#/components/responses/400' }
+        404: { $ref: '#/components/responses/404' }
+        409: { $ref: '#/components/responses/409' }
+        422: { $ref: '#/components/responses/422'}
+
   /decisions/{decisionId}/sanction-checks:
     get:
       operationId: getSanctionChecksForDecision
@@ -373,6 +422,13 @@ components:
     
     '404':
       description: The requested resource does not exist
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    
+    '409':
+      description: The resource being created conflicts with an existing resource
       content:
         application/json:
           schema:

--- a/specs/v1_public_api.yaml
+++ b/specs/v1_public_api.yaml
@@ -165,6 +165,37 @@ paths:
         400: { $ref: '#/components/responses/400' }
         404: { $ref: '#/components/responses/404' }
 
+  /sanction-checks/search:
+    post:
+      operationId: searchSanctionCheck
+      tags: ["Sanction Checks"]
+      security:
+        - BearerTokenAuth: []
+        - ApiKeyAuth: []
+      summary: Perform a free-form sanction search
+      description: Search for sanctioned entities outside of the context of a decision.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SanctionCheckSearchQuery"
+      responses:
+        200:
+          description: Sanction check results from the search
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/BaseResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/SanctionCheckMatchPayload'
+
+        400: { $ref: '#/components/responses/400' }
+
   /sanction-checks/matches/{matchId}:
     post:
       operationId: reviewSanctionCheckMatch

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -1109,15 +1109,17 @@ func (usecase *CaseUseCase) CreateRuleSnoozeEvent(ctx context.Context, tx reposi
 		return err
 	}
 
-	if err := usecase.createCaseContributorIfNotExist(ctx, tx, input.CaseId, input.UserId); err != nil {
-		return err
+	if input.UserId != nil {
+		if err := usecase.createCaseContributorIfNotExist(ctx, tx, input.CaseId, *input.UserId); err != nil {
+			return err
+		}
 	}
 
 	resourceType := models.RuleSnoozeResourceType
 	err = usecase.repository.CreateCaseEvent(ctx, tx, models.CreateCaseEventAttributes{
 		AdditionalNote: &input.Comment,
 		CaseId:         input.CaseId,
-		UserId:         &input.UserId,
+		UserId:         input.UserId,
 		EventType:      models.CaseRuleSnoozeCreated,
 		ResourceType:   &resourceType,
 		ResourceId:     &input.RuleSnoozeId,

--- a/usecases/rule_snoozes.go
+++ b/usecases/rule_snoozes.go
@@ -293,8 +293,9 @@ func (usecase RuleSnoozeUsecase) SnoozeDecision(
 			return usecase.ruleSnoozeRepository.ListActiveRuleSnoozesForDecision(ctx, tx, snoozeGroupIds, *decision.PivotValue)
 		},
 	)
-
-	// TODO: do we really ignore errors here?
+	if err != nil {
+		return models.SnoozesOfDecision{}, errors.Wrap(err, "could not persist decision snooze")
+	}
 
 	usecase.webhooksSender.SendWebhookEventAsync(ctx, webhookEventId)
 

--- a/usecases/sanction_check_usecase.go
+++ b/usecases/sanction_check_usecase.go
@@ -354,6 +354,25 @@ func (uc SanctionCheckUsecase) Search(ctx context.Context, refine models.Sanctio
 	return sanctionCheck, nil
 }
 
+func (uc SanctionCheckUsecase) FreeformSearch(ctx context.Context,
+	orgId string,
+	scc models.SanctionCheckConfig,
+	refine models.SanctionCheckRefineRequest,
+) (models.SanctionCheckWithMatches, error) {
+	query := models.OpenSanctionsQuery{
+		IsRefinement: false,
+		Config:       scc,
+		Queries:      models.AdaptRefineRequestToMatchable(refine),
+	}
+
+	sanctionCheck, err := uc.Execute(ctx, orgId, query)
+	if err != nil {
+		return models.SanctionCheckWithMatches{}, err
+	}
+
+	return sanctionCheck, nil
+}
+
 func (uc SanctionCheckUsecase) FilterOutWhitelistedMatches(ctx context.Context, orgId string,
 	sanctionCheck models.SanctionCheckWithMatches, counterpartyId string,
 ) (models.SanctionCheckWithMatches, error) {

--- a/usecases/security/enforce_security_sanction_checks.go
+++ b/usecases/security/enforce_security_sanction_checks.go
@@ -1,0 +1,27 @@
+package security
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+type EnforceSecuritySanctionCheck interface {
+	EnforceSecurity
+
+	ReadWhitelist(ctx context.Context) error
+	WriteWhitelist(ctx context.Context) error
+	PerformFreeformSearch(ctx context.Context) error
+}
+
+func (e *EnforceSecurityImpl) ReadWhitelist(ctx context.Context) error {
+	return e.Permission(models.SANCTION_CHECK_WHITELIST_READ)
+}
+
+func (e *EnforceSecurityImpl) WriteWhitelist(ctx context.Context) error {
+	return e.Permission(models.SANCTION_CHECK_WHITELIST_WRITE)
+}
+
+func (e *EnforceSecurityImpl) PerformFreeformSearch(ctx context.Context) error {
+	return e.Permission(models.SANCTION_CHECK_FREEFORM_SEARCH)
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -94,6 +94,12 @@ func (usecases *UsecasesWithCreds) NewEnforceTagSecurity() security.EnforceSecur
 	}
 }
 
+func (usecases *UsecasesWithCreds) NewEnforceSanctionCheckSecurity() security.EnforceSecuritySanctionCheck {
+	return &security.EnforceSecurityImpl{
+		Credentials: usecases.Credentials,
+	}
+}
+
 func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 	return DecisionUsecase{
 		enforceSecurity:           usecases.NewEnforceDecisionSecurity(),
@@ -147,6 +153,7 @@ func (usecases *UsecasesWithCreds) NewSanctionCheckUsecase() SanctionCheckUsecas
 		enforceSecurityScenario:       usecases.NewEnforceScenarioSecurity(),
 		enforceSecurityDecision:       usecases.NewEnforceDecisionSecurity(),
 		enforceSecurityCase:           usecases.NewEnforceCaseSecurity(),
+		enforceSecurity:               usecases.NewEnforceSanctionCheckSecurity(),
 		externalRepository:            &usecases.Repositories.MarbleDbRepository,
 		organizationRepository:        usecases.Repositories.OrganizationRepository,
 		inboxReader:                   utils.Ptr(usecases.NewInboxReader()),


### PR DESCRIPTION
This PR adds an endpoint to the public API to perform context-less, free-form searches for sanctioned entities. The first version does not allow for any configuration.