### PR TITLE
Do not set error code on no hit screenings.

### DIFF
--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -299,7 +299,7 @@ func outcomeNoHit(scc models.ScreeningConfig) models.ScreeningWithMatches {
 		Screening: models.Screening{
 			ScreeningConfigId: scc.Id,
 			Status:            models.ScreeningStatusNoHit,
-			ErrorCodes:        []string{ErrScreeningAllFieldsNullOrEmpty},
+			ErrorCodes:        nil,
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes the no hit screening results having a wrong error. 