### PR TITLE
fix panic on async decision exec for canceled scheduled execution

### DIFF
--- a/usecases/scheduled_execution/async_decision_job.go
+++ b/usecases/scheduled_execution/async_decision_job.go
@@ -159,7 +159,9 @@ func (w *AsyncDecisionWorker) Work(ctx context.Context, job *river.Job[models.As
 	for _, webhookEventId := range webhookEventIds {
 		w.webhookEventsSender.SendWebhookEventAsync(ctx, webhookEventId)
 	}
-	testRunCallback()
+	if testRunCallback != nil {
+		testRunCallback()
+	}
 
 	return nil
 }


### PR DESCRIPTION
The testRunCallback can be nil without there being an error, because there is an early exit condition in handleDecision (if the scheduled execution status is "failure").