### PR TITLE
Fixed not passing proper context, breaking audit logs.

### DIFF
--- a/api/handle_users.go
+++ b/api/handle_users.go
@@ -100,7 +100,7 @@ func handlePatchUser(uc usecases.Usecases) func(c *gin.Context) {
 		}
 
 		usecase := usecasesWithCreds(ctx, uc).NewUserUseCase()
-		createdUser, err := usecase.UpdateUser(c, dto.AdaptUpdateUser(data, userId))
+		createdUser, err := usecase.UpdateUser(ctx, dto.AdaptUpdateUser(data, userId))
 		if presentError(ctx, c, err) {
 			return
 		}


### PR DESCRIPTION
In the patch user handler, we did not pass the proper request context to the usecase, breaking anything that relies on anything stored in the context (logging, tracing, audit logs).

Thankfully, authorization did not rely on this.