### PR TITLE
Change permissions to allow inbox admins to update inboxes.

### DIFF
--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -110,6 +110,11 @@ func (e *EnforceSecurity) CreateInbox(organizationId string) error {
 	return args.Error(0)
 }
 
+func (e *EnforceSecurity) UpdateInbox(inbox models.Inbox) error {
+	args := e.Called(inbox)
+	return args.Error(0)
+}
+
 func (e *EnforceSecurity) ReadInboxUser(inboxUser models.InboxUser, actorInboxUsers []models.InboxUser) error {
 	args := e.Called(inboxUser, actorInboxUsers)
 	return args.Error(0)

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -29,6 +29,7 @@ type InboxRepository interface {
 type EnforceSecurityInboxes interface {
 	ReadInbox(i models.Inbox) error
 	CreateInbox(organizationId string) error
+	UpdateInbox(inbox models.Inbox) error
 }
 
 type InboxUsecase struct {
@@ -92,7 +93,7 @@ func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId, name stri
 					"This inbox is archived and cannot be updated")
 			}
 
-			if err := usecase.enforceSecurity.CreateInbox(inbox.OrganizationId); err != nil {
+			if err := usecase.enforceSecurity.UpdateInbox(inbox); err != nil {
 				return models.Inbox{}, err
 			}
 

--- a/usecases/security/enforce_security_inboxes.go
+++ b/usecases/security/enforce_security_inboxes.go
@@ -45,6 +45,19 @@ func (e EnforceSecurityInboxes) CreateInbox(organizationId string) error {
 	return errors.Join(e.Permission(models.INBOX_EDITOR), e.ReadOrganization(organizationId))
 }
 
+func (e EnforceSecurityInboxes) UpdateInbox(inbox models.Inbox) error {
+	// Inbox admins are allowed to update the inbox, even if they are not organization admins
+	for _, inboxMember := range inbox.InboxUsers {
+		if inboxMember.UserId == string(e.Credentials.ActorIdentity.UserId) &&
+			inboxMember.Role == models.InboxUserRoleAdmin {
+			return nil
+		}
+	}
+
+	return errors.Join(e.Permission(models.INBOX_EDITOR),
+		e.ReadOrganization(inbox.OrganizationId))
+}
+
 func (e EnforceSecurityInboxes) ReadInboxUser(inboxUser models.InboxUser, actorInboxUsers []models.InboxUser) error {
 	// org admins can read all inbox users
 	err := e.Permission(models.INBOX_EDITOR)


### PR DESCRIPTION
This PR does two things:

- Allow access to inbox settings, not only to organization admins, but also to inbox admins. If a user is an admin for at least one inbox, they will see the inbox settings section and be able to update it and manage its users.
- Gate the scenarios settings behind being an organization admins. Until now, any user could see it and manipulate the form (even though the backend rejected the action).

This relates to checkmarble/marble-frontend#849.