### PR TITLE
Pascal/simplifiy ci

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Deploy migration job
         run: |
-          gcloud beta run jobs deploy migrations \
+          gcloud run jobs deploy migrations \
             --quiet \
             --image=${{ env.IMAGE }} \
             --region="europe-west1" \
@@ -85,30 +85,9 @@ jobs:
             --image=${{ env.IMAGE }} \
             --region="europe-west1"
 
-      - name: Deploy execute scheduled scenario job
-        run: |
-          gcloud beta run jobs deploy scheduled-executer \
-            --quiet \
-            --image=${{ env.IMAGE }} \
-            --region="europe-west1"
-
       - name: Deploy execute async worker service
         run: |
-          gcloud beta run deploy marble-backend-worker \
+          gcloud run deploy marble-backend-worker \
             --quiet \
             --image=${{ env.IMAGE }} \
             --region="europe-west1"
-
-      - name: Deploy data ingestion job
-        run: |
-          gcloud beta run jobs deploy data-ingestion \
-            --quiet \
-            --image=${{ env.IMAGE }} \
-            --region="europe-west1" \
-
-      - name: Deploy webhook retry
-        run: |
-          gcloud beta run jobs deploy retry-webhooks \
-            --quiet \
-            --image=${{ env.IMAGE }} \
-            --region="europe-west1" \

--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -51,18 +51,68 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
+      - name: Check if image exists (for prod deployments)
+        id: check_image
+        run: |
+          if [[ "${{ inputs.environment }}" == "production" ]] || [[ "${{ inputs.environment }}" == "prod" ]]; then
+            echo "Checking if image already exists for production deployment..."
+            # For production, check if an image exists with the commit hash as tag
+            COMMIT_HASH=$(git rev-parse HEAD)
+            COMMIT_IMAGE="europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${COMMIT_HASH}"
+            echo "Looking for existing image: ${COMMIT_IMAGE}"
+
+            if docker manifest inspect ${COMMIT_IMAGE} > /dev/null 2>&1; then
+              echo "✅ Image with commit hash ${COMMIT_HASH} already exists, will reuse it"
+              echo "existing_image=${COMMIT_IMAGE}" >> "$GITHUB_OUTPUT"
+              echo "should_build=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "❌ No image found for commit hash ${COMMIT_HASH}, will build new image with tag ${{ inputs.version }}"
+              echo "should_build=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "Non-production deployment, will build image"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set deployment image
+        id: deployment_image
+        run: |
+          echo "DEPLOY_IMAGE=${{ env.IMAGE }}" >> "$GITHUB_OUTPUT"
+
       - name: Extract version from tag
         id: version
         run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
+      - name: Prepare image tags
+        if: steps.check_image.outputs.should_build == 'true'
+        id: tags
+        run: |
+          COMMIT_HASH=$(git rev-parse HEAD)
+          COMMIT_IMAGE="europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${COMMIT_HASH}"
+
+          if [[ "${{ inputs.environment }}" == "production" ]] || [[ "${{ inputs.environment }}" == "prod" ]]; then
+            # For production, only tag with the version
+            echo "IMAGE_TAGS=${{ env.IMAGE }}" >> "$GITHUB_OUTPUT"
+          else
+            # For staging, tag with both version (latest) and commit hash
+            echo "IMAGE_TAGS=${{ env.IMAGE }},$COMMIT_IMAGE" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push
+        if: steps.check_image.outputs.should_build == 'true'
         uses: docker/build-push-action@v5
         with:
           push: true
           build-args: |
             MARBLE_VERSION=${{ steps.version.outputs.MARBLE_VERSION }}
             SEGMENT_WRITE_KEY=${{ secrets.segment_write_key_opensource }}
-          tags: ${{ env.IMAGE }}
+          tags: ${{ steps.tags.outputs.IMAGE_TAGS }}
+
+      - name: Tag existing image with version (for prod reuse)
+        if: steps.check_image.outputs.should_build == 'false'
+        run: |
+          echo "Retagging existing image ${{ steps.check_image.outputs.existing_image }} as ${{ env.IMAGE }}"
+          docker buildx imagetools create --tag ${{ env.IMAGE }} ${{ steps.check_image.outputs.existing_image }}
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
@@ -73,7 +123,7 @@ jobs:
         run: |
           gcloud run jobs deploy migrations \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
             --region="europe-west1" \
             --execute-now \
             --wait
