### PR TITLE
fix error where unnecessary indexes were being created

### DIFF
--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -30,10 +30,10 @@ import (
 )
 
 const (
-	testDbLifetime   = 120 // seconds
-	testUser         = "postgres"
+	testDbLifetime   = 120     // seconds
+	testUser         = "admin" // Nb: not using the default "postgres" on purpose, to verify the migrations run even with a different user
 	testPassword     = "pwd"
-	testDbName       = "marble"
+	testDbName       = "marble_db" // Nb: not using the default "marble" on purpose, to verify the migrations run even with a different db name
 	marbleAdminEmail = "test@admin.com"
 )
 

--- a/models/concrete_index_test.go
+++ b/models/concrete_index_test.go
@@ -174,4 +174,24 @@ func TestCovers(t *testing.T) {
 
 		asserts.True(idx.Covers(family), "The index is an instance of the family")
 	})
+
+	t.Run("'Included' columns from index family can also just be in the index - 1", func(t *testing.T) {
+		asserts := assert.New(t)
+		family := NewIndexFamily()
+		family.TableName = "table"
+		family.Flex.InsertSlice([]string{"a", "b", "c"})
+		family.Included.InsertSlice([]string{"d"})
+
+		asserts.True(idx.Covers(family), "The index is an instance of the family")
+	})
+
+	t.Run("'Included' columns from index family can also just be in the index - 2", func(t *testing.T) {
+		asserts := assert.New(t)
+		family := NewIndexFamily()
+		family.TableName = "table"
+		family.Fixed = []string{"a", "b", "c"}
+		family.Included.InsertSlice([]string{"d"})
+
+		asserts.True(idx.Covers(family), "The index is an instance of the family")
+	})
 }

--- a/repositories/ingested_data_indexes_repository.go
+++ b/repositories/ingested_data_indexes_repository.go
@@ -240,6 +240,8 @@ func asynchronouslyCreateIndexes(
 	}
 }
 
