### PR TITLE
fix error on returned database accessors

### DIFF
--- a/usecases/ast_expression_usecase.go
+++ b/usecases/ast_expression_usecase.go
@@ -76,7 +76,10 @@ func getLinkedDatabaseIdentifiers(scenario models.Scenario, dataModel models.Dat
 				continue
 			}
 			visited = append(visited, relation)
-			pathForLink := append(path, linkName)
+
+			// deepcopy so that different identifiers don't collide
+			pathForLink := append(make([]string, 0, len(path)+1), path...)
+			pathForLink = append(pathForLink, linkName)
 
 			for fieldName := range table.Fields {
 				dataAccessors = append(dataAccessors,

--- a/usecases/ast_expression_usecase_test.go
+++ b/usecases/ast_expression_usecase_test.go
@@ -88,13 +88,14 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_loop(t *testing.
 	expectedStr := []string{
 		"transactions-[account]-id",
 		"transactions-[account]-last_transaction_id",
-		"transactions-[account last_transactions]-id",
-		"transactions-[account last_transactions]-account_id",
+		// loops were allowed in a past iteration (as long as any given link was walked only once), but are no longer.
+		// "transactions-[account last_transactions]-id",
+		// "transactions-[account last_transactions]-account_id",
 	}
 	sort.Strings(expectedStr)
 	indentifiersStr := pure_utils.Map(identifiers, dbAccessNodeToString)
 	sort.Strings(indentifiersStr)
-	assert.Equal(t, indentifiersStr, expectedStr)
+	assert.Equal(t, expectedStr, indentifiersStr)
 }
 
 func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_two_branches(t *testing.T) {
@@ -186,5 +187,155 @@ func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_two_branches(t *
 	sort.Strings(expectedStr)
 	indentifiersStr := pure_utils.Map(identifiers, dbAccessNodeToString)
 	sort.Strings(indentifiersStr)
-	assert.Equal(t, indentifiersStr, expectedStr)
+	assert.Equal(t, expectedStr, indentifiersStr)
+}
+
+func TestAstExpressionUsecase_getLinkedDatabaseIdentifiers_with_two_branches_bis(t *testing.T) {
+	scenario := models.Scenario{
+		TriggerObjectType: "transactions",
+	}
+
+	model := models.DataModel{
+		Tables: map[string]models.Table{
+			"projects": {
+				Name: "projects",
+				Fields: map[string]models.Field{
+					"id": {},
+				},
+			},
+			"account_holders": {
+				Name: "account_holders",
+				Fields: map[string]models.Field{
+					"id":         {},
+					"project_id": {},
+					"aml_score":  {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"project": {
+						ParentTableName: "projects",
+						ParentFieldName: "id",
+						ChildFieldName:  "project_id",
+					},
+				},
+			},
+			"accounts": {
+				Name: "accounts",
+				Fields: map[string]models.Field{
+					"id":                {},
+					"project_id":        {},
+					"account_holder_id": {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"projects": {
+						ParentTableName: "projects",
+						ParentFieldName: "id",
+						ChildFieldName:  "project_id",
+					},
+					"account_holder": {
+						ParentTableName: "account_holders",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_holder_id",
+					},
+				},
+			},
+			"cards": {
+				Name: "cards",
+				Fields: map[string]models.Field{
+					"id":                {},
+					"project_id":        {},
+					"account_holder_id": {},
+					"account_id":        {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"projects": {
+						ParentTableName: "projects",
+						ParentFieldName: "id",
+						ChildFieldName:  "project_id",
+					},
+					"account_holder": {
+						ParentTableName: "account_holders",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_holder_id",
+					},
+					"account": {
+						ParentTableName: "accounts",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_id",
+					},
+				},
+			},
+			"transactions": {
+				Name: "transactions",
+				Fields: map[string]models.Field{
+					"id":                {},
+					"project_id":        {},
+					"account_holder_id": {},
+					"account_id":        {},
+					"card_id":           {},
+				},
+				LinksToSingle: map[string]models.LinkToSingle{
+					"projects": {
+						ParentTableName: "projects",
+						ParentFieldName: "id",
+						ChildFieldName:  "project_id",
+					},
+					"account_holder": {
+						ParentTableName: "account_holders",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_holder_id",
+					},
+					"account": {
+						ParentTableName: "accounts",
+						ParentFieldName: "id",
+						ChildFieldName:  "account_id",
+					},
+					"card": {
+						ParentTableName: "cards",
+						ParentFieldName: "id",
+						ChildFieldName:  "card_id",
+					},
+				},
+			},
+		},
+	}
+
+	identifiers, err := getLinkedDatabaseIdentifiers(scenario, model)
+	assert.NoError(t, err)
+
+	expectedStr := []string{
+		"transactions-[card account account_holder project]-id",
+		"transactions-[card account account_holder]-aml_score",
+		"transactions-[card account account_holder]-id",
+		"transactions-[card account account_holder]-project_id",
+		"transactions-[card account projects]-id",
+		"transactions-[card account]-account_holder_id",
+		"transactions-[card account]-id",
+		"transactions-[card account]-project_id",
+		"transactions-[card account_holder project]-id",
+		"transactions-[card account_holder]-aml_score",
+		"transactions-[card account_holder]-id",
+		"transactions-[card account_holder]-project_id",
+		"transactions-[card projects]-id",
+		"transactions-[card]-account_holder_id",
+		"transactions-[card]-account_id",
+		"transactions-[card]-id",
+		"transactions-[card]-project_id",
+		"transactions-[account account_holder project]-id",
+		"transactions-[account account_holder]-aml_score",
+		"transactions-[account account_holder]-id",
+		"transactions-[account account_holder]-project_id",
+		"transactions-[account projects]-id",
+		"transactions-[account]-account_holder_id",
+		"transactions-[account]-id",
+		"transactions-[account]-project_id",
+		"transactions-[account_holder project]-id",
+		"transactions-[account_holder]-aml_score",
+		"transactions-[account_holder]-id",
+		"transactions-[account_holder]-project_id",
+		"transactions-[projects]-id",
+	}
+	sort.Strings(expectedStr)
+	indentifiersStr := pure_utils.Map(identifiers, dbAccessNodeToString)
+	sort.Strings(indentifiersStr)
+	assert.Equal(t, expectedStr, indentifiersStr)
 }


### PR DESCRIPTION
## Content

Two bugs became visible with Swan's data model:
- some database accessors that should be available in the builder, would be returned only randomly (e.g. sometimes you'd get `transactions.accounts.account_holder.aml_score`, sometimes you'd get `transactions.card.accounts.account_holder.aml_score` instead, etc)
- sometimes, the backend would return database accessors that are plainly not valid - like `transactions.card.accounts.account_holder.project.aml_score`. This was due to some pointer confusion.

The diff is more test cases than actual code change.
As you may guess by reading it, it took more time to find the issue than to fix it (perfect storm of recursion and slice pointer spaghetti....).

## Kinda breaking change
Previously, the database accessors that were returned allowed loops (accessors going through the same table several times), as long as any given link was walked only once (to avoid infinite loops).
With this change, loops are no longer possible (any table can be present only once in any given access path).
I think this is ok - I don't know of any clients paid or not that we know of that designed a loopy data model, and the use case is a bit far fetched. _If_ anyone really complains, I'm willing to reopen this, but generally speaking I think it's better we don't push in this direction anyway.