### PR TITLE
Publish API v1 and maintain v1beta backward compatibility.

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -56,8 +56,12 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 		}
 
 		pubapi.InitPublicApi()
-		pubapiv1.Routes(cfg, r.Group("/v1beta"),
-			auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+
+		pubapiv1.Routes(cfg, "v1", r.Group("/v1"), auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+
+		// Mount both the v1 and new v1beta routes under /v1beta for backward compatibility
+		pubapiv1.Routes(cfg, "v1beta", r.Group("/v1beta"), auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+		pubapiv1.BetaRoutes(cfg, r.Group("/v1beta"), auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
 	}
 
 	router := r.Use(auth.AuthedBy(utils.FederatedBearerToken, utils.PublicApiKey))

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -6,8 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func Routes(conf pubapi.Config, unauthed *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usecases) {
-	unauthed.GET("/-/version", handleVersion)
+func Routes(conf pubapi.Config, version string, unauthed *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usecases) {
+	unauthed.GET("/-/version", handleVersion(version))
 
 	authed := unauthed.Group("/", authMiddleware)
 
@@ -43,6 +43,12 @@ func Routes(conf pubapi.Config, unauthed *gin.RouterGroup, authMiddleware gin.Ha
 	}
 }
 
-func handleVersion(c *gin.Context) {
-	pubapi.NewResponse(gin.H{"version": "v1beta"}).Serve(c)
+func BetaRoutes(conf pubapi.Config, unauthed *gin.RouterGroup, authMiddleware gin.HandlerFunc, uc usecases.Usecases) {
+	// New, future v1 endpoints go here.
+}
+
+func handleVersion(version string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		pubapi.NewResponse(gin.H{"version": version}).Serve(c)
+	}
 }


### PR DESCRIPTION
This adds all the `/v1beta` routes under a new prefix: `/v1`.

The same routes are still mounted under `/v1beta` for both backward compatibility (for users using it) and to ease testing of new additions to V1.

`/v1beta` now also sources routes from a second route function so we can safely add new endpoints to that API version until they stabilize.