### PR TITLE
Add migrations_run boolean to signup status.

### DIFF
--- a/api/handle_signup_status.go
+++ b/api/handle_signup_status.go
@@ -15,17 +15,18 @@ func handleSignupStatus(uc usecases.Usecases) func(c *gin.Context) {
 			uc.Repositories.UserRepository,
 		)
 
-		hasAnOrganization, err := signupUc.HasAnOrganization(ctx)
+		migrationsRunForOrgs, hasAnOrganization, err := signupUc.HasAnOrganization(ctx)
 		if presentError(ctx, c, err) {
 			return
 		}
 
-		hasAUser, err := signupUc.HasAUser(ctx)
+		migrationsRunForUsers, hasAUser, err := signupUc.HasAUser(ctx)
 		if presentError(ctx, c, err) {
 			return
 		}
 
 		c.JSON(http.StatusOK, gin.H{
+			"migrations_run":      migrationsRunForOrgs && migrationsRunForUsers,
 			"has_an_organization": hasAnOrganization,
 			"has_a_user":          hasAUser,
 		})

--- a/usecases/signup_usecase.go
+++ b/usecases/signup_usecase.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type SignupUsecase struct {
@@ -25,22 +28,43 @@ func NewSignupUsecase(
 	}
 }
 
-func (uc *SignupUsecase) HasAnOrganization(ctx context.Context) (bool, error) {
+func (uc *SignupUsecase) HasAnOrganization(ctx context.Context) (bool, bool, error) {
 	exec := uc.executorFactory.NewExecutor()
 
 	exists, err := uc.organizationRepository.HasOrganizations(ctx, exec)
-	if err != nil {
-		return false, err
+	if !uc.haveMigrationsRun(err) {
+		return false, false, nil
 	}
-	return exists, nil
+	if err != nil {
+		return false, false, err
+	}
+
+	return true, exists, nil
 }
 
-func (uc *SignupUsecase) HasAUser(ctx context.Context) (bool, error) {
+func (uc *SignupUsecase) HasAUser(ctx context.Context) (bool, bool, error) {
 	exec := uc.executorFactory.NewExecutor()
 
 	exists, err := uc.usersRepository.HasUsers(ctx, exec)
-	if err != nil {
-		return false, err
+	if !uc.haveMigrationsRun(err) {
+		return false, false, nil
 	}
-	return exists, nil
+	if err != nil {
+		return false, false, err
+	}
+
+	return true, exists, nil
+}
+
+func (uc *SignupUsecase) haveMigrationsRun(err error) bool {
+	if err == nil {
+		return true
+	}
+
+	var pgerr *pgconn.PgError
+
+	if errors.As(err, &pgerr) {
+		return pgerr.Code != pgerrcode.UndefinedTable
+	}
+	return true
 }


### PR DESCRIPTION
This would be false if the orgs or users table do not exist, maybe indicating that migrations have not been run properly.

Ultimately, we could also maybe actually check if all migrations were applied, including after upgrades.