### PR TITLE
Reorder and add more case action side effects.

### DIFF
--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -203,6 +203,7 @@ func (repo *MarbleDbRepository) UnsnoozeCase(ctx context.Context, exec Executor,
 	sql := NewQueryBuilder().
 		Update(dbmodels.TABLE_CASES).
 		Set("snoozed_until", nil).
+		Set("boost", nil).
 		Where(squirrel.Eq{"id": caseId})
 
 	return ExecBuilder(ctx, exec, sql)


### PR DESCRIPTION
This touches on the side effects performed on a case when an action is taken, namely:

 - The case going to "Investingating" if it is pending is now a side effect.
 - Trigger side effect on rule snooze and suspicious activity report actions.
 - Fix side effects on case snoozing and unsnoozing (since one of the side effect is to unboost, we lost the snooze effect).
 - Generalize side effects when assigning a case.

Also, remove the 409 if trying to unsnooze a case that is not snoozed.