### PR TITLE
Improved logging for decisions.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,8 @@ CONVOY_PROJECT_ID=
 REQUEST_LOGGING_LEVEL=all
 # 'text', 'json' or 'gcp'
 LOGGING_FORMAT=text
+# 'info' or 'debug'
+# LOG_LEVEL=info
 
 # You can customize the default timeout durations by uncommenting the following settings. Provided values are defaults.
 # BATCH_TIMEOUT_SECOND=55

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -115,6 +115,7 @@ func RunServer(config CompiledConfig) error {
 	}
 
 	logger := utils.NewLogger(serverConfig.loggingFormat)
+
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
 	marbleJwtSigningKey := infra.ReadParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey, serverConfig.jwtSigningKeyFile)
 	license := infra.VerifyLicense(licenseConfig)

--- a/models/decision.go
+++ b/models/decision.go
@@ -79,6 +79,13 @@ type ScenarioExecution struct {
 	Outcome                Outcome
 	OrganizationId         string
 	TestRunId              string
+
+	ExecutionMetrics *ScenarioExecutionMetrics
+}
+
+type ScenarioExecutionMetrics struct {
+	Steps map[string]int64
+	Rules map[string]int64
 }
 
 type RuleExecutionStat struct {
@@ -97,6 +104,7 @@ type RuleExecution struct {
 	Result              bool
 	ResultScoreModifier int
 	Rule                Rule
+	Duration            time.Duration
 }
 
 func AdaptScenarExecToDecision(scenarioExecution ScenarioExecution, clientObject ClientObject, scheduledExecutionId *string) DecisionWithRuleExecutions {

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -119,6 +119,9 @@ type SanctionCheckWithMatches struct {
 	SanctionCheck
 	Matches []SanctionCheckMatch
 	Count   int
+
+	Duration                time.Duration
+	NameRecognitionDuration time.Duration
 }
 
 type SanctionRawSearchResponseWithMatches struct {

--- a/pure_utils/map.go
+++ b/pure_utils/map.go
@@ -108,3 +108,14 @@ func MapKeyValue[KL, KR comparable, VL, VR any](in map[KL]VL, f func(k KL, v VL)
 
 	return out
 }
+
+func MapSliceToMap[T, V any, K comparable](input []T, f func(v T) (K, V)) map[K]V {
+	output := make(map[K]V, len(input))
+
+	for _, item := range input {
+		k, v := f(item)
+		output[k] = v
+	}
+
+	return output
+}

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -231,7 +231,7 @@ func (usecase *CustomListUseCase) ReplaceCustomListValuesFromCSV(ctx context.Con
 		duration := end.Sub(start)
 		// divide by 1e6 convert to milliseconds (base is nanoseconds)
 		avgDuration := float64(duration) / float64(total*1e6)
-		logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested %d custom list values in %s, average %vms", total, duration, avgDuration))
+		logger.DebugContext(ctx, fmt.Sprintf("Successfully ingested %d custom list values in %s, average %vms", total, duration, avgDuration))
 	}
 	defer printDuration()
 

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -527,12 +527,15 @@ func (usecase *DecisionUsecase) CreateDecision(
 		scenarioExecution.ExecutionMetrics.Steps[evaluate_scenario.LogStorageDurationKey] = storageDuration.Milliseconds()
 
 		utils.LoggerFromContext(ctx).InfoContext(ctx,
-			fmt.Sprintf("created decision %s in %dms", decision.DecisionId,
-				decisionDuration.Milliseconds()), "org_id", scenario.OrganizationId, "decision_id",
-			decision.DecisionId, "scenario_id", scenario.Id, "score", scenarioExecution.Score,
-			"outcome", scenarioExecution.Outcome, "duration", decisionDuration.Milliseconds(),
-			"rules", scenarioExecution.ExecutionMetrics.Rules, "steps",
-			scenarioExecution.ExecutionMetrics.Steps)
+			fmt.Sprintf("created decision %s in %dms", decision.DecisionId, decisionDuration.Milliseconds()),
+			"org_id", scenario.OrganizationId,
+			"decision_id", decision.DecisionId,
+			"scenario_id", scenario.Id,
+			"score", scenarioExecution.Score,
+			"outcome", scenarioExecution.Outcome,
+			"duration", decisionDuration.Milliseconds(),
+			"rules", scenarioExecution.ExecutionMetrics.Rules,
+			"steps", scenarioExecution.ExecutionMetrics.Steps)
 
 	}
 
@@ -676,13 +679,16 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 				item.execution.ExecutionMetrics.Steps[evaluate_scenario.LogStorageDurationKey] = storageDuration.Milliseconds()
 
 				utils.LoggerFromContext(ctx).InfoContext(ctx,
-					fmt.Sprintf("created decision (all) %s in %dms", item.decision.DecisionId,
-						decisionDuration.Milliseconds()), "org_id",
-					item.scenario.OrganizationId, "decision_id",
-					item.decision.DecisionId, "scenario_id", item.scenario.Id, "score", item.execution.Score,
-					"outcome", item.execution.Outcome, "duration", decisionDuration.Milliseconds(),
-					"rules", item.execution.ExecutionMetrics.Rules, "steps",
-					item.execution.ExecutionMetrics.Steps)
+					fmt.Sprintf("created decision (all) %s in %dms",
+						item.decision.DecisionId, decisionDuration.Milliseconds()),
+					"org_id", item.scenario.OrganizationId,
+					"decision_id", item.decision.DecisionId,
+					"scenario_id", item.scenario.Id,
+					"score", item.execution.Score,
+					"outcome", item.execution.Outcome,
+					"duration", decisionDuration.Milliseconds(),
+					"rules", item.execution.ExecutionMetrics.Rules,
+					"steps", item.execution.ExecutionMetrics.Steps)
 			}
 
 			webhookEventId := uuid.NewString()

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -314,7 +314,7 @@ func (e ScenarioEvaluator) EvalTestRunScenario(
 			se = models.ScenarioExecution{}
 		}
 	}()
