### PR TITLE
chore: improve migrations by not making them create a postgres user

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
       "go.toolsEnvVars": {
             "GOFUMPT_SPLIT_LONG_LINES": "on"
       },
-      "go.lintTool": "golangci-lint",
       "go.lintOnSave": "package",
       "search.exclude": {
             "go.sum": true,
@@ -15,14 +14,12 @@
             "LICENSE": true,
             ".git/logs": true,
       },
-      "editor.tabSize": 4,
       "files.associations": {
             // This is in order to deactivate github copilot on the .env file. As a result syntax coloring will be disabled because
             // VSCode will treat it as plain text, you can choose your language mode manually on the file
             ".env": "env"
       },
       "github.copilot.enable": {
-            "*": true,
             "env": false,
       },
       "Prettier-SQL.expressionWidth": 80,

--- a/repositories/migrations/20240124111516_create_analytics_schema.sql
+++ b/repositories/migrations/20240124111516_create_analytics_schema.sql
@@ -9,30 +9,6 @@ begin
 end
 $$;
 
-DO $$ BEGIN
-      CREATE USER analytics;
-
-EXCEPTION
-      WHEN duplicate_object THEN RAISE NOTICE '%, skipping',
-      SQLERRM USING ERRCODE = SQLSTATE;
-
-END $$;
-
-GRANT
-SELECT
-      ON ALL TABLES IN SCHEMA analytics TO analytics;
-
-GRANT USAGE ON SCHEMA analytics TO analytics;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA analytics
-GRANT
-SELECT
-      ON TABLES TO analytics;
-
-ALTER ROLE analytics
-SET
-      search_path TO analytics;
-
 -- +goose StatementEnd
 -- +goose Down
 -- +goose StatementBegin

--- a/repositories/migrations/20241105143100_drop_analytics_schema.sql
+++ b/repositories/migrations/20241105143100_drop_analytics_schema.sql
@@ -15,28 +15,4 @@ begin
 end
 $$;
 
-DO $$ BEGIN
-      CREATE USER analytics;
-
-EXCEPTION
-      WHEN duplicate_object THEN RAISE NOTICE '%, skipping',
-      SQLERRM USING ERRCODE = SQLSTATE;
-
-END $$;
-
-GRANT
-SELECT
-      ON ALL TABLES IN SCHEMA analytics TO analytics;
-
-GRANT USAGE ON SCHEMA analytics TO analytics;
-
-ALTER DEFAULT PRIVILEGES IN SCHEMA analytics
-GRANT
-SELECT
-      ON TABLES TO analytics;
-
-ALTER ROLE analytics
-SET
-      search_path TO analytics;
-
 -- +goose StatementEnd


### PR DESCRIPTION
As discussed in slack: the user is not strictly required, in particular it's dropped since Nov 2024.
Worst case side effect of this migration would if if someone currently on a version of marble from between March 2024 and Nov 2024 upgrades to the most recent version, they would remain with an unused user "analytics" (without permissions on anything) => acceptable.