### PR TITLE
Delete orphan sanction checks

### DIFF
--- a/repositories/migrations/20250605000000_allow_multiple_screenings.sql
+++ b/repositories/migrations/20250605000000_allow_multiple_screenings.sql
@@ -130,6 +130,9 @@ begin
 end
 $$ language plpgsql;
 
+delete from sanction_checks sc
+where not exists (select 1 from decisions d where d.id = sc.decision_id);
+
 alter table sanction_check_configs
     alter column config_version set not null;
 


### PR DESCRIPTION
We do not have foreign keys on some tables, purposefully, to improve performance. This is the case for sanction_checks->decisions, which meant that sanction checks would live on after an organization was deleted. This is problematic now because we need all sanction checks to have an existing decision.