### PR TITLE
resolve github code scanning issue on CI

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -12,6 +12,10 @@ on:
         description: "version to deploy"
         required: true
 
+permissions:
+  contents: read
+  id-token: "write" # needed for using open id token to authenticate with GCP services
+
 jobs:
   build_and_deploy_backend:
     name: Build and deploy back-end
@@ -43,7 +47,7 @@ jobs:
           registry: europe-west1-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
-      
+
       - name: Extract version from tag
         id: version
         run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -2,6 +2,11 @@ name: Test back-end
 
 on: [workflow_call]
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 jobs:
   test_backend:
     name: Test back-end


### PR DESCRIPTION
So when using reusable workflows, Github actions expects us to set the permissions on the calling workflow (to actually grant permissions) and on the called workflow (to limit the maximum permissions that may be received).
This is newly detected by github CodeQL scanning.
If this resolves on the backend, I'll do the same on frontend.