### PR TITLE
Implemented case escalation.

### DIFF
--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -523,3 +523,19 @@ func handleReadCasePivotObjects(uc usecases.Usecases) func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"pivot_objects": pure_utils.Map(pivotObjects, dto.AdaptPivotObjectDto)})
 	}
 }
+
+func handleEscalateCase(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		caseId := c.Param("case_id")
+
+		uc := usecasesWithCreds(ctx, uc).NewCaseUseCase()
+
+		if err := uc.EscalateCase(ctx, caseId); err != nil {
+			presentError(ctx, c, err)
+			return
+		}
+
+		c.Status(http.StatusNoContent)
+	}
+}

--- a/api/handle_inboxes.go
+++ b/api/handle_inboxes.go
@@ -64,7 +64,8 @@ func handleListInboxes(uc usecases.Usecases) func(c *gin.Context) {
 }
 
 type CreateInboxInput struct {
-	Name string `json:"name" binding:"required"`
+	Name              string  `json:"name" binding:"required"`
+	EscalationInboxId *string `json:"escalation_inbox_id" binding:"omitempty,uuid"`
 }
 
 func handlePostInbox(uc usecases.Usecases) func(c *gin.Context) {
@@ -83,7 +84,9 @@ func handlePostInbox(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewInboxUsecase()
 		inbox, err := usecase.CreateInbox(ctx, models.CreateInboxInput{
-			Name: createInboxInput.Name, OrganizationId: organizationId,
+			Name:              createInboxInput.Name,
+			OrganizationId:    organizationId,
+			EscalationInboxId: createInboxInput.EscalationInboxId,
 		})
 		if presentError(ctx, c, err) {
 			return
@@ -105,7 +108,8 @@ func handlePatchInbox(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		var data struct {
-			Name string `json:"name" binding:"required"`
+			Name              string  `json:"name" binding:"required"`
+			EscalationInboxId *string `json:"escalation_inbox_id" binding:"omitempty,uuid"`
 		}
 		if err := c.ShouldBind(&data); err != nil {
 			c.Status(http.StatusBadRequest)
@@ -113,7 +117,7 @@ func handlePatchInbox(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		usecase := usecasesWithCreds(ctx, uc).NewInboxUsecase()
-		inbox, err := usecase.UpdateInbox(ctx, getInboxInput.InboxId, data.Name)
+		inbox, err := usecase.UpdateInbox(ctx, getInboxInput.InboxId, data.Name, data.EscalationInboxId)
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/routes.go
+++ b/api/routes.go
@@ -212,6 +212,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 		handleUploadFileToSuspiciousActivityReport(uc))
 	router.DELETE("/cases/:case_id/sar/:reportId", tom,
 		handleDeleteSuspiciousActivityReport(uc))
+	router.POST("/cases/:case_id/escalate", tom, handleEscalateCase(uc))
 
 	router.GET("/inboxes/:inbox_id", tom, handleGetInboxById(uc))
 	router.PATCH("/inboxes/:inbox_id", tom, handlePatchInbox(uc))

--- a/dto/inbox_dto.go
+++ b/dto/inbox_dto.go
@@ -8,24 +8,26 @@ import (
 )
 
 type InboxDto struct {
-	Id         string         `json:"id"`
-	CreatedAt  time.Time      `json:"created_at"`
-	UpdatedAt  time.Time      `json:"updated_at"`
-	Name       string         `json:"name"`
-	Status     string         `json:"status"`
-	Users      []InboxUserDto `json:"users"`
-	CasesCount *int           `json:"cases_count"`
+	Id                string         `json:"id"`
+	CreatedAt         time.Time      `json:"created_at"`
+	UpdatedAt         time.Time      `json:"updated_at"`
+	Name              string         `json:"name"`
+	Status            string         `json:"status"`
+	EscalationInboxId *string        `json:"escalation_inbox_id,omitempty"`
+	Users             []InboxUserDto `json:"users"`
+	CasesCount        *int           `json:"cases_count"`
 }
 
 func AdaptInboxDto(i models.Inbox) InboxDto {
 	return InboxDto{
-		Id:         i.Id,
-		CreatedAt:  i.CreatedAt,
-		UpdatedAt:  i.UpdatedAt,
-		Name:       i.Name,
-		Status:     string(i.Status),
-		Users:      pure_utils.Map(i.InboxUsers, AdaptInboxUserDto),
-		CasesCount: i.CasesCount,
+		Id:                i.Id,
+		CreatedAt:         i.CreatedAt,
+		UpdatedAt:         i.UpdatedAt,
+		Name:              i.Name,
+		Status:            string(i.Status),
+		EscalationInboxId: i.EscalationInboxId,
+		Users:             pure_utils.Map(i.InboxUsers, AdaptInboxUserDto),
+		CasesCount:        i.CasesCount,
 	}
 }
 

--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -100,6 +100,11 @@ func (e *EnforceSecurity) ReadInbox(i models.Inbox) error {
 	return args.Error(0)
 }
 
+func (e *EnforceSecurity) ReadInboxMetadata(i models.Inbox) error {
+	args := e.Called(i)
+	return args.Error(0)
+}
+
 func (e *EnforceSecurity) CreateInbox(organizationId string) error {
 	args := e.Called(organizationId)
 	return args.Error(0)

--- a/mocks/inboxes_repository.go
+++ b/mocks/inboxes_repository.go
@@ -30,8 +30,8 @@ func (r *InboxRepository) CreateInbox(ctx context.Context, exec repositories.Exe
 	return args.Error(0)
 }
 
-func (r *InboxRepository) UpdateInbox(ctx context.Context, exec repositories.Executor, inboxId, name string) error {
-	args := r.Called(exec, inboxId, name)
+func (r *InboxRepository) UpdateInbox(ctx context.Context, exec repositories.Executor, inboxId, name string, escalationInboxId *string) error {
+	args := r.Called(exec, inboxId, name, escalationInboxId)
 	return args.Error(0)
 }
 

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -36,6 +36,7 @@ const (
 	DecisionReviewed      CaseEventType = "decision_reviewed"
 	CaseSnoozed           CaseEventType = "case_snoozed"
 	CaseUnsnoozed         CaseEventType = "case_unsnoozed"
+	CaseEscalated         CaseEventType = "case_escalated"
 )
 
 type CaseEventResourceType string

--- a/models/inbox.go
+++ b/models/inbox.go
@@ -10,22 +10,39 @@ const (
 )
 
 type Inbox struct {
-	Id             string
-	Name           string
-	OrganizationId string
-	Status         InboxStatus
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
-	InboxUsers     []InboxUser
-	CasesCount     *int
+	Id                string
+	Name              string
+	OrganizationId    string
+	Status            InboxStatus
+	EscalationInboxId *string
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+	InboxUsers        []InboxUser
+	CasesCount        *int
+}
+
+type InboxMetadata struct {
+	Id     string
+	Name   string
+	Status InboxStatus
+}
+
+func (i Inbox) GetMetadata() InboxMetadata {
+	return InboxMetadata{
+		Id:     i.Id,
+		Name:   i.Name,
+		Status: i.Status,
+	}
 }
 
 type CreateInboxInput struct {
-	Name           string
-	OrganizationId string
+	Name              string
+	OrganizationId    string
+	EscalationInboxId *string
 }
 
 type UpdateInboxInput struct {
-	Id   string
-	Name string
+	Id                string
+	Name              string
+	EscalationInboxId *string
 }

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -471,3 +471,17 @@ func (repo *MarbleDbRepository) GetCasesWithPivotValue(ctx context.Context, exec
 func orderConditionForCases(p models.PaginationAndSorting) string {
 	return fmt.Sprintf("c.boost is null, c.%s %s, c.id %s", p.Sorting, p.Order, p.Order)
 }
+
+func (repo *MarbleDbRepository) EscalateCase(ctx context.Context, exec Executor, id, inboxId string) error {
+	sql := NewQueryBuilder().
+		Update(dbmodels.TABLE_CASES).
+		SetMap(map[string]any{
+			"inbox_id":      inboxId,
+			"snoozed_until": nil,
+			"assigned_to":   nil,
+			"boost":         models.BoostEscalated,
+		}).
+		Where(squirrel.Eq{"id": id})
+
+	return ExecBuilder(ctx, exec, sql)
+}

--- a/repositories/dbmodels/db_inbox.go
+++ b/repositories/dbmodels/db_inbox.go
@@ -10,12 +10,13 @@ import (
 // Inboxes
 
 type DBInbox struct {
-	Id             string    `db:"id"`
-	OrganizationId string    `db:"organization_id"`
-	CreatedAt      time.Time `db:"created_at"`
-	UpdatedAt      time.Time `db:"updated_at"`
-	Name           string    `db:"name"`
-	Status         string    `db:"status"`
+	Id                string    `db:"id"`
+	OrganizationId    string    `db:"organization_id"`
+	CreatedAt         time.Time `db:"created_at"`
+	UpdatedAt         time.Time `db:"updated_at"`
+	Name              string    `db:"name"`
+	Status            string    `db:"status"`
+	EscalationInboxId *string   `db:"escalation_inbox_id"`
 }
 
 const TABLE_INBOXES = "inboxes"
@@ -24,12 +25,13 @@ var SelectInboxColumn = utils.ColumnList[DBInbox]()
 
 func AdaptInbox(db DBInbox) (models.Inbox, error) {
 	return models.Inbox{
-		Id:             db.Id,
-		OrganizationId: db.OrganizationId,
-		CreatedAt:      db.CreatedAt,
-		UpdatedAt:      db.UpdatedAt,
-		Name:           db.Name,
-		Status:         models.InboxStatus(db.Status),
+		Id:                db.Id,
+		OrganizationId:    db.OrganizationId,
+		CreatedAt:         db.CreatedAt,
+		UpdatedAt:         db.UpdatedAt,
+		Name:              db.Name,
+		Status:            models.InboxStatus(db.Status),
+		EscalationInboxId: db.EscalationInboxId,
 	}, nil
 }
 

--- a/repositories/inboxes_repository.go
+++ b/repositories/inboxes_repository.go
@@ -81,17 +81,19 @@ func (repo *MarbleDbRepository) CreateInbox(ctx context.Context, exec Executor, 
 				"id",
 				"organization_id",
 				"name",
+				"escalation_inbox_id",
 			).
 			Values(
 				newInboxId,
 				input.OrganizationId,
 				input.Name,
+				input.EscalationInboxId,
 			),
 	)
 	return err
 }
 
-func (repo *MarbleDbRepository) UpdateInbox(ctx context.Context, exec Executor, inboxId, name string) error {
+func (repo *MarbleDbRepository) UpdateInbox(ctx context.Context, exec Executor, inboxId, name string, escalationInboxId *string) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
 	}
@@ -102,6 +104,7 @@ func (repo *MarbleDbRepository) UpdateInbox(ctx context.Context, exec Executor, 
 		NewQueryBuilder().Update(dbmodels.TABLE_INBOXES).
 			Set("name", name).
 			Set("updated_at", squirrel.Expr("NOW()")).
+			Set("escalation_inbox_id", escalationInboxId).
 			Where(squirrel.Eq{"id": inboxId}),
 	)
 	return err

--- a/repositories/migrations/20250416151100_add_inbox_escalation.sql
+++ b/repositories/migrations/20250416151100_add_inbox_escalation.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+
+alter table inboxes
+    add column escalation_inbox_id uuid,
+    add constraint fk_escalation_inbox_id
+        foreign key (escalation_inbox_id) references inboxes (id)
+        on delete set null;
+
+-- +goose Down
+
+alter table inboxes
+    drop column escalation_inbox_id;

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -61,6 +61,8 @@ type CaseUseCaseRepository interface {
 	BoostCase(ctx context.Context, exec repositories.Executor, id string, reason models.BoostReason) error
 	UnboostCase(ctx context.Context, exec repositories.Executor, id string) error
 
+	EscalateCase(ctx context.Context, exec repositories.Executor, id, inboxId string) error
+
 	GetCasesWithPivotValue(ctx context.Context, exec repositories.Executor,
 		orgId, pivotId, pivotValue string) ([]models.Case, error)
 }
@@ -1399,4 +1401,67 @@ func (usecase *CaseUseCase) ReadCasePivotObjects(ctx context.Context, caseId str
 	}
 
 	return usecase.ingestedDataReader.ReadPivotObjectsFromValues(ctx, c.OrganizationId, pivotValues)
+}
+
+func (uc *CaseUseCase) EscalateCase(ctx context.Context, caseId string) error {
+	exec := uc.executorFactory.NewExecutor()
+	c, err := uc.repository.GetCaseById(ctx, exec, caseId)
+	if err != nil {
+		return err
+	}
+	if c.Status == models.CaseClosed {
+		return errors.New("case is already closed, cannot escalate")
+	}
+
+	availableInboxIds, err := uc.getAvailableInboxIds(ctx, exec, c.OrganizationId)
+	if err != nil {
+		return err
+	}
+	if err := uc.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), availableInboxIds); err != nil {
+		return err
+	}
+
+	sourceInbox, err := uc.inboxReader.GetInboxById(ctx, c.InboxId)
+	if err != nil {
+		return errors.Wrap(err, "could not read source inbox")
+	}
+	if sourceInbox.EscalationInboxId == nil {
+		return errors.Wrap(models.UnprocessableEntityError,
+			"the source inbox does not have escalation configured")
+	}
+
+	// Not using the inboxReader here because we do not want to check for permission. A user
+	// escalating a case will usually not have access to the target inbox.
+	targetInbox, err := uc.inboxReader.GetEscalationInboxMetadata(ctx, *sourceInbox.EscalationInboxId)
+	if err != nil {
+		return errors.Wrap(err, "could not read target inbox")
+	}
+	if targetInbox.Status != models.InboxStatusActive {
+		return errors.Wrap(models.UnprocessableEntityError, "target inbox is inactive")
+	}
+
+	var userId *string
+	if creds, ok := utils.CredentialsFromCtx(ctx); ok {
+		userId = utils.Ptr(string(creds.ActorIdentity.UserId))
+	}
+
+	return uc.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		if err := uc.repository.EscalateCase(ctx, tx, caseId, targetInbox.Id); err != nil {
+			return errors.Wrap(err, "could not escalate case")
+		}
+
+		event := models.CreateCaseEventAttributes{
+			CaseId:        caseId,
+			UserId:        userId,
+			EventType:     models.CaseEscalated,
+			NewValue:      &targetInbox.Id,
+			PreviousValue: &sourceInbox.Id,
+		}
+
+		if err := uc.repository.CreateCaseEvent(ctx, tx, event); err != nil {
+			return err
+		}
+
+		return nil
+	})
 }

--- a/usecases/inboxes/inboxes.go
+++ b/usecases/inboxes/inboxes.go
@@ -18,6 +18,7 @@ type InboxRepository interface {
 
 type EnforceSecurityInboxes interface {
 	ReadInbox(i models.Inbox) error
+	ReadInboxMetadata(inbox models.Inbox) error
 	CreateInbox(organizationId string) error
 	ReadInboxUser(inboxUser models.InboxUser, actorInboxUsers []models.InboxUser) error
 	CreateInboxUser(i models.CreateInboxUserInput, actorInboxUsers []models.InboxUser,
@@ -42,6 +43,19 @@ func (i *InboxReader) GetInboxById(ctx context.Context, inboxId string) (models.
 	}
 
 	return inbox, err
+}
+
+func (i *InboxReader) GetEscalationInboxMetadata(ctx context.Context, inboxId string) (models.InboxMetadata, error) {
+	inbox, err := i.InboxRepository.GetInboxById(ctx, i.ExecutorFactory.NewExecutor(), inboxId)
+	if err != nil {
+		return models.InboxMetadata{}, err
+	}
+
+	if err := i.EnforceSecurity.ReadInboxMetadata(inbox); err != nil {
+		return models.InboxMetadata{}, err
+	}
+
+	return inbox.GetMetadata(), nil
 }
 
 func (i *InboxReader) ListInboxes(

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -18,7 +18,8 @@ type InboxRepository interface {
 		inboxIds []string, withCaseCount bool) ([]models.Inbox, error)
 	CreateInbox(ctx context.Context, exec repositories.Executor,
 		createInboxAttributes models.CreateInboxInput, newInboxId string) error
-	UpdateInbox(ctx context.Context, exec repositories.Executor, inboxId, name string) error
+	UpdateInbox(ctx context.Context, exec repositories.Executor,
+		inboxId, name string, escalationInboxId *string) error
 	SoftDeleteInbox(ctx context.Context, exec repositories.Executor, inboxId string) error
 
 	ListOrganizationCases(ctx context.Context, exec repositories.Executor, filters models.CaseFilters,
@@ -76,7 +77,7 @@ func (usecase *InboxUsecase) CreateInbox(ctx context.Context, input models.Creat
 	return inbox, nil
 }
 
-func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId, name string) (models.Inbox, error) {
+func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId, name string, escalationInboxId *string) (models.Inbox, error) {
 	inbox, err := executor_factory.TransactionReturnValue(
 		ctx,
 		usecase.transactionFactory,
@@ -95,7 +96,7 @@ func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId, name stri
 				return models.Inbox{}, err
 			}
 
-			if err := usecase.inboxRepository.UpdateInbox(ctx, tx, inboxId, name); err != nil {
+			if err := usecase.inboxRepository.UpdateInbox(ctx, tx, inboxId, name, escalationInboxId); err != nil {
 				return models.Inbox{}, err
 			}
 

--- a/usecases/security/enforce_security_inboxes.go
+++ b/usecases/security/enforce_security_inboxes.go
@@ -26,6 +26,20 @@ func (e EnforceSecurityInboxes) ReadInbox(i models.Inbox) error {
 	return errors.Wrap(models.ForbiddenError, "User does not have access to this inbox")
 }
 
+func (e EnforceSecurityInboxes) ReadInboxMetadata(inbox models.Inbox) error {
+	// org admins can read all inboxes
+	err := e.Permission(models.INBOX_EDITOR)
+	if err == nil {
+		return errors.Join(err, e.ReadOrganization(inbox.OrganizationId))
+	}
+
+	if inbox.OrganizationId != e.Credentials.OrganizationId {
+		return errors.New("user is not authorized to read metadata of the inbox")
+	}
+
+	return nil
+}
+
 func (e EnforceSecurityInboxes) CreateInbox(organizationId string) error {
 	// Only org admins can create inboxes
 	return errors.Join(e.Permission(models.INBOX_EDITOR), e.ReadOrganization(organizationId))


### PR DESCRIPTION
This PR allows the configuration of an escalation inbox on an inbox. That inbox will be the target of the escalation event that will move a case there, unassign and unsnooze it, and boosts it so it is marked as waiting for event.

It also implements the endpoints used to configure the target as well as the one to trigger the event.

It adds a case event related to escalation.