### PR TITLE
fixes: make fuzzy match on aggregate work

### DIFF
--- a/models/ast/ast_filter.go
+++ b/models/ast/ast_filter.go
@@ -45,6 +45,9 @@ var FuncFilterAttributes = FuncAttributes{
 
 type FuzzyMatchOptions struct {
 	Algorithm string
-	Threshold float64 // Threshold represents the similarity score, expressed as a decimal between 0.0 and 1.0.
-	Value     string
+
+	// Threshold represents the similarity score, expressed as a decimal between 0.0 and 1.0.
+	Threshold float64
+
+	Value string
 }

--- a/models/ast/ast_filter.go
+++ b/models/ast/ast_filter.go
@@ -25,14 +25,6 @@ func (op FilterOperator) IsUnary() bool {
 	return slices.Contains([]FilterOperator{FILTER_IS_EMPTY, FILTER_IS_NOT_EMPTY}, op)
 }
 
-func (op FilterOperator) IsComplex() bool {
-	return slices.Contains([]FilterOperator{FILTER_FUZZY_MATCH}, op)
-}
-
-func (op FilterOperator) IsBinary() bool {
-	return !op.IsUnary()
-}
-
 type Filter struct {
 	TableName string
 	FieldName string
@@ -51,13 +43,8 @@ var FuncFilterAttributes = FuncAttributes{
 	},
 }
 
-// var ComplexFilterAttributes = FuncAttributes{
-// 	DebugName: "FUNC_COMPLEX_FILTER",
-// 	AstName:   "ComplexFilter",
-// 	NamedArguments: []string{
-// 		"tableName",
-// 		"fieldName",
-// 		"operator",
-// 		"value",
-// 	},
-// }
+type FuzzyMatchOptions struct {
+	Algorithm string
+	Threshold float64
+	Value     string
+}

--- a/models/ast/ast_filter.go
+++ b/models/ast/ast_filter.go
@@ -45,6 +45,6 @@ var FuncFilterAttributes = FuncAttributes{
 
 type FuzzyMatchOptions struct {
 	Algorithm string
-	Threshold float64
+	Threshold float64 // Threshold represents the similarity score, expressed as a decimal between 0.0 and 1.0.
 	Value     string
 }

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -483,6 +483,7 @@ func addConditionForOperator(query squirrel.SelectBuilder, tableName string, fie
 	case ast.FILTER_ENDS_WITH:
 		return query.Where(squirrel.Like{fmt.Sprintf("%s.%s", tableName, fieldName): fmt.Sprintf("%%%s", value)}), nil
 	case ast.FILTER_FUZZY_MATCH:
+		// TODO: finish implementing the exact logic we want in the sql query.
 		fuzzyFilterOptions, ok := value.(ast.FuzzyMatchOptions)
 		if !ok {
 			return query, fmt.Errorf("invalid value type for FuzzyMatchFilter")

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -55,11 +55,11 @@ type IngestedDataReadRepository interface {
 
 type IngestedDataReadRepositoryImpl struct{}
 
-type FuzzyMatchFilter struct {
-	Value     string
-	Threshold float64
-	Algorithm string
-}
+// type FuzzyMatchFilter struct {
+// 	Value     string
+// 	Threshold float64
+// 	Algorithm string
+// }
 
 // "read db field" methods
 func (repo *IngestedDataReadRepositoryImpl) GetDbField(ctx context.Context, exec Executor, readParams models.DbFieldReadParams) (any, error) {
@@ -483,12 +483,12 @@ func addConditionForOperator(query squirrel.SelectBuilder, tableName string, fie
 	case ast.FILTER_ENDS_WITH:
 		return query.Where(squirrel.Like{fmt.Sprintf("%s.%s", tableName, fieldName): fmt.Sprintf("%%%s", value)}), nil
 	case ast.FILTER_FUZZY_MATCH:
-		fuzzyFilter, ok := value.(FuzzyMatchFilter)
+		fuzzyFilterOptions, ok := value.(ast.FuzzyMatchOptions)
 		if !ok {
 			return query, fmt.Errorf("invalid value type for FuzzyMatchFilter")
 		}
 		return query.Where(fmt.Sprintf("similarity(%s.%s, ?) > ?", tableName, fieldName),
-			fuzzyFilter.Value, fuzzyFilter.Threshold), nil
+			fuzzyFilterOptions.Value, fuzzyFilterOptions.Threshold), nil
 	default:
 		return query, fmt.Errorf("unknown operator %s: %w", operator, models.BadParameterError)
 	}

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -389,7 +389,6 @@ func createQueryAggregated(
 	}
 
 	qualifiedTableName := pgIdentifierWithSchema(exec, tableName)
-	qualifiedFieldName := pgIdentifierWithSchema(exec, tableName, fieldName)
 
 	query := NewQueryBuilder().
 		Select(selectExpression).
@@ -398,6 +397,7 @@ func createQueryAggregated(
 
 	var err error
 	for _, filter := range filters {
+		qualifiedFieldName := pgIdentifierWithSchema(exec, tableName, filter.Filter.FieldName)
 		query, err = addConditionForOperator(query, qualifiedFieldName, filter.FieldType,
 			filter.Filter.Operator, filter.Filter.Value)
 		if err != nil {

--- a/usecases/ast_eval/evaluate/evaluate_filter.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter.go
@@ -87,7 +87,6 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 		if operator == ast.FILTER_IS_IN_LIST || operator == ast.FILTER_IS_NOT_IN_LIST {
 			promotedValue, err = adaptArgumentToListOfStrings(value)
 		} else if operator == ast.FILTER_FUZZY_MATCH {
-			// promotedValue, err = adaptArgumentToBool(value)
 			promotedValue = value
 		} else {
 			promotedValue, err = promoteArgumentToDataType(value, fieldType)

--- a/usecases/ast_eval/evaluate/evaluate_filter.go
+++ b/usecases/ast_eval/evaluate/evaluate_filter.go
@@ -79,33 +79,38 @@ func (f FilterEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) 
 			Value:     nil,
 		}, nil
 	}
+
+	// The value that is promoted here is then passed directly to the ingested data read repository to be used as a filter value in the sql query.
 	var promotedValue any
-	// When value is a float, it cannot be cast to int but SQL can handle the comparision, so no casting is required
-	if fieldType == models.Int && reflect.TypeOf(value) == reflect.TypeOf(float64(0)) {
+	switch {
+	case operator == ast.FILTER_FUZZY_MATCH:
+		// fuzzy match filter takes a custom type (ast.FuzzyMatchOptions), pass it through as it is.
 		promotedValue = value
-	} else {
-		if operator == ast.FILTER_IS_IN_LIST || operator == ast.FILTER_IS_NOT_IN_LIST {
-			promotedValue, err = adaptArgumentToListOfStrings(value)
-		} else if operator == ast.FILTER_FUZZY_MATCH {
-			promotedValue = value
-		} else {
-			promotedValue, err = promoteArgumentToDataType(value, fieldType)
-		}
-		if err != nil {
-			return MakeEvaluateError(errors.Join(
-				errors.Wrap(ast.ErrArgumentInvalidType,
-					fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableName, fieldName)),
-				ast.NewNamedArgumentError("value"),
-				err,
-			))
-		}
+	case fieldType == models.Int && reflect.TypeOf(value) == reflect.TypeOf(float64(0)):
+		// When value is a float, it cannot be cast to int but SQL can handle the comparision, so no casting is required
+		promotedValue = value
+	case operator == ast.FILTER_IS_IN_LIST || operator == ast.FILTER_IS_NOT_IN_LIST:
+		// isInList filter takes a slice of strings, accept a slice of any and cast it to a slice of strings (and normalize them)
+		promotedValue, err = adaptArgumentToListOfStrings(value)
+		// err is checked outside of the switch
+	default:
+		// by default, it is assumed that the value on the right of the comparison should have the same type as the field on the left
+		promotedValue, err = promoteArgumentToDataType(value, fieldType)
+		// err is checked outside of the switch
+	}
+	if err != nil {
+		return MakeEvaluateError(errors.Join(
+			errors.Wrap(ast.ErrArgumentInvalidType,
+				fmt.Sprintf("value is not compatible with selected field %s.%s in Evaluate filter", tableName, fieldName)),
+			ast.NewNamedArgumentError("value"),
+			err,
+		))
 	}
 
-	returnValue := ast.Filter{
+	return ast.Filter{
 		TableName: tableName,
 		FieldName: fieldName,
 		Operator:  operator,
 		Value:     promotedValue,
-	}
-	return returnValue, nil
+	}, nil
 }

--- a/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
+++ b/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
@@ -30,7 +30,8 @@ func (f FuzzyMatchOptionsEvaluator) Evaluate(ctx context.Context, arguments ast.
 		))
 	}
 
-	threshold, err := AdaptNamedArgument(arguments.NamedArgs, "threshold", promoteArgumentToFloat64)
+	threshold, err := AdaptNamedArgument(arguments.NamedArgs, "threshold",
+		promoteArgumentToFloat64) // Threshold is received as an integer (0–100) from the client and converted to a float (0.0–1.0) for internal processing.
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
+++ b/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
@@ -12,9 +12,9 @@ import (
 type FuzzyMatchOptionsEvaluator struct{}
 
 var allowedFuzzyMatchAlgorithms = []string{
-	"bag_of_words_similarity",
-	"direct_string_similarity",
-	"token_set_ratio", // TODO: remove this option
+	"bag_of_words_similarity_db",
+	"direct_string_similarity_db",
+	"token_set_ratio",
 }
 
 func (f FuzzyMatchOptionsEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
@@ -30,8 +30,9 @@ func (f FuzzyMatchOptionsEvaluator) Evaluate(ctx context.Context, arguments ast.
 		))
 	}
 
+	// Threshold is received as an integer (0–100) from the client and converted to a float (0.0–1.0) for internal processing.
 	threshold, err := AdaptNamedArgument(arguments.NamedArgs, "threshold",
-		promoteArgumentToFloat64) // Threshold is received as an integer (0–100) from the client and converted to a float (0.0–1.0) for internal processing.
+		promoteArgumentToFloat64)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
+++ b/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
@@ -49,7 +49,7 @@ func (f FuzzyMatchOptionsEvaluator) Evaluate(ctx context.Context, arguments ast.
 
 	return ast.FuzzyMatchOptions{
 		Algorithm: algorithm,
-		Threshold: threshold,
+		Threshold: threshold / 100,
 		Value:     value,
 	}, nil
 }

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -97,6 +97,6 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 	environment.AddEvaluator(ast.FUNC_IS_MULTIPLE_OF, evaluate.IsMultipleOf{})
 	environment.AddEvaluator(ast.FUNC_STRING_TEMPLATE, evaluate.StringTemplate{})
 	environment.AddEvaluator(ast.FUNC_STRING_CONCAT, evaluate.StringConcat{})
-	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH_FILTER_OPTIONS, evaluate.FuzzyMatchOptions{})
+	environment.AddEvaluator(ast.FUNC_FUZZY_MATCH_FILTER_OPTIONS, evaluate.FuzzyMatchOptionsEvaluator{})
 	return environment
 }


### PR DESCRIPTION
Continued from @siiick 's PR. Making some changes to make it work, and to decide on the final design.

## To finish
### Backend
(continuation of this PR, or the one it merges into)
- adapt list of algorithm names that are acceptable (won't be the same as for main ast fuzzy match)
- adapt proper score thresold (between 0 and 1 or 0 and 100?)
- finish writing proper logic for the final SQL query
### Frontend
- check that the examples of strings that we give, are still relevant for our final scoring logic
- adapt list of algorithm names that are acceptable (won't be the same as for main ast fuzzy match)
- adapt translations, view only component, and other visual stuff