### PR TITLE
fix(test): Screening test could fail because of a bad item selection in array

### DIFF
--- a/pubapi/tests/specs/v1/screening.go
+++ b/pubapi/tests/specs/v1/screening.go
@@ -175,21 +175,17 @@ func screenings(t *testing.T, e *httpexpect.Expect) {
 		screeningsArray.Length().IsEqual(2)
 
 		// Find and validate the original screening (should now have status "no_hit")
-		originalScreening := screeningsArray.Find(func(index int, value *httpexpect.Value) bool {
-			return value.Object().Value("id").String().Raw() == "11111111-1111-1111-1111-111111111111"
-		})
-		originalScreening.Object().HasValue("id", "11111111-1111-1111-1111-111111111111")
-		originalScreening.Object().HasValue("status", "no_hit")
+		originalScreening := screeningsArray.Value(0).Object()
+		originalScreening.HasValue("id", "11111111-1111-1111-1111-111111111111")
+		originalScreening.HasValue("status", "no_hit")
 
 		// Find and validate the new screening (should have status "in_review")
-		newScreening := screeningsArray.Find(func(index int, value *httpexpect.Value) bool {
-			return value.Object().Value("id").String().Raw() == newScreeningId
-		})
-		newScreening.Object().HasValue("id", newScreeningId)
-		newScreening.Object().HasValue("status", "in_review")
+		newScreening := screeningsArray.Value(1).Object()
+		newScreening.HasValue("id", newScreeningId)
+		newScreening.HasValue("status", "in_review")
 
 		// Validate the new screening has the expected match
-		newScreeningMatches := newScreening.Object().Value("matches").Array()
+		newScreeningMatches := newScreening.Value("matches").Array()
 		newScreeningMatches.Length().IsEqual(1)
 
 		newScreeningMatch := newScreeningMatches.Value(0).Object().Path("$.payload").Object()

--- a/repositories/screening_repository.go
+++ b/repositories/screening_repository.go
@@ -99,7 +99,8 @@ func selectScreeningsWithMatches() squirrel.SelectBuilder {
 			strings.Join(columnsNames("scm", dbmodels.SelectScreeningMatchesColumn), ","))).
 		From(dbmodels.TABLE_SCREENINGS + " AS sc").
 		LeftJoin(dbmodels.TABLE_SCREENING_MATCHES + " AS scm ON sc.id = scm.sanction_check_id").
-		GroupBy("sc.id")
+		GroupBy("sc.id").
+		OrderBy("sc.created_at")
 }
 
 func (*MarbleDbRepository) ArchiveScreening(ctx context.Context, exec Executor, id string) error {


### PR DESCRIPTION
This pull request enhances the `screenings` test in `pubapi/tests/specs/v1/screening.go` to improve validation of the screening refine operation and its resulting data. Previously, the test relied on the order of screenings, assuming the last item was the new `sanction_check` after refinement.

I made two commits:
- The first fixes the test by retrieving the new screening ID after refinement and checking screening statuses based on their IDs.
- The second updates the database query to include an `ORDER BY created_at` clause, ensuring the screening list is always sorted by creation date, with the most recent item at the end. The test was adapted to verify this order.