### PR TITLE
Set application_name on PostgreSQL connections.

### DIFF
--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 
 // Deprecated
 func RunScheduledExecuter(apiVersion string) error {
+	appName := fmt.Sprintf("marble-scheduled-executor %s", apiVersion)
 	// This is where we read the environment variables and set up the configuration for the application.
 	gcpConfig := infra.GcpConfig{
 		EnableTracing: utils.GetEnv("ENABLE_GCP_TRACING", false),
@@ -76,7 +78,7 @@ func RunScheduledExecuter(apiVersion string) error {
 	}
 	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
 
-	pool, err := infra.NewPostgresConnectionPool(ctx, pgConfig.GetConnectionString(),
+	pool, err := infra.NewPostgresConnectionPool(ctx, appName, pgConfig.GetConnectionString(),
 		telemetryRessources.TracerProvider, pgConfig.MaxPoolConnections)
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)
@@ -113,6 +115,7 @@ func RunScheduledExecuter(apiVersion string) error {
 	)
 
 	uc := usecases.NewUsecases(repositories,
+		usecases.WithAppName(appName),
 		usecases.WithLicense(license),
 		usecases.WithConvoyServer(convoyConfiguration.APIUrl),
 	)

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 
 // Deprecated
 func RunSendPendingWebhookEvents(apiVersion string) error {
+	appName := fmt.Sprintf("marble-webhook-retrier %s", apiVersion)
 	// This is where we read the environment variables and set up the configuration for the application.
 	gcpConfig := infra.GcpConfig{
 		EnableTracing: utils.GetEnv("ENABLE_GCP_TRACING", false),
@@ -74,7 +76,7 @@ func RunSendPendingWebhookEvents(apiVersion string) error {
 	}
 	ctx = utils.StoreOpenTelemetryTracerInContext(ctx, telemetryRessources.Tracer)
 
-	pool, err := infra.NewPostgresConnectionPool(ctx, pgConfig.GetConnectionString(),
+	pool, err := infra.NewPostgresConnectionPool(ctx, appName, pgConfig.GetConnectionString(),
 		telemetryRessources.TracerProvider, pgConfig.MaxPoolConnections)
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)
@@ -89,6 +91,7 @@ func RunSendPendingWebhookEvents(apiVersion string) error {
 			convoyConfiguration.RateLimit,
 		))
 	uc := usecases.NewUsecases(repositories,
+		usecases.WithAppName(appName),
 		usecases.WithFailedWebhooksRetryPageSize(jobConfig.failedWebhooksRetryPageSize),
 		usecases.WithLicense(license),
 		usecases.WithConvoyServer(convoyConfiguration.APIUrl),

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -24,6 +24,7 @@ import (
 )
 
 func RunServer(config CompiledConfig) error {
+	appName := fmt.Sprintf("marble-backend %s", config.Version)
 	logger := utils.NewLogger(utils.GetEnv("LOGGING_FORMAT", "text"))
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
 
@@ -192,7 +193,7 @@ func RunServer(config CompiledConfig) error {
 		utils.LogAndReportSentryError(ctx, err)
 	}
 
-	pool, err := infra.NewPostgresConnectionPool(ctx, pgConfig.GetConnectionString(),
+	pool, err := infra.NewPostgresConnectionPool(ctx, appName, pgConfig.GetConnectionString(),
 		telemetryRessources.TracerProvider, pgConfig.MaxPoolConnections)
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)
@@ -239,6 +240,7 @@ func RunServer(config CompiledConfig) error {
 	deps := api.InitDependencies(ctx, apiConfig, pool, marbleJwtSigningKey)
 
 	uc := usecases.NewUsecases(repositories,
+		usecases.WithAppName(appName),
 		usecases.WithApiVersion(config.Version),
 		usecases.WithBatchIngestionMaxSize(serverConfig.batchIngestionMaxSize),
 		usecases.WithIngestionBucketUrl(serverConfig.ingestionBucketUrl),

--- a/infra/postgres_connections_pool.go
+++ b/infra/postgres_connections_pool.go
@@ -26,6 +26,7 @@ type ClientDbConfig struct {
 
 func NewPostgresConnectionPool(
 	ctx context.Context,
+	appName string,
 	connectionString string,
 	tp trace.TracerProvider,
 	maxConnections int,
@@ -44,6 +45,10 @@ func NewPostgresConnectionPool(
 		cfg.MaxConns = DEFAULT_MAX_CONNECTIONS
 	}
 	cfg.MaxConnIdleTime = MAX_CONNECTION_IDLE_TIME
+
+	cfg.ConnConfig.RuntimeParams = map[string]string{
+		"application_name": appName,
+	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)
 	if err != nil {

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -116,7 +116,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Need to declare this after the migrations, to have the correct search path
-	dbPool, err := infra.NewPostgresConnectionPool(ctx, pgConfig.GetConnectionString(), nil, pgConfig.MaxPoolConnections)
+	dbPool, err := infra.NewPostgresConnectionPool(ctx, "marble-test", pgConfig.GetConnectionString(), nil, pgConfig.MaxPoolConnections)
 	if err != nil {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}
@@ -154,6 +154,7 @@ func TestMain(m *testing.M) {
 	firebaseAdminClient.On("CreateUser", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	testUsecases = usecases.NewUsecases(repos,
+		usecases.WithAppName("marble-test"),
 		usecases.WithLicense(models.NewFullLicense()),
 		usecases.WithIngestionBucketUrl("file://./tempFiles?create_dir=true"),
 		usecases.WithCaseManagerBucketUrl("file://./tempFiles?create_dir=true"),

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -119,7 +119,7 @@ func setupApi(t *testing.T, ctx context.Context, dsn string) string {
 
 	gin.SetMode(gin.ReleaseMode)
 
-	pool, err := infra.NewPostgresConnectionPool(ctx, dsn, nil, 10)
+	pool, err := infra.NewPostgresConnectionPool(ctx, "", dsn, nil, 10)
 	if err != nil {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}

--- a/repositories/db_executor_getter.go
+++ b/repositories/db_executor_getter.go
@@ -20,6 +20,7 @@ import (
 const defaultOrgConfigKey = "default"
 
 type ExecutorGetter struct {
+	appName              string
 	marbleConnectionPool *pgxpool.Pool
 
 	// uses the organizationId as the key
@@ -157,6 +158,7 @@ func (g ExecutorGetter) getPoolAndSchema(
 		var err error
 		pool, err = infra.NewPostgresConnectionPool(
 			ctx,
+			g.appName,
 			config.ConnectionString,
 			g.tp,
 			config.MaxConns,

--- a/usecases/executor_factory/executor_factory.go
+++ b/usecases/executor_factory/executor_factory.go
@@ -23,15 +23,18 @@ type organizationGetter interface {
 }
 
 type DbExecutorFactory struct {
+	appName                      string
 	orgGetter                    organizationGetter
 	transactionFactoryRepository executorFactoryRepository
 }
 
 func NewDbExecutorFactory(
+	appName string,
 	orgGetter organizationGetter,
 	transactionFactoryRepository executorFactoryRepository,
 ) DbExecutorFactory {
 	return DbExecutorFactory{
+		appName:                      appName,
 		orgGetter:                    orgGetter,
 		transactionFactoryRepository: transactionFactoryRepository,
 	}

--- a/usecases/task_queue.go
+++ b/usecases/task_queue.go
@@ -157,10 +157,10 @@ func (w *TaskQueueWorker) removeQueuesFromMissingOrgs(ctx context.Context,
 	return nil
 }
 
-func QueuesFromOrgs(ctx context.Context, orgsRepo repositories.OrganizationRepository,
+func QueuesFromOrgs(ctx context.Context, appName string, orgsRepo repositories.OrganizationRepository,
 	execGetter repositories.ExecutorGetter, offloadingConfig infra.OffloadingConfig,
 ) (queues map[string]river.QueueConfig, periodics []*river.PeriodicJob, err error) {
-	exec_fac := executor_factory.NewDbExecutorFactory(orgsRepo, execGetter)
+	exec_fac := executor_factory.NewDbExecutorFactory(appName, orgsRepo, execGetter)
 	orgs, err := orgsRepo.AllOrganizations(ctx, exec_fac.NewExecutor())
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -21,6 +21,7 @@ import (
 
 type Usecases struct {
 	Repositories                repositories.Repositories
+	appName                     string
 	apiVersion                  string
 	batchIngestionMaxSize       int
 	ingestionBucketUrl          string
@@ -40,6 +41,12 @@ type Usecases struct {
 }
 
 type Option func(*options)
+
+func WithAppName(appName string) Option {
+	return func(o *options) {
+		o.appName = appName
+	}
+}
 
 func WithApiVersion(apiVersion string) Option {
 	return func(o *options) {
@@ -146,6 +153,7 @@ func WithAIAgentConfig(config infra.AIAgentConfiguration) Option {
 }
 
 type options struct {
+	appName                     string
 	apiVersion                  string
 	batchIngestionMaxSize       int
 	ingestionBucketUrl          string
@@ -170,6 +178,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 	}
 	return Usecases{
 		Repositories:                repositories,
+		appName:                     o.appName,
 		apiVersion:                  o.apiVersion,
 		batchIngestionMaxSize:       o.batchIngestionMaxSize,
 		ingestionBucketUrl:          o.ingestionBucketUrl,
@@ -199,6 +208,7 @@ func NewUsecases(repositories repositories.Repositories, opts ...Option) Usecase
 
 func (usecases *Usecases) NewExecutorFactory() executor_factory.ExecutorFactory {
 	return executor_factory.NewDbExecutorFactory(
+		usecases.appName,
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.Repositories.ExecutorGetter,
 	)
@@ -206,6 +216,7 @@ func (usecases *Usecases) NewExecutorFactory() executor_factory.ExecutorFactory 
 
 func (usecases *Usecases) NewTransactionFactory() executor_factory.TransactionFactory {
 	return executor_factory.NewDbExecutorFactory(
+		usecases.appName,
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.Repositories.ExecutorGetter,
 	)


### PR DESCRIPTION
This PR adds a connection name to every PostgreSQL connection (in the form of "<app> <version>", for example, "marble-backend 0.49.0") so we can disambiguate connection metrics by app.