### PR TITLE
Register propagator into OTEL machinery and use them for OpenSanctions.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/cockroachdb/errors"
 	"github.com/getsentry/sentry-go"
@@ -90,7 +91,7 @@ func RunServer(config CompiledConfig) error {
 	}
 
 	openSanctionsConfig := infra.InitializeOpenSanctions(
-		http.DefaultClient,
+		otelhttp.DefaultClient,
 		utils.GetEnv("OPENSANCTIONS_API_HOST", ""),
 		utils.GetEnv("OPENSANCTIONS_AUTH_METHOD", ""),
 		utils.GetEnv("OPENSANCTIONS_API_KEY", ""),

--- a/repositories/opensanctions_repository.go
+++ b/repositories/opensanctions_repository.go
@@ -231,6 +231,9 @@ func (repo OpenSanctionsRepository) GetLatestLocalDataset(ctx context.Context) (
 }
 
 func (repo OpenSanctionsRepository) Search(ctx context.Context, query models.OpenSanctionsQuery) (models.ScreeningRawSearchResponseWithMatches, error) {
+	ctx, span := utils.OpenTelemetryTracerFromContext(ctx).Start(ctx, "yente-request")
+	defer span.End()
+
 	req, rawQuery, err := repo.searchRequest(ctx, &query)
 	if err != nil {
 		return models.ScreeningRawSearchResponseWithMatches{}, err
@@ -238,9 +241,6 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, query models.Ope
 
 	utils.LoggerFromContext(ctx).InfoContext(ctx, "sending screening query")
 	startedAt := time.Now()
-
-	ctx, span := utils.OpenTelemetryTracerFromContext(ctx).Start(ctx, "yente-request")
-	defer span.End()
 
 	resp, err := repo.opensanctions.Client().Do(req)
 


### PR DESCRIPTION
This registers the propagators so they can be used by `otelhttp` to send span context to upstream services.