### PR TITLE
fix(ai_agent): update ThreadId method from Clear to Close for proper resource management

### DIFF
--- a/usecases/ai_agent/ai_agent_usecase.go
+++ b/usecases/ai_agent/ai_agent_usecase.go
@@ -485,7 +485,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(ctx context.Context, caseId strin
 	if err != nil {
 		return nil, errors.Wrap(err, "could not generate data model summary")
 	}
-	defer requestDataModelSummary.ThreadId.Clear()
+	defer requestDataModelSummary.ThreadId.Close()
 
 	dataModelSummary, err := requestDataModelSummary.Get(0)
 	if err != nil {


### PR DESCRIPTION
In AI case review, we create a thread but we reset the thread instead of closing it properly. 

Use the right method