-	logger.InfoContext(ctx, "Evaluating scenario test run", "scenarioId", params.Scenario.Id)
+	logger.DebugContext(ctx, "Evaluating scenario test run", "scenarioId", params.Scenario.Id)
 	exec := e.executorFactory.NewExecutor()
 	tracer := utils.OpenTelemetryTracerFromContext(ctx)
 	ctx, span := tracer.Start(ctx, "evaluate_scenario.EvalTestRunScenario",
@@ -395,7 +395,7 @@ func (e ScenarioEvaluator) EvalScenario(
 		}
 	}()
 
-	logger.InfoContext(ctx, "Evaluating scenario", "scenarioId", params.Scenario.Id)
+	logger.DebugContext(ctx, "Evaluating scenario", "scenarioId", params.Scenario.Id)
 	exec := e.executorFactory.NewExecutor()
 
 	// If the scenario has no live version, don't try to Eval() it, return early

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -545,7 +545,7 @@ func (e ScenarioEvaluator) evalScenarioRule(
 		ruleExecution.Outcome = "hit"
 		ruleExecution.ResultScoreModifier = rule.ScoreModifier
 
-		logger.InfoContext(ctx, fmt.Sprintf("rule evaluated in %dms",
+		logger.DebugContext(ctx, fmt.Sprintf("rule evaluated in %dms",
 			ruleStats.Took.Milliseconds()), "duration",
 			ruleStats.Took.Milliseconds(), "nodes", ruleStats.Nodes, "skipped", ruleStats.SkippedCount,
 			"cached", ruleStats.CachedCount, "ruleName", rule.Name, "score_modifier",

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -103,7 +103,7 @@ func (usecase *IngestionUseCase) IngestObject(
 		return 0, err
 	}
 
-	logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
+	logger.DebugContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
 		slog.String("organization_id", organizationId),
 		slog.String("object_type", objectType),
 		slog.Int("nb_objects", nb),
@@ -193,7 +193,7 @@ func (usecase *IngestionUseCase) IngestObjects(
 		return 0, err
 	}
 
-	logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
+	logger.DebugContext(ctx, fmt.Sprintf("Successfully ingested objects: %d objects", nb),
 		slog.String("organization_id", organizationId),
 		slog.String("object_type", objectType),
 		slog.Int("nb_objects", nb),
@@ -493,7 +493,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(ctx context.Context, organ
 		// divide by 1e6 convert to milliseconds (base is nanoseconds)
 		avgDuration := float64(duration) / float64(total*1e6)
 		if total > 0 {
-			logger.InfoContext(ctx, fmt.Sprintf("Successfully ingested %d objects in %s, average %vms", total, duration, avgDuration))
+			logger.DebugContext(ctx, fmt.Sprintf("Successfully ingested %d objects in %s, average %vms", total, duration, avgDuration))
 		}
 	}
 	defer printDuration()

--- a/usecases/scheduled_execution/async_decision_job.go
+++ b/usecases/scheduled_execution/async_decision_job.go
@@ -357,12 +357,15 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 		scenarioExecution.ExecutionMetrics.Steps[evaluate_scenario.LogStorageDurationKey] = storageDuration.Milliseconds()
 
 		utils.LoggerFromContext(ctx).InfoContext(ctx,
-			fmt.Sprintf("created decision (async) %s in %dms", decision.DecisionId,
-				decisionDuration.Milliseconds()), "org_id", scenario.OrganizationId, "decision_id",
-			decision.DecisionId, "scenario_id", scenario.Id, "score", scenarioExecution.Score,
-			"outcome", scenarioExecution.Outcome, "duration", decisionDuration.Milliseconds(),
-			"rules", scenarioExecution.ExecutionMetrics.Rules, "steps",
-			scenarioExecution.ExecutionMetrics.Steps)
+			fmt.Sprintf("created decision (async) %s in %dms", decision.DecisionId, decisionDuration.Milliseconds()),
+			"org_id", scenario.OrganizationId,
+			"decision_id", decision.DecisionId,
+			"scenario_id", scenario.Id,
+			"score", scenarioExecution.Score,
+			"outcome", scenarioExecution.Outcome,
+			"duration", decisionDuration.Milliseconds(),
+			"rules", scenarioExecution.ExecutionMetrics.Rules,
+			"steps", scenarioExecution.ExecutionMetrics.Steps)
 	}
 
 	if decision.SanctionCheckExecution != nil {

--- a/usecases/webhook_events_usecase.go
+++ b/usecases/webhook_events_usecase.go
@@ -213,7 +213,7 @@ func (usecase WebhookEventsUsecase) _sendWebhookEvent(ctx context.Context, webho
 		return models.Scheduled, err
 	}
 
-	logger.InfoContext(ctx, fmt.Sprintf("Start processing webhook event %s", webhookEvent.Id))
+	logger.DebugContext(ctx, fmt.Sprintf("Start processing webhook event %s", webhookEvent.Id))
 
 	webhookEventUpdate := models.WebhookEventUpdate{Id: webhookEvent.Id}
 

--- a/utils/logging.go
+++ b/utils/logging.go
@@ -174,8 +174,8 @@ func (h *GcpHandler) Handle(ctx context.Context, r slog.Record) error {
 	return h.internalHandler.Handle(ctx, r)
 }
 
-func NewGcpHandler(projectId string) *GcpHandler {
-	slogOption := slog.HandlerOptions{ReplaceAttr: GCPLoggerAttributeReplacer}
+func NewGcpHandler(projectId string, slogOption slog.HandlerOptions) *GcpHandler {
+	slogOption.ReplaceAttr = GCPLoggerAttributeReplacer
 	jsonHandler := slog.NewJSONHandler(os.Stdout, &slogOption)
 	return &GcpHandler{projectId: projectId, internalHandler: jsonHandler}
 }


### PR DESCRIPTION
 - Decision storage in now measured and logged
 - Each decision, on top of logging the overall evaluation duration now also logs:
   - Each macro-step in the decision process (trigger expression, rules execution, sanctions check, name recognition)
   - Each rule individual duration
 - Add a `LOG_LEVEL` knob (set to `info` or `debug`) to control how verbose JSON and GCP adapters are