### PR TITLE
Return field statistics on navigation.

### DIFF
--- a/api/handle_client_data.go
+++ b/api/handle_client_data.go
@@ -60,7 +60,7 @@ func handleReadClientDataAsList(uc usecases.Usecases) func(c *gin.Context) {
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestedDataReaderUsecase()
 
-		clientObjects, nextPagination, err := usecase.ReadIngestedClientObjects(ctx, orgId,
+		clientObjects, fieldStats, nextPagination, err := usecase.ReadIngestedClientObjects(ctx, orgId,
 			objectType, dto.AdaptClientDataListRequestBody(input))
 		if presentError(ctx, c, err) {
 			return
@@ -71,7 +71,10 @@ func handleReadClientDataAsList(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		c.JSON(http.StatusOK, dto.ClientDataListResponse{
-			Data:       clientObjectDtos,
+			Data: clientObjectDtos,
+			Metadata: dto.ClientDataListMetadata{
+				FieldStatistics: dto.AdaptClientDataListFieldStatistics(fieldStats),
+			},
 			Pagination: dto.AdaptClientDataListPaginationDto(nextPagination),
 		})
 	}

--- a/dto/client_data_object.go
+++ b/dto/client_data_object.go
@@ -89,6 +89,7 @@ type ClientObjectMetadata struct {
 
 type ClientDataListResponse struct {
 	Data       []ClientObjectDetail     `json:"data"`
+	Metadata   ClientDataListMetadata   `json:"metadata"`
 	Pagination ClientDataListPagination `json:"pagination"`
 }
 
@@ -98,11 +99,37 @@ func (c ClientDataListResponse) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(struct {
 		Data       []ClientObjectDetail     `json:"data"`
+		Metadata   ClientDataListMetadata   `json:"metadata"`
 		Pagination ClientDataListPagination `json:"pagination"`
 	}{
 		Data:       c.Data,
+		Metadata:   c.Metadata,
 		Pagination: c.Pagination,
 	})
+}
+
+type ClientDataListMetadata struct {
+	FieldStatistics map[string]ClientDataListFieldStatistic `json:"field_statistics"`
+}
+
+type ClientDataListFieldStatistic struct {
+	Type      string `json:"type"`
+	Format    string `json:"format,omitempty"`
+	MaxLength int    `json:"max_length,omitempty"`
+}
+
+func AdaptClientDataListFieldStatistics(stats []models.FieldStatistics) map[string]ClientDataListFieldStatistic {
+	out := make(map[string]ClientDataListFieldStatistic, len(stats))
+
+	for _, s := range stats {
+		out[s.FieldName] = ClientDataListFieldStatistic{
+			Type:      s.Type.String(),
+			Format:    s.Format,
+			MaxLength: s.MaxLength,
+		}
+	}
+
+	return out
 }
 
 type ClientDataListPagination struct {

--- a/models/client_data_object.go
+++ b/models/client_data_object.go
@@ -99,3 +99,16 @@ type ExplorationOptions struct {
 	FilterFieldValue  StringOrNumber
 	OrderingFieldName string
 }
+
+const (
+	FieldStatisticTypeUuid = "uuid"
+)
+
+type FieldStatistics struct {
+	FieldName string
+	Histogram []string
+
+	Type      DataType
+	Format    string
+	MaxLength int
+}

--- a/usecases/ai_agent_usecase.go
+++ b/usecases/ai_agent_usecase.go
@@ -44,7 +44,7 @@ type AiAgentUsecaseIngestedDataReader interface {
 		orgId string,
 		objectType string,
 		input models.ClientDataListRequestBody,
-	) (objects []models.ClientObjectDetail, pagination models.ClientDataListPagination, err error)
+	) (objects []models.ClientObjectDetail, fieldStats []models.FieldStatistics, pagination models.ClientDataListPagination, err error)
 }
 
 type AiAgentUsecaseDataModelUsecase interface {
@@ -201,7 +201,7 @@ func (uc AiAgentUsecase) GetCaseDataZip(ctx context.Context, caseId string) (io.
 				continue
 			}
 			if navOption.Status == models.IndexStatusValid {
-				objects, _, err := uc.ingestedDataReader.ReadIngestedClientObjects(ctx,
+				objects, _, _, err := uc.ingestedDataReader.ReadIngestedClientObjects(ctx,
 					c.OrganizationId, navOption.TargetTableName, models.ClientDataListRequestBody{
 						ExplorationOptions: models.ExplorationOptions{
 							SourceTableName:   pivotObject.PivotObjectName,


### PR DESCRIPTION
This adds global metadata with ingested data field statistics to the navigation endpoint. Notably, it gives for each field:

* The field type as defined in the data model
* If it is a string, if it is a recognized format (for now, `uuid`)
* The maximum length of the values (order of magnitude for numbers, length for strings)

These should be considered as hints for the frontend to adapt the display.