### PR TITLE
Add public API tests for search and refine.

### DIFF
--- a/pubapi/tests/fixtures/sanction_checks.yml
+++ b/pubapi/tests/fixtures/sanction_checks.yml
@@ -7,3 +7,13 @@
   search_datasets: RAW=array['one', 'two']
   match_threshold: 0.9
   match_limit: 20
+
+- id: 22222222-2222-2222-2222-222222222222
+  decision_id: 11111111-1111-1111-1111-111111111111
+  sanction_check_config_id: 11111111-1111-1111-1111-111111111111
+  status: in_review
+  search_input:
+    lorem: ipsum
+  search_datasets: RAW=array['one', 'two']
+  match_threshold: 0.9
+  match_limit: 20


### PR DESCRIPTION
The public API was missing some tests when interacting with OpenSanctions, this adds functional testing for both search and refine.