### PR TITLE
feat(metrics_collection): implement metrics ingestion API and update …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,8 +143,11 @@ SENTRY_DSN=
 # OFFLOADING_WRITES_PER_SEC=200
 
 # Configure metrics collection.
+# By default, the metrics collection is enabled
 # METRICS_COLLECTION_ENABLED=true
 # METRICS_COLLECTION_JOB_INTERVAL=1h
+# If metrics collection is enabled, the metrics ingestion url must be set
+METRICS_INGESTION_URL=http://localhost:8080/metrics
 
 # Abort and exit if license cannot be validated.
 KILL_IF_READ_LICENSE_ERROR=false

--- a/api/handle_metrics_ingestion.go
+++ b/api/handle_metrics_ingestion.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/gin-gonic/gin"
+)
+
+// Handle metrics ingestion from the metrics collection worker.
+func handleMetricsIngestion(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		logger := utils.LoggerFromContext(c.Request.Context())
+		var metricsCollectionDto dto.MetricsCollectionDto
+		if err := c.ShouldBindJSON(&metricsCollectionDto); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error":   "Invalid request body",
+				"details": err.Error(),
+			})
+			return
+		}
+
+		// Debug log the body
+		logger.DebugContext(c.Request.Context(), "Metrics collection received",
+			"metrics_collection", metricsCollectionDto,
+		)
+
+		metricsCollection := dto.AdaptMetricsCollection(metricsCollectionDto)
+
+		usecase := uc.NewMetricsIngestionUsecase()
+		err := usecase.IngestMetrics(c.Request.Context(), metricsCollection)
+		if presentError(c.Request.Context(), c, err) {
+			logger.WarnContext(c.Request.Context(), "Failed to ingest metrics", "error", err)
+			return
+		}
+
+		// Success response
+		c.JSON(http.StatusOK, gin.H{
+			"status":        "success",
+			"message":       "Metrics collection processed successfully",
+			"collection_id": metricsCollection.CollectionID,
+			"metrics_count": len(metricsCollection.Metrics),
+		})
+	}
+}

--- a/api/handle_metrics_ingestion.go
+++ b/api/handle_metrics_ingestion.go
@@ -15,10 +15,7 @@ func handleMetricsIngestion(uc usecases.Usecases) func(c *gin.Context) {
 		logger := utils.LoggerFromContext(c.Request.Context())
 		var metricsCollectionDto dto.MetricsCollectionDto
 		if err := c.ShouldBindJSON(&metricsCollectionDto); err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error":   "Invalid request body",
-				"details": err.Error(),
-			})
+			c.Status(http.StatusBadRequest)
 			return
 		}
 

