### PR TITLE
Allow reading from soft-deleted custom lists during scenario evaluation.

### DIFF
--- a/mocks/custom_list_repository.go
+++ b/mocks/custom_list_repository.go
@@ -18,8 +18,10 @@ func (cl *CustomListRepository) AllCustomLists(ctx context.Context, exec reposit
 	return args.Get(0).([]models.CustomList), args.Error(1)
 }
 
-func (cl *CustomListRepository) GetCustomListById(ctx context.Context, exec repositories.Executor, id string) (models.CustomList, error) {
-	args := cl.Called(exec, id)
+func (cl *CustomListRepository) GetCustomListById(ctx context.Context, exec repositories.Executor,
+	id string, includeDeleted bool,
+) (models.CustomList, error) {
+	args := cl.Called(exec, id, includeDeleted)
 	return args.Get(0).(models.CustomList), args.Error(1)
 }
 

--- a/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
+++ b/usecases/ast_eval/evaluate/evaluate_custom_list_values.go
@@ -39,7 +39,7 @@ func (clva CustomListValuesAccess) Evaluate(ctx context.Context, arguments ast.A
 		return MakeEvaluateError(err)
 	}
 
-	list, err := clva.CustomListRepository.GetCustomListById(ctx, exec, listId)
+	list, err := clva.CustomListRepository.GetCustomListById(ctx, exec, listId, true)
 	if errors.Is(err, models.NotFoundError) {
 		return MakeEvaluateError(ast.ErrListNotFound)
 	} else if err != nil {

--- a/usecases/ast_eval/evaluate/evaluate_custom_list_values_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_custom_list_values_test.go
@@ -48,7 +48,7 @@ func TestCustomListValues(t *testing.T) {
 	testCustomListValues := []models.CustomListValue{{Value: "test"}, {Value: "test2"}}
 
 	execFactory.On("NewExecutor").Return(exec)
-	clr.On("GetCustomListById", exec, testListId).Return(testList, nil)
+	clr.On("GetCustomListById", exec, testListId, true).Return(testList, nil)
 	clr.On("GetCustomListValues", exec, models.GetCustomListValuesInput{Id: testListId}).Return(testCustomListValues, nil)
 
 	er.On("ReadOrganization", testListOrgId).Return(nil)
@@ -74,7 +74,7 @@ func TestCustomListValuesNoAccess(t *testing.T) {
 	customListEval := evaluate.NewCustomListValuesAccess(clr, er, execFactory)
 
 	execFactory.On("NewExecutor").Return(exec)
-	clr.On("GetCustomListById", exec, testListId).Return(testList, nil)
+	clr.On("GetCustomListById", exec, testListId, true).Return(testList, nil)
 	er.On("ReadOrganization", testListOrgId).Return(models.ForbiddenError)
 
 	_, errs := customListEval.Evaluate(context.TODO(), ast.Arguments{NamedArgs: testCustomListNamedArgs})

--- a/usecases/custom_list_usecase.go
+++ b/usecases/custom_list_usecase.go
@@ -60,7 +60,7 @@ func (usecase *CustomListUseCase) CreateCustomList(
 		if err != nil {
 			return models.CustomList{}, err
 		}
-		return usecase.CustomListRepository.GetCustomListById(ctx, tx, newCustomListId)
+		return usecase.CustomListRepository.GetCustomListById(ctx, tx, newCustomListId, false)
 	})
 	if err != nil {
 		return models.CustomList{}, err
@@ -80,7 +80,7 @@ func (usecase *CustomListUseCase) UpdateCustomList(ctx context.Context,
 		tx repositories.Transaction,
 	) (models.CustomList, error) {
 		if updateCustomList.Name != nil || updateCustomList.Description != nil {
-			customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, updateCustomList.Id)
+			customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, updateCustomList.Id, false)
 			if err != nil {
 				return models.CustomList{}, err
 			}
@@ -92,7 +92,7 @@ func (usecase *CustomListUseCase) UpdateCustomList(ctx context.Context,
 				return models.CustomList{}, err
 			}
 		}
-		return usecase.CustomListRepository.GetCustomListById(ctx, tx, updateCustomList.Id)
+		return usecase.CustomListRepository.GetCustomListById(ctx, tx, updateCustomList.Id, false)
 	})
 	if err != nil {
 		return models.CustomList{}, err
@@ -107,7 +107,7 @@ func (usecase *CustomListUseCase) UpdateCustomList(ctx context.Context,
 
 func (usecase *CustomListUseCase) SoftDeleteCustomList(ctx context.Context, listId string) error {
 	err := usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, listId)
+		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, listId, false)
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func (usecase *CustomListUseCase) SoftDeleteCustomList(ctx context.Context, list
 
 func (usecase *CustomListUseCase) GetCustomListById(ctx context.Context, id string) (models.CustomList, error) {
 	customList, err := usecase.CustomListRepository.GetCustomListById(ctx,
-		usecase.executorFactory.NewExecutor(), id)
+		usecase.executorFactory.NewExecutor(), id, false)
 	if err != nil {
 		return models.CustomList{}, err
 	}
@@ -162,7 +162,7 @@ func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 	value, err := executor_factory.TransactionReturnValue(ctx, usecase.transactionFactory, func(
 		tx repositories.Transaction,
 	) (models.CustomListValue, error) {
-		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, addCustomListValue.CustomListId)
+		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, addCustomListValue.CustomListId, false)
 		if err != nil {
 			return models.CustomListValue{}, err
 		}
@@ -190,7 +190,7 @@ func (usecase *CustomListUseCase) AddCustomListValue(ctx context.Context,
 
 func (usecase *CustomListUseCase) ReadCustomListValuesToCSV(ctx context.Context, customListID string, w io.Writer) (string, error) {
 	exec := usecase.executorFactory.NewExecutor()
-	customList, err := usecase.CustomListRepository.GetCustomListById(ctx, exec, customListID)
+	customList, err := usecase.CustomListRepository.GetCustomListById(ctx, exec, customListID, false)
 	if err != nil {
 		return "", err
 	}
@@ -249,7 +249,7 @@ func (usecase *CustomListUseCase) ReplaceCustomListValuesFromCSV(ctx context.Con
 
 	var results models.BatchInsertCustomListValueResults
 	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, customListID)
+		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, customListID, false)
 		if err != nil {
 			return err
 		}
@@ -370,7 +370,8 @@ func (usecase *CustomListUseCase) DeleteCustomListValue(ctx context.Context,
 	}
 
 	err := usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx, deleteCustomListValue.CustomListId)
+		customList, err := usecase.CustomListRepository.GetCustomListById(ctx, tx,
+			deleteCustomListValue.CustomListId, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR makes it so deleted lists can still be used during scenario evaluation, but do not appear elsewhere.