### PR TITLE
Remove cascade on iteration rules foreign key to snooze groups.

### DIFF
--- a/repositories/migrations/20250506113500_remove_snooze_groups_cascade.sql
+++ b/repositories/migrations/20250506113500_remove_snooze_groups_cascade.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+
+alter table scenario_iteration_rules
+  drop constraint scenario_iteration_rules_snooze_group_id_fkey,
+  add constraint scenario_iteration_rules_snooze_group_id_fkey
+    foreign key (scenario_iteration_id) references scenario_iterations
+    on delete set null;
+
+-- +goose Down
+
+-- Omited because we really don't want this.


### PR DESCRIPTION
This removes the `on delete cascade` set on the snooze groups foreign key on the iteration rules tables, to guard against deleting rules when truncating live data.