### PR TITLE
Allow reviewing screening match on a partial result.

### DIFF
--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -565,7 +565,7 @@ func (uc ScreeningUsecase) UpdateMatchStatus(
 			}
 
 			// else, if it is the last match pending and it is not a hit, the screening should be set to "no_hit"
-			if update.Status == models.ScreeningMatchStatusNoHit && len(pendingMatchesExcludingThis) == 0 {
+			if !data.sanction.Partial && update.Status == models.ScreeningMatchStatusNoHit && len(pendingMatchesExcludingThis) == 0 {
 				err = uc.repository.UpdateScreeningStatus(ctx, tx,
 					data.sanction.Id, models.ScreeningStatusNoHit)
 				if err != nil {


### PR DESCRIPTION
Until now, we could only review matches on "full" results, when the number of hit did not cross the set threshold. If it did, we required to refine the search to get less results.

Now, we will allow any kind of match review, including whitelisting matches, with this behavior:

 - If a match is set as a confirmed_hit, the screening is marked as confirmed_hit, and all other pending matches are set a skipped.
 - If a match is set as a no_hit, no side effect is performed.
 - If **all** matches are set a no_hits, no side effect is performed.