### PR TITLE
Add all datasets, tagged, to the list of datasets

### DIFF
--- a/dto/sanction_check_dataset_dto.go
+++ b/dto/sanction_check_dataset_dto.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -26,7 +27,8 @@ var datasetTagMapping = map[string]string{
 	"regulatory":       "adverse-media",
 	"debarment":        "adverse-media",
 	"special_interest": "adverse-media",
-	"enrichers":        "third-partiers",
+	"enrichers":        "third-parties",
+	"crime":            "adverse-media",
 	"peps":             "peps",
 	"sanctions":        "sanctions",
 }
@@ -46,9 +48,18 @@ func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsC
 		for idx, d := range s.Datasets {
 			var tag string
 
-			for _, ds := range d.Tags {
+			for _, ds := range d.Tags.Slice() {
 				if t, ok := datasetTagMapping[ds]; ok {
 					tag = t
+					break
+				}
+
+				if strings.Contains(ds, "sanctions") {
+					tag = "sanctions"
+					break
+				}
+				if strings.Contains(ds, "wanted") {
+					tag = "adverse-media"
 					break
 				}
 			}

--- a/dto/sanction_check_dataset_dto.go
+++ b/dto/sanction_check_dataset_dto.go
@@ -19,6 +19,16 @@ type OpenSanctionsCatalogSection struct {
 type OpenSanctionsCatalogDataset struct {
 	Name  string `json:"name"`
 	Title string `json:"title"`
+	Tag   string `json:"tag"`
+}
+
+var datasetTagMapping = map[string]string{
+	"regulatory":       "adverse-media",
+	"debarment":        "adverse-media",
+	"special_interest": "adverse-media",
+	"enrichers":        "third-partiers",
+	"peps":             "peps",
+	"sanctions":        "sanctions",
 }
 
 func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsCatalog {
@@ -34,9 +44,19 @@ func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsC
 		}
 
 		for idx, d := range s.Datasets {
+			var tag string
+
+			for _, ds := range d.Tags {
+				if t, ok := datasetTagMapping[ds]; ok {
+					tag = t
+					break
+				}
+			}
+
 			section.Datasets[idx] = OpenSanctionsCatalogDataset{
 				Name:  d.Name,
 				Title: d.Title,
+				Tag:   tag,
 			}
 		}
 

--- a/dto/sanction_check_dataset_dto.go
+++ b/dto/sanction_check_dataset_dto.go
@@ -31,6 +31,15 @@ var datasetTagMapping = map[string]string{
 	"crime":            "adverse-media",
 	"peps":             "peps",
 	"sanctions":        "sanctions",
+
+	// Upstream tags
+	"list.sanction":         "sanctions",
+	"list.sanction.counter": "sanctions",
+	"list.sanction.eu":      "sanctions",
+	"list.pep":              "peps",
+	"list.regulatory":       "adverse-media",
+	"list.risk":             "adverse-media",
+	"list.wanted":           "adverse-media",
 }
 
 func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsCatalog {
@@ -48,19 +57,29 @@ func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsC
 		for idx, d := range s.Datasets {
 			var tag string
 
-			for _, ds := range d.Tags.Slice() {
-				if t, ok := datasetTagMapping[ds]; ok {
-					tag = t
-					break
+			if tags, ok := model.Tags.Get(d.Name); ok {
+				for _, upstreamTag := range tags {
+					if t, ok := datasetTagMapping[upstreamTag]; ok {
+						tag = t
+					}
 				}
+			}
 
-				if strings.Contains(ds, "sanctions") {
-					tag = "sanctions"
-					break
-				}
-				if strings.Contains(ds, "wanted") {
-					tag = "adverse-media"
-					break
+			if tag == "" {
+				for _, ds := range d.Path.Slice() {
+					if t, ok := datasetTagMapping[ds]; ok {
+						tag = t
+						break
+					}
+
+					if strings.Contains(ds, "sanctions") {
+						tag = "sanctions"
+						break
+					}
+					if strings.Contains(ds, "wanted") {
+						tag = "adverse-media"
+						break
+					}
 				}
 			}
 

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -23,6 +23,7 @@ type OpenSanctionsCatalogSection struct {
 type OpenSanctionsCatalogDataset struct {
 	Name  string
 	Title string
+	Tags  []string
 }
 
 type OpenSanctionsQuery struct {

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -7,12 +7,14 @@ import (
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/cockroachdb/errors"
 	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 const OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY = 1 * time.Hour
 
 type OpenSanctionsCatalog struct {
 	Sections []OpenSanctionsCatalogSection
+	Tags     *expirable.LRU[string, []string]
 }
 
 type OpenSanctionsCatalogSection struct {
@@ -24,7 +26,7 @@ type OpenSanctionsCatalogSection struct {
 type OpenSanctionsCatalogDataset struct {
 	Name  string
 	Title string
-	Tags  set.Set[string]
+	Path  set.Set[string]
 }
 
 type OpenSanctionsQuery struct {

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -6,6 +6,7 @@ import (
 	"github.com/adhocore/gronx"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/cockroachdb/errors"
+	"github.com/hashicorp/go-set/v2"
 )
 
 const OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY = 1 * time.Hour
@@ -23,7 +24,7 @@ type OpenSanctionsCatalogSection struct {
 type OpenSanctionsCatalogDataset struct {
 	Name  string
 	Title string
-	Tags  []string
+	Tags  set.Set[string]
 }
 
 type OpenSanctionsQuery struct {

--- a/repositories/httpmodels/http_opensanctions_dataset.go
+++ b/repositories/httpmodels/http_opensanctions_dataset.go
@@ -1,7 +1,6 @@
 package httpmodels
 
 import (
-	"fmt"
 	"maps"
 	"slices"
 	"strings"

--- a/repositories/httpmodels/http_opensanctions_dataset.go
+++ b/repositories/httpmodels/http_opensanctions_dataset.go
@@ -9,6 +9,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 var (
@@ -40,7 +41,7 @@ type HTTPOpenSanctionCatalogDataset struct {
 	Children     []string `json:"children"`
 }
 
-func AdaptOpenSanctionCatalog(datasets []HTTPOpenSanctionCatalogDataset) models.OpenSanctionsCatalog {
+func AdaptOpenSanctionCatalog(datasets []HTTPOpenSanctionCatalogDataset, tags *expirable.LRU[string, []string]) models.OpenSanctionsCatalog {
 	sections := make(map[string]*models.OpenSanctionsCatalogSection, len(OPEN_SANCTIONS_CONTINENT_CODES))
 	datasetMap := make(map[string]*HTTPOpenSanctionCatalogDataset, len(datasets))
 	loadedDatasets := make(map[string]*set.Set[string])
@@ -82,6 +83,7 @@ func AdaptOpenSanctionCatalog(datasets []HTTPOpenSanctionCatalogDataset) models.
 
 	return models.OpenSanctionsCatalog{
 		Sections: slices.SortedFunc(maps.Values(pure_utils.MapValues(sections, f)), sortF),
+		Tags:     tags,
 	}
 }
 
@@ -118,7 +120,7 @@ func findDatasets(sections map[string]*models.OpenSanctionsCatalogSection,
 		sections[regionCode].Datasets = append(sections[regionCode].Datasets, models.OpenSanctionsCatalogDataset{
 			Name:  dataset.Name,
 			Title: dataset.Title,
-			Tags:  *tags,
+			Path:  *tags,
 		})
 	}
 }

--- a/repositories/httpmodels/http_opensanctions_dataset_freshness.go
+++ b/repositories/httpmodels/http_opensanctions_dataset_freshness.go
@@ -37,6 +37,13 @@ type HTTPOpenSanctionRemoteDataset struct {
 	} `json:"coverage"`
 }
 
+type HTTPOpenSanctionsRemoteIndexTags struct {
+	Datasets []struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	} `json:"datasets"`
+}
+
 func AdaptOpenSanctionDatasetFreshness(dataset HTTPOpenSanctionRemoteDataset) models.OpenSanctionsUpstreamDatasetFreshness {
 	return models.OpenSanctionsUpstreamDatasetFreshness{
 		Name:       dataset.Name,

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -310,7 +310,7 @@ func (repo OpenSanctionsRepository) searchRequest(ctx context.Context,
 			"could not parse OpenSanctions response")
 	}
 
-	requestUrl := fmt.Sprintf("%s/match/sanctions", repo.opensanctions.Host())
+	requestUrl := fmt.Sprintf("%s/match/default", repo.opensanctions.Host())
 
 	if qs := repo.buildQueryString(&query.Config, &query); len(qs) > 0 {
 		requestUrl = fmt.Sprintf("%s?%s", requestUrl, qs.Encode())

--- a/repositories/opensanctions_repository_test.go
+++ b/repositories/opensanctions_repository_test.go
@@ -43,7 +43,7 @@ func TestOpenSanctionsSelfHostedApi(t *testing.T) {
 	}
 
 	gock.New("https://yente.local").
-		Post("/match/sanctions").
+		Post("/match/default").
 		Reply(http.StatusBadRequest)
 
 	_, err := repo.Search(context.TODO(), query)
@@ -71,7 +71,7 @@ func TestOpenSanctionsSelfHostedAndApiKey(t *testing.T) {
 	}
 
 	gock.New("https://yente.local").
-		Post("/match/sanctions").
+		Post("/match/default").
 		MatchParam("api_key", "abcdef").
 		Reply(http.StatusBadRequest)
 
@@ -100,7 +100,7 @@ func TestOpenSanctionsSaaSAndApiKey(t *testing.T) {
 	}
 
 	gock.New(infra.OPEN_SANCTIONS_API_HOST).
-		Post("/match/sanctions").
+		Post("/match/default").
 		MatchParam("api_key", "abcdef").
 		Reply(http.StatusBadRequest)
 
@@ -129,7 +129,7 @@ func TestOpenSanctionsSelfHostedAndBearerToken(t *testing.T) {
 	}
 
 	gock.New("https://yente.local").
-		Post("/match/sanctions").
+		Post("/match/default").
 		MatchHeader("authorization", "Bearer abcdef").
 		Reply(http.StatusBadRequest)
 
@@ -158,7 +158,7 @@ func TestOpenSanctionsSelfHostedAndBasicAuth(t *testing.T) {
 	}
 
 	gock.New("https://yente.local").
-		Post("/match/sanctions").
+		Post("/match/default").
 		MatchHeader("authorization", "Basic YWJjZGVmOmhlbGxvd29ybGQ=").
 		Reply(http.StatusBadRequest)
 
@@ -187,7 +187,7 @@ func TestOpenSanctionsError(t *testing.T) {
 	}
 
 	gock.New(infra.OPEN_SANCTIONS_API_HOST).
-		Post("/match/sanctions").
+		Post("/match/default").
 		Reply(http.StatusBadRequest)
 
 	_, err := repo.Search(context.TODO(), query)
@@ -217,7 +217,7 @@ func TestOpenSanctionsSuccessfulPartialResponse(t *testing.T) {
 	body, _ := os.ReadFile("./fixtures/opensanctions/response_partial.json")
 
 	gock.New(infra.OPEN_SANCTIONS_API_HOST).
-		Post("/match/sanctions").
+		Post("/match/default").
 		Reply(http.StatusOK).
 		BodyString(string(body))
 
@@ -251,7 +251,7 @@ func TestOpenSanctionsSuccessfulFullResponse(t *testing.T) {
 	body, _ := os.ReadFile("./fixtures/opensanctions/response_full.json")
 
 	gock.New(infra.OPEN_SANCTIONS_API_HOST).
-		Post("/match/sanctions").
+		Post("/match/default").
 		Reply(http.StatusOK).
 		BodyString(string(body))
 


### PR DESCRIPTION
~This adds a new section when configuring screening for a scenario including all lists pertaining to politically exposed people.~

This PR:

 - Removes the restriction on _which_ datasets we consider for showing in the app (before, we only displayed `sanctions` datasets
 - We add a new field to the dataset spec we return, `tag`, which represents what kind of category the dataset is. The list of possible tags for now is:
   - `adverse-media`
   - `third-parties`
   - `peps`
   - `sanctions`

To note, quite a few dataset are not classified into one of those superset datasets, and therefore will not have a tag.

The OpenSanctions / Yente endpoint we use also changes to target `/match/default`, instead of `/match/sanctions`.

Finally, to prepare for !1023 (that will separate label name recognition config and mangle them to be a `StringConcat`, the DTO will now wrap a plain payload into a `StringConcat`.