### PR TITLE
Create the Firebase user at the same time as the Marble user.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -225,6 +225,8 @@ func RunServer(config CompiledConfig) error {
 		repositories.WithBigQueryInfra(bigQueryInfra),
 	)
 
+	deps := api.InitDependencies(ctx, apiConfig, pool, marbleJwtSigningKey)
+
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithApiVersion(config.Version),
 		usecases.WithBatchIngestionMaxSize(serverConfig.batchIngestionMaxSize),
@@ -237,6 +239,7 @@ func RunServer(config CompiledConfig) error {
 		usecases.WithOpensanctions(openSanctionsConfig.IsSet()),
 		usecases.WithNameRecognition(openSanctionsConfig.IsNameRecognitionSet()),
 		usecases.WithTestMode(serverConfig.firebaseEmulatorHost != ""),
+		usecases.WithFirebaseAdmin(deps.FirebaseAdmin),
 	)
 
 	////////////////////////////////////////////////////////////
@@ -259,8 +262,6 @@ func RunServer(config CompiledConfig) error {
 			return err
 		}
 	}
-
-	deps := api.InitDependencies(ctx, apiConfig, pool, marbleJwtSigningKey)
 
 	router := api.InitRouterMiddlewares(ctx, apiConfig, apiConfig.DisableSegment,
 		deps.SegmentClient, telemetryRessources)

--- a/mocks/firebase_token_verifier.go
+++ b/mocks/firebase_token_verifier.go
@@ -16,3 +16,13 @@ func (m *FirebaseTokenVerifier) VerifyFirebaseToken(ctx context.Context, firebas
 	args := m.Called(ctx, firebaseToken)
 	return args.Get(0).(models.FirebaseIdentity), args.Error(1)
 }
+
+type FirebaseAdminClient struct {
+	mock.Mock
+}
+
+func (m *FirebaseAdminClient) CreateUser(ctx context.Context, email, name string) error {
+	args := m.Called(ctx, email, name)
+
+	return args.Error(0)
+}

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -137,7 +137,7 @@ func setupApi(t *testing.T, ctx context.Context, dsn string) string {
 		t.Fatal(err)
 	}
 
-	deps := api.InitDependencies(ctx, cfg, pool, key, nil)
+	deps := api.InitDependencies(ctx, cfg, pool, key, nil, nil, nil)
 	openSanctions := infra.InitializeOpenSanctions(http.DefaultClient, "http://screening", " ", " ")
 	repos := repositories.NewRepositories(pool, infra.GcpConfig{},
 		repositories.WithOpenSanctions(openSanctions),

--- a/repositories/firebase/admin.go
+++ b/repositories/firebase/admin.go
@@ -44,7 +44,10 @@ func (c AdminClient) CreateUser(ctx context.Context, email, name string) error {
 			return nil
 		}
 
-		return errors.Wrap(err, "could not create firebase user")
+		utils.LoggerFromContext(ctx).WarnContext(ctx, fmt.Sprintf("could not create firebase user %s, your administrator will need to create it manually", email),
+			"email", email)
+
+		return nil
 	}
 
 	utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user created for user %s", user.Email),

