### PR TITLE
docs: clarify goose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ goose create add_some_column sql
 
 It happens that the migrations end up being misordered. This happens if two people pushed new migrations A and B, B having a timestamp greated than A, but B B is commited first to main. The issue can occur when pushing to the main branch, or when pulling changes from remote main to the local branch. In this case, you may need to roll back a few local migrations before you can migrate up again.
 
-The easiest way of doings this is by installing the goose cli with brew (`brew install goose`), configuring the goose environment variables (typically `export GOOSE_DRIVER=postgres` and `export GOOSE_DBSTRING="user=postgres dbname=marble host=localhost password=marble"` should work), and then running `goose down` as many times as needed from the `repositories/migrations` folder. See also [the goose doc](https://github.com/pressly/goose).
+The easiest way of doings this is by installing the goose cli with brew (`brew install goose`), configuring the goose environment variables
+(typically `export GOOSE_DRIVER=postgres GOOSE_DBSTRING="user=postgres dbname=marble host=localhost password=marble" GOOSE_MIGRATION_DIR="./repositories/migrations"` should work),
+and then running `goose down` as many times as needed from the repository root folder. See also [the goose doc](https://github.com/pressly/goose).
 
 ##### (VSCode) Install recommended VSCode extensions
 


### PR DESCRIPTION
Updated the README.md to:
	•	Include the GOOSE_MIGRATION_DIR environment variable in the example setup, which is required to run goose from the repository root.
	•	Reflect the correct working directory for running goose down (previously repositories/migrations, now the root folder).