### PR TITLE
offloading improvement

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -217,8 +217,10 @@ func RunTaskQueue(apiVersion string) error {
 		FetchPollInterval: 100 * time.Millisecond,
 		Queues:            queues,
 
-		// Must be larger than the time it takes to process a job. Increase it if we want to use longer-lived jobs.
-		RescueStuckJobsAfter: 1 * time.Minute,
+		// Must be larger than the time it takes to process a job, if the job does not implement Timeout().
+		// Jobs that do not implement this and run for longer than this value will be rescued by the worker, which we should
+		// avoid if it is actually still running.
+		RescueStuckJobsAfter: 2 * time.Minute,
 		WorkerMiddleware: []rivertype.WorkerMiddleware{
 			jobs.NewTracingMiddleware(telemetryRessources.Tracer),
 			jobs.NewSentryMiddleware(),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -107,7 +107,7 @@ func RunTaskQueue(apiVersion string) error {
 		BucketUrl:       utils.GetEnv("OFFLOADING_BUCKET_URL", ""),
 		JobInterval:     utils.GetEnvDuration("OFFLOADING_JOB_INTERVAL", 30*time.Minute),
 		OffloadBefore:   utils.GetEnvDuration("OFFLOADING_BEFORE", 7*24*time.Hour),
-		BatchSize:       utils.GetEnv("OFFLOADING_BATCH_SIZE", 10_000),
+		BatchSize:       utils.GetEnv("OFFLOADING_BATCH_SIZE", 1000),
 		SavepointEvery:  utils.GetEnv("OFFLOADING_SAVE_POINTS", 100),
 		WritesPerSecond: utils.GetEnv("OFFLOADING_WRITES_PER_SEC", 200),
 	}

--- a/jobs/middlewares.go
+++ b/jobs/middlewares.go
@@ -89,7 +89,7 @@ func NewLoggerMiddleware(l *slog.Logger) LoggerMiddleware {
 type RecovererMiddleware struct{}
 
 func (m RecovererMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) (err error) {
-	defer utils.RecoverAndReportSentryError(ctx, "RecoveredMiddleware.Work")
+	defer utils.RecoverAndReportSentryError(ctx, "RecovererMiddleware.Work")
 	return doInner(ctx)
 }
 

--- a/repositories/sql_to_row.go
+++ b/repositories/sql_to_row.go
@@ -56,8 +56,7 @@ func SqlToFallibleChannelOfModel[Model any](ctx context.Context, exec Executor, 
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
-			default:
-				modelsChannel <- ModelResult[Model]{model, err}
+			case modelsChannel <- ModelResult[Model]{model, err}:
 			}
 			return nil
 		})
@@ -69,8 +68,7 @@ func SqlToFallibleChannelOfModel[Model any](ctx context.Context, exec Executor, 
 			select {
 			case <-ctx.Done():
 				return
-			default:
-				modelsChannel <- ModelResult[Model]{*new(Model), err}
+			case modelsChannel <- ModelResult[Model]{*new(Model), err}:
 			}
 			return
 		}

--- a/usecases/scheduled_execution/auto_assignment_job.go
+++ b/usecases/scheduled_execution/auto_assignment_job.go
@@ -2,6 +2,7 @@ package scheduled_execution
 
 import (
 	"context"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/usecases/feature_access"
@@ -39,4 +40,8 @@ func (w *AutoAssignmentWorker) Work(ctx context.Context, job *river.Job[models.A
 	}
 
 	return w.autoAssignmentUsecase.RunAutoAssigner(ctx, job.Args.OrgId, job.Args.InboxId)
+}
+
+func (w *AutoAssignmentWorker) Timeout(job *river.Job[models.AutoAssignmentArgs]) time.Duration {
+	return 20 * time.Second
 }

--- a/usecases/scheduled_execution/index_cleanup_job.go
+++ b/usecases/scheduled_execution/index_cleanup_job.go
@@ -84,3 +84,7 @@ func (w *IndexCleanupWorker) Work(ctx context.Context, job *river.Job[models.Ind
 
 	return nil
 }
+
+func (w *IndexCleanupWorker) Timeout(job *river.Job[models.IndexCleanupArgs]) time.Duration {
+	return 20 * time.Second
+}

--- a/usecases/scheduled_execution/index_creation_job.go
+++ b/usecases/scheduled_execution/index_creation_job.go
@@ -62,6 +62,10 @@ func (w *IndexCreationWorker) Work(ctx context.Context, job *river.Job[models.In
 	return err
 }
 
+func (w *IndexCreationWorker) Timeout(job *river.Job[models.IndexCreationArgs]) time.Duration {
+	return 20 * time.Second
+}
+
 type IndexCreationStatusWorker struct {
 	river.WorkerDefaults[models.IndexCreationStatusArgs]
 
@@ -152,6 +156,10 @@ func (w *IndexCreationStatusWorker) Work(ctx context.Context, job *river.Job[mod
 		"worker: finished creating indices", "indices", mapIndexNames(job.Args.Indices))
 
 	return nil
+}
+
+func (w *IndexCreationStatusWorker) Timeout(job *river.Job[models.IndexCreationStatusArgs]) time.Duration {
+	return 10 * time.Second
 }
 
 func mapIndexNames(indices []models.ConcreteIndex) []string {

--- a/usecases/scheduled_execution/index_rollover_job.go
+++ b/usecases/scheduled_execution/index_rollover_job.go
@@ -22,12 +22,10 @@ const (
 	INDEX_DELETION_DRY_RUN         = true
 )
 
-var (
-	indexRolloverWhitelistPrefixes = []string{
-		"uniq_idx",
-		"nav_",
-	}
-)
+var indexRolloverWhitelistPrefixes = []string{
+	"uniq_idx",
+	"nav_",
+}
 
 func NewIndexDeletionPeriodicJob(orgId string) *river.PeriodicJob {
 	return river.NewPeriodicJob(
@@ -48,7 +46,8 @@ func NewIndexDeletionPeriodicJob(orgId string) *river.PeriodicJob {
 }
 
 type indexDeletionIndexEditor interface {
-	GetRequiredIndices(ctx context.Context, organizationId string) (toCreate []models.AggregateQueryFamily, err error)
+	GetRequiredIndices(ctx context.Context, organizationId string) (
+		toCreate []models.AggregateQueryFamily, err error)
 }
 
 type IndexDeletionWorker struct {
@@ -144,7 +143,8 @@ IndexDeletion:
 			}
 		}
 
-		logger.DebugContext(ctx, fmt.Sprintf("index %s.%s.%s is candidate for deletion", exec.DatabaseSchema().Schema, index.TableName, index.Name()),
+		logger.DebugContext(ctx, fmt.Sprintf("index %s.%s.%s is candidate for deletion",
+			exec.DatabaseSchema().Schema, index.TableName, index.Name()),
 			"schema", exec.DatabaseSchema().Schema,
 			"table", index.TableName,
 			"index", index.Name(),
@@ -155,7 +155,8 @@ IndexDeletion:
 
 			switch err {
 			case nil:
-				logger.InfoContext(ctx, fmt.Sprintf("index %s.%s.%s was deleted successfully", exec.DatabaseSchema().Schema, index.TableName, index.Name()),
+				logger.InfoContext(ctx, fmt.Sprintf("index %s.%s.%s was deleted successfully",
+					exec.DatabaseSchema().Schema, index.TableName, index.Name()),
 					"schema", exec.DatabaseSchema().Schema,
 					"table", index.TableName,
 					"index", index.Name())
@@ -184,4 +185,8 @@ IndexDeletion:
 	}
 
 	return nil
+}
+
+func (w *IndexDeletionWorker) Timeout(job *river.Job[models.IndexDeletionArgs]) time.Duration {
+	return 20 * time.Second
 }

--- a/usecases/scheduled_execution/match_enrichment_job.go
+++ b/usecases/scheduled_execution/match_enrichment_job.go
@@ -2,6 +2,7 @@ package scheduled_execution
 
 import (
 	"context"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
@@ -77,4 +78,8 @@ func (w *MatchEnrichmentWorker) Work(ctx context.Context, job *river.Job[models.
 	}
 
 	return errs
+}
+
+func (w *MatchEnrichmentWorker) Timeout(job *river.Job[models.MatchEnrichmentArgs]) time.Duration {
+	return 10 * time.Second
 }

--- a/usecases/scheduled_execution/offloading_job.go
+++ b/usecases/scheduled_execution/offloading_job.go
@@ -25,8 +25,11 @@ type offloadingRepository interface {
 	SaveWatermark(ctx context.Context, exec repositories.Executor,
 		orgId *string, watermarkType models.WatermarkType, watermarkId *string, watermarkTime time.Time, params json.RawMessage) error
 
-	GetOffloadableDecisionRules(ctx context.Context, exec repositories.Executor,
-		req models.OffloadDecisionRuleRequest) (<-chan repositories.ModelResult[models.OffloadableDecisionRule], error)
+	GetOffloadableDecisionRules(
+		ctx context.Context,
+		tx repositories.Transaction,
+		req models.OffloadDecisionRuleRequest,
+	) (<-chan repositories.ModelResult[models.OffloadableDecisionRule], error)
 	RemoveDecisionRulePayload(ctx context.Context, tx repositories.Transaction, ids []*string) error
 }
 
@@ -103,96 +106,130 @@ func (w OffloadingWorker) Work(ctx context.Context, job *river.Job[models.Offloa
 			Watermark:    wm,
 		}
 
-		rules, err := w.repository.GetOffloadableDecisionRules(ctx, exec, req)
-		if err != nil {
-			return err
-		}
-
-		// Slice of pointers to not have to keep track of which decision were skipped or not, the
-		// query ignores NULL IDs.
-		offloadedIds := make([]*string, w.config.SavepointEvery)
-		idx := 0
-
-		var lastOfBatch *models.OffloadableDecisionRule
-
-		for item := range rules {
-			select {
-			case <-timeout:
-				return nil
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				if err := w.limiter.Wait(ctx); err != nil {
-					return err
-				}
+		err = w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+			// The transaction is only so we can "set local" to disable hash joins in the repo call below - writes should still be made outside of the transaction,
+			// as we specificially don't want to wait for the end of the transaction to write the save points.
+			rules, err := w.repository.GetOffloadableDecisionRules(ctx, tx, req)
+			if err != nil {
+				return err
 			}
 
-			if item.Error != nil {
-				return item.Error
-			}
+			// Slice of pointers to not have to keep track of which decision were skipped or not, the
+			// query ignores NULL IDs.
+			offloadedIds := make([]*string, w.config.SavepointEvery)
+			idx := 0
 
-			rule := item.Model
-			offloadedIds[idx%w.config.SavepointEvery] = nil
+			var lastOfBatch *models.OffloadableDecisionRule
 
-			if rule.RuleExecutionId != nil && rule.RuleEvaluation != nil && rule.RuleOutcome != nil {
-				key := w.repository.GetOffloadedDecisionRuleKey(req.OrgId,
-					rule.DecisionId, *rule.RuleId, *rule.RuleOutcome, rule.CreatedAt)
-
-				opts := blob.WriterOptions{}
-
-				// Only if we work on GCS, retrieve the typed writer and set the Custom-Time fixed metadata to the rule creation time.
-				// We do not (currently) set the date on other blob storage platforms (but maybe we should?)
-				opts.BeforeWrite = func(asFunc func(any) bool) error {
-					var gcsWriter *storage.Writer
-
-					if asFunc(&gcsWriter) {
-						gcsWriter.CustomTime = rule.CreatedAt
-					}
-
+			for item := range rules {
+				select {
+				case <-timeout:
 					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+					if err := w.limiter.Wait(ctx); err != nil {
+						return err
+					}
 				}
 
-				wr, err := w.blobRepository.OpenStreamWithOptions(ctx, w.config.BucketUrl, key, &opts)
-				if err != nil {
-					return err
-				}
-				defer wr.Close()
-
-				enc := json.NewEncoder(wr)
-
-				if err := enc.Encode(rule.RuleEvaluation); err != nil {
-					return err
+				if item.Error != nil {
+					return item.Error
 				}
 
-				if err := wr.Close(); err != nil {
-					return err
+				rule := item.Model
+				offloadedIds[idx%w.config.SavepointEvery] = nil
+
+				if rule.RuleExecutionId != nil && rule.RuleEvaluation != nil && rule.RuleOutcome != nil {
+					key := w.repository.GetOffloadedDecisionRuleKey(req.OrgId,
+						rule.DecisionId, *rule.RuleId, *rule.RuleOutcome, rule.CreatedAt)
+
+					opts := blob.WriterOptions{}
+
+					// Only if we work on GCS, retrieve the typed writer and set the Custom-Time fixed metadata to the rule creation time.
+					// We do not (currently) set the date on other blob storage platforms (but maybe we should?)
+					opts.BeforeWrite = func(asFunc func(any) bool) error {
+						var gcsWriter *storage.Writer
+
+						if asFunc(&gcsWriter) {
+							gcsWriter.CustomTime = rule.CreatedAt
+						}
+
+						return nil
+					}
+
+					wr, err := w.blobRepository.OpenStreamWithOptions(ctx, w.config.BucketUrl, key, &opts)
+					if err != nil {
+						return err
+					}
+					defer wr.Close()
+
+					enc := json.NewEncoder(wr)
+
+					if err := enc.Encode(rule.RuleEvaluation); err != nil {
+						return err
+					}
+
+					if err := wr.Close(); err != nil {
+						return err
+					}
+
+					offloadedIds[idx%w.config.SavepointEvery] = rule.RuleExecutionId
 				}
 
-				offloadedIds[idx%w.config.SavepointEvery] = rule.RuleExecutionId
+				idx += 1
+
+				// If we get here, we have a full batch, so we can send the whole slice to be persisted.
+				// See below for the other case.
+				if idx%w.config.SavepointEvery == 0 {
+					err = w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+						if err := w.repository.RemoveDecisionRulePayload(ctx, tx, offloadedIds); err != nil {
+							return err
+						}
+						if err := w.repository.SaveWatermark(
+							ctx,
+							tx,
+							&job.Args.OrgId,
+							models.WatermarkTypeDecisionRules,
+							&rule.DecisionId,
+							rule.CreatedAt,
+							nil,
+						); err != nil {
+							return err
+						}
+
+						logger.Debug(fmt.Sprintf("offloading save point after %d decision rules", idx), "org_id", job.Args.OrgId)
+
+						return nil
+					})
+					if err != nil {
+						return err
+					}
+				}
+
+				lastOfBatch = &rule
 			}
 
-			idx += 1
+			if idx == 0 {
+				return nil
+			}
 
-			// If we get here, we have a full batch, so we can send the whole slice to be persisted.
-			// See below for the other case.
-			if idx%w.config.SavepointEvery == 0 {
-				err = w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-					if err := w.repository.RemoveDecisionRulePayload(ctx, tx, offloadedIds); err != nil {
+			// If we did not get a multiple of of save point batch size, we still have len(rules)%batch_size
+			// items to persist.
+			if idx%w.config.SavepointEvery > 0 {
+				remainingItems := offloadedIds[:idx%w.config.SavepointEvery]
+
+				err := w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+					if err := w.repository.RemoveDecisionRulePayload(ctx, tx, remainingItems); err != nil {
 						return err
 					}
-					if err := w.repository.SaveWatermark(
-						ctx,
-						tx,
-						&job.Args.OrgId,
-						models.WatermarkTypeDecisionRules,
-						&rule.DecisionId,
-						rule.CreatedAt,
-						nil,
-					); err != nil {
+					if err := w.repository.SaveWatermark(ctx, tx,
+						&job.Args.OrgId, models.WatermarkTypeDecisionRules,
+						&lastOfBatch.DecisionId, lastOfBatch.CreatedAt, nil); err != nil {
 						return err
 					}
 
-					logger.Debug(fmt.Sprintf("offloading save point after %d decision rules", idx), "org_id", job.Args.OrgId)
+					logger.Debug(fmt.Sprintf("offloading save point after %d decision rules", idx+1), "org_id", job.Args.OrgId)
 
 					return nil
 				})
@@ -201,42 +238,16 @@ func (w OffloadingWorker) Work(ctx context.Context, job *river.Job[models.Offloa
 				}
 			}
 
-			lastOfBatch = &rule
-		}
-
-		if idx == 0 {
-			return nil
-		}
-
-		// If we did not get a multiple of of save point batch size, we still have len(rules)%batch_size
-		// items to persist.
-		if idx%w.config.SavepointEvery > 0 {
-			remainingItems := offloadedIds[:idx%w.config.SavepointEvery]
-
-			err := w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-				if err := w.repository.RemoveDecisionRulePayload(ctx, tx, remainingItems); err != nil {
-					return err
-				}
-				if err := w.repository.SaveWatermark(ctx, tx,
-					&job.Args.OrgId, models.WatermarkTypeDecisionRules,
-					&lastOfBatch.DecisionId, lastOfBatch.CreatedAt, nil); err != nil {
-					return err
-				}
-
-				logger.Debug(fmt.Sprintf("offloading save point after %d decision rules", idx+1), "org_id", job.Args.OrgId)
-
-				return nil
-			})
-			if err != nil {
-				return err
+			if wm == nil {
+				logger.Debug(fmt.Sprintf("offloaded batch of %d decisions rules", idx), "org_id", job.Args.OrgId)
+			} else {
+				logger.Debug(fmt.Sprintf("offloaded batch of %d decisions rules", idx), "org_id",
+					job.Args.OrgId, "watermark_id", wm.WatermarkId, "watermark_time", wm.WatermarkTime)
 			}
-		}
-
-		if wm == nil {
-			logger.Debug(fmt.Sprintf("offloaded batch of %d decisions rules", idx), "org_id", job.Args.OrgId)
-		} else {
-			logger.Debug(fmt.Sprintf("offloaded batch of %d decisions rules", idx), "org_id",
-				job.Args.OrgId, "watermark_id", wm.WatermarkId, "watermark_time", wm.WatermarkTime)
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 }

--- a/usecases/scheduled_execution/offloading_job.go
+++ b/usecases/scheduled_execution/offloading_job.go
@@ -185,7 +185,8 @@ func (w OffloadingWorker) Work(ctx context.Context, job *river.Job[models.Offloa
 						return err
 					}
 
-					offloadedIds[idx%w.config.SavepointEvery] = rule.RuleExecutionId
+					id := *rule.RuleExecutionId
+					offloadedIds[idx%w.config.SavepointEvery] = &id
 				}
 
 				idx += 1

--- a/usecases/scheduled_execution/offloading_job.go
+++ b/usecases/scheduled_execution/offloading_job.go
@@ -106,10 +106,10 @@ func (w OffloadingWorker) Work(ctx context.Context, job *river.Job[models.Offloa
 			Watermark:    wm,
 		}
 
-		err = w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		err = w.transactionFactory.Transaction(ctx, func(outerTx repositories.Transaction) error {
 			// The transaction is only so we can "set local" to disable hash joins in the repo call below - writes should still be made outside of the transaction,
 			// as we specificially don't want to wait for the end of the transaction to write the save points.
-			rules, err := w.repository.GetOffloadableDecisionRules(ctx, tx, req)
+			rules, err := w.repository.GetOffloadableDecisionRules(ctx, outerTx, req)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- Implement Timeout() on all river jobs, so that they are not aggressively rescued by the river rescuer routine (which could have weird effects if the job is still running)
- disable hash joins in the query that lists decisions to offload - and run in a transaction in order to do so (at the cost of some more loop state handling)
- add spans in offloading routine