@@ -82,12 +132,12 @@ jobs:
         run: |
           gcloud run deploy marble-backend \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
             --region="europe-west1"
 
       - name: Deploy execute async worker service
         run: |
           gcloud run deploy marble-backend-worker \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
             --region="europe-west1"

--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -24,7 +24,8 @@ jobs:
     name: Build and deploy back-end
     environment: ${{ inputs.environment }}
     env:
-      IMAGE: europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${{ inputs.version }}
+      VERSION_IMAGE: europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${{ inputs.version }}
+      COMMIT_IMAGE: europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${{ github.sha }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,7 +43,7 @@ jobs:
           token_format: access_token
           project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER_ID }}
-          service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL}}
+          service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
 
       - name: Login to Google Artifact Registry
         uses: docker/login-action@v3
@@ -54,44 +55,19 @@ jobs:
       - name: Check if image exists (for production deployments)
         id: check_image
         run: |
-          if [[ "${{ inputs.environment }}" == "production" ]]; then
-            echo "Checking if image already exists for production deployment..."
-            # For production, check if an image exists with the commit hash as tag
-            COMMIT_HASH=$(git rev-parse HEAD)
-            COMMIT_IMAGE="europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${COMMIT_HASH}"
-            echo "Looking for existing image: ${COMMIT_IMAGE}"
+          echo "Looking for existing image: ${{ env.COMMIT_IMAGE }}"
 
-            if docker manifest inspect ${COMMIT_IMAGE} > /dev/null 2>&1; then
-              echo "✅ Image with commit hash ${COMMIT_HASH} already exists, will reuse it"
-              echo "existing_image=${COMMIT_IMAGE}" >> "$GITHUB_OUTPUT"
-              echo "should_build=false" >> "$GITHUB_OUTPUT"
-            else
-              echo "❌ No image found for commit hash ${COMMIT_HASH}, will build new image with tag ${{ inputs.version }}"
-              echo "should_build=true" >> "$GITHUB_OUTPUT"
-            fi
+          if docker manifest inspect ${{ env.COMMIT_IMAGE }} > /dev/null 2>&1; then
+            echo "✅ Image with commit hash ${{ github.sha }} already exists, will reuse it"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
           else
-            echo "Non-production deployment, will build image"
+            echo "❌ No image found for commit hash ${{ github.sha }}, build a new one"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract version from tag
         id: version
         run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare image tags
-        if: steps.check_image.outputs.should_build == 'true'
-        id: tags
-        run: |
-          COMMIT_HASH=$(git rev-parse HEAD)
-          COMMIT_IMAGE="europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${COMMIT_HASH}"
-
-          if [[ "${{ inputs.environment }}" == "production" ]]; then
-            # For production, only tag with the version
-            echo "IMAGE_TAGS=${{ env.IMAGE }}" >> "$GITHUB_OUTPUT"
-          else
-            # For staging, tag with both version (latest) and commit hash
-            echo "IMAGE_TAGS=${{ env.IMAGE }},$COMMIT_IMAGE" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Build and push
         if: steps.check_image.outputs.should_build == 'true'
@@ -101,15 +77,14 @@ jobs:
           build-args: |
             MARBLE_VERSION=${{ steps.version.outputs.MARBLE_VERSION }}
             SEGMENT_WRITE_KEY=${{ secrets.segment_write_key_opensource }}
-          tags: ${{ steps.tags.outputs.IMAGE_TAGS }}
+          tags: ${{ env.COMMIT_IMAGE }}
 
-      - name: Tag existing image with version (for production deployment reuse)
-        if: steps.check_image.outputs.should_build == 'false'
+      - name: Tag existing image with version
         run: |
