### PR TITLE
start testing with postgres 17

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: postgres
-    image: postgres:16
+    image: postgres:17
     shm_size: 1g
     restart: always
     environment:


### PR DESCRIPTION
Start testing with postgres 17 now that migration to 16 is done.
I started working with 17 on this new computer. Will run a migration 16->17 when I get my regular one back.
@leo-marble  maybe you can start using this version as well