### PR TITLE
Update Yente to 4.3.1.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - es:/usr/share/elasticsearch/data
   yente:
     container_name: yente
-    image: ghcr.io/opensanctions/yente:4.2.1
+    image: ghcr.io/opensanctions/yente:4.3.1
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
**Note**: version 4.4.0 was just released, so we might go directly to that after testing.