### PR TITLE
Match rule_hit workflow condition when confirmed_hit or in_review.

### DIFF
--- a/usecases/decision_workflows/conditions.go
+++ b/usecases/decision_workflows/conditions.go
@@ -78,7 +78,7 @@ func ruleHit(ruleIds []uuid.UUID) DecisionWorkflowsCondition {
 		}
 		for _, screeningExec := range req.Decision.ScreeningExecutions {
 			for _, ruleId := range ruleIds {
-				if screeningExec.Config.StableId == ruleId.String() && screeningExec.Status == models.ScreeningStatusConfirmedHit {
+				if screeningExec.Config.StableId == ruleId.String() && (screeningExec.Status == models.ScreeningStatusInReview || screeningExec.Status == models.ScreeningStatusConfirmedHit) {
 					return true, nil
 				}
 			}


### PR DESCRIPTION
A screening rule must match the rule_hit condition when it is either confirmed_hit or in_review.