### PR TITLE
Replace migration moving pg_trgm to check if we are extension owner.

### DIFF
--- a/repositories/migrations/20250424120000_add_fuzzystrmatch_extension.sql
+++ b/repositories/migrations/20250424120000_add_fuzzystrmatch_extension.sql
@@ -1,7 +1,29 @@
 -- +goose Up
+-- +goose StatementBegin
+
 CREATE EXTENSION if not exists fuzzystrmatch SCHEMA public;
-ALTER EXTENSION pg_trgm SET SCHEMA public;
+
+do $$
+declare
+  extension_name text := 'pg_trgm';
+begin
+  perform true
+  from pg_user pgu
+  inner join pg_extension pge on pge.extowner = pgu.usesysid
+  where
+    pgu.usename = current_user and
+    pge.extname = extension_name;
+
+  if found then
+    execute 'alter extension ' || quote_ident(extension_name) || ' set schema public';
+  else
+    raise notice 'WARN: could not install the %s extension into the public schema because we are not the owner', extension_name;
+  end if;
+end;
+$$ language plpgsql;
+
+-- +goose StatementEnd
 
 -- +goose Down
+
 DROP EXTENSION if exists fuzzystrmatch;
-ALTER EXTENSION pg_trgm SET SCHEMA marble;


### PR DESCRIPTION
Moving the extension to be housed in a specific schema requires that the current user be the owner of the extension. This causes issue on platform where the managed database precreates the extension with their administrative roles.

This checks whether the current user is the owner, and only moves the extension if so.