### PR TITLE
feat(organization): public_id field to organization model

### DIFF
--- a/dto/organization_dto.go
+++ b/dto/organization_dto.go
@@ -1,6 +1,8 @@
 package dto
 
-import "github.com/checkmarble/marble-backend/models"
+import (
+	"github.com/checkmarble/marble-backend/models"
+)
 
 type APIOrganization struct {
 	Id                      string  `json:"id"`

--- a/models/organization.go
+++ b/models/organization.go
@@ -1,7 +1,11 @@
 package models
 
+import "github.com/google/uuid"
+
 type Organization struct {
 	Id string
+
+	PublicId uuid.UUID
 
 	// Name of the organization. Because this can be used to map to the organization's ingested data schema, it is unique and immutable.
 	Name string

--- a/repositories/dbmodels/db_organization.go
+++ b/repositories/dbmodels/db_organization.go
@@ -3,17 +3,19 @@ package dbmodels
 import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/google/uuid"
 )
 
 type DBOrganizationResult struct {
-	Id                         string  `db:"id"`
-	DeletedAt                  *int    `db:"deleted_at"`
-	Name                       string  `db:"name"`
-	TransferCheckScenarioId    *string `db:"transfer_check_scenario_id"`
-	UseMarbleDbSchemaAsDefault bool    `db:"use_marble_db_schema_as_default"`
-	DefaultScenarioTimezone    *string `db:"default_scenario_timezone"`
-	ScreeningThreshold         int     `db:"sanctions_threshold"`
-	ScreeningLimit             int     `db:"sanctions_limit"`
+	Id                         string    `db:"id"`
+	PublicId                   uuid.UUID `db:"public_id"`
+	DeletedAt                  *int      `db:"deleted_at"`
+	Name                       string    `db:"name"`
+	TransferCheckScenarioId    *string   `db:"transfer_check_scenario_id"`
+	UseMarbleDbSchemaAsDefault bool      `db:"use_marble_db_schema_as_default"`
+	DefaultScenarioTimezone    *string   `db:"default_scenario_timezone"`
+	ScreeningThreshold         int       `db:"sanctions_threshold"`
+	ScreeningLimit             int       `db:"sanctions_limit"`
 }
 
 const TABLE_ORGANIZATION = "organizations"
@@ -23,6 +25,7 @@ var ColumnsSelectOrganization = utils.ColumnList[DBOrganizationResult]()
 func AdaptOrganization(db DBOrganizationResult) (models.Organization, error) {
 	return models.Organization{
 		Id:                         db.Id,
+		PublicId:                   db.PublicId,
 		Name:                       db.Name,
 		TransferCheckScenarioId:    db.TransferCheckScenarioId,
 		UseMarbleDbSchemaAsDefault: db.UseMarbleDbSchemaAsDefault,

--- a/repositories/migrations/20250709131753_add_organization_public_id.sql
+++ b/repositories/migrations/20250709131753_add_organization_public_id.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE organizations ADD COLUMN public_id UUID NOT NULL UNIQUE DEFAULT (uuid_generate_v4());
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Don't need to drop the column, it's not used anymore and it's not a big deal to keep it. We avoid recreating the column with different public ID
+
+-- +goose StatementEnd


### PR DESCRIPTION
This pull request introduces a new `PublicId` field to the `Organization` model, designed to provide a UUID for external tools, making links easier and avoiding exposure of internal IDs. Changes span across multiple files to integrate this field into the API, database models, and migrations.

### Database-related changes:
* [`repositories/migrations/20250709131753_add_organization_public_id.sql`](diffhunk://#diff-0d2ead86b45e41338016595495740a637d09655268573eb3a262066a28454537R1-R14): Added a new `public_id` column to the `organizations` table with a unique UUID default value generated by `uuid_generate_v4()`. This ensures every organization has a distinct external identifier.
* [`repositories/dbmodels/db_organization.go`](diffhunk://#diff-00fd0e6f9c59a34bef8bec124cfd98c8bc77e4b89b5c79cf1e9358c5e92c3095R6-R11): Updated the `DBOrganizationResult` struct to include the `PublicId` field and adapted the `AdaptOrganization` function to map the new field to the `Organization` model. [[1]](diffhunk://#diff-00fd0e6f9c59a34bef8bec124cfd98c8bc77e4b89b5c79cf1e9358c5e92c3095R6-R11) [[2]](diffhunk://#diff-00fd0e6f9c59a34bef8bec124cfd98c8bc77e4b89b5c79cf1e9358c5e92c3095R28)

### API-related changes:
* [`dto/organization_dto.go`](diffhunk://#diff-65c318513659d2917a45703d44fc06531b5937c3a5f1784c28b46299ec748263R7): Added the `PublicId` field to the `APIOrganization` struct and updated the `AdaptOrganizationDto` function to include the new field when adapting the model for API responses. [[1]](diffhunk://#diff-65c318513659d2917a45703d44fc06531b5937c3a5f1784c28b46299ec748263R7) [[2]](diffhunk://#diff-65c318513659d2917a45703d44fc06531b5937c3a5f1784c28b46299ec748263R17)

### Model changes:
* [`models/organization.go`](diffhunk://#diff-ae19bd1ea7ff7bceae3689076271936aee2856e9f16469c35305128b054fb5a9R3-R8): Introduced the `PublicId` field as a `uuid.UUID` in the `Organization` struct, with comments explaining its purpose for external tools.