### PR TITLE
Fail early on event sending when segment is disabled.

### DIFF
--- a/api/router.go
+++ b/api/router.go
@@ -67,6 +67,7 @@ func corsOption(ctx context.Context, conf Configuration) cors.Config {
 func InitRouterMiddlewares(
 	ctx context.Context,
 	conf Configuration,
+	disableSegment bool,
 	segmentClient analytics.Client,
 	telemetryRessources infra.TelemetryRessources,
 ) *gin.Engine {
@@ -83,7 +84,9 @@ func InitRouterMiddlewares(
 	r.Use(cors.New(corsOption(ctx, conf)))
 	r.Use(middleware.NewLogging(logger, conf.RequestLoggingLevel))
 	r.Use(utils.StoreLoggerInContextMiddleware(logger))
-	r.Use(utils.StoreSegmentClientInContextMiddleware(segmentClient))
+	if !disableSegment {
+		r.Use(utils.StoreSegmentClientInContextMiddleware(segmentClient))
+	}
 	r.Use(otelgin.Middleware(
 		conf.AppName,
 		otelgin.WithTracerProvider(telemetryRessources.TracerProvider),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -201,7 +201,7 @@ func RunServer(config CompiledConfig) error {
 
 	deps := api.InitDependencies(ctx, apiConfig, pool, marbleJwtSigningKey)
 
-	router := api.InitRouterMiddlewares(ctx, apiConfig, deps.SegmentClient, telemetryRessources)
+	router := api.InitRouterMiddlewares(ctx, apiConfig, apiConfig.DisableSegment, deps.SegmentClient, telemetryRessources)
 	server := api.NewServer(router, apiConfig, uc, deps.Authentication, deps.TokenHandler, logger)
 
 	notify, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -170,6 +170,7 @@ func TestMain(m *testing.M) {
 		MarbleAppUrl:        "http://localhost:3000",
 		RequestLoggingLevel: "all",
 		TokenLifetimeMinute: 60,
+		DisableSegment:      true,
 		SegmentWriteKey:     "",
 		BatchTimeout:        55 * time.Second,
 		DecisionTimeout:     10 * time.Second,
@@ -180,7 +181,7 @@ func TestMain(m *testing.M) {
 	deps := api.InitDependencies(ctx, apiConfig, dbPool, privateKey, tokenVerifier)
 
 	telemetryRessources, _ := infra.InitTelemetry(infra.TelemetryConfiguration{Enabled: false}, "")
-	router := api.InitRouterMiddlewares(ctx, apiConfig, deps.SegmentClient, telemetryRessources)
+	router := api.InitRouterMiddlewares(ctx, apiConfig, apiConfig.DisableSegment, deps.SegmentClient, telemetryRessources)
 	server := api.NewServer(router, apiConfig, testUsecases,
 		deps.Authentication, deps.TokenHandler, logger, api.WithLocalTest(true))
 

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -135,7 +135,7 @@ func setupApi(t *testing.T, ctx context.Context, dsn string) string {
 	repos := repositories.NewRepositories(pool, "",
 		repositories.WithOpenSanctions(openSanctions))
 	uc := usecases.NewUsecases(repos, usecases.WithLicense(models.NewFullLicense()), usecases.WithOpensanctions(true))
-	router := api.InitRouterMiddlewares(ctx, cfg, nil, infra.TelemetryRessources{})
+	router := api.InitRouterMiddlewares(ctx, cfg, true, nil, infra.TelemetryRessources{})
 
 	server := api.NewServer(
 		router,

--- a/usecases/tracking/track.go
+++ b/usecases/tracking/track.go
@@ -53,10 +53,8 @@ func TrackEventWithUserId(ctx context.Context, event models.AnalyticsEvent, user
 }
 
 func Identify(ctx context.Context, userId models.UserId, traits map[string]interface{}) {
-	logger := utils.LoggerFromContext(ctx)
 	segmentClient, found := utils.SegmentClientFromContext(ctx)
 	if !found || segmentClient == nil {
-		logger.ErrorContext(ctx, "Segment client not found in context")
 		return
 	}
 
@@ -76,10 +74,8 @@ func Identify(ctx context.Context, userId models.UserId, traits map[string]inter
 }
 
 func Group(ctx context.Context, userId models.UserId, organizationId string, traits map[string]interface{}) {
-	logger := utils.LoggerFromContext(ctx)
 	segmentClient, found := utils.SegmentClientFromContext(ctx)
 	if !found || segmentClient == nil {
-		logger.ErrorContext(ctx, "Segment client not found in context")
 		return
 	}
 
@@ -114,10 +110,8 @@ func getCredentialsAndAnalyticsClientFromContext(ctx context.Context) (models.Cr
 }
 
 func getAnalyticsClientFromContext(ctx context.Context) (analytics.Client, bool) {
-	logger := utils.LoggerFromContext(ctx)
 	segmentClient, found := utils.SegmentClientFromContext(ctx)
 	if !found || segmentClient == nil {
-		logger.ErrorContext(ctx, "Segment client not found in context")
 		return nil, false
 	}
 	return segmentClient, true


### PR DESCRIPTION
We added a way to disable segment, but events were still being sent (with an invalid key), making the logs filled with segment errors.