### PR TITLE
return information on "can be annotaged" status of a client object

### DIFF
--- a/dto/client_data_object.go
+++ b/dto/client_data_object.go
@@ -31,8 +31,9 @@ func AdaptClientObjectDetailDto(c models.ClientObjectDetail) (ClientObjectDetail
 
 	out := ClientObjectDetail{
 		Metadata: ClientObjectMetadata{
-			ValidFrom:  c.Metadata.ValidFrom,
-			ObjectType: c.Metadata.ObjectType,
+			ValidFrom:      c.Metadata.ValidFrom,
+			ObjectType:     c.Metadata.ObjectType,
+			CanBeAnnotated: c.CanBeAnnotated(),
 		},
 		Data:           c.Data,
 		RelatedObjects: relatedObjects,
@@ -55,7 +56,7 @@ func (c ClientObjectDetail) MarshalJSON() ([]byte, error) {
 		c.Data = make(map[string]any)
 	}
 	return json.Marshal(struct {
-		Metadata       ClientObjectMetadata     `json:"metadata,omitzero"`
+		Metadata       ClientObjectMetadata     `json:"metadata"`
 		Data           map[string]any           `json:"data"`
 		RelatedObjects []RelatedObject          `json:"related_objects"`
 		Annotations    GroupedEntityAnnotations `json:"annotations,omitzero"`
@@ -81,8 +82,9 @@ func AdaptRelatedObjectDto(o models.RelatedObject) (RelatedObject, error) {
 }
 
 type ClientObjectMetadata struct {
-	ValidFrom  time.Time `json:"valid_from"`
-	ObjectType string    `json:"object_type"`
+	ValidFrom      *time.Time `json:"valid_from"`
+	ObjectType     string     `json:"object_type"`
+	CanBeAnnotated bool       `json:"can_be_annotated"`
 }
 
 type ClientDataListResponse struct {

--- a/dto/entity_annotation.go
+++ b/dto/entity_annotation.go
@@ -20,6 +20,8 @@ type EntityAnnotationDto struct {
 	Payload     any       `json:"payload"`
 	AnnotatedBy *string   `json:"annotated_by,omitempty"`
 	CreatedAt   time.Time `json:"created_at"`
+	ObjectType  string    `json:"object_type,"`
+	ObjectId    string    `json:"object_id"`
 }
 
 type EntityAnnotationForObjectsParams struct {
@@ -58,6 +60,8 @@ func AdaptEntityAnnotation(model models.EntityAnnotation) (EntityAnnotationDto, 
 		Payload:     payload,
 		AnnotatedBy: userId,
 		CreatedAt:   model.CreatedAt,
+		ObjectType:  model.ObjectType,
+		ObjectId:    model.ObjectId,
 	}, nil
 }
 

--- a/models/client_data_object.go
+++ b/models/client_data_object.go
@@ -43,22 +43,20 @@ func (p PivotType) String() string {
 	}
 }
 
-func PivotTypeFromString(s string) PivotType {
-	switch s {
-	case "object":
-		return PivotTypeObject
-	case "field":
-		return PivotTypeField
-	default:
-		return PivotTypeUnknown
-	}
-}
-
 type ClientObjectDetail struct {
 	Metadata       ClientObjectMetadata
 	Data           map[string]any
 	RelatedObjects []RelatedObject
 	Annotations    GroupedEntityAnnotations
+}
+
+func (c ClientObjectDetail) CanBeAnnotated() bool {
+	objectId, present := c.Data["object_id"]
+	if !present {
+		return false
+	}
+	_, isString := objectId.(string)
+	return isString
 }
 
 type RelatedObject struct {
@@ -67,7 +65,7 @@ type RelatedObject struct {
 }
 
 type ClientObjectMetadata struct {
-	ValidFrom  time.Time
+	ValidFrom  *time.Time
 	ObjectType string
 }
 

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -102,7 +102,7 @@ func (usecase IngestedDataReaderUsecase) GetIngestedObject(
 		validFrom, _ := object.Metadata["valid_from"].(time.Time)
 		clientObject := models.ClientObjectDetail{
 			Data:     object.Data,
-			Metadata: models.ClientObjectMetadata{ValidFrom: validFrom, ObjectType: objectType},
+			Metadata: models.ClientObjectMetadata{ValidFrom: &validFrom, ObjectType: objectType},
 		}
 		clientObjects[i] = clientObject
 	}
@@ -390,7 +390,7 @@ func (usecase IngestedDataReaderUsecase) ReadIngestedClientObjects(
 		validFrom, _ := object.Metadata["valid_from"].(time.Time)
 		clientObject := models.ClientObjectDetail{
 			Data:     object.Data,
-			Metadata: models.ClientObjectMetadata{ValidFrom: validFrom, ObjectType: objectType},
+			Metadata: models.ClientObjectMetadata{ValidFrom: &validFrom, ObjectType: objectType},
 		}
 
 		var annotations []models.EntityAnnotation


### PR DESCRIPTION
Incremental changes to the API consumed by the case manager, to facilitate some data display by the frontend following QA of object annotations.