--- a/repositories/firebase/admin.go
+++ b/repositories/firebase/admin.go
@@ -1,0 +1,101 @@
+package firebase
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"firebase.google.com/go/v4/auth"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+)
+
+type Adminer interface {
+	CreateUser(ctx context.Context, email, name string) error
+}
+
+type AdminClient struct {
+	apiKey string
+	client *auth.Client
+}
+
+func NewAdminClient(apiKey string, client *auth.Client) *AdminClient {
+	return &AdminClient{
+		apiKey: apiKey,
+		client: client,
+	}
+}
+
+func (c AdminClient) CreateUser(ctx context.Context, email, name string) error {
+	req := new(auth.UserToCreate).
+		Email(email).
+		EmailVerified(false).
+		DisplayName(name)
+
+	user, err := c.client.CreateUser(ctx, req)
+	if err != nil {
+		if auth.IsEmailAlreadyExists(err) {
+			utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user already exists for user %s, skipping creating it", email),
+				"email", email)
+
+			return nil
+		}
+
+		return errors.Wrap(err, "could not create firebase user")
+	}
+
+	utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user created for user %s", user.Email),
+		"uid", user.UID,
+		"email", user.Email)
+
+	if err := c.SendPasswordResetEmail(ctx, user); err != nil {
+		utils.LoggerFromContext(ctx).WarnContext(ctx, fmt.Sprintf("could not send the password reset email to user %s: %s", user.Email, err.Error()),
+			"uid", user.UID,
+			"email", user.Email)
+	}
+
+	return nil
+}
+
+func (c AdminClient) SendPasswordResetEmail(ctx context.Context, user *auth.UserRecord) error {
+	payload := struct {
+		RequestType string `json:"requestType"` //nolint:tagliatelle
+		Email       string `json:"email"`
+	}{
+		RequestType: "PASSWORD_RESET",
+		Email:       user.Email,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrap(err, "could not create password reset request")
+	}
+
+	q := url.Values{}
+	q.Set("key", c.apiKey)
+
+	u := fmt.Sprintf("https://identitytoolkit.googleapis.com/v1/accounts:sendOobCode?%s", q.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return errors.Wrap(err, "could not create password reset request")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "could not send password reset request")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errors.Newf("password reset request returned status %d", resp.StatusCode)
+	}
+
+	utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user password reset email sent for user %s", user.Email),
+		"uid", user.UID,
+		"email", user.Email)
+
+	return nil
+}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -5,6 +5,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/repositories/firebase"
 	"github.com/checkmarble/marble-backend/usecases/ast_eval"
 	"github.com/checkmarble/marble-backend/usecases/ast_eval/evaluate"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
@@ -34,6 +35,7 @@ type Usecases struct {
 	hasTestMode                 bool
 	license                     models.LicenseValidation
 	metricsCollectionConfig     infra.MetricCollectionConfig
+	firebaseAdmin               firebase.Adminer
 }
 
 type Option func(*options)
@@ -124,6 +126,12 @@ func WithTestMode(activated bool) Option {
 	}
 }
 
+func WithFirebaseAdmin(client firebase.Adminer) Option {
+	return func(o *options) {
+		o.firebaseClient = client
+	}
+}
+
 func WithMetricsCollectionConfig(config infra.MetricCollectionConfig) Option {
 	return func(o *options) {
 		o.metricsCollectionConfig = config
@@ -145,6 +153,7 @@ type options struct {
 	hasNameRecognitionSetup     bool
 	hasTestMode                 bool
 	metricsCollectionConfig     infra.MetricCollectionConfig
+	firebaseClient              firebase.Adminer
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -167,6 +176,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		hasNameRecognizerSetup:      o.hasNameRecognitionSetup,
 		hasTestMode:                 o.hasTestMode,
 		metricsCollectionConfig:     o.metricsCollectionConfig,
+		firebaseAdmin:               o.firebaseClient,
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -353,6 +353,7 @@ func (usecases *UsecasesWithCreds) NewUserUseCase() UserUseCase {
 		executorFactory:     usecases.NewExecutorFactory(),
 		transactionFactory:  usecases.NewTransactionFactory(),
 		userRepository:      &usecases.Repositories.MarbleDbRepository,
+		firebaseAdmin:       usecases.firebaseAdmin,
 	}
 }
 


### PR DESCRIPTION
This PR adds two side effects to creating a Marble user:
 * The matching Firebase user is created is it does not already exist
 * The password reset email is sent (if the user was indeed created)

This might be a breaking (actually breaking) change if a user managed their IAM manually when setting up Firebase. If they used a permission-less service account (which is sufficient for login), creating users would fail on this branch because we would not have the permission to create the user.

Either we relax error handling on that path (ignoring not being able to create the user - not recommended since it would bring hard to debug errors), or we communicate that the service account requires the **Firebase Authentication Admin** permission.

This **does not**:
 * Delete Firebase users when Marble users are deleted (we cannot assume the project is dedicated to us)
 * Roll back if the Firebase user was created but an error happened when sending the email