### PR TITLE
Fixed memory leak caused by defer retaining writers.

### DIFF
--- a/usecases/scheduled_execution/offloading_job.go
+++ b/usecases/scheduled_execution/offloading_job.go
@@ -173,11 +173,14 @@ func (w OffloadingWorker) Work(ctx context.Context, job *river.Job[models.Offloa
 					if err != nil {
 						return err
 					}
-					defer wr.Close()
 
 					enc := json.NewEncoder(wr)
 
 					if err := enc.Encode(rule.RuleEvaluation); err != nil {
+						if err := wr.Close(); err != nil {
+							logger.Error(fmt.Sprintf("could not close writer after write failure: %s", err.Error()))
+						}
+
 						return err
 					}
 


### PR DESCRIPTION
We had a memory leak caused by using `defer` in a (lengthy) hot loop. The deferred function would hold a reference to the writer-to-be-closed and prevent the garbage collector from freeing the memory, leading to OOM.