### PR TITLE
feat(migrations): add migration to set file_temp_reference as NOT NULL

### DIFF
--- a/repositories/migrations/20250820142413_alter_temp_file_ref_non_null.sql
+++ b/repositories/migrations/20250820142413_alter_temp_file_ref_non_null.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Update existing rows with a computed default value
+UPDATE ai_case_reviews 
+SET file_temp_reference = 'ai_case_reviews/temp/' || case_id::text || '/' || id::text || '.json'
+WHERE file_temp_reference IS NULL;
+
+-- Make the column NOT NULL now that all rows have values
+ALTER TABLE ai_case_reviews 
+ALTER COLUMN file_temp_reference SET NOT NULL;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE ai_case_reviews 
+ALTER COLUMN file_temp_reference DROP NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
fix: https://marble-eu.sentry.io/issues/59004707/?alert_rule_id=193450&alert_type=issue&notification_uuid=94bec797-d449-4b8b-a91e-136ea703cf8e&project=4509310347640912&referrer=slack 

`file_temp_reference` column was set as nullable column but the data model in code expect a non null value. 

I changed the nullable setting of this column and fill a default value for existing row. 

We don't have many rows so the migration should be ok and fast