### PR TITLE
Be explicit about OpenSanctions match request content-type.

### DIFF
--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -357,6 +357,7 @@ func (repo OpenSanctionsRepository) searchRequest(ctx context.Context,
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestUrl, &body)
+	req.Header.Set("content-type", "application/json")
 
 	repo.authenticateRequest(req)
 


### PR DESCRIPTION
We were not passing any `content-type` to Yente's match request, which was okay for Yente, but not for servers more respectful of HTTP semantics. 👀 