### PR TITLE
Custom screening lists support

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -96,6 +96,10 @@ func RunServer(config CompiledConfig) error {
 		utils.GetEnv("OPENSANCTIONS_API_KEY", ""),
 	)
 
+	if scope := utils.GetEnv("OPENSANCTIONS_SCOPE", ""); scope != "" {
+		openSanctionsConfig.WithScope(scope)
+	}
+
 	if apiUrl := utils.GetEnv("NAME_RECOGNITION_API_URL", ""); apiUrl != "" {
 		openSanctionsConfig.WithNameRecognition(apiUrl,
 			utils.GetEnv("NAME_RECOGNITION_API_KEY", ""))

--- a/dto/open_sanctions_dataset_dto.go
+++ b/dto/open_sanctions_dataset_dto.go
@@ -57,10 +57,18 @@ func AdaptOpenSanctionsCatalog(model models.OpenSanctionsCatalog) OpenSanctionsC
 		for idx, d := range s.Datasets {
 			var tag string
 
-			if tags, ok := model.Tags.Get(d.Name); ok {
-				for _, upstreamTag := range tags {
-					if t, ok := datasetTagMapping[upstreamTag]; ok {
-						tag = t
+			for _, upstreamTag := range d.Tags {
+				if t, ok := datasetTagMapping[upstreamTag]; ok {
+					tag = t
+				}
+			}
+
+			if tag == "" {
+				if tags, ok := model.Tags.Get(d.Name); ok {
+					for _, upstreamTag := range tags {
+						if t, ok := datasetTagMapping[upstreamTag]; ok {
+							tag = t
+						}
 					}
 				}
 			}

--- a/infra/opensanctions.go
+++ b/infra/opensanctions.go
@@ -22,6 +22,7 @@ type OpenSanctions struct {
 	host        string
 	authMethod  OpenSanctionsAuthMethod
 	credentials string
+	scope       string
 
 	nameRecognition *NameRecognitionProvider
 }
@@ -36,6 +37,7 @@ func InitializeOpenSanctions(client *http.Client, host, authMethod, creds string
 		client:      client,
 		host:        host,
 		credentials: creds,
+		scope:       "default",
 	}
 
 	if os.IsSelfHosted() {
@@ -46,6 +48,12 @@ func InitializeOpenSanctions(client *http.Client, host, authMethod, creds string
 			os.authMethod = OPEN_SANCTIONS_AUTH_BASIC
 		}
 	}
+
+	return os
+}
+
+func (os *OpenSanctions) WithScope(scope string) *OpenSanctions {
+	os.scope = scope
 
 	return os
 }
@@ -96,6 +104,10 @@ func (os OpenSanctions) Credentials() string {
 
 func (os OpenSanctions) NameRecognition() *NameRecognitionProvider {
 	return os.nameRecognition
+}
+
+func (os OpenSanctions) Scope() string {
+	return os.scope
 }
 
 func (ner OpenSanctions) IsNameRecognitionSet() bool {

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -27,6 +27,7 @@ type OpenSanctionsCatalogSection struct {
 type OpenSanctionsCatalogDataset struct {
 	Name  string
 	Title string
+	Tags  []string
 	Path  set.Set[string]
 }
 

--- a/repositories/httpmodels/http_opensanctions_dataset.go
+++ b/repositories/httpmodels/http_opensanctions_dataset.go
@@ -38,6 +38,7 @@ type HTTPOpenSanctionCatalogDataset struct {
 	Load         bool     `json:"load"`
 	IndexVersion *string  `json:"index_version"`
 	Children     []string `json:"children"`
+	Tags         []string `json:"tags"`
 }
 
 func AdaptOpenSanctionCatalog(datasets []HTTPOpenSanctionCatalogDataset, tags *expirable.LRU[string, []string]) models.OpenSanctionsCatalog {
@@ -119,6 +120,7 @@ func findDatasets(sections map[string]*models.OpenSanctionsCatalogSection,
 		sections[regionCode].Datasets = append(sections[regionCode].Datasets, models.OpenSanctionsCatalogDataset{
 			Name:  dataset.Name,
 			Title: dataset.Title,
+			Tags:  dataset.Tags,
 			Path:  *tags,
 		})
 	}

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -350,7 +350,7 @@ func (repo OpenSanctionsRepository) searchRequest(ctx context.Context,
 			"could not parse OpenSanctions response")
 	}
 
-	requestUrl := fmt.Sprintf("%s/match/default", repo.opensanctions.Host())
+	requestUrl := fmt.Sprintf("%s/match/%s", repo.opensanctions.Host(), repo.opensanctions.Scope())
 
 	if qs := repo.buildQueryString(&query.Config, query); len(qs) > 0 {
 		requestUrl = fmt.Sprintf("%s?%s", requestUrl, qs.Encode())


### PR DESCRIPTION
This PR introduces two changes:

 * A configuration knob to configure which scope is used when performing match request. It defaults to `default`, including official lists, but can be changed to, for example, point to a superset scope containing the official and custom lists.
 * Consideration of tags placed directly on local datasets, so custom lists can be classified.