-          echo "Retagging existing image ${{ steps.check_image.outputs.existing_image }} as ${{ env.IMAGE }}"
-          docker buildx imagetools create --tag ${{ env.IMAGE }} ${{ steps.check_image.outputs.existing_image }}
+          echo "Retagging existing image ${{ env.COMMIT_IMAGE }} as ${{ env.VERSION_IMAGE }}"
+          docker buildx imagetools create --tag ${{ env.VERSION_IMAGE }} ${{ env.COMMIT_IMAGE }}
 
-      - name: "Set up Cloud SDK"
+      - name: Set up Cloud SDK
         uses: "google-github-actions/setup-gcloud@v2"
         with:
           install_components: beta
@@ -118,7 +93,7 @@ jobs:
         run: |
           gcloud run jobs deploy migrations \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ env.VERSION_IMAGE }} \
             --region="europe-west1" \
             --execute-now \
             --wait
@@ -127,12 +102,12 @@ jobs:
         run: |
           gcloud run deploy marble-backend \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ env.VERSION_IMAGE }} \
             --region="europe-west1"
 
       - name: Deploy execute async worker service
         run: |
           gcloud run deploy marble-backend-worker \
             --quiet \
-            --image=${{ env.IMAGE }} \
+            --image=${{ env.VERSION_IMAGE }} \
             --region="europe-west1"

--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -51,10 +51,10 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Check if image exists (for prod deployments)
+      - name: Check if image exists (for production deployments)
         id: check_image
         run: |
-          if [[ "${{ inputs.environment }}" == "production" ]] || [[ "${{ inputs.environment }}" == "prod" ]]; then
+          if [[ "${{ inputs.environment }}" == "production" ]]; then
             echo "Checking if image already exists for production deployment..."
             # For production, check if an image exists with the commit hash as tag
             COMMIT_HASH=$(git rev-parse HEAD)
@@ -74,11 +74,6 @@ jobs:
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set deployment image
-        id: deployment_image
-        run: |
-          echo "DEPLOY_IMAGE=${{ env.IMAGE }}" >> "$GITHUB_OUTPUT"
-
       - name: Extract version from tag
         id: version
         run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
@@ -90,7 +85,7 @@ jobs:
           COMMIT_HASH=$(git rev-parse HEAD)
           COMMIT_IMAGE="europe-west1-docker.pkg.dev/marble-infra/marble/marble-backend:${COMMIT_HASH}"
 
-          if [[ "${{ inputs.environment }}" == "production" ]] || [[ "${{ inputs.environment }}" == "prod" ]]; then
+          if [[ "${{ inputs.environment }}" == "production" ]]; then
             # For production, only tag with the version
             echo "IMAGE_TAGS=${{ env.IMAGE }}" >> "$GITHUB_OUTPUT"
           else
@@ -108,7 +103,7 @@ jobs:
             SEGMENT_WRITE_KEY=${{ secrets.segment_write_key_opensource }}
           tags: ${{ steps.tags.outputs.IMAGE_TAGS }}
 
-      - name: Tag existing image with version (for prod reuse)
+      - name: Tag existing image with version (for production deployment reuse)
         if: steps.check_image.outputs.should_build == 'false'
         run: |
           echo "Retagging existing image ${{ steps.check_image.outputs.existing_image }} as ${{ env.IMAGE }}"
@@ -123,7 +118,7 @@ jobs:
         run: |
           gcloud run jobs deploy migrations \
             --quiet \
-            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
+            --image=${{ env.IMAGE }} \
             --region="europe-west1" \
             --execute-now \
             --wait
@@ -132,12 +127,12 @@ jobs:
         run: |
           gcloud run deploy marble-backend \
             --quiet \
-            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
+            --image=${{ env.IMAGE }} \
             --region="europe-west1"
 
       - name: Deploy execute async worker service
         run: |
           gcloud run deploy marble-backend-worker \
             --quiet \
-            --image=${{ steps.deployment_image.outputs.DEPLOY_IMAGE }} \
+            --image=${{ env.IMAGE }} \
             --region="europe-west1"


### PR DESCRIPTION
- Commit 1: remove deprecated cloud run jobs from deployment step (then, will also remove them from terraform)
- Commit 2: try an improvement where we tag images with the commit hash, and reuse existing images for prod deployments if available