### PR TITLE
feat(cases): rework case ordering

### DIFF
--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -477,7 +477,7 @@ func (repo *MarbleDbRepository) GetCasesWithPivotValue(ctx context.Context, exec
 }
 
 func orderConditionForCases(p models.PaginationAndSorting) string {
-	return fmt.Sprintf("c.boost is null, c.assigned_to is not null, c.%s %s, c.id %s", p.Sorting, p.Order, p.Order)
+	return fmt.Sprintf("c.boost is null %s, c.%s %s, c.id %s", p.Order, p.Sorting, p.Order, p.Order)
 }
 
 func (repo *MarbleDbRepository) EscalateCase(ctx context.Context, exec Executor, id, inboxId string) error {

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -300,8 +300,8 @@ func casesWithRankColumns() []string {
 }
 
 func casesCoreQueryWithRank(pagination models.PaginationAndSorting) squirrel.SelectBuilder {
-	orderCondition := fmt.Sprintf("c.boost is null, c.assigned_to is not null, c.%s %s, c.id %s",
-		pagination.Sorting, pagination.Order, pagination.Order)
+	orderCondition := fmt.Sprintf("c.boost is null %s, c.%s %s, c.id %s",
+		pagination.Order, pagination.Sorting, pagination.Order, pagination.Order)
 
 	return squirrel.StatementBuilder.
 		Select(dbmodels.SelectCaseColumn...).


### PR DESCRIPTION
- Remove ordering based on assignment status
- Boosted cases are now prioritized depending on the pagination order