### PR TITLE
return ingested object tags along with pivot objects in a case

### DIFF
--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0
+          version: v2.1
           args: --timeout=2m
 
       - name: Build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,4 +25,10 @@
       "Prettier-SQL.expressionWidth": 80,
       "Prettier-SQL.SQLFlavourOverride": "postgresql",
       "mise.configureExtensionsAutomatically": false,
+      "go.lintTool": "golangci-lint",
+      "go.lintFlags": [
+            "run",
+            "--config=${workspaceFolder}/.golangci.yml",
+            "--allow-parallel-runners",
+      ],
 }

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -561,8 +561,7 @@ func handleReadCasePivotObjects(uc usecases.Usecases) func(c *gin.Context) {
 
 		uc := usecasesWithCreds(ctx, uc).NewCaseUseCase()
 		pivotObjects, err := uc.ReadCasePivotObjects(ctx, caseId)
-		if err != nil {
-			presentError(ctx, c, err)
+		if presentError(ctx, c, err) {
 			return
 		}
 
@@ -573,8 +572,12 @@ func handleReadCasePivotObjects(uc usecases.Usecases) func(c *gin.Context) {
 				strings.Compare(a.PivotValue, b.PivotValue),
 			)
 		})
+		pivotDtos, err := pure_utils.MapErr(pivotObjects, dto.AdaptPivotObjectDto)
+		if presentError(ctx, c, err) {
+			return
+		}
 
-		c.JSON(http.StatusOK, gin.H{"pivot_objects": pure_utils.Map(pivotObjects, dto.AdaptPivotObjectDto)})
+		c.JSON(http.StatusOK, gin.H{"pivot_objects": pivotDtos})
 	}
 }
 

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -572,12 +572,12 @@ func handleReadCasePivotObjects(uc usecases.Usecases) func(c *gin.Context) {
 				strings.Compare(a.PivotValue, b.PivotValue),
 			)
 		})
-		pivotDtos, err := pure_utils.MapErr(pivotObjects, dto.AdaptPivotObjectDto)
+		pivotObjectDtos, err := pure_utils.MapErr(pivotObjects, dto.AdaptPivotObjectDto)
 		if presentError(ctx, c, err) {
 			return
 		}
 
-		c.JSON(http.StatusOK, gin.H{"pivot_objects": pivotDtos})
+		c.JSON(http.StatusOK, gin.H{"pivot_objects": pivotObjectDtos})
 	}
 }
 

--- a/api/handle_client_data.go
+++ b/api/handle_client_data.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
@@ -54,15 +55,18 @@ func handleReadClientDataAsList(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestedDataReaderUsecase()
 
-		// TODO: use adapter
 		clientObjects, nextPagination, err := usecase.ReadIngestedClientObjects(ctx, orgId,
 			objectType, dto.AdaptClientDataListRequestBody(input))
 		if presentError(ctx, c, err) {
 			return
 		}
+		clientObjectDtos, err := pure_utils.MapErr(clientObjects, dto.AdaptClientObjectDetailDto)
+		if presentError(ctx, c, err) {
+			return
+		}
 
 		c.JSON(http.StatusOK, dto.ClientDataListResponse{
-			Data:       clientObjects,
+			Data:       clientObjectDtos,
 			Pagination: dto.AdaptClientDataListPaginationDto(nextPagination),
 		})
 	}

