### PR TITLE
Pascal/mar 896 order of db field options shown in the rule builder is

### DIFF
--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -46,7 +46,6 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 		},
 	}
 
-	u := AstExpressionUsecase{}
-	_, err := u.getLinkedDatabaseIdentifiers(scenario, model)
+	_, err := getLinkedDatabaseIdentifiers(scenario, model)
 	assert.NoError(t, err)
 }

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -1,14 +1,50 @@
 package usecases
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
-func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
+func dbAccessNodeToString(node ast.Node) string {
+	return fmt.Sprintf("%s-%s-%s",
+		node.NamedChildren["tableName"].Constant,
+		node.NamedChildren["path"].Constant,
+		node.NamedChildren["fieldName"].Constant,
+	)
+}
+
+func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_loop(t *testing.T) {
+	/*
+		                +----------------+
+		                |  transactions |
+		                |               |
+		                | id            |
+		                | account_id    |
+		                +----------------+
+		                     ↑   ↓
+		                     |   |
+		                +----------------+
+		                |   accounts     |
+		                |               |
+		                | id            |
+		                | last_trans_id |
+		                +----------------+
+
+		Legend:
+		↑ : LinksToSingle from transactions to accounts via account.id
+		↓ : LinksToSingle from accounts to transactions via last_transactions
+
+		Relationships:
+		- transactions → accounts: via account_id → id
+		- accounts → transactions: via last_transaction → id
+	*/
 	scenario := models.Scenario{
 		TriggerObjectType: "transactions",
 	}
@@ -46,6 +82,109 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers(t *testing.T) {
 		},
 	}
 
-	_, err := getLinkedDatabaseIdentifiers(scenario, model)
+	identifiers, err := getLinkedDatabaseIdentifiers(scenario, model)
 	assert.NoError(t, err)
+
+	expectedStr := []string{
+		"transactions-[account]-id",
+		"transactions-[account]-last_transaction_id",
+		"transactions-[account last_transactions]-id",
+		"transactions-[account last_transactions]-account_id",
+	}
+	sort.Strings(expectedStr)
+	indentifiersStr := pure_utils.Map(identifiers, dbAccessNodeToString)
+	sort.Strings(indentifiersStr)
+	assert.Equal(t, indentifiersStr, expectedStr)
+}
+
+func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_two_branches(t *testing.T) {
+	/*
+		                    +------------+
+		                    | companies  |
+		                    |            |
+		                    | id         |
+		                    +------------+
+		                     ↑          ↑
+		                     |          |
+		                     |          |
+		                +------------+  |
+		                | accounts   |  |
+		                |            |  |
+		                | id         |  |
+		                | company_id |  |
+		                +------------+  |
+		                     ↑         |
+		                     |         |
+		                +------------+ |
+		                |transactions| |
+		                |            | |
+		                | id         | |
+		                | account_id | |
+		                | company_id |-+
+		                +------------+
+
+		Legend:
+		↑ : Represents LinksToSingle relationship
+	*/
+	scenario := models.Scenario{
+		TriggerObjectType: "transactions",
+	}
+
+	model := models.DataModel{
+		Tables: map[string]models.Table{
+			"companies": {
+				Name: "companies",
+				Fields: map[string]models.Field{
+					"id": {},
+				},
+			},
+			"accounts": {
+				Name: "accounts",
+				Fields: map[string]models.Field{
+					"id":         {},
+					"company_id": {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"company": {
+						ParentTableName: "companies",
+						ParentFieldName: "id",
+						ChildFieldName:  "company_id",
+					},
+				},
+			},
+			"transactions": {
+				Name: "transactions",
+				Fields: map[string]models.Field{
+					"id":         {},
+					"account_id": {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"account": {
+						ParentTableName: "accounts",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_id",
+					},
+					"company": {
+						ParentTableName: "companies",
+						ParentFieldName: "id",
+						ChildFieldName:  "company_id",
+					},
+				},
+			},
+		},
+	}
+
+	identifiers, err := getLinkedDatabaseIdentifiers(scenario, model)
+	assert.NoError(t, err)
+
+	expectedStr := []string{
+		"transactions-[account]-id",
+		"transactions-[account]-company_id",
+		"transactions-[account company]-id",
+		"transactions-[company]-id",
+	}
+	sort.Strings(expectedStr)
+	indentifiersStr := pure_utils.Map(identifiers, dbAccessNodeToString)
+	sort.Strings(indentifiersStr)
+	assert.Equal(t, indentifiersStr, expectedStr)
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -219,12 +219,11 @@ func (usecases *UsecasesWithCreds) NewRuleUsecase() RuleUsecase {
 }
 
 func (usecases *UsecasesWithCreds) AstExpressionUsecase() AstExpressionUsecase {
-	return AstExpressionUsecase{
-		EnforceSecurity:     usecases.NewEnforceScenarioSecurity(),
-		DataModelRepository: usecases.Repositories.MarbleDbRepository,
-		Repository:          &usecases.Repositories.MarbleDbRepository,
-		executorFactory:     usecases.NewExecutorFactory(),
-	}
+	return NewAstExpressionUsecase(
+		usecases.NewExecutorFactory(),
+		usecases.NewEnforceScenarioSecurity(),
+		&usecases.Repositories.MarbleDbRepository,
+	)
 }
 
 func (usecases *UsecasesWithCreds) NewCustomListUseCase() CustomListUseCase {


### PR DESCRIPTION
There was a logic error in the recursion of the data model exploration to return all possible DB field accesses.
Specifically, the second test case (added in `usecases/ast_expression_usecase_test.go`) was failing randomly, because it was only exploring links once by pair of "link name, target table", instead of once by pair of "link name, start table".