+// ⚠️ ⚠️ WARNING ⚠️ ⚠️ : if we change how we create indexes (including, but not only, if we every allow to create indexes on something else than table columns),
+// We need to review the index parsing logic in repositories/pg_indexes.go.
 func createIndexSQL(ctx context.Context, exec Executor, index models.ConcreteIndex) error {
 	logger := utils.LoggerFromContext(ctx)
 	qualifiedTableName := pgIdentifierWithSchema(exec, index.TableName)

--- a/repositories/migrations/20240124111516_create_analytics_schema.sql
+++ b/repositories/migrations/20240124111516_create_analytics_schema.sql
@@ -3,7 +3,11 @@
 -- create the analytics schema and an analytics user
 CREATE SCHEMA IF NOT EXISTS analytics;
 
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO postgres;
+do $$
+begin
+   execute 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO ' || current_user;
+end
+$$;
 
 DO $$ BEGIN
       CREATE USER analytics;

--- a/repositories/migrations/20241105143100_drop_analytics_schema.sql
+++ b/repositories/migrations/20241105143100_drop_analytics_schema.sql
@@ -9,7 +9,11 @@ DROP USER IF EXISTS analytics;
 -- +goose StatementBegin
 CREATE SCHEMA IF NOT EXISTS analytics;
 
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO postgres;
+do $$
+begin
+   execute 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA analytics TO ' || current_user;
+end
+$$;
 
 DO $$ BEGIN
       CREATE USER analytics;

--- a/repositories/pg_indexes/pg_indexes.go
+++ b/repositories/pg_indexes/pg_indexes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
-var columnNamesRegex = regexp.MustCompile(`(\([a-zA-Z0-9,_\ ]+\))`)
+var columnNamesRegex = regexp.MustCompile(`(\([\"a-zA-Z0-9,_\ ]+\))`)
 
 type PGIndex struct {
 	CreationInProgress bool
@@ -33,9 +33,9 @@ func parseCreateIndexStatement(sql string) models.ConcreteIndex {
 	indexedColumnsRaw := strings.Split(strings.Trim(matches[0], "() "), ",")
 	indexedColumnNames := pure_utils.Map(indexedColumnsRaw, func(s string) string {
 		// We discard the order of the index (ASC/DESC) because this is not relevant or modelized (yet) for our purposes
-		parts := strings.Split(strings.Trim(s, " "), " ")
+		colName, _, _ := strings.Cut(s, " DESC")
 		// the first part of the string must be the column name
-		return parts[0]
+		return strings.Trim(colName, " \"")
 	})
 
 	var includedColumnNames []string
@@ -43,7 +43,7 @@ func parseCreateIndexStatement(sql string) models.ConcreteIndex {
 	if len(matches) > 1 {
 		names := strings.Split(strings.Trim(matches[1], "() "), ",")
 		includedColumnNames = pure_utils.Map(names, func(s string) string {
-			return strings.Trim(s, " ")
+			return strings.Trim(s, " \"")
 		})
 	}
 

--- a/repositories/pg_indexes/pg_indexes_test.go
+++ b/repositories/pg_indexes/pg_indexes_test.go
@@ -49,4 +49,43 @@ func TestParseCreateIndexStatement(t *testing.T) {
 			idx,
 		)
 	})
+
+	t.Run("With escaped field name", func(t *testing.T) {
+		asserts := assert.New(t)
+		idx := parseCreateIndexStatement(`CREATE INDEX index_name ON Transaction (id, "userpublicid" DESC)`)
+		fmt.Println(idx)
+		asserts.Equal(
+			models.ConcreteIndex{
+				Indexed:  []string{"id", "userpublicid"},
+				Included: nil,
+			},
+			idx,
+		)
+	})
+
+	t.Run("With escaped field name, case sensitive", func(t *testing.T) {
+		asserts := assert.New(t)
+		idx := parseCreateIndexStatement(`CREATE INDEX index_name ON Transaction (id, "TIME" DESC)`)
+		fmt.Println(idx)
+		asserts.Equal(
+			models.ConcreteIndex{
+				Indexed:  []string{"id", "TIME"},
+				Included: nil,
+			},
+			idx,
+		)
+	})
+
+	t.Run("With escaped field name in included", func(t *testing.T) {
+		asserts := assert.New(t)
+		idx := parseCreateIndexStatement(`CREATE INDEX index_name ON Transaction (id, "userpublicid" DESC) INCLUDE ("time")`)
+		fmt.Println(idx)
+		asserts.Equal(
+			models.ConcreteIndex{
+				Indexed:  []string{"id", "userpublicid"},
+				Included: []string{"time"},
+			},
+			idx,
+		)
+	})
 }

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -167,6 +167,9 @@ func (usecase *DataModelUseCase) CreateDataModelField(ctx context.Context, field
 	if field.Name == "id" {
 		return "", errors.Wrap(models.BadParameterError, "field name 'id' is reserved")
 	}
+	// NB: even if we decide in the future to be more permissive on allowed field names, for instance if we escape them and allow special characters
+	// (which I don't think we should), they MUST still remain lower case, unless we first migrate all non escaped fields&tables in data_model_fields/data_model_tables
+	// to lower case and change logic in models/concrete_index.go ConcreteIndex.Covers()
 	if !validNameRegex.MatchString(field.Name) {
 		return "", errors.Wrap(models.BadParameterError,
 			"field name must only contain lower case alphanumeric characters and underscores, and start by a letter")


### PR DESCRIPTION
## Three unrelated bugs in one PR, separate commits

### Swan bug:
First commit
Index `(account_id DESC) INCLUDE (booked_at)` being created even though there is already an index `(account_id DESC, booked_at DESC, status DESC) INCLUDE (available_balance_after)`
=> Logic error in the "does an existing index cover our needs" logic

### Payrex bug:
Second commit
See issue https://github.com/checkmarble/marble/issues/91
Index parsing is broken for escaped field names. I thought we wouldn't have any, because we (currently) don't escape field names when we create the tables (we probably should, in which case this is a good preparation PR). However, we still have escaped field names if reserver sql keywords are used as index names.
E.g. you can create a table 
```sql
create table test_idx_table (
 id int primary key,
 time time
);

create index test_idx on test_idx_table(id, time)
```

without escaping the field name "time", but if we later read the index creation DDL using `pg_get_indexdef(pg_class_idx.oid) AS indexdef` it will have the escaped field name
```sql
CREATE INDEX test_idx ON marble.test_idx_table USING btree (id, "time")
```

### Josh's bug
Third commit
(see [slack discusion](https://marble-communitysiege.slack.com/archives/C06FRFB7V2M/p1744010732737959))
We previously modified our migrations so that they can be run with a postgres user other than the default superuser "postgres", but we missed one such migration. This fixes it. I also modified the postgres default user in the end to end test suite so we can detect this.