### PR TITLE
Various case manager improvements

### DIFF
--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -25,6 +25,16 @@ func (e *EnforceSecurity) Permissions(permissions []models.Permission) error {
 	return args.Error(0)
 }
 
+func (e *EnforceSecurity) OrgId() string {
+	args := e.Called()
+	return args.String(0)
+}
+
+func (e *EnforceSecurity) UserId() *string {
+	args := e.Called()
+	return args.Get(0).(*string)
+}
+
 func (e *EnforceSecurity) ReadDecision(decision models.Decision) error {
 	args := e.Called(decision)
 	return args.Error(0)

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -298,7 +298,7 @@ func casesWithRankColumns() []string {
 }
 
 func casesCoreQueryWithRank(pagination models.PaginationAndSorting) squirrel.SelectBuilder {
-	orderCondition := fmt.Sprintf("c.boost is null, c.%s %s, c.id %s",
+	orderCondition := fmt.Sprintf("c.boost is null, c.assigned_to is not null, c.%s %s, c.id %s",
 		pagination.Sorting, pagination.Order, pagination.Order)
 
 	return squirrel.StatementBuilder.
@@ -472,7 +472,7 @@ func (repo *MarbleDbRepository) GetCasesWithPivotValue(ctx context.Context, exec
 }
 
 func orderConditionForCases(p models.PaginationAndSorting) string {
-	return fmt.Sprintf("c.boost is null, c.%s %s, c.id %s", p.Sorting, p.Order, p.Order)
+	return fmt.Sprintf("c.boost is null, c.assigned_to is not null, c.%s %s, c.id %s", p.Sorting, p.Order, p.Order)
 }
 
 func (repo *MarbleDbRepository) EscalateCase(ctx context.Context, exec Executor, id, inboxId string) error {

--- a/repositories/migrations/20250512144400_change_case_index.sql
+++ b/repositories/migrations/20250512144400_change_case_index.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- +goose StatementBegin
+
+alter index idx_inbox_cases rename to idx_inbox_cases_2;
+
+create index idx_inbox_cases
+    on cases (org_id, inbox_id, (boost is null), (assigned_to is not null), created_at desc, id desc);
+
+drop index idx_inbox_cases_2;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+alter index idx_inbox_cases rename to idx_inbox_cases_2;
+
+create index idx_inbox_cases
+    on cases (org_id, inbox_id, (boost is null), created_at desc, id desc);
+
+drop index idx_inbox_cases_2;
+
+-- +goose StatementEnd

--- a/usecases/security/enforce_security.go
+++ b/usecases/security/enforce_security.go
@@ -11,6 +11,9 @@ type EnforceSecurity interface {
 	Permission(permission models.Permission) error
 	ReadOrganization(organizationId string) error
 	Permissions(permissions []models.Permission) error
+
+	OrgId() string
+	UserId() *string
 }
 
 type EnforceSecurityImpl struct {
@@ -21,6 +24,18 @@ func NewEnforceSecurity(credentials models.Credentials) *EnforceSecurityImpl {
 	return &EnforceSecurityImpl{
 		Credentials: credentials,
 	}
+}
+
+func (e *EnforceSecurityImpl) OrgId() string {
+	return e.Credentials.OrganizationId
+}
+
+func (e *EnforceSecurityImpl) UserId() *string {
+	if e.Credentials.ActorIdentity.UserId == "" {
+		return nil
+	}
+
+	return utils.Ptr(string(e.Credentials.ActorIdentity.UserId))
 }
 
 func (e *EnforceSecurityImpl) ReadOrganization(organizationId string) error {

--- a/usecases/security/enforce_security_user_test.go
+++ b/usecases/security/enforce_security_user_test.go
@@ -21,6 +21,14 @@ func (mockUserEnforceSecurity) Permissions(permissions []models.Permission) erro
 	return nil
 }
 
+func (mockUserEnforceSecurity) UserId() *string {
+	return nil
+}
+
+func (mockUserEnforceSecurity) OrgId() string {
+	return ""
+}
+
 func TestUpdateUserRole(t *testing.T) {
 	tts := []struct {
 		name      string


### PR DESCRIPTION
* Change default case ordering as specified by MAR-959.
* Centralize case action side effects (unboosting and self-assigning).