### PR TITLE
compile segment write key into the binary & rotate key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,7 +118,8 @@ LOGGING_FORMAT=text
 # Configure various external integrations.
 # Send traces to Google Cloud Platform (see https://cloud.google.com/trace/docs/setup/go-ot). Requires Application Default Credentials.
 ENABLE_GCP_TRACING=false 
-SEGMENT_WRITE_KEY=UgkImFmHmBZAWh5fxIKBY3QtvlcBrhqQ
+SEGMENT_WRITE_KEY=
+DISABLE_SEGMENT=false
 SENTRY_DSN=
 
 # Abort and exit if license cannot be validated.

--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -11,6 +11,9 @@ on:
         type: string
         description: "version to deploy"
         required: true
+      segment_write_key_opensource:
+        type: string
+        description: write key for segment (open source deployment)
 
 permissions:
   contents: read
@@ -58,6 +61,7 @@ jobs:
           push: true
           build-args: |
             MARBLE_VERSION=${{ steps.version.outputs.MARBLE_VERSION }}
+            SEGMENT_WRITE_KEY=${{ inputs.segment_write_key_opensource }}
           tags: ${{ env.IMAGE }}
 
       - name: "Set up Cloud SDK"

--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -11,8 +11,8 @@ on:
         type: string
         description: "version to deploy"
         required: true
+    secrets:
       segment_write_key_opensource:
-        type: string
         description: write key for segment (open source deployment)
 
 permissions:
@@ -61,7 +61,7 @@ jobs:
           push: true
           build-args: |
             MARBLE_VERSION=${{ steps.version.outputs.MARBLE_VERSION }}
-            SEGMENT_WRITE_KEY=${{ inputs.segment_write_key_opensource }}
+            SEGMENT_WRITE_KEY=${{ secrets.segment_write_key_opensource }}
           tags: ${{ env.IMAGE }}
 
       - name: "Set up Cloud SDK"

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -26,4 +26,5 @@ jobs:
     with:
       environment: "production"
       version: ${{ github.ref_name }}
+    secrets:
       segment_write_key_opensource: ${{ secrets.SEGMENT_WRITE_KEY_OPENSOURCE }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -26,3 +26,4 @@ jobs:
     with:
       environment: "production"
       version: ${{ github.ref_name }}
+      segment_write_key_opensource: ${{ secrets.SEGMENT_WRITE_KEY_OPENSOURCE }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -26,3 +26,4 @@ jobs:
     with:
       environment: "staging"
       version: latest
+      segment_write_key_opensource: ${{ secrets.SEGMENT_WRITE_KEY_OPENSOURCE }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -26,4 +26,5 @@ jobs:
     with:
       environment: "staging"
       version: latest
+    secrets:
       segment_write_key_opensource: ${{ secrets.SEGMENT_WRITE_KEY_OPENSOURCE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM golang:1.24 AS build
 
 ARG MARBLE_VERSION=dev
+ARG SEGMENT_WRITE_KEY=
 
 WORKDIR /go/src/app
 COPY . .
 
 RUN go get
 
-RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.apiVersion=${MARBLE_VERSION}'"
+RUN CGO_ENABLED=0 go build -o /go/bin/app -ldflags="-X 'main.apiVersion=${MARBLE_VERSION}' -X 'main.segmentWriteKey=${SEGMENT_WRITE_KEY}'"
 
 FROM alpine:3.19
 

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -11,6 +11,7 @@ type Configuration struct {
 	RequestLoggingLevel string
 	TokenLifetimeMinute int
 	SegmentWriteKey     string
+	DisableSegment      bool
 	BatchTimeout        time.Duration
 	DecisionTimeout     time.Duration
 	DefaultTimeout      time.Duration

--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -43,6 +43,9 @@ func InitDependencies(
 	jwtRepository := repositories.NewJWTRepository(signingKey)
 	tokenValidator := token.NewValidator(database, jwtRepository)
 	tokenGenerator := token.NewGenerator(database, jwtRepository, firebaseClient, conf.TokenLifetimeMinute)
+	if conf.DisableSegment {
+		conf.SegmentWriteKey = ""
+	}
 	segmentClient := analytics.New(conf.SegmentWriteKey)
 
 	return dependencies{

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,6 @@
+package cmd
+
+type CompiledConfig struct {
+	Version         string
+	SegmentWriteKey string
+}

--- a/main.go
+++ b/main.go
@@ -11,8 +11,16 @@ import (
 
 // Static variable set at compilation-time through linker flags.
 //
-//	$ go build -ldflags '-X main.apiVersion=v0.10.0' .
-var apiVersion string = "dev"
+//	$ go build -ldflags '-X main.apiVersion=v0.10.0 -X ...' .
+var (
+	apiVersion      string = "dev"
+	segmentWriteKey string = ""
+)
+
+var compiledConfig = cmd.CompiledConfig{
+	Version:         apiVersion,
+	SegmentWriteKey: segmentWriteKey,
+}
 
 func main() {
 	shouldRunMigrations := flag.Bool("migrations", false, "Run migrations")
@@ -42,7 +50,7 @@ func main() {
 	}
 
 	if *shouldRunServer {
-		err := cmd.RunServer(apiVersion)
+		err := cmd.RunServer(compiledConfig)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
The gist of it is: stop passing the segment key around as cleartext env var shared with customers (even though it's still accessible for anyone motivated - but that still hides it much better against anything automated).
Also, just expose a new "DISABLE_SEGMENT" env var to opt out of sending segment events. Remains backwards compatible with overwriting the default segment write key with an empty string.