### PR TITLE
Fix docker case warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as build
+FROM golang:1.24 AS build
 
 ARG MARBLE_VERSION=dev
 


### PR DESCRIPTION
Fix docker warning 

```
FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
```