### PR TITLE
Fix memory leak in match enrichment

### DIFF
--- a/repositories/name_recognition_repository.go
+++ b/repositories/name_recognition_repository.go
@@ -60,11 +60,12 @@ func (repo NameRecognitionRepository) PerformNameRecognition(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
+
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return nil, errors.New(fmt.Sprintf("status code %d", resp.StatusCode))
 	}
-
-	defer resp.Body.Close()
 
 	var payload []NameRecognitionMatch
 

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -195,14 +195,14 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, query models.Ope
 			errors.Wrap(err, "could not perform sanction check")
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		return models.SanctionRawSearchResponseWithMatches{}, fmt.Errorf(
 			"sanction check API returned status %d", resp.StatusCode)
 	}
 
 	var matches httpmodels.HTTPOpenSanctionsResult
-
-	defer resp.Body.Close()
 
 	if err := json.NewDecoder(resp.Body).Decode(&matches); err != nil {
 		return models.SanctionRawSearchResponseWithMatches{}, errors.Wrap(err,
@@ -243,6 +243,8 @@ func (repo OpenSanctionsRepository) EnrichMatch(ctx context.Context, match model
 			errors.Wrap(err, "could not enrich sanction check match")
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, errors.WithDetail(models.NotFoundError, "an entity with this ID was not found")
@@ -251,8 +253,6 @@ func (repo OpenSanctionsRepository) EnrichMatch(ctx context.Context, match model
 		return nil, fmt.Errorf(
 			"sanction check API returned status %d on enrichment", resp.StatusCode)
 	}
-
-	defer resp.Body.Close()
 
 	var newMatch json.RawMessage
 

--- a/usecases/scheduled_execution/index_creation_job.go
+++ b/usecases/scheduled_execution/index_creation_job.go
@@ -2,7 +2,6 @@ package scheduled_execution
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
@@ -109,8 +108,6 @@ func (w *IndexCreationStatusWorker) Work(ctx context.Context, job *river.Job[mod
 	// if we find all of them, it means the process successfully finished.
 	for _, index := range validIndices {
 		if slices.ContainsFunc(job.Args.Indices, func(i models.ConcreteIndex) bool {
-			n := i.Name()
-			fmt.Println("n", n)
 			return i.TableName == index.TableName &&
 				i.Name() == index.Name()
 		}) {

--- a/usecases/scheduled_execution/match_enrichment_job.go
+++ b/usecases/scheduled_execution/match_enrichment_job.go
@@ -6,9 +6,15 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/riverqueue/river"
 )
+
+type OpenSanctionsProvider interface {
+	IsConfigured(context.Context) (bool, error)
+	IsSelfHosted(context.Context) bool
+}
 
 type SanctionCheckRepository interface {
 	GetSanctionCheck(ctx context.Context, exec repositories.Executor, id string) (models.SanctionCheckWithMatches, error)
@@ -22,23 +28,37 @@ type MatchEnrichmentWorker struct {
 	river.WorkerDefaults[models.MatchEnrichmentArgs]
 
 	executorFactory      executor_factory.ExecutorFactory
+	openSanctionsConfig  OpenSanctionsProvider
 	sanctionCheckUsecase SanctionCheckUsecase
 	repository           SanctionCheckRepository
 }
 
 func NewMatchEnrichmentWorker(
 	executorFactory executor_factory.ExecutorFactory,
+	openSanctionsProvider OpenSanctionsProvider,
 	sanctionCheckUsecase SanctionCheckUsecase,
 	repository SanctionCheckRepository,
 ) MatchEnrichmentWorker {
 	return MatchEnrichmentWorker{
 		executorFactory:      executorFactory,
+		openSanctionsConfig:  openSanctionsProvider,
 		sanctionCheckUsecase: sanctionCheckUsecase,
 		repository:           repository,
 	}
 }
 
 func (w *MatchEnrichmentWorker) Work(ctx context.Context, job *river.Job[models.MatchEnrichmentArgs]) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	if ok, err := w.openSanctionsConfig.IsConfigured(ctx); err != nil || !ok {
+		logger.WarnContext(ctx, "MatchEnrichmentWorker: Open Sanctions provider not configured, aborting...")
+		return nil
+	}
+	if !w.openSanctionsConfig.IsSelfHosted(ctx) {
+		logger.WarnContext(ctx, "MatchEnrichmentWorker: Open Sanctions provider is not self-hosted, aborting...")
+		return nil
+	}
+
 	var errs error
 
 	scc, err := w.repository.GetSanctionCheck(ctx, w.executorFactory.NewExecutor(), job.Args.SanctionCheckId)

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -556,6 +556,7 @@ func (usecases UsecasesWithCreds) NewTestRunSummaryWorker() *scheduled_execution
 func (usecases UsecasesWithCreds) NewMatchEnrichmentWorker() *scheduled_execution.MatchEnrichmentWorker {
 	w := scheduled_execution.NewMatchEnrichmentWorker(
 		usecases.NewExecutorFactory(),
+		usecases.Usecases.Repositories.OpenSanctionsRepository,
 		usecases.NewSanctionCheckUsecase(),
 		&usecases.Repositories.MarbleDbRepository,
 	)


### PR DESCRIPTION
Two issues surfaced in the match enrichment job:
* It would still run if the server was properly configured with self-hosted Yente, but not the worker. We want to short-circuit execution in the worker in those cases.
* If the enrichment process had a response from OS but a failing status code, the unclosed body would cause a memory leak.