### PR TITLE
Created a /config endpoint.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,10 @@ LOGGING_FORMAT=text
 
 # Uncomment this line if you are using the Firebase emulator for testing.
 # FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
+# Set your Firebase settings as described in your app
+FIREBASE_PROJECT_ID=
+FIREBASE_API_KEY=
+FIREBASE_AUTH_DOMAIN=
 
 # If running the worker process in an environment requiring all processes to respond on an HTTP port, uncomment this setting.
 # For example, Cloud Run requires all services to process liveness checks to keep running.

--- a/.env.example
+++ b/.env.example
@@ -41,8 +41,8 @@ CREATE_ORG_ADMIN_EMAIL=jbe@zorg.com
 # Configure the ID of your Firebase project for authentication and the path to the service account's JSON private key file.
 #  - The 'Project ID' can be found in the 'General' section of your Firebase project's settings page.
 #  - The private key must be generated in the 'Service accounts' tab by clicking 'Generate new private key'
-# If using the Firebase emulator, this should match the emulator's project ID.
-GOOGLE_CLOUD_PROJECT="firebase-project-id"
+# If using the Firebase emulator, this should match the emulator's project ID. In a real deployment, it should be auto-detected from your credentials.
+# GOOGLE_CLOUD_PROJECT=test-project
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/service/account/private/key.json
 
 # Configure the document blob storage backend.
@@ -113,10 +113,13 @@ LOGGING_FORMAT=text
 
 # Uncomment this line if you are using the Firebase emulator for testing.
 # FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"
+
 # Set your Firebase settings as described in your app
-FIREBASE_PROJECT_ID=
-FIREBASE_API_KEY=
-FIREBASE_AUTH_DOMAIN=
+FIREBASE_API_KEY=dummy
+# For SSO, if your auth domain is different from <project_id>.firebaseapp.com, define it here.
+# FIREBASE_AUTH_DOMAIN=
+# If your Firebase project differs from the global Google Cloud project you use, you can set it here.
+# FIREBASE_PROJECT_ID=test-project
 
 # If running the worker process in an environment requiring all processes to respond on an HTTP port, uncomment this setting.
 # For example, Cloud Run requires all services to process liveness checks to keep running.

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -1,6 +1,10 @@
 package api
 
