### PR TITLE
Case events for annotations

### DIFF
--- a/api/handle_client_data.go
+++ b/api/handle_client_data.go
@@ -34,7 +34,12 @@ func handleGetIngestedObject(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		c.JSON(http.StatusOK, objects[0])
+		output, err := dto.AdaptClientObjectDetailDto(objects[0])
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, output)
 	}
 }
 

--- a/api/handle_entity_annotations.go
+++ b/api/handle_entity_annotations.go
@@ -56,6 +56,32 @@ func handleListEntityAnnotations(uc usecases.Usecases) gin.HandlerFunc {
 	}
 }
 
+func handleGetEntityAnnotation(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		creds, _ := utils.CredentialsFromCtx(ctx)
+
+		id := c.Param("id")
+
+		uc := usecasesWithCreds(ctx, uc)
+		annotationsUsecase := uc.NewEntityAnnotationUsecase()
+
+		annotations, err := annotationsUsecase.Get(ctx, creds.OrganizationId, id)
+		if err != nil {
+			presentError(ctx, c, err)
+			return
+		}
+
+		out, err := dto.AdaptEntityAnnotation(annotations)
+		if err != nil {
+			presentError(ctx, c, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, out)
+	}
+}
+
 func handleListEntityAnnotationsForObjects(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -227,6 +253,7 @@ func handleCreateEntityFileAnnotation(uc usecases.Usecases) gin.HandlerFunc {
 
 		req := models.CreateEntityAnnotationRequest{
 			OrgId:          creds.OrganizationId,
+			CaseId:         payload.CaseId,
 			ObjectType:     objectType,
 			ObjectId:       objectId,
 			AnnotationType: models.EntityAnnotationFile,

--- a/api/routes.go
+++ b/api/routes.go
@@ -75,6 +75,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 
 	router.GET("/client_data/:object_type/:object_id", tom, handleGetIngestedObject(uc))
 	router.GET("/client_data/:object_type/:object_id/annotations", tom, handleListEntityAnnotations(uc))
+	router.GET("/client_data/annotations/:id", tom, handleGetEntityAnnotation(uc))
 	router.POST("/client_data/:object_type/annotations", tom,
 		handleListEntityAnnotationsForObjects(uc))
 	router.POST("/client_data/:object_type/:object_id/annotations", tom, handleCreateEntityAnnotation(uc))

--- a/dto/entity_annotation.go
+++ b/dto/entity_annotation.go
@@ -35,6 +35,7 @@ type PostEntityAnnotationDto struct {
 }
 
 type PostEntityFileAnnotationDto struct {
+	CaseId  *string                `form:"case_id" binding:"omitempty,uuid"`
 	Caption string                 `form:"caption" binding:"required"`
 	Files   []multipart.FileHeader `form:"files[]" binding:"gte=1"`
 }

--- a/models/case_event.go
+++ b/models/case_event.go
@@ -42,6 +42,7 @@ const (
 	CaseSnoozed           CaseEventType = "case_snoozed"
 	CaseUnsnoozed         CaseEventType = "case_unsnoozed"
 	CaseEscalated         CaseEventType = "case_escalated"
+	CaseEntityAnnotated   CaseEventType = "entity_annotated"
 )
 
 type CaseEventResourceType string
@@ -52,6 +53,7 @@ const (
 	CaseFileResourceType   CaseEventResourceType = "case_file"
 	RuleSnoozeResourceType CaseEventResourceType = "rule_snooze"
 	SarResourceType        CaseEventResourceType = "sar"
+	AnnotationResourceType CaseEventResourceType = "annotation"
 )
 
 type CreateCaseEventAttributes struct {

--- a/models/entity_annotation.go
+++ b/models/entity_annotation.go
@@ -89,6 +89,7 @@ type AnnotationByIdRequest struct {
 	OrgId          string
 	AnnotationId   string
 	AnnotationType *EntityAnnotationType
+	IncludeDeleted bool
 }
 
 type GroupedEntityAnnotations struct {

--- a/repositories/entity_annotation_repository.go
+++ b/repositories/entity_annotation_repository.go
@@ -18,9 +18,12 @@ func (repo *MarbleDbRepository) GetEntityAnnotationById(
 	}
 
 	filters := squirrel.Eq{
-		"id":         req.AnnotationId,
-		"org_id":     req.OrgId,
-		"deleted_at": nil,
+		"id":     req.AnnotationId,
+		"org_id": req.OrgId,
+	}
+
+	if !req.IncludeDeleted {
+		filters["deleted_at"] = nil
 	}
 
 	sql := NewQueryBuilder().

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -650,6 +650,7 @@ func (usecases *UsecasesWithCreds) NewEntityAnnotationUsecase() EntityAnnotation
 		repository:                 &usecases.Repositories.MarbleDbRepository,
 		dataModelRepository:        usecases.Repositories.MarbleDbRepository,
 		ingestedDataReadRepository: usecases.Repositories.IngestedDataReadRepository,
+		caseUsecase:                usecases.NewCaseUseCase(),
 		tagRepository:              &usecases.Repositories.MarbleDbRepository,
 		blobRepository:             usecases.Repositories.BlobRepository,
 		bucketUrl:                  usecases.caseManagerBucketUrl,


### PR DESCRIPTION
This PR creates a link between an entity annotation and the case it was added from (if applicable):

 * Any annotation created will also create a case event of type `entity_annotated`.
 * A file annotation will attach the file to the case.

It also fixes an issue with the client object viewer where the models would not be serialized.