### PR TITLE
Safe create extensions and remove drop extensions.

### DIFF
--- a/repositories/migrations/20250117095221_fuzzy_match_on_case_name.sql
+++ b/repositories/migrations/20250117095221_fuzzy_match_on_case_name.sql
@@ -1,6 +1,7 @@
 -- +goose NO TRANSACTION
 -- +goose Up
-CREATE EXTENSION pg_trgm;
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 -- +goose StatementBegin
 
@@ -28,5 +29,3 @@ CREATE INDEX CONCURRENTLY case_org_id_idx ON cases (org_id, created_at DESC);
 DROP INDEX CONCURRENTLY IF EXISTS case_org_id_idx_2;
 
 DROP INDEX CONCURRENTLY IF EXISTS trgm_cases_on_name;
-
-DROP EXTENSION pg_trgm;

--- a/repositories/migrations/20250424120000_add_fuzzystrmatch_extension.sql
+++ b/repositories/migrations/20250424120000_add_fuzzystrmatch_extension.sql
@@ -1,29 +1,5 @@
 -- +goose Up
--- +goose StatementBegin
 
 CREATE EXTENSION if not exists fuzzystrmatch SCHEMA public;
 
-do $$
-declare
-  extension_name text := 'pg_trgm';
-begin
-  perform true
-  from pg_user pgu
-  inner join pg_extension pge on pge.extowner = pgu.usesysid
-  where
-    pgu.usename = current_user and
-    pge.extname = extension_name;
-
-  if found then
-    execute 'alter extension ' || quote_ident(extension_name) || ' set schema public';
-  else
-    raise notice 'WARN: could not install the %s extension into the public schema because we are not the owner', extension_name;
-  end if;
-end;
-$$ language plpgsql;
-
--- +goose StatementEnd
-
 -- +goose Down
-
-DROP EXTENSION if exists fuzzystrmatch;


### PR DESCRIPTION
This PR tries to be conservative with the way we set up Postgres extensions. Because some managed services already have those extensions created in a way we cannot move them.