### PR TITLE
Differentiate between different types of tags.

### DIFF
--- a/dto/tag_dto.go
+++ b/dto/tag_dto.go
@@ -27,8 +27,9 @@ func AdaptTagDto(t models.Tag) APITag {
 }
 
 type CreateTagBody struct {
-	Name  string `json:"name" binding:"required"`
-	Color string `json:"color" binding:"required,hexcolor"`
+	Target string `json:"target" binding:"required,oneof=case object"`
+	Name   string `json:"name" binding:"required"`
+	Color  string `json:"color" binding:"required,hexcolor"`
 }
 
 type UpdateTagBody struct {

--- a/models/tag.go
+++ b/models/tag.go
@@ -4,6 +4,7 @@ import "time"
 
 type Tag struct {
 	Id             string
+	Target         TagTarget
 	Name           string
 	Color          string
 	OrganizationId string
@@ -16,6 +17,7 @@ type Tag struct {
 type CreateTagAttributes struct {
 	Color          string
 	OrganizationId string
+	Target         TagTarget
 	Name           string
 }
 
@@ -23,4 +25,23 @@ type UpdateTagAttributes struct {
 	Color string
 	Name  string
 	TagId string
+}
+
+type TagTarget string
+
+const (
+	TagTargetCase    TagTarget = "case"
+	TagTargetObject  TagTarget = "object"
+	TagTargetUnknown TagTarget = "unknown"
+)
+
+func TagTargetFromString(s string) TagTarget {
+	switch s {
+	case "case":
+		return TagTargetCase
+	case "object":
+		return TagTargetObject
+	default:
+		return TagTargetUnknown
+	}
 }

--- a/repositories/dbmodels/db_tag.go
+++ b/repositories/dbmodels/db_tag.go
@@ -13,6 +13,7 @@ type DBTag struct {
 	Name           string           `db:"name"`
 	Color          string           `db:"color"`
 	OrganizationId string           `db:"org_id"`
+	Target         string           `db:"target"`
 	CreatedAt      time.Time        `db:"created_at"`
 	UpdatedAt      time.Time        `db:"updated_at"`
 	DeletedAt      pgtype.Timestamp `db:"deleted_at"`
@@ -30,6 +31,7 @@ var SelectTagColumn = utils.ColumnList[DBTag]()
 func AdaptTag(db DBTag) (models.Tag, error) {
 	return models.Tag{
 		Id:             db.Id,
+		Target:         models.TagTargetFromString(db.Target),
 		Name:           db.Name,
 		Color:          db.Color,
 		OrganizationId: db.OrganizationId,

--- a/repositories/migrations/20250416141100_create_tag_types.sql
+++ b/repositories/migrations/20250416141100_create_tag_types.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+
+alter table tags
+    add column target text not null default 'case',
+    add constraint tag_kind_check check (target in ('case', 'object'));
+
+-- +goose Down
+
+alter table tags
+    drop column target;

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -803,6 +803,9 @@ func (usecase *CaseUseCase) createCaseTag(ctx context.Context, exec repositories
 		return err
 	}
 
+	if tag.Target != models.TagTargetCase {
+		return errors.Wrap(models.BadParameterError, "provided tag is not targeting cases")
+	}
 	if tag.DeletedAt != nil {
 		return fmt.Errorf("tag %s is deleted %w", tag.Id, models.BadParameterError)
 	}

--- a/usecases/entity_annotations_usecase.go
+++ b/usecases/entity_annotations_usecase.go
@@ -198,8 +198,13 @@ func (uc EntityAnnotationUsecase) validateAnnotation(ctx context.Context, req mo
 		if !ok {
 			return errors.New("invalid payload for annotation type")
 		}
-		if _, err := uc.tagRepository.GetTagById(ctx, uc.executorFactory.NewExecutor(), payload.Tag); err != nil {
+		tag, err := uc.tagRepository.GetTagById(ctx, uc.executorFactory.NewExecutor(), payload.Tag)
+		if err != nil {
 			return errors.Wrap(models.NotFoundError, "unknown tag")
+		}
+		if tag.Target != models.TagTargetObject {
+			return errors.Wrap(models.UnprocessableEntityError,
+				"provided tag is not targeting ingested objects")
 		}
 		exists, err := uc.repository.IsObjectTagSet(ctx, uc.executorFactory.NewExecutor(), req, payload.Tag)
 		if err != nil {

--- a/usecases/tag_usecase.go
+++ b/usecases/tag_usecase.go
@@ -15,7 +15,7 @@ import (
 
 type TagUseCaseRepository interface {
 	ListOrganizationTags(ctx context.Context, exec repositories.Executor, organizationId string,
-		withCaseCount bool) ([]models.Tag, error)
+		target models.TagTarget, withCaseCount bool) ([]models.Tag, error)
 	CreateTag(ctx context.Context, exec repositories.Executor, attributes models.CreateTagAttributes, newTagId string) error
 	UpdateTag(ctx context.Context, exec repositories.Executor, attributes models.UpdateTagAttributes) error
 	GetTagById(ctx context.Context, exec repositories.Executor, tagId string) (models.Tag, error)
@@ -30,12 +30,11 @@ type TagUseCase struct {
 	repository         TagUseCaseRepository
 }
 
-func (usecase *TagUseCase) ListAllTags(ctx context.Context, organizationId string, withCaseCount bool) ([]models.Tag, error) {
-	tags, err := usecase.repository.ListOrganizationTags(
-		ctx,
-		usecase.executorFactory.NewExecutor(),
-		organizationId,
-		withCaseCount)
+func (usecase *TagUseCase) ListAllTags(ctx context.Context, organizationId string,
+	target models.TagTarget, withCaseCount bool,
+) ([]models.Tag, error) {
+	tags, err := usecase.repository.ListOrganizationTags(ctx,
+		usecase.executorFactory.NewExecutor(), organizationId, target, withCaseCount)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds a `target` column on the `tags` table indicating what resource the tag can be used with. Valid values are `case` and `object`.

It also modified all endpoints to take a `target` parameter.

All existing tags are marked as targeting cases.