### PR TITLE
feat(worker): add worker monitor service based on river UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,17 @@ services:
       YENTE_INDEX_TYPE: elasticsearch
       YENTE_INDEX_URL: "http://es:9200"
       YENTE_UPDATE_TOKEN: ""
+  worker-monitor:
+    container_name: worker-monitor
+    image: ghcr.io/riverqueue/riverui:latest
+    ports:
+      - "8001:8080"
+    environment:
+      DATABASE_URL: "postgresql://postgres:marble@db:5432/marble"
+      RIVER_BASIC_AUTH_USER: ${RIVER_BASIC_AUTH_USER:-}
+      RIVER_BASIC_AUTH_PASS: ${RIVER_BASIC_AUTH_PASS:-}
+    depends_on:
+      - db
 
 volumes:
   postgres-db:


### PR DESCRIPTION
This pull request adds a new service to the `docker-compose.yml` file. The main change is the introduction of a `worker-monitor` service for monitoring purposes.

New service added:

* Added a `worker-monitor` service using the `ghcr.io/riverqueue/riverui:latest` image, exposing port 8001 and configuring the database connection via the `DATABASE_URL` environment variable.

Notes:
I chose port 8001 arbitrarily, but it can be changed if needed.