### PR TITLE
better log on recovered panic

### DIFF
--- a/jobs/middlewares.go
+++ b/jobs/middlewares.go
@@ -89,11 +89,7 @@ func NewLoggerMiddleware(l *slog.Logger) LoggerMiddleware {
 type RecovererMiddleware struct{}
 
 func (m RecovererMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) (err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = fmt.Errorf("panic: %v", r)
-		}
-	}()
+	defer utils.RecoverAndReportSentryError(ctx, "RecoveredMiddleware.Work")
 	return doInner(ctx)
 }
 

--- a/repositories/organization_repository.go
+++ b/repositories/organization_repository.go
@@ -105,21 +105,28 @@ func (repo *OrganizationRepositoryPostgresql) UpdateOrganization(ctx context.Con
 	}
 
 	updateRequest := NewQueryBuilder().Update(dbmodels.TABLE_ORGANIZATION)
+	hasUpdates := false
 
 	if updateOrganization.DefaultScenarioTimezone != nil {
 		updateRequest = updateRequest.Set(
 			"default_scenario_timezone",
 			*updateOrganization.DefaultScenarioTimezone)
+		hasUpdates = true
 	}
 	if updateOrganization.SanctionCheckConfig.MatchThreshold != nil {
 		updateRequest = updateRequest.Set("sanctions_threshold",
 			*updateOrganization.SanctionCheckConfig.MatchThreshold)
+		hasUpdates = true
 	}
 	if updateOrganization.SanctionCheckConfig.MatchLimit != nil {
 		updateRequest = updateRequest.Set("sanctions_limit",
 			*updateOrganization.SanctionCheckConfig.MatchLimit)
+		hasUpdates = true
 	}
 
+	if !hasUpdates {
+		return nil
+	}
 	updateRequest = updateRequest.Where("id = ?", updateOrganization.Id)
 
 	err := ExecBuilder(ctx, exec, updateRequest)

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -694,12 +694,7 @@ func (usecase *DecisionUsecase) executeTestRun(
 	scenario models.Scenario,
 	scenarioExecution *models.ScenarioExecution,
 ) {
-	defer func() {
-		if r := recover(); r != nil {
-			err := fmt.Errorf("error when creating phantom decisions with scenario id: %v", r)
-			utils.LogAndReportSentryError(ctx, err)
-		}
-	}()
+	defer utils.RecoverAndReportSentryError(ctx, "executeTestRun")
 	phantomInput := models.CreatePhantomDecisionInput{
 		OrganizationId:     organizationId,
 		Scenario:           scenario,

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -261,8 +261,8 @@ func (e ScenarioEvaluator) EvalTestRunScenario(
 	///////////////////////////////
 	defer func() {
 		if r := recover(); r != nil {
-			logger.ErrorContext(ctx, "recovered from panic during Eval. stacktrace from panic: ")
-			logger.ErrorContext(ctx, string(debug.Stack()))
+			logger.ErrorContext(ctx, "recovered from panic during EvalTestRunScenario. stacktrace from panic:")
+			utils.LogAndReportSentryError(ctx, errors.New(string(debug.Stack())))
 
 			err = models.ErrPanicInScenarioEvalution
 			se = models.ScenarioExecution{}
@@ -341,8 +341,8 @@ func (e ScenarioEvaluator) EvalScenario(
 	///////////////////////////////
 	defer func() {
 		if r := recover(); r != nil {
-			logger.ErrorContext(ctx, "recovered from panic during Eval. stacktrace from panic: ")
-			logger.ErrorContext(ctx, string(debug.Stack()))
+			logger.ErrorContext(ctx, "recovered from panic during EvalScenario. stacktrace from panic:")
+			utils.LogAndReportSentryError(ctx, errors.New(string(debug.Stack())))
 
 			err = models.ErrPanicInScenarioEvalution
 			se = models.ScenarioExecution{}

--- a/usecases/scheduled_execution/run_scheduled_execution.go
+++ b/usecases/scheduled_execution/run_scheduled_execution.go
@@ -104,12 +104,8 @@ func (usecase *RunScheduledExecution) ExecuteAllScheduledScenarios(ctx context.C
 	executionErrorChan := make(chan error, len(pendingScheduledExecutions))
 
 	startScheduledExecution := func(scheduledExecution models.ScheduledExecution) {
-		defer func() {
-			if r := recover(); r != nil {
-				err := fmt.Errorf("panic in ExecuteAllScheduledScenarios: %v", r)
-				utils.LogAndReportSentryError(ctx, err)
-			}
-		}()
+		defer utils.RecoverAndReportSentryError(ctx, "ExecuteAllScheduledScenarios")
+
 		defer waitGroup.Done()
 		ctx = utils.StoreLoggerInContext(
 			ctx,

--- a/utils/sentry.go
+++ b/utils/sentry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/getsentry/sentry-go"
 )
@@ -22,5 +23,13 @@ func LogAndReportSentryError(ctx context.Context, err error) {
 		hub.CaptureException(err)
 	} else {
 		sentry.CaptureException(err)
+	}
+}
+
+func RecoverAndReportSentryError(ctx context.Context, callerName string) {
+	if r := recover(); r != nil {
+		logger := LoggerFromContext(ctx)
+		logger.ErrorContext(ctx, fmt.Sprintf("Recovered from panic in %s", callerName))
+		LogAndReportSentryError(ctx, errors.New(string(debug.Stack())))
 	}
 }


### PR DESCRIPTION
Better log when a panic is recovered.
See for instance
[slack](https://checkmarble.slack.com/archives/C063SMVJ4BY/p1743689992837139)
[sentry](https://checkmarble.sentry.io/issues/6505381706/?project=4506439156236288&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0)


Also fixes this sentry issue https://checkmarble.sentry.io/issues/6425972939/?project=4506439156236288&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1