### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore


### PR DESCRIPTION
Add dependabot configuration file to enable this tools 

Use basic settings and limit the number of opened PRs created by dependabot. 
Run this tools every week