### PR TITLE
retry deadlocks, reorder & refactor case side effects

### DIFF
--- a/repositories/errors.go
+++ b/repositories/errors.go
@@ -10,3 +10,13 @@ func IsUniqueViolationError(err error) bool {
 	var pgxErr *pgconn.PgError
 	return errors.As(err, &pgxErr) && pgxErr.Code == pgerrcode.UniqueViolation
 }
+
+func IsDeadlockError(err error) bool {
+	var pgxErr *pgconn.PgError
+	return errors.As(err, &pgxErr) && pgxErr.Code == pgerrcode.DeadlockDetected
+}
+
+func IsSerializationFailureError(err error) bool {
+	var pgxErr *pgconn.PgError
+	return errors.As(err, &pgxErr) && pgxErr.Code == pgerrcode.SerializationFailure
+}


### PR DESCRIPTION
This bug was occurring if closing a case before a contributor has been added to it.
- retry deadlock and serialization errors on transaction commit once, immediately (and log a warning)
- refactor case action side effects a bit so that deadlocks are less likely to happen in the first place