### PR TITLE
WIP move org_id Nullable to Non nullable

### DIFF
--- a/models/screening.go
+++ b/models/screening.go
@@ -96,7 +96,7 @@ func (scs ScreeningMatchStatus) String() string {
 type Screening struct {
 	Id                  string
 	DecisionId          string
-	OrgId               *string
+	OrgId               string
 	ScreeningConfigId   string
 	Status              ScreeningStatus
 	Config              ScreeningConfigRef

--- a/repositories/dbmodels/db_screening.go
+++ b/repositories/dbmodels/db_screening.go
@@ -18,7 +18,7 @@ var (
 type DBScreening struct {
 	Id                  string                           `db:"id"`
 	DecisionId          string                           `db:"decision_id"`
-	OrgId               *string                          `db:"org_id"`
+	OrgId               string                           `db:"org_id"`
 	ScreeningConfigId   string                           `db:"sanction_check_config_id"`
 	Status              string                           `db:"status"`
 	SearchInput         json.RawMessage                  `db:"search_input"`

--- a/repositories/migrations/20250723134215_change_org_id_sanction_check_to_non_nullable.sql
+++ b/repositories/migrations/20250723134215_change_org_id_sanction_check_to_non_nullable.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE sanction_checks ALTER COLUMN org_id SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE sanction_checks ALTER COLUMN org_id DROP NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
This pull request includes changes to the `OrgId` field in the `Screening` and `DBScreening` models, transitioning it from a nullable pointer type (`*string`) to a non-nullable string type (`string`). These changes ensure that `OrgId` is always populated, simplifying the handling of this field throughout the codebase.

### Changes to `OrgId` field:

* [`models/screening.go`](diffhunk://#diff-746191281230ef5acc235a715c7bcd51999fcf79f19a3092211565ddaeaeb75dL99-R99): Updated the `OrgId` field in the `Screening` struct from `*string` to `string`, ensuring that the organization ID is always non-null.
* [`repositories/dbmodels/db_screening.go`](diffhunk://#diff-07ea9c6ca7617ee7650112f0301d4786f05380e0af23dd5bdeb863f11c83ea16L21-R21): Updated the `OrgId` field in the `DBScreening` struct from `*string` to `string`, aligning with the database schema and ensuring consistency with the `Screening` model.