--- a/api/handle_metrics_ingestion.go
+++ b/api/handle_metrics_ingestion.go
@@ -19,11 +19,6 @@ func handleMetricsIngestion(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		// Debug log the body
-		logger.DebugContext(c.Request.Context(), "Metrics collection received",
-			"metrics_collection", metricsCollectionDto,
-		)
-
 		metricsCollection := dto.AdaptMetricsCollection(metricsCollectionDto)
 
 		usecase := uc.NewMetricsIngestionUsecase()

--- a/api/routes.go
+++ b/api/routes.go
@@ -42,6 +42,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	r.GET("/config", tom, handleGetConfig(uc, conf))
 	r.GET("/is-sso-available", tom, handleIsSSOEnabled(uc))
 	r.GET("/signup-status", tom, handleSignupStatus(uc))
+	r.POST("/metrics", tom, handleMetricsIngestion(uc))
 
 	// Public API initialization
 	{

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -103,7 +103,7 @@ func RunTaskQueue(apiVersion string) error {
 	metricCollectionConfig := infra.MetricCollectionConfig{
 		Enabled:             utils.GetEnv("METRICS_COLLECTION_ENABLED", true),
 		JobInterval:         utils.GetEnvDuration("METRICS_COLLECTION_JOB_INTERVAL", 1*time.Hour),
-		MetricsIngestionUrl: utils.GetEnv("METRICS_INGESTION_URL", ""),
+		MetricsIngestionURL: utils.GetEnv("METRICS_INGESTION_URL", ""),
 	}
 	if err := metricCollectionConfig.Validate(); err != nil {
 		utils.LogAndReportSentryError(ctx, err)

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -207,8 +207,8 @@ func RunTaskQueue(apiVersion string) error {
 		return err
 	}
 
-	for _, queue := range slices.Collect(maps.Keys(nonOrgQueues)) {
-		if err := riverClient.QueueResume(ctx, queue, &river.QueuePauseOpts{}); err != nil {
+	for k := range nonOrgQueues {
+		if err := riverClient.QueueResume(ctx, k, &river.QueuePauseOpts{}); err != nil {
 			utils.LogAndReportSentryError(ctx, err)
 			return err
 		}

--- a/dto/metrics_dto.go
+++ b/dto/metrics_dto.go
@@ -1,0 +1,76 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/google/uuid"
+)
+
+type MetricCollectionFrequencyDto string
+
+const (
+	MetricCollectionFrequencyInstantDto MetricCollectionFrequencyDto = "instant"
+	MetricCollectionFrequencyDailyDto   MetricCollectionFrequencyDto = "daily"
+	MetricCollectionFrequencyMonthlyDto MetricCollectionFrequencyDto = "monthly"
+)
+
+type MetricDataDto struct {
+	Name           string                       `json:"name" binding:"required"`
+	Value          any                          `json:"value" binding:"required"`
+	Timestamp      time.Time                    `json:"timestamp" binding:"required"`
+	OrganizationID *string                      `json:"organization_id,omitempty"`
+	From           *time.Time                   `json:"from,omitempty"`
+	To             *time.Time                   `json:"to,omitempty"`
+	Frequency      MetricCollectionFrequencyDto `json:"frequency" binding:"required"`
+}
+
+type MetricsCollectionDto struct {
+	CollectionID uuid.UUID       `json:"collection_id" binding:"required"`
+	Timestamp    time.Time       `json:"timestamp" binding:"required"`
+	Metrics      []MetricDataDto `json:"metrics" binding:"required"`
+	Version      string          `json:"version" binding:"required"`
+}
+
+func AdaptMetricDataDto(metricData models.MetricData) MetricDataDto {
+	return MetricDataDto{
+		Name:           metricData.Name,
+		Value:          metricData.Value,
+		Timestamp:      metricData.Timestamp,
+		OrganizationID: metricData.OrganizationID,
+		From:           metricData.From,
+		To:             metricData.To,
+		Frequency:      MetricCollectionFrequencyDto(metricData.Frequency),
+	}
+}
+
+func AdaptMetricsCollectionDto(metricsCollection models.MetricsCollection) MetricsCollectionDto {
+	return MetricsCollectionDto{
+		CollectionID: metricsCollection.CollectionID,
+		Timestamp:    metricsCollection.Timestamp,
+		Metrics:      pure_utils.Map(metricsCollection.Metrics, AdaptMetricDataDto),
+		Version:      metricsCollection.Version,
+	}
+}
+
+func AdaptMetricData(metricDataDto MetricDataDto) models.MetricData {
+	return models.MetricData{
+		Name:           metricDataDto.Name,
+		Value:          metricDataDto.Value,
+		Timestamp:      metricDataDto.Timestamp,
+		OrganizationID: metricDataDto.OrganizationID,
+		From:           metricDataDto.From,
+		To:             metricDataDto.To,
+		Frequency:      models.MetricCollectionFrequency(metricDataDto.Frequency),
+	}
+}
+
+func AdaptMetricsCollection(metricsCollectionDto MetricsCollectionDto) models.MetricsCollection {
+	return models.MetricsCollection{
+		CollectionID: metricsCollectionDto.CollectionID,
+		Timestamp:    metricsCollectionDto.Timestamp,
+		Metrics:      pure_utils.Map(metricsCollectionDto.Metrics, AdaptMetricData),
+		Version:      metricsCollectionDto.Version,
+	}
+}

--- a/infra/metrics_collection.go
+++ b/infra/metrics_collection.go
@@ -1,8 +1,31 @@
 package infra
 
-import "time"
+import (
+	"net/url"
+	"time"
+
+	"github.com/cockroachdb/errors"
+)
 
 type MetricCollectionConfig struct {
-	Enabled     bool
-	JobInterval time.Duration
+	Enabled             bool
+	JobInterval         time.Duration
+	MetricsIngestionUrl string
+}
+
+// If metrics collection is enabled, the metrics ingestion url must be set
+func (cfg MetricCollectionConfig) Validate() error {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	if cfg.MetricsIngestionUrl == "" {
+		return errors.New("metrics ingestion url is not set")
+	}
+
+	if _, err := url.ParseRequestURI(cfg.MetricsIngestionUrl); err != nil {
+		return errors.Newf("invalid metrics ingestion url: %w", err)
+	}
+
+	return nil
 }

--- a/infra/metrics_collection.go
+++ b/infra/metrics_collection.go
@@ -10,7 +10,7 @@ import (
 type MetricCollectionConfig struct {
 	Enabled             bool
 	JobInterval         time.Duration
-	MetricsIngestionUrl string
+	MetricsIngestionURL string
 }
 
 // If metrics collection is enabled, the metrics ingestion url must be set
@@ -19,11 +19,11 @@ func (cfg MetricCollectionConfig) Validate() error {
 		return nil
 	}
 
-	if cfg.MetricsIngestionUrl == "" {
+	if cfg.MetricsIngestionURL == "" {
 		return errors.New("metrics ingestion url is not set")
 	}
 
-	if _, err := url.ParseRequestURI(cfg.MetricsIngestionUrl); err != nil {
+	if _, err := url.ParseRequestURI(cfg.MetricsIngestionURL); err != nil {
 		return errors.Newf("invalid metrics ingestion url: %w", err)
 	}
 

--- a/usecases/metrics_ingestion.go
+++ b/usecases/metrics_ingestion.go
@@ -1,0 +1,51 @@
+package usecases
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/google/uuid"
+)
+
+type MetricIngestionUsecase struct{}
+
+func NewMetricIngestionUsecase() MetricIngestionUsecase {
+	return MetricIngestionUsecase{}
+}
+
+func (u *MetricIngestionUsecase) IngestMetrics(ctx context.Context, metrics models.MetricsCollection) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Check if the collection is already ingested
+	alreadyIngested, err := u.isCollectionAlreadyIngested(ctx, metrics.CollectionID)
+	if err != nil {
+		return err
+	}
+	if alreadyIngested {
+		logger.InfoContext(ctx, "Collection already ingested", "collection_id", metrics.CollectionID)
+		return nil
+	}
+
+	// Ingest the collection
+	err = u.ingestCollection(ctx, metrics)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (u *MetricIngestionUsecase) isCollectionAlreadyIngested(_ context.Context, _ uuid.UUID) (bool, error) {
+	// TODO: Implement the logic to check if the collection is already ingested
+	return false, nil
+}
+
+func (u *MetricIngestionUsecase) ingestCollection(ctx context.Context, collection models.MetricsCollection) error {
+	logger := utils.LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "Ingesting collection", "collection", collection)
+
+	// TODO: Implement the ingestion logic
+
+	return nil
+}

--- a/usecases/metrics_ingestion.go
+++ b/usecases/metrics_ingestion.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
-	"github.com/google/uuid"
 )
 
 type MetricsIngestionUsecase struct{}
@@ -15,30 +14,13 @@ func NewMetricsIngestionUsecase() MetricsIngestionUsecase {
 }
 
 func (u *MetricsIngestionUsecase) IngestMetrics(ctx context.Context, metrics models.MetricsCollection) error {
-	logger := utils.LoggerFromContext(ctx)
-
-	// Check if the collection is already ingested
-	alreadyIngested, err := u.isCollectionAlreadyIngested(ctx, metrics.CollectionID)
-	if err != nil {
-		return err
-	}
-	if alreadyIngested {
-		logger.InfoContext(ctx, "Collection already ingested", "collection_id", metrics.CollectionID)
-		return nil
-	}
-
 	// Ingest the collection
-	err = u.ingestCollection(ctx, metrics)
+	err := u.ingestCollection(ctx, metrics)
 	if err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (u *MetricsIngestionUsecase) isCollectionAlreadyIngested(_ context.Context, _ uuid.UUID) (bool, error) {
-	// TODO: Implement the logic to check if the collection is already ingested
-	return false, nil
 }
 
 func (u *MetricsIngestionUsecase) ingestCollection(ctx context.Context, collection models.MetricsCollection) error {

--- a/usecases/metrics_ingestion.go
+++ b/usecases/metrics_ingestion.go
@@ -8,13 +8,13 @@ import (
 	"github.com/google/uuid"
 )
 
-type MetricIngestionUsecase struct{}
+type MetricsIngestionUsecase struct{}
 
-func NewMetricIngestionUsecase() MetricIngestionUsecase {
-	return MetricIngestionUsecase{}
+func NewMetricsIngestionUsecase() MetricsIngestionUsecase {
+	return MetricsIngestionUsecase{}
 }
 
-func (u *MetricIngestionUsecase) IngestMetrics(ctx context.Context, metrics models.MetricsCollection) error {
+func (u *MetricsIngestionUsecase) IngestMetrics(ctx context.Context, metrics models.MetricsCollection) error {
 	logger := utils.LoggerFromContext(ctx)
 
 	// Check if the collection is already ingested
@@ -36,12 +36,12 @@ func (u *MetricIngestionUsecase) IngestMetrics(ctx context.Context, metrics mode
 	return nil
 }
 
-func (u *MetricIngestionUsecase) isCollectionAlreadyIngested(_ context.Context, _ uuid.UUID) (bool, error) {
+func (u *MetricsIngestionUsecase) isCollectionAlreadyIngested(_ context.Context, _ uuid.UUID) (bool, error) {
 	// TODO: Implement the logic to check if the collection is already ingested
 	return false, nil
 }
 
-func (u *MetricIngestionUsecase) ingestCollection(ctx context.Context, collection models.MetricsCollection) error {
+func (u *MetricsIngestionUsecase) ingestCollection(ctx context.Context, collection models.MetricsCollection) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "Ingesting collection", "collection", collection)
 

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -33,6 +33,7 @@ type Usecases struct {
 	hasNameRecognizerSetup      bool
 	hasTestMode                 bool
 	license                     models.LicenseValidation
+	metricsCollectionConfig     infra.MetricCollectionConfig
 }
 
 type Option func(*options)
@@ -123,6 +124,12 @@ func WithTestMode(activated bool) Option {
 	}
 }
 
+func WithMetricsCollectionConfig(config infra.MetricCollectionConfig) Option {
+	return func(o *options) {
+		o.metricsCollectionConfig = config
+	}
+}
+
 type options struct {
 	apiVersion                  string
 	batchIngestionMaxSize       int
@@ -137,6 +144,7 @@ type options struct {
 	hasOpensanctionsSetup       bool
 	hasNameRecognitionSetup     bool
 	hasTestMode                 bool
+	metricsCollectionConfig     infra.MetricCollectionConfig
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -158,6 +166,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		hasOpensanctionsSetup:       o.hasOpensanctionsSetup,
 		hasNameRecognizerSetup:      o.hasNameRecognitionSetup,
 		hasTestMode:                 o.hasTestMode,
+		metricsCollectionConfig:     o.metricsCollectionConfig,
 	}
 }
 
@@ -356,5 +365,10 @@ func (usecases *Usecases) NewMetricsCollectionWorker() scheduled_execution.Metri
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
+		usecases.metricsCollectionConfig,
 	)
+}
+
+func (usecases *Usecases) NewMetricsIngestionUsecase() MetricIngestionUsecase {
+	return NewMetricIngestionUsecase()
 }

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -369,6 +369,6 @@ func (usecases *Usecases) NewMetricsCollectionWorker() scheduled_execution.Metri
 	)
 }
 
-func (usecases *Usecases) NewMetricsIngestionUsecase() MetricIngestionUsecase {
-	return NewMetricIngestionUsecase()
+func (usecases *Usecases) NewMetricsIngestionUsecase() MetricsIngestionUsecase {
+	return NewMetricsIngestionUsecase()
 }


### PR DESCRIPTION
This pull request introduces metrics ingestion capabilities to the backend. It adds support for receiving, validating, and processing metrics collected by the worker, and makes the ingestion endpoint configurable.

---

## Key Changes

1. **Metrics Ingestion Endpoint**
   - Added a new POST `/metrics` endpoint (`api/handle_metrics_ingestion.go` and `api/routes.go`) to receive metrics collections.

3. **Metrics Ingestion Usecase**
   - Added `usecases/metrics_ingestion.go` to encapsulate ingestion logic, with stubs for idempotency and processing.

4. **Worker Metrics Collection & Sending**
   - Updated the metrics collection job (`usecases/scheduled_execution/metrics_collection_job.go`) to send collected metrics via HTTP POST to the configured ingestion URL.
   - Added retries for robustness.

5. **Configuration Enhancements**
   - Extended `infra/metrics_collection.go` and `.env.example` to support a `METRICS_INGESTION_URL` setting and enforce its presence when metrics collection is enabled.
   - Added configuration validation

---

## How to Use

- Set `METRICS_COLLECTION_ENABLED=true` and specify a valid `METRICS_INGESTION_URL` in your environment.
- The backend will now collect metrics periodically and POST them to the configured ingestion endpoint.