### PR TITLE
Change Yente healthcheck to /readyz

### DIFF
--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -56,7 +56,7 @@ func (repo OpenSanctionsRepository) IsConfigured(ctx context.Context) (bool, err
 		}
 	}
 
-	catalogUrl := fmt.Sprintf("%s/healthz", repo.opensanctions.Host())
+	catalogUrl := fmt.Sprintf("%s/readyz", repo.opensanctions.Host())
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogUrl, nil)
 	if err != nil {


### PR DESCRIPTION
An undocumented "feature" of Cloud Run is that they reserve the `/healthz` path for internal purpose, meaning that the backend service will never get requests destined to that endpoint.

As we use that endpoint on Yente to check if it is up, this failed constantly with a 404 error.

This PR moves our healthcheck to `/readyz`, which is not reserved and serves - more or less - the same purpose.