### PR TITLE
Add custom OTEL sampler based on route prefix.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,8 +126,12 @@ FIREBASE_API_KEY=dummy
 # CLOUD_RUN_PROBE_PORT=9000
 
 # Configure various external integrations.
-# Send traces to Google Cloud Platform (see https://cloud.google.com/trace/docs/setup/go-ot). Requires Application Default Credentials.
+# Send traces to aither an OpenTelemetry-compatible GRPC collector (otlp, default) or to Google Cloud Platform (gcp) (see https://cloud.google.com/trace/docs/setup/go-ot).
+# The GCP collector requires Application Default Credentials.
 ENABLE_GCP_TRACING=false
+# TRACING_EXPORTER=otlp
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
 SEGMENT_WRITE_KEY=
 DISABLE_SEGMENT=false
 SENTRY_DSN=
@@ -153,7 +157,7 @@ KILL_IF_READ_LICENSE_ERROR=false
 # BIGQUERY_PROJECT_ID=
 
 # Configure AI agent settings
-# openai or aistudio 
+# openai or aistudio
 # AI_AGENT_MAIN_AGENT_PROVIDER_TYPE=
 # URL of the AI provider (can be left empty for aistudio)
 # AI_AGENT_MAIN_AGENT_URL=

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -131,6 +131,7 @@ func RunServer(config CompiledConfig) error {
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
 		firebaseEmulatorHost             string
+		telemetryExporter                string
 		otelSamplingRates                string
 	}{
 		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", 0),
@@ -143,6 +144,7 @@ func RunServer(config CompiledConfig) error {
 		sentryDsn:                        utils.GetEnv("SENTRY_DSN", ""),
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
 		firebaseEmulatorHost:             utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
+		telemetryExporter:                utils.GetEnv("TRACING_EXPORTER", "gcp"),
 		otelSamplingRates:                utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 	}
 
@@ -181,6 +183,7 @@ func RunServer(config CompiledConfig) error {
 		ApplicationName: apiConfig.AppName,
 		Enabled:         gcpConfig.EnableTracing,
 		ProjectID:       gcpConfig.ProjectId,
+		Exporter:        serverConfig.telemetryExporter,
 		SamplingMap:     infra.NewTelemetrySamplingMap(ctx, serverConfig.otelSamplingRates),
 	}
 	telemetryRessources, err := infra.InitTelemetry(tracingConfig, config.Version)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -131,6 +131,7 @@ func RunServer(config CompiledConfig) error {
 		sentryDsn                        string
 		transferCheckEnrichmentBucketUrl string
 		firebaseEmulatorHost             string
+		otelSamplingRates                string
 	}{
 		batchIngestionMaxSize:            utils.GetEnv("BATCH_INGESTION_MAX_SIZE", 0),
 		caseManagerBucket:                utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
@@ -142,6 +143,7 @@ func RunServer(config CompiledConfig) error {
 		sentryDsn:                        utils.GetEnv("SENTRY_DSN", ""),
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
 		firebaseEmulatorHost:             utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
+		otelSamplingRates:                utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 	}
 
 	marbleJwtSigningKey := infra.ReadParseOrGenerateSigningKey(ctx, serverConfig.jwtSigningKey, serverConfig.jwtSigningKeyFile)
@@ -179,6 +181,7 @@ func RunServer(config CompiledConfig) error {
 		ApplicationName: apiConfig.AppName,
 		Enabled:         gcpConfig.EnableTracing,
 		ProjectID:       gcpConfig.ProjectId,
+		SamplingMap:     infra.NewTelemetrySamplingMap(ctx, serverConfig.otelSamplingRates),
 	}
 	telemetryRessources, err := infra.InitTelemetry(tracingConfig, config.Version)
 	if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -144,7 +144,7 @@ func RunServer(config CompiledConfig) error {
 		sentryDsn:                        utils.GetEnv("SENTRY_DSN", ""),
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
 		firebaseEmulatorHost:             utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
-		telemetryExporter:                utils.GetEnv("TRACING_EXPORTER", "gcp"),
+		telemetryExporter:                utils.GetEnv("TRACING_EXPORTER", "otlp"),
 		otelSamplingRates:                utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 	}
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -82,6 +82,8 @@ func RunTaskQueue(apiVersion string) error {
 		cloudRunProbePort           string
 		caseReviewTimeout           time.Duration
 		caseManagerBucket           string
+		telemetryExporter           string
+		otelSamplingRates           string
 	}{
 		appName:                     "marble-backend",
 		env:                         utils.GetEnv("ENV", "development"),
@@ -92,6 +94,8 @@ func RunTaskQueue(apiVersion string) error {
 		cloudRunProbePort:           utils.GetEnv("CLOUD_RUN_PROBE_PORT", ""),
 		caseReviewTimeout:           utils.GetEnvDuration("AI_CASE_REVIEW_TIMEOUT", 5*time.Minute),
 		caseManagerBucket:           utils.GetEnv("CASE_MANAGER_BUCKET_URL", ""),
+		telemetryExporter:           utils.GetEnv("TRACING_EXPORTER", "otlp"),
+		otelSamplingRates:           utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 	}
 
 	logger := utils.NewLogger(workerConfig.loggingFormat)
@@ -138,6 +142,8 @@ func RunTaskQueue(apiVersion string) error {
 		ApplicationName: workerConfig.appName,
 		Enabled:         gcpConfig.EnableTracing,
 		ProjectID:       gcpConfig.ProjectId,
+		Exporter:        workerConfig.telemetryExporter,
+		SamplingMap:     infra.NewTelemetrySamplingMap(ctx, workerConfig.otelSamplingRates),
 	}
 	telemetryRessources, err := infra.InitTelemetry(tracingConfig, apiVersion)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/biter777/countries v1.7.5
 	github.com/checkmarble/llm-adapter v0.0.0-20250729112324-4bb3f0d138b1
 	github.com/cockroachdb/errors v1.12.0
-	github.com/exaring/otelpgx v0.6.1
+	github.com/exaring/otelpgx v0.9.3
 	github.com/gavv/httpexpect/v2 v2.16.0
 	github.com/getkin/kin-openapi v0.132.0
 	github.com/getsentry/sentry-go v0.28.1

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 	go.opentelemetry.io/contrib/detectors/gcp v1.35.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.52.0
 	go.opentelemetry.io/otel v1.37.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	gocloud.dev v0.39.0
@@ -262,8 +263,10 @@ require (
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.60.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.60.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.35.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/arch v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -869,8 +869,8 @@ github.com/envoyproxy/protoc-gen-validate v0.9.1/go.mod h1:OKNgG7TCp5pF4d6XftA0+
 github.com/envoyproxy/protoc-gen-validate v0.10.1/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfUKS7KJ7spH3d86P8=
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
-github.com/exaring/otelpgx v0.6.1 h1:oVm7H3obc7eXg0iXWk62wJTWprB2pHu6rYApHjqmCUs=
-github.com/exaring/otelpgx v0.6.1/go.mod h1:DuRveXIeRNz6VJrMTj2uCBFqiocMx4msCN1mIMmbZUI=
+github.com/exaring/otelpgx v0.9.3 h1:4yO02tXC7ZJZ+hcqcUkfxblYNCIFGVhpUWI0iw1TzPU=
+github.com/exaring/otelpgx v0.9.3/go.mod h1:R5/M5LWsPPBZc1SrRE5e0DiU48bI78C1/GPTWs6I66U=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/go.sum
+++ b/go.sum
@@ -969,6 +969,8 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGw
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
+github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=
+github.com/golang/glog v1.2.4/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -1487,6 +1489,8 @@ go.opentelemetry.io/otel v1.37.0 h1:9zhNfelUvx0KBfu/gb+ZgeAfAgtWrfHJZcAqFC228wQ=
 go.opentelemetry.io/otel v1.37.0/go.mod h1:ehE/umFRLnuLa/vSccNq9oS1ErUlkkK71gMcN34UG8I=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0 h1:Mne5On7VWdx7omSrSSZvM4Kw7cS7NQkOOmLcgscI51U=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0/go.mod h1:IPtUMKL4O3tH5y+iXVyAXqpAwMuzC1IrxVS81rummfE=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0 h1:3d+S281UTjM+AbF31XSOYn1qXn3BgIdWl8HNEpx08Jk=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.19.0/go.mod h1:0+KuTDyKL4gjKCF75pHOX4wuzYDUZYfAQdSu43o+Z2I=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0 h1:IeMeyr1aBvBiPVYihXIaeIZba6b8E1bYp7lbdxK8CQg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.19.0/go.mod h1:oVdCUtjq9MK9BlS7TtucsQwUcXcymNiEDjgDD2jMtZU=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.35.0 h1:PB3Zrjs1sG1GBX51SXyTSoOTqcDglmsk7nT6tkKPb/k=

--- a/infra/config.go
+++ b/infra/config.go
@@ -145,7 +145,8 @@ type TelemetryConfiguration struct {
 }
 
 type TelemetrySamplingMap struct {
-	SpanNames map[string]float64 `json:"span_names"`
+	SpanNames  map[string]float64 `json:"span_names"`
+	HttpRoutes map[string]float64 `json:"http_routes"`
 }
 
 func NewTelemetrySamplingMap(ctx context.Context, path string) TelemetrySamplingMap {

--- a/infra/config.go
+++ b/infra/config.go
@@ -140,6 +140,7 @@ type TelemetryConfiguration struct {
 	Enabled         bool
 	ApplicationName string
 	ProjectID       string
+	Exporter        string
 	SamplingMap     TelemetrySamplingMap
 }
 

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -239,7 +239,13 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, query models.Ope
 	utils.LoggerFromContext(ctx).InfoContext(ctx, "sending screening query")
 	startedAt := time.Now()
 
+	ctx, span := utils.OpenTelemetryTracerFromContext(ctx).Start(ctx, "yente-request")
+	defer span.End()
+
 	resp, err := repo.opensanctions.Client().Do(req)
+
+	span.End()
+
 	if err != nil {
 		return models.ScreeningRawSearchResponseWithMatches{},
 			errors.Wrap(err, "could not perform screening")


### PR DESCRIPTION
This PR implements a probabilistic sampler for our tracing setup, it applies a default rate of `0.3` based on the Trace ID that is overriden by:
 * Statically defined rules based on HTTP route prefix.
 * Static analysis of the SQL queries (to remove `set_config` and duplicate `prepare` statements)

The goal here is to not be overwhelmed by traces from heavily called endpoints (decisions, ingestion, etc.) and to completely disable traces for infrastructure endpoints (such as /liveness).