-import "time"
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/infra"
+)
 
 type Configuration struct {
 	Env                 string
@@ -15,4 +19,14 @@ type Configuration struct {
 	BatchTimeout        time.Duration
 	DecisionTimeout     time.Duration
 	DefaultTimeout      time.Duration
+
+	FirebaseConfig FirebaseConfig
+	MetabaseConfig infra.MetabaseConfiguration
+}
+
+type FirebaseConfig struct {
+	EmulatorUrl string
+	ProjectId   string
+	ApiKey      string
+	AuthDomain  string
 }

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -25,8 +25,12 @@ type Configuration struct {
 }
 
 type FirebaseConfig struct {
-	EmulatorUrl string
-	ProjectId   string
-	ApiKey      string
-	AuthDomain  string
+	EmulatorHost string
+	ProjectId    string
+	ApiKey       string
+	AuthDomain   string
+}
+
+func (cfg FirebaseConfig) IsEmulator() bool {
+	return cfg.EmulatorHost != ""
 }

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -10,6 +10,7 @@ type Configuration struct {
 	Env                 string
 	AppName             string
 	Port                string
+	MarbleApiUrl        string
 	MarbleAppUrl        string
 	MarbleBackofficeUrl string
 	RequestLoggingLevel string

--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -36,7 +36,8 @@ func InitDependencies(
 	database := postgres.New(dbPool)
 
 	if len(optTokenVerifier) == 0 {
-		optTokenVerifier = append(optTokenVerifier, infra.InitializeFirebase(ctx))
+		optTokenVerifier = append(optTokenVerifier,
+			infra.InitializeFirebase(ctx, conf.FirebaseConfig.ProjectId))
 	}
 
 	firebaseClient := firebase.New(optTokenVerifier[0])

--- a/api/handle_config.go
+++ b/api/handle_config.go
@@ -43,8 +43,8 @@ func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Contex
 			},
 			Auth: dto.ConfigAuthDto{
 				Firebase: dto.ConfigAuthFirebaseDto{
-					IsEmulator:  cfg.FirebaseConfig.EmulatorUrl != "",
-					EmulatorUrl: cfg.FirebaseConfig.EmulatorUrl,
+					IsEmulator:  cfg.FirebaseConfig.EmulatorHost != "",
+					EmulatorUrl: cfg.FirebaseConfig.EmulatorHost,
 					ProjectId:   cfg.FirebaseConfig.ProjectId,
 					ApiKey:      cfg.FirebaseConfig.ApiKey,
 					AuthDomain:  cfg.FirebaseConfig.AuthDomain,

--- a/api/handle_config.go
+++ b/api/handle_config.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		licenseUsecase := uc.NewLicenseUsecase()
+		versionUsecase := uc.NewVersionUsecase()
+
+		signupUsecase := usecases.NewSignupUsecase(uc.NewExecutorFactory(),
+			uc.Repositories.OrganizationRepository,
+			uc.Repositories.UserRepository,
+		)
+
+		migrationsRunForOrgs, hasAnOrganization, err := signupUsecase.HasAnOrganization(ctx)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		migrationsRunForUsers, hasAUser, err := signupUsecase.HasAUser(ctx)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		out := dto.ConfigDto{
+			Version: versionUsecase.ApiVersion,
+			Status: dto.ConfigStatusDto{
+				Migrations: migrationsRunForOrgs && migrationsRunForUsers,
+				HasOrg:     hasAnOrganization,
+				HasUser:    hasAUser,
+			},
+			Urls: dto.ConfigUrlsDto{
+				Marble:   cfg.MarbleAppUrl,
+				Metabase: cfg.MetabaseConfig.SiteUrl,
+			},
+			Auth: dto.ConfigAuthDto{
+				Firebase: dto.ConfigAuthFirebaseDto{
+					IsEmulator:  cfg.FirebaseConfig.EmulatorUrl != "",
+					EmulatorUrl: cfg.FirebaseConfig.EmulatorUrl,
+					ProjectId:   cfg.FirebaseConfig.ProjectId,
+					ApiKey:      cfg.FirebaseConfig.ApiKey,
+					AuthDomain:  cfg.FirebaseConfig.AuthDomain,
+				},
+			},
+			Features: dto.ConfigFeaturesDto{
+				Sso:     licenseUsecase.HasSsoEnabled(),
+				Segment: !cfg.DisableSegment,
+			},
+		}
+
+		c.JSON(http.StatusOK, out)
+	}
+}

--- a/api/handle_config.go
+++ b/api/handle_config.go
@@ -16,8 +16,8 @@ func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Contex
 		versionUsecase := uc.NewVersionUsecase()
 
 		signupUsecase := usecases.NewSignupUsecase(uc.NewExecutorFactory(),
-			uc.Repositories.OrganizationRepository,
-			uc.Repositories.UserRepository,
+			&uc.Repositories.MarbleDbRepository,
+			&uc.Repositories.MarbleDbRepository,
 		)
 
 		migrationsRunForOrgs, hasAnOrganization, err := signupUsecase.HasAnOrganization(ctx)
@@ -38,16 +38,17 @@ func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Contex
 				HasUser:    hasAUser,
 			},
 			Urls: dto.ConfigUrlsDto{
-				Marble:   cfg.MarbleAppUrl,
-				Metabase: cfg.MetabaseConfig.SiteUrl,
+				Marble:    dto.NewNullString(cfg.MarbleAppUrl),
+				MarbleApi: dto.NewNullString(cfg.MarbleApiUrl),
+				Metabase:  dto.NewNullString(cfg.MetabaseConfig.SiteUrl),
 			},
 			Auth: dto.ConfigAuthDto{
 				Firebase: dto.ConfigAuthFirebaseDto{
-					IsEmulator:  cfg.FirebaseConfig.EmulatorHost != "",
-					EmulatorUrl: cfg.FirebaseConfig.EmulatorHost,
-					ProjectId:   cfg.FirebaseConfig.ProjectId,
-					ApiKey:      cfg.FirebaseConfig.ApiKey,
-					AuthDomain:  cfg.FirebaseConfig.AuthDomain,
+					IsEmulator:   cfg.FirebaseConfig.EmulatorHost != "",
+					EmulatorHost: cfg.FirebaseConfig.EmulatorHost,
+					ProjectId:    dto.NewNullString(cfg.FirebaseConfig.ProjectId),
+					ApiKey:       dto.NewNullString(cfg.FirebaseConfig.ApiKey),
+					AuthDomain:   dto.NewNullString(cfg.FirebaseConfig.AuthDomain),
 				},
 			},
 			Features: dto.ConfigFeaturesDto{

--- a/api/handle_post_firebase_id_token.go
+++ b/api/handle_post_firebase_id_token.go
@@ -39,6 +39,8 @@ func (t *TokenHandler) GenerateToken(c *gin.Context) {
 
 	marbleToken, expirationTime, err := t.generator.GenerateToken(ctx, key, bearerToken)
 	if err != nil {
+		utils.LoggerFromContext(ctx).ErrorContext(ctx, err.Error())
+
 		_ = c.Error(fmt.Errorf("generator.GenerateToken error: %w", err))
 
 		if errors.Is(err, models.ErrUnknownUser) {

--- a/api/handle_post_firebase_id_token.go
+++ b/api/handle_post_firebase_id_token.go
@@ -39,7 +39,7 @@ func (t *TokenHandler) GenerateToken(c *gin.Context) {
 
 	marbleToken, expirationTime, err := t.generator.GenerateToken(ctx, key, bearerToken)
 	if err != nil {
-		utils.LoggerFromContext(ctx).ErrorContext(ctx, err.Error())
+		utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not verify firebase token", "error", err)
 
 		_ = c.Error(fmt.Errorf("generator.GenerateToken error: %w", err))
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -39,6 +39,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	r.GET("/version", tom, handleVersion(uc))
 	r.POST("/token", tom, tokenHandler.GenerateToken)
 	r.GET("/validate-license/*license_key", tom, handleValidateLicense(uc))
+	r.GET("/config", tom, handleGetConfig(uc, conf))
 	r.GET("/is-sso-available", tom, handleIsSSOEnabled(uc))
 	r.GET("/signup-status", tom, handleSignupStatus(uc))
 

--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -90,7 +90,7 @@ func RunBatchIngestion(apiVersion string) error {
 
 	repositories := repositories.NewRepositories(
 		pool,
-		gcpConfig.GoogleApplicationCredentials,
+		infra.GcpConfig{},
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(convoyConfiguration),
 			convoyConfiguration.RateLimit,

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -102,7 +102,7 @@ func RunScheduledExecuter(apiVersion string) error {
 
 	repositories := repositories.NewRepositories(
 		pool,
-		gcpConfig.GoogleApplicationCredentials,
+		infra.GcpConfig{},
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(convoyConfiguration),
 			convoyConfiguration.RateLimit,

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -83,7 +83,7 @@ func RunSendPendingWebhookEvents(apiVersion string) error {
 
 	repositories := repositories.NewRepositories(
 		pool,
-		gcpConfig.GoogleApplicationCredentials,
+		infra.GcpConfig{},
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(convoyConfiguration),
 			convoyConfiguration.RateLimit,

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os/signal"
@@ -36,6 +37,21 @@ func RunServer(config CompiledConfig) error {
 		BatchTimeout:        time.Duration(utils.GetEnv("BATCH_TIMEOUT_SECOND", 55)) * time.Second,
 		DecisionTimeout:     time.Duration(utils.GetEnv("DECISION_TIMEOUT_SECOND", 10)) * time.Second,
 		DefaultTimeout:      time.Duration(utils.GetEnv("DEFAULT_TIMEOUT_SECOND", 5)) * time.Second,
+
+		MetabaseConfig: infra.MetabaseConfiguration{
+			SiteUrl:             utils.GetEnv("METABASE_SITE_URL", ""),
+			JwtSigningKey:       []byte(utils.GetEnv("METABASE_JWT_SIGNING_KEY", "")),
+			TokenLifetimeMinute: utils.GetEnv("METABASE_TOKEN_LIFETIME_MINUTE", 10),
+			Resources: map[models.EmbeddingType]int{
+				models.GlobalDashboard: utils.GetEnv("METABASE_GLOBAL_DASHBOARD_ID", 0),
+			},
+		},
+		FirebaseConfig: api.FirebaseConfig{
+			EmulatorUrl: utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
+			ApiKey:      utils.GetEnv("FIREBASE_API_KEY", ""),
+			AuthDomain:  utils.GetEnv("FIREBASE_AUTH_DOMAIN", ""),
+			ProjectId:   utils.GetEnv("FIREBASE_PROJECT_ID", ""),
+		},
 	}
 	if apiConfig.DisableSegment {
 		apiConfig.SegmentWriteKey = ""
@@ -55,14 +71,6 @@ func RunServer(config CompiledConfig) error {
 		MaxPoolConnections: utils.GetEnv("PG_MAX_POOL_SIZE", infra.DEFAULT_MAX_CONNECTIONS),
 		ClientDbConfigFile: utils.GetEnv("CLIENT_DB_CONFIG_FILE", ""),
 		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
-	}
-	metabaseConfig := infra.MetabaseConfiguration{
-		SiteUrl:             utils.GetEnv("METABASE_SITE_URL", ""),
-		JwtSigningKey:       []byte(utils.GetEnv("METABASE_JWT_SIGNING_KEY", "")),
-		TokenLifetimeMinute: utils.GetEnv("METABASE_TOKEN_LIFETIME_MINUTE", 10),
-		Resources: map[models.EmbeddingType]int{
-			models.GlobalDashboard: utils.GetEnv("METABASE_GLOBAL_DASHBOARD_ID", 0),
-		},
 	}
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),
@@ -122,6 +130,25 @@ func RunServer(config CompiledConfig) error {
 	marbleJwtSigningKey := infra.ReadParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey, serverConfig.jwtSigningKeyFile)
 	license := infra.VerifyLicense(licenseConfig)
 
+	if apiConfig.FirebaseConfig.ProjectId == "" {
+		logger.Warn("no FIREBASE_PROJECT_ID specified, defaulting to GOOGLE_CLOUD_PROJECT", "project", gcpConfig.ProjectId)
+		apiConfig.FirebaseConfig.ProjectId = gcpConfig.ProjectId
+	}
+	if apiConfig.FirebaseConfig.ApiKey == "" {
+		logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
+	}
+	if apiConfig.FirebaseConfig.AuthDomain == "" {
+		if apiConfig.FirebaseConfig.EmulatorUrl != "" {
+			apiConfig.FirebaseConfig.AuthDomain = apiConfig.FirebaseConfig.EmulatorUrl
+			logger.Warn("no FIREBASE_AUTH_DOMAIN specified, defaulting to FIREBASE_AUTH_EMULATOR_HOST",
+				"auth_domain", apiConfig.FirebaseConfig.EmulatorUrl)
+		} else {
+			apiConfig.FirebaseConfig.AuthDomain = fmt.Sprintf("%s.firebaseapp.com", apiConfig.FirebaseConfig.ProjectId)
+			logger.Warn(fmt.Sprintf("no FIREBASE_AUTH_DOMAIN specified, defaulting to %s", apiConfig.FirebaseConfig.AuthDomain))
+		}
+		logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
+	}
+
 	infra.SetupSentry(serverConfig.sentryDsn, apiConfig.Env, config.Version)
 	defer sentry.Flush(3 * time.Second)
 
@@ -156,7 +183,7 @@ func RunServer(config CompiledConfig) error {
 	repositories := repositories.NewRepositories(
 		pool,
 		gcpConfig.GoogleApplicationCredentials,
-		repositories.WithMetabase(infra.InitializeMetabase(metabaseConfig)),
+		repositories.WithMetabase(infra.InitializeMetabase(apiConfig.MetabaseConfig)),
 		repositories.WithTransferCheckEnrichmentBucket(serverConfig.transferCheckEnrichmentBucketUrl),
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(convoyConfiguration),
@@ -176,7 +203,7 @@ func RunServer(config CompiledConfig) error {
 		usecases.WithCaseManagerBucketUrl(serverConfig.caseManagerBucket),
 		usecases.WithLicense(license),
 		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
-		usecases.WithMetabase(metabaseConfig.SiteUrl),
+		usecases.WithMetabase(apiConfig.MetabaseConfig.SiteUrl),
 		usecases.WithOpensanctions(openSanctionsConfig.IsSet()),
 		usecases.WithNameRecognition(openSanctionsConfig.IsNameRecognitionSet()),
 		usecases.WithTestMode(serverConfig.firebaseEmulatorHost != ""),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -30,6 +30,7 @@ func RunServer(config CompiledConfig) error {
 	apiConfig := api.Configuration{
 		Env:                 utils.GetEnv("ENV", "development"),
 		AppName:             "marble-backend",
+		MarbleApiUrl:        utils.GetEnv("MARBLE_API_URL", ""),
 		MarbleAppUrl:        utils.GetEnv("MARBLE_APP_URL", ""),
 		MarbleBackofficeUrl: utils.GetEnv("MARBLE_BACKOFFICE_URL", ""),
 		Port:                utils.GetRequiredEnv[string]("PORT"),
@@ -138,6 +139,12 @@ func RunServer(config CompiledConfig) error {
 
 	logger.Info("successfully authenticated in GCP", "principal", gcpConfig.PrincipalEmail, "project", gcpConfig.ProjectId)
 
+	if apiConfig.FirebaseConfig.ProjectId == "" {
+		logger.Info("FIREBASE_PROJECT_ID was not provided, falling back to Google Cloud project", "project", gcpConfig.ProjectId)
+
+		apiConfig.FirebaseConfig.ProjectId = gcpConfig.ProjectId
+	}
+
 	if !apiConfig.FirebaseConfig.IsEmulator() {
 		if apiConfig.FirebaseConfig.ApiKey == "" {
 			logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
@@ -151,12 +158,6 @@ func RunServer(config CompiledConfig) error {
 	} else {
 		// The auth domain, when using the emulator, is always the emulator host itself
 		apiConfig.FirebaseConfig.AuthDomain = apiConfig.FirebaseConfig.EmulatorHost
-	}
-
-	if apiConfig.FirebaseConfig.ProjectId == "" {
-		logger.Info("FIREBASE_PROJECT_ID was not provided, falling back to Google Cloud project", "project", gcpConfig.ProjectId)
-
-		apiConfig.FirebaseConfig.ProjectId = gcpConfig.ProjectId
 	}
 
 	logger.Info("firebase project configured", "project", apiConfig.FirebaseConfig.ProjectId)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -194,7 +194,7 @@ func RunServer(config CompiledConfig) error {
 
 	repositories := repositories.NewRepositories(
 		pool,
-		gcpConfig.GoogleApplicationCredentials,
+		gcpConfig,
 		repositories.WithMetabase(infra.InitializeMetabase(apiConfig.MetabaseConfig)),
 		repositories.WithTransferCheckEnrichmentBucket(serverConfig.transferCheckEnrichmentBucketUrl),
 		repositories.WithConvoyClientProvider(

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -23,6 +23,9 @@ import (
 )
 
 func RunServer(config CompiledConfig) error {
+	logger := utils.NewLogger(utils.GetEnv("LOGGING_FORMAT", "text"))
+	ctx := utils.StoreLoggerInContext(context.Background(), logger)
+
 	// This is where we read the environment variables and set up the configuration for the application.
 	apiConfig := api.Configuration{
 		Env:                 utils.GetEnv("ENV", "development"),
@@ -47,20 +50,26 @@ func RunServer(config CompiledConfig) error {
 			},
 		},
 		FirebaseConfig: api.FirebaseConfig{
-			EmulatorUrl: utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
-			ApiKey:      utils.GetEnv("FIREBASE_API_KEY", ""),
-			AuthDomain:  utils.GetEnv("FIREBASE_AUTH_DOMAIN", ""),
-			ProjectId:   utils.GetEnv("FIREBASE_PROJECT_ID", ""),
+			ProjectId:    utils.GetEnv("FIREBASE_PROJECT_ID", ""),
+			EmulatorHost: utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
+			ApiKey:       utils.GetEnv("FIREBASE_API_KEY", ""),
+			AuthDomain:   utils.GetEnv("FIREBASE_AUTH_DOMAIN", ""),
 		},
 	}
 	if apiConfig.DisableSegment {
 		apiConfig.SegmentWriteKey = ""
 	}
-	gcpConfig := infra.GcpConfig{
-		EnableTracing:                utils.GetEnv("ENABLE_GCP_TRACING", false),
-		ProjectId:                    utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
-		GoogleApplicationCredentials: utils.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""),
+
+	gcpConfig, err := infra.NewGcpConfig(
+		ctx,
+		utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
+		utils.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""),
+		utils.GetEnv("ENABLE_GCP_TRACING", false),
+	)
+	if err != nil {
+		return err
 	}
+
 	pgConfig := infra.PgConfig{
 		ConnectionString:   utils.GetEnv("PG_CONNECTION_STRING", ""),
 		Database:           utils.GetEnv("PG_DATABASE", "marble"),
@@ -124,30 +133,33 @@ func RunServer(config CompiledConfig) error {
 		firebaseEmulatorHost:             utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
 	}
 
-	logger := utils.NewLogger(serverConfig.loggingFormat)
-
-	ctx := utils.StoreLoggerInContext(context.Background(), logger)
 	marbleJwtSigningKey := infra.ReadParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey, serverConfig.jwtSigningKeyFile)
 	license := infra.VerifyLicense(licenseConfig)
 
+	logger.Info("successfully authenticated in GCP", "principal", gcpConfig.PrincipalEmail, "project", gcpConfig.ProjectId)
+
+	if !apiConfig.FirebaseConfig.IsEmulator() {
+		if apiConfig.FirebaseConfig.ApiKey == "" {
+			logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
+		}
+
+		if apiConfig.FirebaseConfig.AuthDomain == "" {
+			logger.Warn(fmt.Sprintf("no FIREBASE_AUTH_DOMAIN specified, defaulting to %s", apiConfig.FirebaseConfig.AuthDomain))
+
+			apiConfig.FirebaseConfig.AuthDomain = fmt.Sprintf("%s.firebaseapp.com", apiConfig.FirebaseConfig.ProjectId)
+		}
+	} else {
+		// The auth domain, when using the emulator, is always the emulator host itself
+		apiConfig.FirebaseConfig.AuthDomain = apiConfig.FirebaseConfig.EmulatorHost
+	}
+
 	if apiConfig.FirebaseConfig.ProjectId == "" {
-		logger.Warn("no FIREBASE_PROJECT_ID specified, defaulting to GOOGLE_CLOUD_PROJECT", "project", gcpConfig.ProjectId)
+		logger.Info("FIREBASE_PROJECT_ID was not provided, falling back to Google Cloud project", "project", gcpConfig.ProjectId)
+
 		apiConfig.FirebaseConfig.ProjectId = gcpConfig.ProjectId
 	}
-	if apiConfig.FirebaseConfig.ApiKey == "" {
-		logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
-	}
-	if apiConfig.FirebaseConfig.AuthDomain == "" {
-		if apiConfig.FirebaseConfig.EmulatorUrl != "" {
-			apiConfig.FirebaseConfig.AuthDomain = apiConfig.FirebaseConfig.EmulatorUrl
-			logger.Warn("no FIREBASE_AUTH_DOMAIN specified, defaulting to FIREBASE_AUTH_EMULATOR_HOST",
-				"auth_domain", apiConfig.FirebaseConfig.EmulatorUrl)
-		} else {
-			apiConfig.FirebaseConfig.AuthDomain = fmt.Sprintf("%s.firebaseapp.com", apiConfig.FirebaseConfig.ProjectId)
-			logger.Warn(fmt.Sprintf("no FIREBASE_AUTH_DOMAIN specified, defaulting to %s", apiConfig.FirebaseConfig.AuthDomain))
-		}
-		logger.Warn("no FIREBASE_API_KEY specified, this will be an error in the future")
-	}
+
+	logger.Info("firebase project configured", "project", apiConfig.FirebaseConfig.ProjectId)
 
 	infra.SetupSentry(serverConfig.sentryDsn, apiConfig.Env, config.Version)
 	defer sentry.Flush(3 * time.Second)

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -134,7 +134,7 @@ func RunTaskQueue(apiVersion string) error {
 
 	repositories := repositories.NewRepositories(
 		pool,
-		gcpConfig.GoogleApplicationCredentials,
+		infra.GcpConfig{},
 		repositories.WithRiverClient(riverClient),
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(convoyConfiguration),

--- a/dto/config_dto.go
+++ b/dto/config_dto.go
@@ -1,0 +1,37 @@
+package dto
+
+type ConfigDto struct {
+	Version  string            `json:"version"`
+	Status   ConfigStatusDto   `json:"status"`
+	Urls     ConfigUrlsDto     `json:"urls"`
+	Auth     ConfigAuthDto     `json:"auth"`
+	Features ConfigFeaturesDto `json:"features"`
+}
+
+type ConfigStatusDto struct {
+	Migrations bool `json:"migrations"`
+	HasOrg     bool `json:"has_org"`
+	HasUser    bool `json:"has_user"`
+}
+
+type ConfigUrlsDto struct {
+	Marble   string `json:"marble"`
+	Metabase string `json:"metabase"`
+}
+
+type ConfigAuthDto struct {
+	Firebase ConfigAuthFirebaseDto `json:"firebase"`
+}
+
+type ConfigAuthFirebaseDto struct {
+	IsEmulator  bool   `json:"is_emulator"`
+	EmulatorUrl string `json:"emulator_url,omitempty"`
+	ProjectId   string `json:"project_id"`
+	ApiKey      string `json:"api_key"`
+	AuthDomain  string `json:"auth_domain"`
+}
+
+type ConfigFeaturesDto struct {
+	Sso     bool `json:"sso"`
+	Segment bool `json:"segment"`
+}

--- a/dto/config_dto.go
+++ b/dto/config_dto.go
@@ -1,5 +1,25 @@
 package dto
 
+import (
+	"encoding/json"
+)
+
+type NullString struct {
+	s string
+}
+
+func NewNullString(s string) NullString {
+	return NullString{s: s}
+}
+
+func (s NullString) MarshalJSON() ([]byte, error) {
+	if s.s == "" {
+		return []byte(`null`), nil
+	}
+
+	return json.Marshal(s.s)
+}
+
 type ConfigDto struct {
 	Version  string            `json:"version"`
 	Status   ConfigStatusDto   `json:"status"`
@@ -15,8 +35,9 @@ type ConfigStatusDto struct {
 }
 
 type ConfigUrlsDto struct {
-	Marble   string `json:"marble"`
-	Metabase string `json:"metabase"`
+	Marble    NullString `json:"marble"`
+	MarbleApi NullString `json:"api"` //nolint:tagliatelle
+	Metabase  NullString `json:"metabase"`
 }
 
 type ConfigAuthDto struct {
@@ -24,11 +45,11 @@ type ConfigAuthDto struct {
 }
 
 type ConfigAuthFirebaseDto struct {
-	IsEmulator  bool   `json:"is_emulator"`
-	EmulatorUrl string `json:"emulator_url,omitempty"`
-	ProjectId   string `json:"project_id"`
-	ApiKey      string `json:"api_key"`
-	AuthDomain  string `json:"auth_domain"`
+	IsEmulator   bool       `json:"is_emulator"`
+	EmulatorHost string     `json:"emulator_host,omitempty"`
+	ProjectId    NullString `json:"project_id"`
+	ApiKey       NullString `json:"api_key"`
+	AuthDomain   NullString `json:"auth_domain"`
 }
 
 type ConfigFeaturesDto struct {

--- a/infra/config.go
+++ b/infra/config.go
@@ -34,6 +34,10 @@ func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCre
 		utils.LoggerFromContext(ctx).Warn("could not validate Google Cloud credentials, some features might not work properly", "error", err)
 	}
 
+	if !strings.HasSuffix(adcPrincipal, GcpServiceAccountSuffix) {
+		utils.LoggerFromContext(ctx).Warn("you might be authenticated with user Google user account (instead of a service account), file downloads will not be functional")
+	}
+
 	// We determine the Google Cloud project in the following priority:
 	//  - The value of GOOGLE_CLOUD_PROJECT, that can override automatic detection
 	//  - The project we detect from the ADC / private key file
@@ -54,6 +58,7 @@ func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCre
 			projectId = strings.TrimSuffix(domain, GcpServiceAccountSuffix)
 		}
 	}
+
 	if projectId == "" {
 		return GcpConfig{}, errors.New("could not detect Google Cloud project ID, you must set GOOGLE_CLOUD_PROJECT")
 	}

--- a/infra/config.go
+++ b/infra/config.go
@@ -1,15 +1,89 @@
 package infra
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/oauth2/v1"
+)
+
+const (
+	GcpServiceAccountSuffix = ".iam.gserviceaccount.com"
 )
 
 type GcpConfig struct {
 	ProjectId                    string
+	PrincipalEmail               string
 	GoogleApplicationCredentials string
 	EnableTracing                bool
+}
+
+func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCredentials string, enableTracing bool) (GcpConfig, error) {
+	// Errors to validate GCP credentials do not have to be a hard fail.
+	// They are common when trying out the product with the emulator (no service account required).
+	// So long as the GCP project is defined in the configuration, most things will work.
+	// Failing to retrieve the principal is OK for now, but will become an error when we implement keyless signing.
+	adcProjectId, adcPrincipal, err := FindServiceAccountPrincipal(ctx)
+	if err != nil {
+		utils.LoggerFromContext(ctx).Warn("could not validate Google Cloud credentials, some features might not work properly", "error", err)
+	}
+
+	// We determine the Google Cloud project in the following priority:
+	//  - The value of GOOGLE_CLOUD_PROJECT, that can override automatic detection
+	//  - The project we detect from the ADC / private key file
+	//  - The project extracted from the service account email address
+	var projectId string
+
+	if projectId == "" && gcpProjectId != "" {
+		projectId = gcpProjectId
+	}
+	if projectId == "" && adcProjectId != "" {
+		projectId = adcProjectId
+	}
+	// In the case ADC is authenticated with a user account, and even when impersonating a
+	// service account, the project will not be detected here, so we extract it from the
+	// service account email.
+	if projectId == "" && strings.HasSuffix(adcPrincipal, GcpServiceAccountSuffix) {
+		if _, domain, ok := strings.Cut(adcPrincipal, "@"); ok {
+			projectId = strings.TrimSuffix(domain, GcpServiceAccountSuffix)
+		}
+	}
+	if projectId == "" {
+		return GcpConfig{}, errors.New("could not detect Google Cloud project ID, you must set GOOGLE_CLOUD_PROJECT")
+	}
+
+	cfg := GcpConfig{
+		ProjectId:                    projectId,
+		PrincipalEmail:               adcPrincipal,
+		GoogleApplicationCredentials: googleApplicationCredentials,
+		EnableTracing:                enableTracing,
+	}
+
+	return cfg, nil
+}
+
+func FindServiceAccountPrincipal(ctx context.Context) (string, string, error) {
+	creds, err := google.FindDefaultCredentials(ctx, compute.CloudPlatformScope)
+	if err != nil {
+		return "", "", errors.Wrap(err, "credentials not found (set GOOGLE_APPLICATION_CREDENTIALS)")
+	}
+
+	svc, err := oauth2.NewService(ctx)
+	if err != nil {
+		return "", "", errors.Wrap(err, "could not create token service")
+	}
+	tokenInfo, err := svc.Tokeninfo().Do()
+	if err != nil {
+		return "", "", errors.Wrap(err, "could not obtain token from application credentials")
+	}
+
+	return creds.ProjectID, tokenInfo.Email, nil
 }
 
 type PgConfig struct {

--- a/infra/firebase_client.go
+++ b/infra/firebase_client.go
@@ -8,8 +8,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func InitializeFirebase(ctx context.Context) *auth.Client {
-	app, err := firebase.NewApp(ctx, nil)
+func InitializeFirebase(ctx context.Context, projectId string) *auth.Client {
+	app, err := firebase.NewApp(ctx, &firebase.Config{ProjectID: projectId})
 	if err != nil {
 		panic(errors.Wrap(err, "error initializing app"))
 	}

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -142,7 +142,7 @@ func TestMain(m *testing.M) {
 	// but it is not blocking (an error will be logged but the test will pass). We sill need to pass the provider
 	// or else the repository will panic.
 	repos := repositories.NewRepositories(dbPool,
-		"",
+		infra.GcpConfig{},
 		repositories.WithConvoyClientProvider(
 			infra.InitializeConvoyRessources(infra.ConvoyConfiguration{}), 0),
 		repositories.WithRiverClient(riverClient),

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -139,7 +139,7 @@ func setupApi(t *testing.T, ctx context.Context, dsn string) string {
 
 	deps := api.InitDependencies(ctx, cfg, pool, key, nil)
 	openSanctions := infra.InitializeOpenSanctions(http.DefaultClient, "http://screening", " ", " ")
-	repos := repositories.NewRepositories(pool, "",
+	repos := repositories.NewRepositories(pool, infra.GcpConfig{},
 		repositories.WithOpenSanctions(openSanctions),
 		repositories.WithRiverClient(riverClient))
 	uc := usecases.NewUsecases(repos, usecases.WithLicense(models.NewFullLicense()), usecases.WithOpensanctions(true))

--- a/repositories/blob_repository.go
+++ b/repositories/blob_repository.go
@@ -1,22 +1,22 @@
 package repositories
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/checkmarble/marble-backend/infra"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
+	"golang.org/x/oauth2/google"
 
+	credentials "cloud.google.com/go/iam/credentials/apiv1"
+	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"github.com/cockroachdb/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -26,6 +26,7 @@ import (
 	"gocloud.dev/blob/gcsblob"
 	_ "gocloud.dev/blob/s3blob"
 	"gocloud.dev/gcp"
+	"google.golang.org/api/compute/v1"
 )
 
 const (
@@ -43,37 +44,15 @@ type BlobRepository interface {
 }
 
 type blobRepository struct {
-	buckets                      map[string]*blob.Bucket
-	m                            sync.Mutex
-	googleAccessId               string
-	googleApplicationCredentials string
-	serviceAccountPemKey         []byte
+	buckets   map[string]*blob.Bucket
+	m         sync.Mutex
+	gcpConfig infra.GcpConfig
 }
 
-func NewBlobRepository(googleApplicationCredentials string) BlobRepository {
-	var pemKey []byte
-	var googleAccessId string
-	if googleApplicationCredentials != "" {
-		key, err := os.ReadFile(googleApplicationCredentials)
-		if err != nil {
-			panic(errors.Wrap(err, "failed to read service account key"))
-		}
-		pemKey, err = gcpServiceAccountKeyToPEM(key)
-		if err != nil {
-			panic(errors.Wrap(err, "failed to convert service account key to PEM"))
-		}
-
-		googleAccessId, err = gcpServiceAccountKeyToGoogleAccessId(key)
-		if err != nil {
-			panic(errors.Wrap(err, "failed to get google access id"))
-		}
-	}
-
+func NewBlobRepository(gcpConfig infra.GcpConfig) BlobRepository {
 	return &blobRepository{
-		buckets:                      make(map[string]*blob.Bucket),
-		googleAccessId:               googleAccessId,
-		googleApplicationCredentials: googleApplicationCredentials,
-		serviceAccountPemKey:         pemKey,
+		buckets:   make(map[string]*blob.Bucket),
+		gcpConfig: gcpConfig,
 	}
 }
 
@@ -98,20 +77,35 @@ func (repository *blobRepository) openBlobBucket(ctx context.Context, bucketUrl 
 		}
 		if url.Scheme == "gs" {
 			// in the GCS case, we need to set those values in the url
-			creds, err := gcp.DefaultCredentials(ctx)
+			creds, err := google.FindDefaultCredentials(ctx, compute.CloudPlatformScope)
 			if err != nil {
 				return nil, err
 			}
-			client, err := gcp.NewHTTPClient(
-				gcp.DefaultTransport(),
-				gcp.CredentialsTokenSource(creds))
+			client, err := gcp.NewHTTPClient(gcp.DefaultTransport(), gcp.CredentialsTokenSource(creds))
 			if err != nil {
 				return nil, err
 			}
 
 			bucket, err = gcsblob.OpenBucket(ctx, client, url.Host, &gcsblob.Options{
-				GoogleAccessID: repository.googleAccessId,
-				PrivateKey:     repository.serviceAccountPemKey,
+				GoogleAccessID: repository.gcpConfig.PrincipalEmail,
+				MakeSignBytes: func(requestCtx context.Context) gcsblob.SignBytesFunc {
+					return func(p []byte) ([]byte, error) {
+						signClient, err := credentials.NewIamCredentialsClient(ctx)
+						if err != nil {
+							return nil, err
+						}
+
+						resp, err := signClient.SignBlob(requestCtx, &credentialspb.SignBlobRequest{
+							Name:    repository.gcpConfig.PrincipalEmail,
+							Payload: p,
+						})
+						if err != nil {
+							return nil, err
+						}
+
+						return resp.GetSignedBlob(), nil
+					}
+				},
 			})
 			if err != nil {
 				return nil, err
@@ -225,64 +219,4 @@ func (repo *blobRepository) GenerateSignedUrl(ctx context.Context, bucketUrl, ke
 			Method: http.MethodGet,
 			Expiry: signedUrlExpiry,
 		})
-}
-
-func gcpServiceAccountKeyToPEM(key []byte) ([]byte, error) {
-	type serviceAccountKey struct {
-		PrivateKey     string `json:"private_key"`
-		GoogleAccessId string `json:"client_email"` //nolint:tagliatelle
-	}
-	// Parse the JSON data from the service account key file
-	var k serviceAccountKey
-	err := json.Unmarshal(key, &k)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal service account key")
-	}
-
-	block, _ := pem.Decode([]byte(k.PrivateKey))
-	if block == nil {
-		return nil, errors.Wrap(err, "Failed to decode PEM")
-	}
-
-	buf := new(bytes.Buffer)
-	err = pem.Encode(buf, block)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to encode PEM")
-	}
-
-	return buf.Bytes(), nil
-}
-
-func gcpServiceAccountKeyToGoogleAccessId(key []byte) (string, error) {
-	// Parse the JSON data from the service account key file
-
-	var sa struct {
-		ClientEmail        string `json:"client_email"`
-		SAImpersonationURL string `json:"service_account_impersonation_url"` //nolint:tagliatelle
-		CredType           string `json:"type"`                              //nolint:tagliatelle
-	}
-
-	err := json.Unmarshal(key, &sa)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal service account key")
-	}
-
-	switch sa.CredType {
-	case "impersonated_service_account", "external_account":
-		start, end := strings.LastIndex(sa.SAImpersonationURL, "/"),
-			strings.LastIndex(sa.SAImpersonationURL, ":")
-
-		if end <= start {
-			return "", errors.New("error parsing external or impersonated service account credentials")
-		} else {
-			return sa.SAImpersonationURL[start+1 : end], nil
-		}
-	case "service_account":
-		if sa.ClientEmail != "" {
-			return sa.ClientEmail, nil
-		}
-		return "", errors.New("empty service account client email")
-	default:
-		return "", errors.New("unable to parse credentials; only service_account, external_account and impersonated_service_account credentials are supported")
-	}
 }

--- a/repositories/repositories.go
+++ b/repositories/repositories.go
@@ -110,14 +110,14 @@ func WithUnionAll(builder squirrel.SelectBuilder, unionAllQuery squirrel.SelectB
 
 func NewRepositories(
 	marbleConnectionPool *pgxpool.Pool,
-	googleApplicationCredentials string,
+	gcpConfig infra.GcpConfig,
 	opts ...Option,
 ) Repositories {
 	options := getOptions(opts)
 
 	executorGetter := NewExecutorGetter(marbleConnectionPool, options.clientDbConfig, options.tp)
 
-	blobRepository := NewBlobRepository(googleApplicationCredentials)
+	blobRepository := NewBlobRepository(gcpConfig)
 
 	return Repositories{
 		ExecutorGetter:                executorGetter,


### PR DESCRIPTION
This endpoint will rule them all, it merges:

 - /version
 - /is-sso-available
 - /signup-status

And adds more data for the backend to be able to send the frontend its configurationon the fly.

---

The goal, ultimately, is to offload the frontend from configuration, as much as possible for directives not strictly related to the frontend (or secret ones). We will take advantage that there is constant communication between the two to provide essential parameters through the new `/config` endpoint.

There are several advantages:

 - It becomes impossible to have configuration drift between the backend and frontend
 - Configuration is more centralized and partly less duplicated
 - Relaunching the backend is usually sufficient to perform configuration changes

This PR also tries to determine a few sane defaults for some of those pesky directives that trip up a lot of our users, initially.

 - `FIREBASE_PROJECT_ID` defaults to `GOOGLE_CLOUD_PROJECT`.
 - `FIREBASE_AUTH_DOMAIN` now defaults to the emulator host when using the emulator, or to `${PROJECT_ID}.firebaseapp.com` otherwise, which is most cases renders the directives moot.

There might others we want to to introduce.

---

This is a breaking change!

Some of the configuration directives should now be added to the backend environment. The backend can start and function without them, but will transmit empty values to the frontend. Therefore, we must, on the frontend, introduce a transition period where the local environment is still observed if the backend does not return values.

Note that even with this, it still might be a breaking change in this case:

 - The frontend had a correct environment variable
 - The backend had the same, unused, but invalid directive that the user added when trying to set up Marble

In this case, the frontend would prioritize the setting returned by the backend and use the wrong value.

Should we reverse the priority? Use local environment if present, and fall back to the `/config`-provided one? If we do that, we need to request the users to change their config with a clear deprecation deadline, otherwise we will be stuck there.