--- a/api/handle_client_data.go
+++ b/api/handle_client_data.go
@@ -54,6 +54,7 @@ func handleReadClientDataAsList(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestedDataReaderUsecase()
 
+		// TODO: use adapter
 		clientObjects, nextPagination, err := usecase.ReadIngestedClientObjects(ctx, orgId,
 			objectType, dto.AdaptClientDataListRequestBody(input))
 		if presentError(ctx, c, err) {

--- a/dto/client_data_object.go
+++ b/dto/client_data_object.go
@@ -86,17 +86,17 @@ type ClientObjectMetadata struct {
 }
 
 type ClientDataListResponse struct {
-	Data       []models.ClientObjectDetail `json:"data"`
-	Pagination ClientDataListPagination    `json:"pagination"`
+	Data       []ClientObjectDetail     `json:"data"`
+	Pagination ClientDataListPagination `json:"pagination"`
 }
 
 func (c ClientDataListResponse) MarshalJSON() ([]byte, error) {
 	if c.Data == nil {
-		c.Data = make([]models.ClientObjectDetail, 0)
+		c.Data = make([]ClientObjectDetail, 0)
 	}
 	return json.Marshal(struct {
-		Data       []models.ClientObjectDetail `json:"data"`
-		Pagination ClientDataListPagination    `json:"pagination"`
+		Data       []ClientObjectDetail     `json:"data"`
+		Pagination ClientDataListPagination `json:"pagination"`
 	}{
 		Data:       c.Data,
 		Pagination: c.Pagination,
@@ -183,6 +183,11 @@ type GroupedEntityAnnotations struct {
 	Comments []EntityAnnotationDto `json:"comments,omitzero"`
 	Tags     []EntityAnnotationDto `json:"tags,omitzero"`
 	Files    []EntityAnnotationDto `json:"files,omitzero"`
+}
+
+// Implements IsZero so that omitzero can be used when marshalling ClientObjectDetail
+func (g GroupedEntityAnnotations) IsZero() bool {
+	return len(g.Comments) == 0 && len(g.Tags) == 0 && len(g.Files) == 0
 }
 
 func AdaptGroupedEntityAnnotations(a models.GroupedEntityAnnotations) (GroupedEntityAnnotations, error) {

--- a/dto/entity_annotation.go
+++ b/dto/entity_annotation.go
@@ -65,7 +65,7 @@ type EntityAnnotationCommentDto struct {
 }
 
 type EntityAnnotationTagDto struct {
-	Tag string `json:"tag"`
+	Tag string `json:"tag_id"`
 }
 
 type EntityAnnotationFileDto struct {

--- a/dto/entity_annotation.go
+++ b/dto/entity_annotation.go
@@ -65,7 +65,7 @@ type EntityAnnotationCommentDto struct {
 }
 
 type EntityAnnotationTagDto struct {
-	Tag string `json:"tag_id"`
+	TagId string `json:"tag_id"`
 }
 
 type EntityAnnotationFileDto struct {

--- a/dto/entity_annotation_test.go
+++ b/dto/entity_annotation_test.go
@@ -14,7 +14,7 @@ func TestDecodeEntityAnnotation(t *testing.T) {
 		ok      bool
 	}{
 		{models.EntityAnnotationComment, []byte(`{"text":"comment text"}`), true},
-		{models.EntityAnnotationTag, []byte(`{"tag": "tag_id"}`), true},
+		{models.EntityAnnotationTag, []byte(`{"tag_id": "tag_id"}`), true},
 
 		{models.EntityAnnotationComment, []byte(`{}`), false},
 		{models.EntityAnnotationTag, []byte(`{}`), false},
@@ -45,7 +45,7 @@ func TestDecodeEntityAnnotation(t *testing.T) {
 			payload, ok := genericPayload.(models.EntityAnnotationTagPayload)
 
 			assert.True(t, ok)
-			assert.Equal(t, "tag_id", payload.Tag)
+			assert.Equal(t, "tag_id", payload.TagId)
 
 		case models.EntityAnnotationFile:
 			payload, ok := genericPayload.(models.EntityAnnotationFilePayload)

--- a/dto/entity_annotation_test.go
+++ b/dto/entity_annotation_test.go
@@ -62,7 +62,7 @@ func TestAdaptEntityAnnotation(t *testing.T) {
 		payload []byte
 	}{
 		{models.EntityAnnotationComment, []byte(`{"text":"comment text"}`)},
-		{models.EntityAnnotationTag, []byte(`{"tag": "tag_id"}`)},
+		{models.EntityAnnotationTag, []byte(`{"tag_id": "tag_id"}`)},
 		{models.EntityAnnotationFile, []byte(`{"caption":"thecaption", "bucket":"bucket_name", "files":[{"id": "theid", "key": "thekey", "filename": "thefilename"}]}`)},
 	}
 
@@ -85,7 +85,7 @@ func TestAdaptEntityAnnotation(t *testing.T) {
 			payload, ok := genericPayload.(EntityAnnotationTagDto)
 
 			assert.True(t, ok)
-			assert.Equal(t, "tag_id", payload.Tag)
+			assert.Equal(t, "tag_id", payload.TagId)
 
 		case models.EntityAnnotationFile:
 			payload, ok := genericPayload.(EntityAnnotationFileDto)

--- a/models/client_data_object.go
+++ b/models/client_data_object.go
@@ -15,6 +15,7 @@ type PivotObject struct {
 	IsIngested        bool
 	PivotObjectData   ClientObjectDetail
 	NumberOfDecisions int
+	Annotations       GroupedEntityAnnotations
 }
 
 // PivotType corresponds to the type of entity that is materialized by a pivot value.

--- a/models/client_data_object.go
+++ b/models/client_data_object.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -15,7 +14,6 @@ type PivotObject struct {
 	IsIngested        bool
 	PivotObjectData   ClientObjectDetail
 	NumberOfDecisions int
-	Annotations       GroupedEntityAnnotations
 }
 
 // PivotType corresponds to the type of entity that is materialized by a pivot value.
@@ -56,40 +54,21 @@ func PivotTypeFromString(s string) PivotType {
 	}
 }
 
-// This struct is used as a DTO, but instead of using struct tags directly they are set on an anonymous struct below in the MarshalJSON method.
-// This is so we can set the RelatedObjects and Data to empty slices/maps if they are nil, and avoid return a null array/object.
 type ClientObjectDetail struct {
 	Metadata       ClientObjectMetadata
 	Data           map[string]any
 	RelatedObjects []RelatedObject
-}
-
-func (c ClientObjectDetail) MarshalJSON() ([]byte, error) {
-	if c.RelatedObjects == nil {
-		c.RelatedObjects = make([]RelatedObject, 0)
-	}
-	if c.Data == nil {
-		c.Data = make(map[string]any)
-	}
-	return json.Marshal(struct {
-		Metadata       ClientObjectMetadata `json:"metadata,omitzero"`
-		Data           map[string]any       `json:"data"`
-		RelatedObjects []RelatedObject      `json:"related_objects"`
-	}{
-		Metadata:       c.Metadata,
-		Data:           c.Data,
-		RelatedObjects: c.RelatedObjects,
-	})
+	Annotations    GroupedEntityAnnotations
 }
 
 type RelatedObject struct {
-	LinkName string             `json:"link_name"`
-	Detail   ClientObjectDetail `json:"related_object_detail"` //nolint:tagliatelle
+	LinkName string
+	Detail   ClientObjectDetail
 }
 
 type ClientObjectMetadata struct {
-	ValidFrom  time.Time `json:"valid_from"`
-	ObjectType string    `json:"object_type"`
+	ValidFrom  time.Time
+	ObjectType string
 }
 
 type StringOrNumber struct {

--- a/models/entity_annotation.go
+++ b/models/entity_annotation.go
@@ -90,3 +90,26 @@ type AnnotationByIdRequest struct {
 	AnnotationId   string
 	AnnotationType *EntityAnnotationType
 }
+
+type GroupedEntityAnnotations struct {
+	Comments []EntityAnnotation
+	Tags     []EntityAnnotation
+	Files    []EntityAnnotation
+}
+
+func GroupAnnotationsByType(annotations []EntityAnnotation) GroupedEntityAnnotations {
+	grouped := GroupedEntityAnnotations{}
+
+	for _, annotation := range annotations {
+		switch annotation.AnnotationType {
+		case EntityAnnotationComment:
+			grouped.Comments = append(grouped.Comments, annotation)
+		case EntityAnnotationTag:
+			grouped.Tags = append(grouped.Tags, annotation)
+		case EntityAnnotationFile:
+			grouped.Files = append(grouped.Files, annotation)
+		}
+	}
+
+	return grouped
+}

--- a/models/entity_annotation_payload.go
+++ b/models/entity_annotation_payload.go
@@ -61,7 +61,7 @@ type EntityAnnotationFilePayloadFile struct {
 func (EntityAnnotationFilePayload) entityAnnotationPayload() {}
 
 type EntityAnnotationTagPayload struct {
-	Tag string `json:"tag" binding:"required"`
+	TagId string `json:"tag_id" binding:"required"`
 }
 
 func (EntityAnnotationTagPayload) entityAnnotationPayload() {}

--- a/pubapi/tests/e2e_test.go
+++ b/pubapi/tests/e2e_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"testing"
@@ -16,7 +15,7 @@ func TestPublicApi(t *testing.T) {
 	for _, version := range []string{"v1beta"} {
 		t.Run(fmt.Sprintf("Public API %s integration tests", version), func(it *testing.T) {
 			ctx := context.Background()
-			ctx = utils.StoreLoggerInContext(ctx, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			ctx = utils.StoreLoggerInContext(ctx, slog.New(slog.DiscardHandler))
 
 			pg := setupPostgres(it, ctx)
 			sock := setupApi(it, ctx, pg.MustConnectionString(ctx))

--- a/repositories/entity_annotation_repository.go
+++ b/repositories/entity_annotation_repository.go
@@ -31,7 +31,7 @@ func (repo *MarbleDbRepository) GetEntityAnnotationById(
 	return SqlToListOfModels(ctx, exec, sql, dbmodels.AdaptEntityAnnotation)
 }
 
-func (repo *MarbleDbRepository) GetEntityAnnotations(
+func (repo MarbleDbRepository) GetEntityAnnotations(
 	ctx context.Context,
 	exec Executor,
 	req models.EntityAnnotationRequest,
@@ -59,7 +59,7 @@ func (repo *MarbleDbRepository) GetEntityAnnotations(
 	return SqlToListOfModels(ctx, exec, sql, dbmodels.AdaptEntityAnnotation)
 }
 
-func (repo *MarbleDbRepository) GetEntityAnnotationsForObjects(
+func (repo MarbleDbRepository) GetEntityAnnotationsForObjects(
 	ctx context.Context,
 	exec Executor,
 	req models.EntityAnnotationRequestForObjects,
@@ -102,7 +102,7 @@ func (repo *MarbleDbRepository) GetEntityAnnotationsForObjects(
 	return annotationsByObject, nil
 }
 
-func (repo *MarbleDbRepository) GetEntityAnnotationsForCase(
+func (repo MarbleDbRepository) GetEntityAnnotationsForCase(
 	ctx context.Context,
 	exec Executor,
 	req models.CaseEntityAnnotationRequest,

--- a/usecases/entity_annotations_usecase.go
+++ b/usecases/entity_annotations_usecase.go
@@ -198,7 +198,7 @@ func (uc EntityAnnotationUsecase) validateAnnotation(ctx context.Context, req mo
 		if !ok {
 			return errors.New("invalid payload for annotation type")
 		}
-		tag, err := uc.tagRepository.GetTagById(ctx, uc.executorFactory.NewExecutor(), payload.Tag)
+		tag, err := uc.tagRepository.GetTagById(ctx, uc.executorFactory.NewExecutor(), payload.TagId)
 		if err != nil {
 			return errors.Wrap(models.NotFoundError, "unknown tag")
 		}
@@ -206,7 +206,7 @@ func (uc EntityAnnotationUsecase) validateAnnotation(ctx context.Context, req mo
 			return errors.Wrap(models.UnprocessableEntityError,
 				"provided tag is not targeting ingested objects")
 		}
-		exists, err := uc.repository.IsObjectTagSet(ctx, uc.executorFactory.NewExecutor(), req, payload.Tag)
+		exists, err := uc.repository.IsObjectTagSet(ctx, uc.executorFactory.NewExecutor(), req, payload.TagId)
 		if err != nil {
 			return err
 		}

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -262,7 +262,7 @@ func (usecase IngestedDataReaderUsecase) enrichPivotObjectWithData(
 	if err != nil {
 		return models.PivotObject{}, err
 	}
-	pivotObject.Annotations = models.GroupAnnotationsByType(annotations)
+	pivotObject.PivotObjectData.Annotations = models.GroupAnnotationsByType(annotations)
 
 	// Enriches the pivot object with one level of related objects (fiend objects that are linked to the pivot object, without further recursion)
 	pivotObject.PivotObjectData, err = usecase.enrichClientDataObjectWithRelatedObjectsData(

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -310,14 +310,14 @@ func (usecase IngestedDataReaderUsecase) ReadIngestedClientObjects(
 	if !ok {
 		err = errors.Wrapf(models.NotFoundError,
 			"Field '%s' not found in table '%s' in ReadIngestedClientObjects",
-			explo.FilterFieldName, explo.SourceTableName)
+			explo.FilterFieldName, targetTable.Name)
 		return
 	}
 	_, ok = targetTable.Fields[explo.OrderingFieldName]
 	if !ok {
 		err = errors.Wrapf(models.NotFoundError,
 			"Field '%s' not found in table '%s' in ReadIngestedClientObjects",
-			explo.OrderingFieldName, explo.SourceTableName)
+			explo.OrderingFieldName, targetTable.Name)
 		return
 	}
 	navigationOptionFound := false

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -393,6 +393,20 @@ func (usecase IngestedDataReaderUsecase) ReadIngestedClientObjects(
 			Metadata: models.ClientObjectMetadata{ValidFrom: validFrom, ObjectType: objectType},
 		}
 
+		var annotations []models.EntityAnnotation
+		annotations, err = usecase.repository.GetEntityAnnotations(
+			ctx,
+			usecase.executorFactory.NewExecutor(),
+			models.EntityAnnotationRequest{
+				OrgId:      orgId,
+				ObjectType: objectType,
+				ObjectId:   object.Data["object_id"].(string),
+			})
+		if err != nil {
+			return
+		}
+		clientObject.Annotations = models.GroupAnnotationsByType(annotations)
+
 		clientObject, err = usecase.enrichClientDataObjectWithRelatedObjectsData(
 			ctx,
 			orgId,


### PR DESCRIPTION
### Content

- [x] return annotations on reading pivot objects in case
- [x] return annotations on reading client objects as table

### Related
See openapi spec change in https://github.com/checkmarble/marble-frontend/pull/799

 ### Comments
I went ahead and implemented grouped by tag type in the backend, because I figured _someone_ would have to do it systematically when displaying them, so we might as well do it in the backend where it minimizes data manipulation. But you let me know if this is overengineered @ChibiBlasphem .

Nb: the `annotations` nested object is not required, and will be only present if any annotations are present.

New example of output payload:
```json
...
{
            "pivot_object_id": "account_id",
            "pivot_value": "account_id",
            "pivot_id": "038f72a2-2c98-47e6-ba85-28547075aafc",
            "pivot_type": "object",
            "pivot_object_name": "accounts",
            "pivot_field_name": "object_id",
            "is_ingested": true,
            "pivot_object_data": {
                "metadata": {
                    "valid_from": "2025-04-09T04:25:21.952291+08:00",
                    "object_type": "accounts"
                },
                "data": {
                    "account_id": null,
                    "company_id": "company_id",
                    "company_number": null,
                    "object_id": "account_id",
                    "updated_at": "2006-01-02T23:04:05.999999+08:00"
                },
                "related_objects": [],
                "annotations": {
                    "comments": [],
                    "tags": [
                        {
                            "id": "d878666a-53a7-489a-b38b-5b2f64e89a35",
                            "type": "tag",
                            "payload": {
                                "tag": "291ec3e1-66a0-47a4-98c8-f989873a586a"
                            },
                            "annotated_by": "0cd34ca6-de6e-440d-9460-8f2ae2824e37",
                            "created_at": "2025-04-18T14:39:43.903321+08:00"
                        }
                    ],
                    "files": []
                }
            },
            "number_of_decisions": 24
        },
... 
```