### PR TITLE
Pascal/mar 937 improve sentry error reporting backend

### DIFF
--- a/api/present_error.go
+++ b/api/present_error.go
@@ -68,13 +68,13 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 		logger.WarnContext(ctx, fmt.Sprintf("Deadline exceeded: %v", err))
 		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
 	case errors.Is(err, context.Canceled):
-		logger.WarnContext(ctx, fmt.Sprintf("Deadline exceeded: %v", err))
+		logger.WarnContext(ctx, fmt.Sprintf("Context canceled: %v", err))
 		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
 
 	default:
 		logger.ErrorContext(ctx, fmt.Sprintf("Unexpected Error: %+v", err))
 		if hub := sentrygin.GetHubFromContext(c); hub != nil {
-			hub.CaptureException(err)
+			utils.CaptureSentryException(ctx, hub, err)
 		} else {
 			sentry.CaptureException(err)
 		}

--- a/models/credentials.go
+++ b/models/credentials.go
@@ -1,9 +1,5 @@
 package models
 
-import (
-	"fmt"
-)
-
 type Identity struct {
 	UserId     UserId
 	Email      string
@@ -17,10 +13,6 @@ type Credentials struct {
 	OrganizationId string
 	PartnerId      *string
 	Role           Role
-}
-
-func (c Credentials) ActorIdentityDescription() string {
-	return fmt.Sprintf("%s%s (%s)", c.ActorIdentity.Email, c.ActorIdentity.ApiKeyName, c.Role.String())
 }
 
 func NewCredentialWithUser(user User) Credentials {


### PR DESCRIPTION
# Objective
- reduce spam on Sentry by grouping DB connection related issues
- make issues more easily readable
- add more context on issues (concerned user)

See [Sentry doc on fingerprinting](https://docs.sentry.io/concepts/data-management/event-grouping/fingerprint-rules/#combining-matchers)

## Content
- Rewrite events before sending to Sentry to have better issue titles in Sentry
- Add information on user/API key as user attribute or tags for display on Sentry (and for more precise "archive until it happens to another XX users" feature)

### Left for future work:
- add useful breadcrumbs to issues
- do something similar on the frontend project
    - use similary Sentry config on the frontend project to automatically ignore errors that are caused by a 500 on the backend ? => Ok I added this `error.value:"*HTTP Client Error with status code: 500*" -> api-client-error`

## Before/After title change:
### Before:
<img width="500" alt="Capture d’écran 2025-04-30 à 21 40 50" src="https://github.com/user-attachments/assets/5ac989f8-373e-41bf-baa0-eda2960e0168" />
--- 
### After (see how the title is now "cannot scan ...")
<img width="500" alt="Capture d’écran 2025-04-30 à 21 40 41" src="https://github.com/user-attachments/assets/38878350-922f-44b9-a73e-174ff2c6027c" />

## Limitations
Because we use `UnwrapAll` to get the first error, in the case of errors generated by third party libraries, the errors we'll see on Sentry will only be as good as what they generate.

## Related change (non-code)
In Sentry, I set this fingerprinting behavior for errors on the backend project:
```
# group errors from creating a DB connection. Group them by the DB that is concerned.
error.type:"\*pgconn.ConnectError" -> db_connection_error, {{ error.type }}

# for local testing: group db connection errors, grouping them by URL/PORT
error.value:"*connect: connection refused*" -> db_connection_error, {{ error.type }}

# for cloudsql db: group db connection errors, effectively grouping them by unix socket (hence by db)
error.value:"*/cloudsql*" error.value:"*failed to receive message: unexpected EOF" -> db_connection_error, {{ error.type }}
```

If it does what I think it does (tested locally to some extent), it should group all errors related to DB connections, grouping them further by the DB that is concerned (so that client DBs will be grouped separately from the Marble DB and from each other)