### PR TITLE
fix: list of allowed webhook events was not consistent

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -46,6 +46,8 @@ var validWebhookEventTypes = []WebhookEventType{
 	WebhookEventType_CaseCommentCreated,
 	WebhookEventType_CaseFileCreated,
 	WebhookEventType_DecisionCreated,
+	WebhookEventType_CaseRuleSnoozeCreated,
+	WebhookEventType_CaseDecisionReviewed,
 }
 
 type WebhookEventContent struct {


### PR DESCRIPTION
Bug notified by Gemba, updating the list of event types that should be dispatched was broken because of the mismatch in allowed values.

Problem: it seems that in a recent (?) version of convoy, the "Advanced Webhook Subscription" feature has been moved behind the paywall: https://www.getconvoy.io/pricing.
No big issue for our managed instance as I'm happy to pay for the license and let them apply restrictions on open source, but I'm a bit unhappy that this breaking change breaks some functionality for our self-hosted end users.
I'll add a warning on the UI to explain the option is limited to paying convoy users.