### PR TITLE
Case review AI agent pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ e2e_test
 .idea
 .vscode/mise-tools/
 __debug_bin*
+
+prompts

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -644,3 +644,18 @@ func handleGetCaseDataForCopilot(uc usecases.Usecases) func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	}
 }
+
+func handleCreateCaseReview(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		caseId := c.Param("case_id")
+
+		usecase := usecasesWithCreds(ctx, uc).NewAiAgentUsecase()
+		review, err := usecase.CreateCaseReview(ctx, caseId)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{"review": review})
+	}
+}

--- a/api/handle_cases.go
+++ b/api/handle_cases.go
@@ -656,6 +656,11 @@ func handleCreateCaseReview(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		c.JSON(http.StatusCreated, gin.H{"review": review})
+		c.JSON(http.StatusOK, dto.CaseReview{
+			Ok:          review.Ok,
+			Output:      review.Output,
+			SanityCheck: review.SanityCheck,
+			Thought:     review.Thought,
+		})
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -226,6 +226,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.POST("/cases/:case_id/escalate", tom, handleEscalateCase(uc))
 
 	router.GET("/cases/:case_id/data_for_investigation", timeoutMiddleware(conf.BatchTimeout), handleGetCaseDataForCopilot(uc))
+	router.POST("cases/:case_id/review", timeoutMiddleware(conf.BatchTimeout), handleCreateCaseReview(uc))
 
 	router.GET("/inboxes/:inbox_id", tom, handleGetInboxById(uc))
 	router.GET("/inboxes/:inbox_id/metadata", tom, handleGetInboxMetadataById(uc))

--- a/dto/agent_dto/agent_printer.go
+++ b/dto/agent_dto/agent_printer.go
@@ -1,0 +1,5 @@
+package agent_dto
+
+type AgentPrinter interface {
+	PrintForAgent() (string, error)
+}

--- a/dto/agent_dto/case.go
+++ b/dto/agent_dto/case.go
@@ -38,7 +38,9 @@ func AdaptCaseDto(c models.Case, tags []models.Tag, inboxes []models.Inbox, user
 		InboxName: inboxName,
 		Name:      c.Name,
 		Status:    c.Status.EnrichedStatus(c.SnoozedUntil, c.Boost),
-		Outcome:   string(c.Outcome),
+		// TODO: Commented out for now because we don't want the AI agent to "cheat" by using the real outcome
+		// while we iterate on the prompts. Final behavior may change but is still undetermined.
+		// Outcome:   string(c.Outcome),
 		Tags: pure_utils.Map(c.Tags, func(t models.CaseTag) string {
 			for _, tag := range tags {
 				if tag.Id == t.TagId {
@@ -86,10 +88,13 @@ func AdaptCaseEventDto(caseEvent models.CaseEvent, users []models.User) CaseEven
 		}
 	}
 	return CaseEvent{
-		UserName:       userName,
-		CreatedAt:      caseEvent.CreatedAt,
-		EventType:      string(caseEvent.EventType),
-		AdditionalNote: caseEvent.AdditionalNote,
+		UserName:  userName,
+		CreatedAt: caseEvent.CreatedAt,
+		EventType: string(caseEvent.EventType),
+		// TODO: Commented out for now because we don't want the AI agent to "cheat" by using the human review to generate a review
+		// while we iterate on the prompts. Final behavior may change but is still undetermined.
+		// AdditionalNote: caseEvent.AdditionalNote,
+		AdditionalNote: "Redacted",
 		NewValue:       caseEvent.NewValue,
 		ResourceType:   string(caseEvent.ResourceType),
 	}

--- a/dto/agent_dto/case.go
+++ b/dto/agent_dto/case.go
@@ -124,7 +124,12 @@ type CaseWithDecisions struct {
 	Decisions []Decision `json:"decisions"`
 }
 
+type IngestedDataResult struct {
+	Data        []models.ClientObjectDetail `json:"data"`
+	ReadOptions models.ExplorationOptions   `json:"-"`
+}
+
 type CasePivotObjectData struct {
-	IngestedData map[string][]models.ClientObjectDetail `json:"ingested_data"`
-	RelatedCases []CaseWithDecisions                    `json:"related_cases"`
+	IngestedData map[string]IngestedDataResult `json:"ingested_data"`
+	RelatedCases []CaseWithDecisions           `json:"related_cases"`
 }

--- a/dto/agent_dto/case.go
+++ b/dto/agent_dto/case.go
@@ -98,6 +98,7 @@ func AdaptCaseWithDecisionsDto(
 	rules []models.Rule,
 	users []models.User,
 	getScenarioIteration func(scenarioIterationId string) (models.ScenarioIteration, error),
+	getScreenings func(decisionId string) ([]models.ScreeningWithMatches, error),
 ) (CaseWithDecisions, error) {
 	decisions := make([]Decision, len(c.Decisions))
 	for i := range c.Decisions {
@@ -105,7 +106,12 @@ func AdaptCaseWithDecisionsDto(
 		if err != nil {
 			return CaseWithDecisions{}, err
 		}
-		decisions[i] = AdaptDecision(c.Decisions[i].Decision, iteration, c.Decisions[i].RuleExecutions, rules)
+		screenings, err := getScreenings(c.Decisions[i].DecisionId)
+		if err != nil {
+			return CaseWithDecisions{}, err
+		}
+		decisions[i] = AdaptDecision(c.Decisions[i].Decision, iteration,
+			c.Decisions[i].RuleExecutions, rules, screenings)
 	}
 	return CaseWithDecisions{
 		Case:      AdaptCaseDto(c, tags, inboxes, users),

--- a/dto/agent_dto/data_model.go
+++ b/dto/agent_dto/data_model.go
@@ -13,11 +13,14 @@ type LinkToSingle struct {
 }
 
 type Field struct {
-	DataType    string `json:"data_type"`
-	Description string `json:"description"`
-	IsEnum      bool   `json:"is_enum"`
-	Name        string `json:"name"`
-	EnumSample  []any  `json:"enum_sample,omitempty"`
+	DataType    string   `json:"data_type"`
+	Description string   `json:"description"`
+	IsEnum      bool     `json:"is_enum"`
+	Name        string   `json:"name"`
+	EnumSample  []any    `json:"enum_sample,omitempty"`
+	Histogram   []string `json:"histogram,omitempty"`
+	Format      string   `json:"format,omitempty"`
+	MaxLength   int      `json:"max_length,omitempty"`
 }
 
 type Table struct {
@@ -45,6 +48,9 @@ func adaptDataModelField(field models.Field) Field {
 		IsEnum:      field.IsEnum,
 		Name:        field.Name,
 		EnumSample:  field.Values,
+		Histogram:   field.FieldStatistics.Histogram,
+		Format:      field.FieldStatistics.Format,
+		MaxLength:   field.FieldStatistics.MaxLength,
 	}
 }
 

--- a/dto/agent_dto/decisions.go
+++ b/dto/agent_dto/decisions.go
@@ -40,9 +40,12 @@ func AcaptDecisionRule(rule models.RuleExecution, ruleDefs []models.Rule) Decisi
 }
 
 type DecisionScenario struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Version     int    `json:"version"`
+	Name                    string `json:"name"`
+	Description             string `json:"description"`
+	Version                 int    `json:"version"`
+	ReviewThreshold         *int   `json:"review_threshold"`
+	BlockAndReviewThreshold *int   `json:"block_and_review_threshold"`
+	DeclineThreshold        *int   `json:"decline_threshold"`
 }
 
 type Decision struct {
@@ -55,16 +58,20 @@ type Decision struct {
 	Rules             []DecisionRule   `json:"rules"`
 }
 
-func AdaptDecision(decision models.Decision, ruleExecutions []models.RuleExecution, rules []models.Rule) Decision {
+func AdaptDecision(decision models.Decision, scenario models.ScenarioIteration, ruleExecutions []models.RuleExecution, rules []models.Rule,
+) Decision {
 	return Decision{
 		CreatedAt:         decision.CreatedAt,
 		TriggerObject:     decision.ClientObject.Data,
 		TriggerObjectType: decision.ClientObject.TableName,
 		Outcome:           decision.Outcome.String(),
 		Scenario: DecisionScenario{
-			Name:        decision.ScenarioName,
-			Description: decision.ScenarioDescription,
-			Version:     decision.ScenarioVersion,
+			Name:                    decision.ScenarioName,
+			Description:             decision.ScenarioDescription,
+			Version:                 decision.ScenarioVersion,
+			ReviewThreshold:         scenario.ScoreReviewThreshold,
+			BlockAndReviewThreshold: scenario.ScoreBlockAndReviewThreshold,
+			DeclineThreshold:        scenario.ScoreDeclineThreshold,
 		},
 		Score: decision.Score,
 		Rules: pure_utils.Map(ruleExecutions, func(ruleExec models.RuleExecution) DecisionRule {

--- a/dto/agent_dto/decisions.go
+++ b/dto/agent_dto/decisions.go
@@ -59,9 +59,9 @@ type Screening struct {
 }
 
 type ScreeningMatch struct {
-	IsMatch bool   `json:"is_match"`
-	Status  string `json:"status"`
-	Payload []byte `json:"payload"`
+	IsMatch bool            `json:"is_match"`
+	Status  string          `json:"status"`
+	Payload json.RawMessage `json:"payload"`
 }
 
 type ScreeningWithMatches struct {

--- a/dto/agent_dto/decisions.go
+++ b/dto/agent_dto/decisions.go
@@ -49,16 +49,22 @@ type DecisionScenario struct {
 }
 
 type Decision struct {
-	CreatedAt         time.Time        `json:"created_at"`
-	TriggerObject     map[string]any   `json:"trigger_object"`
-	TriggerObjectType string           `json:"trigger_object_type"`
-	Outcome           string           `json:"outcome"`
-	Scenario          DecisionScenario `json:"scenario"`
-	Score             int              `json:"score"`
-	Rules             []DecisionRule   `json:"rules"`
+	CreatedAt         time.Time                     `json:"created_at"`
+	TriggerObject     map[string]any                `json:"trigger_object"`
+	TriggerObjectType string                        `json:"trigger_object_type"`
+	Outcome           string                        `json:"outcome"`
+	Scenario          DecisionScenario              `json:"scenario"`
+	Score             int                           `json:"score"`
+	Rules             []DecisionRule                `json:"rules"`
+	Screenings        []models.ScreeningWithMatches `json:"screenings"`
 }
 
-func AdaptDecision(decision models.Decision, scenario models.ScenarioIteration, ruleExecutions []models.RuleExecution, rules []models.Rule,
+func AdaptDecision(
+	decision models.Decision,
+	scenario models.ScenarioIteration,
+	ruleExecutions []models.RuleExecution,
+	rules []models.Rule,
+	screenings []models.ScreeningWithMatches,
 ) Decision {
 	return Decision{
 		CreatedAt:         decision.CreatedAt,
@@ -77,5 +83,6 @@ func AdaptDecision(decision models.Decision, scenario models.ScenarioIteration, 
 		Rules: pure_utils.Map(ruleExecutions, func(ruleExec models.RuleExecution) DecisionRule {
 			return AcaptDecisionRule(ruleExec, rules)
 		}),
+		Screenings: screenings,
 	}
 }

--- a/dto/case_review.go
+++ b/dto/case_review.go
@@ -1,0 +1,8 @@
+package dto
+
+type CaseReview struct {
+	Ok          bool   `json:"ok"`
+	Output      string `json:"output"`
+	SanityCheck string `json:"sanity_check,omitempty"`
+	Thought     string `json:"thought,omitempty"`
+}

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	golang.org/x/text v0.26.0
 	golang.org/x/time v0.7.0
 	google.golang.org/api v0.203.0
+	google.golang.org/genai v1.12.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 )
@@ -164,7 +165,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.13.0 // indirect
 	github.com/googleapis/go-sql-spanner v1.7.4 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1067,8 +1067,8 @@ github.com/googleapis/go-sql-spanner v1.7.4 h1:pwndJlqgIMOewkORveYQQocaSyOGqaQg8
 github.com/googleapis/go-sql-spanner v1.7.4/go.mod h1:DfuJMbqpcDQwtbol+TnfO+AUyeoW5H+w8Gm216dTPys=
 github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+cLsWGBF62rFAi7WjWO4=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
-github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
-github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
@@ -1956,6 +1956,8 @@ google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine/v2 v2.0.6 h1:LvPZLGuchSBslPBp+LAhihBeGSiRh1myRoYK4NtuBIw=
 google.golang.org/appengine/v2 v2.0.6/go.mod h1:WoEXGoXNfa0mLvaH5sV3ZSGXwVmy8yf7Z1JKf3J3wLI=
+google.golang.org/genai v1.12.0 h1:0JjAdwvEAha9ZpPH5hL6dVG8bpMnRbAMCgv2f2LDnz4=
+google.golang.org/genai v1.12.0/go.mod h1:HFXR1zT3LCdLxd/NW6IOSCczOYyRAxwaShvYbgPSeVw=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/mocks/scenario_iteration_read_repository.go
+++ b/mocks/scenario_iteration_read_repository.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -11,14 +13,14 @@ type ScenarioIterationReadRepository struct {
 	mock.Mock
 }
 
-func (s *ScenarioIterationReadRepository) GetScenarioIteration(exec repositories.Executor,
+func (s *ScenarioIterationReadRepository) GetScenarioIteration(ctx context.Context, exec repositories.Executor,
 	scenarioIterationId string,
 ) (models.ScenarioIteration, error) {
 	args := s.Called(exec, scenarioIterationId)
 	return args.Get(0).(models.ScenarioIteration), args.Error(1)
 }
 
-func (s *ScenarioIterationReadRepository) ListScenarioIterations(exec repositories.Executor,
+func (s *ScenarioIterationReadRepository) ListScenarioIterations(ctx context.Context, exec repositories.Executor,
 	organizationId string, filters models.GetScenarioIterationFilters,
 ) ([]models.ScenarioIteration, error) {
 	args := s.Called(exec, organizationId, filters)

--- a/models/ai_agent_config.go
+++ b/models/ai_agent_config.go
@@ -20,7 +20,7 @@ func LoadAiAgentModelConfig(configPath string) (*AiAgentModelConfig, error) {
 	if configPath == "" {
 		// Return default configuration if no path is provided
 		return &AiAgentModelConfig{
-			DefaultModel: "gemini-2.5-flash-lite-preview-06-17",
+			DefaultModel: "gemini-2.5-flash",
 			PromptModels: make(map[string]string),
 		}, nil
 	}
@@ -38,7 +38,7 @@ func LoadAiAgentModelConfig(configPath string) (*AiAgentModelConfig, error) {
 
 	// Set default model if not specified
 	if config.DefaultModel == "" {
-		config.DefaultModel = "gemini-2.5-flash-lite-preview-06-17"
+		config.DefaultModel = "gemini-2.5-flash"
 	}
 
 	// Initialize maps if they're nil

--- a/models/ai_agent_config.go
+++ b/models/ai_agent_config.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// AiAgentModelConfig represents the configuration for AI agent models
+type AiAgentModelConfig struct {
+	// Default model to use when no specific model is configured for a prompt
+	DefaultModel string `json:"default_model"`
+
+	// Model configurations for specific prompts
+	PromptModels map[string]string `json:"prompt_models"`
+}
+
+// LoadAiAgentModelConfig loads the AI agent model configuration from a JSON file
+func LoadAiAgentModelConfig(configPath string) (*AiAgentModelConfig, error) {
+	if configPath == "" {
+		// Return default configuration if no path is provided
+		return &AiAgentModelConfig{
+			DefaultModel: "gemini-2.5-flash-lite-preview-06-17",
+			PromptModels: make(map[string]string),
+		}, nil
+	}
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open AI agent config file %s: %w", configPath, err)
+	}
+	defer file.Close()
+
+	var config AiAgentModelConfig
+	if err := json.NewDecoder(file).Decode(&config); err != nil {
+		return nil, fmt.Errorf("could not decode AI agent config file %s: %w", configPath, err)
+	}
+
+	// Set default model if not specified
+	if config.DefaultModel == "" {
+		config.DefaultModel = "gemini-2.5-flash-lite-preview-06-17"
+	}
+
+	// Initialize maps if they're nil
+	if config.PromptModels == nil {
+		config.PromptModels = make(map[string]string)
+	}
+
+	return &config, nil
+}
+
+// GetModelForPrompt returns the appropriate model for a given prompt path
+func (c *AiAgentModelConfig) GetModelForPrompt(promptPath string) string {
+	// First, check for exact prompt path match
+	if model, exists := c.PromptModels[promptPath]; exists {
+		return model
+	}
+
+	// Finally, return the default model
+	return c.DefaultModel
+}

--- a/models/case_review.go
+++ b/models/case_review.go
@@ -1,0 +1,8 @@
+package models
+
+type CaseReview struct {
+	Ok          bool
+	Output      string
+	SanityCheck string
+	Thought     string
+}

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -109,6 +109,14 @@ type Table struct {
 	NavigationOptions []NavigationOption
 }
 
+func (t Table) FieldNames() []string {
+	fieldNames := make([]string, 0, len(t.Fields))
+	for fieldName := range t.Fields {
+		fieldNames = append(fieldNames, fieldName)
+	}
+	return fieldNames
+}
+
 func (t Table) Copy() Table {
 	fields := make(map[string]Field)
 	for k, v := range t.Fields {

--- a/models/data_model.go
+++ b/models/data_model.go
@@ -151,6 +151,17 @@ func ColumnNames(table Table) []string {
 	return columnNames
 }
 
+func (t Table) WithFieldStatistics(fieldStats []FieldStatistics) Table {
+	// This method mutates the table to add sample values to the fields that have them
+	for _, fieldStat := range fieldStats {
+		if field, ok := t.Fields[fieldStat.FieldName]; ok {
+			field.FieldStatistics = fieldStat
+			t.Fields[fieldStat.FieldName] = field
+		}
+	}
+	return t
+}
+
 // ///////////////////////////////
 // Data Type
 // ///////////////////////////////
@@ -164,6 +175,7 @@ type Field struct {
 	Nullable          bool
 	TableId           string
 	Values            []any
+	FieldStatistics   FieldStatistics
 	UnicityConstraint UnicityConstraint
 }
 
@@ -400,7 +412,7 @@ func (d DataModel) AddNavigationOptionsToDataModel(indexes []ConcreteIndex, pivo
 	return dm
 }
 
-// Controls hwo the data model should be read. This allows us to specify what level of detail is needed on the returned data model, allowing to bypass some
+// Controls how the data model should be read. This allows us to specify what level of detail is needed on the returned data model, allowing to bypass some
 // possibly expensive queries where only a partial data model is useful, while still factorizing the data model reading code in just one usecase method.
 type DataModelReadOptions struct {
 	// Controls whether the returned data model should include a sample of the enum values that have been seen, for fields that are flagged as enum.
@@ -413,6 +425,9 @@ type DataModelReadOptions struct {
 
 	// Controls whether the returned data model should include information on fields marked as unique. If false, all fields will appear as having no unicity constraint.
 	IncludeUnicityConstraints bool
+
+	// Controls where sample data from the pg table statistics should be included in the data model.
+	IncludeSamples bool
 }
 
 // ///////////////////////////////

--- a/models/screening.go
+++ b/models/screening.go
@@ -118,6 +118,7 @@ type Screening struct {
 type ScreeningConfigRef struct {
 	Name string
 }
+
 type ScreeningWithMatches struct {
 	Screening
 	Matches            []ScreeningMatch

--- a/pure_utils/maps.go
+++ b/pure_utils/maps.go
@@ -1,0 +1,11 @@
+package pure_utils
+
+func Keys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, len(m))
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return keys
+}

--- a/usecases/ai_agent_usecase.go
+++ b/usecases/ai_agent_usecase.go
@@ -26,7 +26,7 @@ import (
 	"google.golang.org/genai"
 )
 
-const HIGH_NB_ROWS_THRESHOLD = 0
+const HIGH_NB_ROWS_THRESHOLD = 100
 
 type AiAgentUsecaseRepository interface {
 	GetCaseById(ctx context.Context, exec repositories.Executor, caseId string) (models.Case, error)
@@ -93,7 +93,9 @@ func NewAiAgentUsecase(
 		executorFactory:    executorFactory,
 		ingestedDataReader: ingestedDataReader,
 		dataModelUsecase:   dataModelUsecase,
-		gcpRegion:          utils.GetEnv("GCP_REGION", "global"),
+
+		// Some models are only available in the "global" region. Choose a proper region in production.
+		gcpRegion: utils.GetEnv("VERTEX_AI_GCP_REGION", "global"),
 	}
 }
 

--- a/usecases/ai_agent_usecase.go
+++ b/usecases/ai_agent_usecase.go
@@ -205,7 +205,7 @@ func (uc *AiAgentUsecase) generateContent(
 	client *genai.Client,
 	promptPath string,
 	data map[string]any,
-	tools []*genai.Tool,
+	generateContentConfig *genai.GenerateContentConfig,
 ) (string, error) {
 	prompt, err := readPrompt(promptPath)
 	if err != nil {
@@ -245,9 +245,7 @@ func (uc *AiAgentUsecase) generateContent(
 	result, err := client.Models.GenerateContent(ctx,
 		model,
 		genai.Text(prompt),
-		&genai.GenerateContentConfig{
-			Tools: tools,
-		},
+		generateContentConfig,
 	)
 	if err != nil {
 		return "", err
@@ -299,7 +297,7 @@ func (uc *AiAgentUsecase) CreateCaseReview(ctx context.Context, caseId string) (
 		map[string]any{
 			"data_model": caseDtos.dataModel,
 		},
-		nil,
+		&genai.GenerateContentConfig{},
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "could not generate data model summary")
@@ -314,8 +312,10 @@ func (uc *AiAgentUsecase) CreateCaseReview(ctx context.Context, caseId string) (
 			"decisions":            caseDtos.decisions,
 			"activity_description": clientActivityDescription,
 		},
-		[]*genai.Tool{
-			{GoogleSearch: &genai.GoogleSearch{}},
+		&genai.GenerateContentConfig{
+			Tools: []*genai.Tool{
+				{GoogleSearch: &genai.GoogleSearch{}},
+			},
 		},
 	)
 	if err != nil {
@@ -330,7 +330,7 @@ func (uc *AiAgentUsecase) CreateCaseReview(ctx context.Context, caseId string) (
 		map[string]any{
 			"decisions": caseDtos.decisions,
 		},
-		nil,
+		&genai.GenerateContentConfig{},
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "could not generate rule thresholds")
@@ -353,8 +353,10 @@ func (uc *AiAgentUsecase) CreateCaseReview(ctx context.Context, caseId string) (
 			"rules_summary":      rulesDefinitionsReview,
 			"rule_thresholds":    ruleThresholds,
 		},
-		[]*genai.Tool{
-			{GoogleSearch: &genai.GoogleSearch{}},
+		&genai.GenerateContentConfig{
+			Tools: []*genai.Tool{
+				{GoogleSearch: &genai.GoogleSearch{}},
+			},
 		},
 	)
 	if err != nil {
@@ -378,7 +380,7 @@ func (uc *AiAgentUsecase) CreateCaseReview(ctx context.Context, caseId string) (
 			"rule_thresholds":    ruleThresholds,
 			"case_review":        caseReview,
 		},
-		nil,
+		&genai.GenerateContentConfig{},
 	)
 	if err != nil {
 		return "", errors.Wrap(err, "could not generate sanity check")

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -20,6 +20,7 @@ type ingestedDataReaderClientDbRepository interface {
 		params models.ExplorationOptions,
 		cursorId *string,
 		limit int,
+		fieldsToRead ...string,
 	) ([]models.DataModelObject, error)
 	QueryIngestedObjectByUniqueField(
 		ctx context.Context,
@@ -288,6 +289,7 @@ func (usecase IngestedDataReaderUsecase) ReadIngestedClientObjects(
 	orgId string,
 	objectType string,
 	input models.ClientDataListRequestBody,
+	fieldsToRead ...string,
 ) (objects []models.ClientObjectDetail, fieldStats []models.FieldStatistics, pagination models.ClientDataListPagination, err error) {
 	dataModel, err := usecase.dataModelUsecase.GetDataModel(ctx, orgId, models.DataModelReadOptions{
 		IncludeNavigationOptions: true,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -286,12 +286,13 @@ func (usecases *UsecasesWithCreds) NewOrganizationUseCase() OrganizationUseCase 
 
 func (usecases *UsecasesWithCreds) NewDataModelUseCase() DataModelUseCase {
 	return DataModelUseCase{
-		clientDbIndexEditor:          usecases.NewClientDbIndexEditor(),
-		dataModelRepository:          usecases.Repositories.MarbleDbRepository,
-		enforceSecurity:              usecases.NewEnforceOrganizationSecurity(),
-		executorFactory:              usecases.NewExecutorFactory(),
-		organizationSchemaRepository: usecases.Repositories.OrganizationSchemaRepository,
-		transactionFactory:           usecases.NewTransactionFactory(),
+		clientDbIndexEditor:           usecases.NewClientDbIndexEditor(),
+		dataModelRepository:           usecases.Repositories.MarbleDbRepository,
+		enforceSecurity:               usecases.NewEnforceOrganizationSecurity(),
+		executorFactory:               usecases.NewExecutorFactory(),
+		organizationSchemaRepository:  usecases.Repositories.OrganizationSchemaRepository,
+		transactionFactory:            usecases.NewTransactionFactory(),
+		dataModelIngestedDataReadRepo: usecases.Repositories.IngestedDataReadRepository,
 	}
 }
 


### PR DESCRIPTION
# High level summary
## Architecture
### Input data
The agent takes some input data, namely the following (all in json format unless specified otherwise):
- data model of the org
- case base metadata
- case events
- Marble-input description of the organization's activity
- definition of all the rules that are used in decisions present in the case
- decision result with rule execution details for every decision in the case
- for every "pivot object" present in the case (should be just one in most cases):
   - previous cases for the entity (without rule exec details)
   - data from the tables where we can navigate to from the pivot object entity, as in the case manager, formatted in csv format:
      - all the related rows/columns for entities that have fewer than 100 rows
      - 500 most recent entries for the 15 most relevant/useful columns (as determined by a prompt given data samples) for entities that yield more than 100 rows

### Pipeline
The data is pipelined through a relatively simple DAG of prompts run on GCP's Vertex AI. The output of a prompt is used as input for the next prompt in the DAG (or as output).
The last-but-one prompt generates the actual case review, while the last one is a sanity check against hallucinations and other thing we want to protect against.

<img width="1490" alt="Capture d’écran 2025-07-01 à 09 35 40" src="https://github.com/user-attachments/assets/11e17a15-8c0c-4bef-abd4-0383c0b2136c" />

### Google search input
Vertex AI models handle google search to get contextual data autonomously (without needed to do it "in code"), which I activated for the "rules definition review" and the "case review prompt".

## Output
The endpoint returns:
```json
{
    "ok": true,
    "output": "the case review goes here",
    "sanity_check": "comment from the sanity check goes here, if ok=false",
    "thought": "model thought output goes here, if there is any (depends on the model that is used in particular)"
}
```

## Implementation details
### Permissions
Uses the same permissions (user-based) as the previously created endpoint that returns a .zip summary of a case

### Billing attribution
All LLM calls can be assigned to the context org with a label that is automatically set

### Prompts
In the future, for self-hosted user we will probably want to include the prompts used by the agent in the code. I'm thinking of compiling them into the binary, without necessarily having them hard coded in the backend repo. Probably still version controlled in a private git repo very soon. For the first iterations, just experiment with a (maybe version controlled) GCS bucket. To be discussed.

In any case, the set of (pretty basic prompts) used in this technical demonstrator are found [here](https://www.notion.so/checkmarble/Prompts-21fd1b7bc7c480518007f31e609d35f8) in notion.

### Libraries
This POC entirely uses Google's [genai](https://pkg.go.dev/google.golang.org/genai@v1.12.0) SDK for interacting with models. It can be used in "service account" mode or in "use my API key" mode, though this PR only does the former.
I found it fairly easy to use and work with and it's rather well documented.
As far as I was able to find, there is no "universal adapter" SDK that works. Go's adapted [langchain](https://pkg.go.dev/github.com/tmc/langchaingo) library is still quite a bit below the python version's expressivity.

### Other LLM-calling details
There are two places where I force an output schema for the response. It's fairly easy to setup. If we want to do "tool calling" in models, it's only a slightly more complex syntax and it should be easy to add when we want to.

## Dependencies
- a folder `prompts/case_review` that contains prompt templates in markdown. Must be present at runtime. The prompt **_should_** use the keys that are passed to the template in the go code. The prompt _**must not**_ use any template keys that are not passed by the go code.
   - optionally, a set of files `prompts/org_desc/{orgId}.md` that contain any raw text information on the organization's activity
- a file `prompts/ai_agent_models.json` that configures which model is used for which prompt (and the default fallback)
- all the files above are read at request runtime. The idea is to load them as a volume backed by GCS (to be created with terraform in a follow-up PR). We will want to put a cache on it probably, later. 

Also,
- `VERTEX_AI_GCP_REGION` env var (default to `global`) that selects which region models are run in. Beware that model availability is region-dependent, e.g. the fast and cheap preview `gemini-2.5-flash-lite-preview-06-17` is only available in `global`. 
- permission for the service account executing the backend to use vertex AI (need to set it up on terraform, I've been testing with my end user credentials so far)



# Main side changes
- introduce a new package agent_dto (nested in dto): we need some more focused DTOs to share data with the agent, that focus on text fields and less on internal ids etc.
    - some of the dto adapters also require a callback to get data on related objects, this made it easier to collect all the relevant data to make a proper dto that doesn't just consist of a bunch of ids
- introduce an optional (variadic) param to the method that lists client objects to select fields that we want
- add option to read data histograms together with the data model (rather than just in the new endpoint that returns statistics on fields)

# Next up
We'll see how we refactor this in the future to make the configuration easier - if and when we need to.
I'm afraid I'll try to squash before mergin so I can more easily cherry-pick for a prod hotfix, but after the review.