### PR TITLE
Consider all entity referents when checking against whitelists.

### DIFF
--- a/dto/sanction_check_dto.go
+++ b/dto/sanction_check_dto.go
@@ -81,6 +81,7 @@ func AdaptSanctionCheckRefineDto(dto SanctionCheckRefineDto) models.SanctionChec
 type SanctionCheckMatchDto struct {
 	Id                           string                         `json:"id"`
 	EntityId                     string                         `json:"entity_id"`
+	Referents                    []string                       `json:"referents"`
 	QueryIds                     []string                       `json:"query_ids"`
 	Status                       string                         `json:"status"`
 	ReviewedBy                   *string                        `json:"reviewer_id,omitempty"` //nolint:tagliatelle
@@ -95,6 +96,7 @@ func AdaptSanctionCheckMatchDto(m models.SanctionCheckMatch) SanctionCheckMatchD
 	match := SanctionCheckMatchDto{
 		Id:                           m.Id,
 		EntityId:                     m.EntityId,
+		Referents:                    m.Referents,
 		Status:                       m.Status.String(),
 		ReviewedBy:                   m.ReviewedBy,
 		QueryIds:                     m.QueryIds,

--- a/models/sanction_check.go
+++ b/models/sanction_check.go
@@ -168,6 +168,7 @@ type SanctionCheckMatch struct {
 	IsMatch                      bool
 	SanctionCheckId              string
 	EntityId                     string
+	Referents                    []string
 	Status                       SanctionCheckMatchStatus
 	QueryIds                     []string
 	UniqueCounterpartyIdentifier *string

--- a/repositories/httpmodels/http_opensanctions_result.go
+++ b/repositories/httpmodels/http_opensanctions_result.go
@@ -20,6 +20,7 @@ type HTTPOpenSanctionsResult struct {
 
 type HTTPOpenSanctionResultResult struct {
 	Id         string   `json:"id"`
+	Referents  []string `json:"referents"`
 	Match      bool     `json:"match"`
 	Schema     string   `json:"schema"`
 	Datasets   []string `json:"datasets"`
@@ -51,9 +52,10 @@ func AdaptOpenSanctionsResult(query json.RawMessage, result HTTPOpenSanctionsRes
 
 			if _, ok := matches[parsed.Id]; !ok {
 				entity := models.SanctionCheckMatch{
-					IsMatch:  parsed.Match,
-					Payload:  match,
-					EntityId: parsed.Id,
+					IsMatch:   parsed.Match,
+					Payload:   match,
+					EntityId:  parsed.Id,
+					Referents: parsed.Referents,
 				}
 
 				matches[parsed.Id] = entity


### PR DESCRIPTION
We used to only check for whitelisted match against the main entity ID at the time of the screening. This completely shadowed that an entity can have its ID changed over its lifetime.

This PR now considers all previous "referents" IDs when checking whether the match was whitelisted or not.