### PR TITLE
Expose ingestion error in API.

### DIFF
--- a/dto/upload_log_dto.go
+++ b/dto/upload_log_dto.go
@@ -12,14 +12,21 @@ type UploadLogDto struct {
 	FinishedAt      *time.Time `json:"finished_at"`
 	LinesProcessed  int        `json:"lines_processed"`
 	NumRowsIngested int        `json:"num_rows_ingested"`
+	Error           string     `json:"error"`
 }
 
 func AdaptUploadLogDto(log models.UploadLog) UploadLogDto {
+	error := ""
+	if log.Error != nil {
+		error = *log.Error
+	}
+
 	return UploadLogDto{
 		Status:          string(log.UploadStatus),
 		StartedAt:       log.StartedAt,
 		FinishedAt:      log.FinishedAt,
 		LinesProcessed:  log.LinesProcessed,
 		NumRowsIngested: log.RowsIngested,
+		Error:           error,
 	}
 }

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -13,6 +13,7 @@ type UploadLog struct {
 	FinishedAt     *time.Time
 	LinesProcessed int
 	RowsIngested   int
+	Error          *string
 }
 
 type UploadStatus string
@@ -44,4 +45,5 @@ type UpdateUploadLogStatusInput struct {
 	CurrentUploadStatusCondition UploadStatus // for optimistic locking. Only rows matching this current status will be updated
 	FinishedAt                   *time.Time
 	NumRowsIngested              *int
+	Error                        *string
 }

--- a/repositories/dbmodels/db_upload_logs.go
+++ b/repositories/dbmodels/db_upload_logs.go
@@ -18,6 +18,7 @@ type DBUploadLog struct {
 	FinishedAt      *time.Time `db:"finished_at"`
 	LinesProcessed  int        `db:"lines_processed"`
 	NumRowsIngested int        `db:"num_rows_ingested"`
+	Error           *string    `db:"error"`
 }
 
 const TABLE_UPLOAD_LOGS = "upload_logs"
@@ -36,5 +37,6 @@ func AdaptUploadLog(db DBUploadLog) (models.UploadLog, error) {
 		FinishedAt:     db.FinishedAt,
 		LinesProcessed: db.LinesProcessed,
 		RowsIngested:   db.NumRowsIngested,
+		Error:          db.Error,
 	}, nil
 }

--- a/repositories/migrations/20250901140500_add_error_to_upload_log.sql
+++ b/repositories/migrations/20250901140500_add_error_to_upload_log.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+alter table upload_logs
+    add column error text null;
+
+-- +goose Down
+
+alter table upload_logs
+    drop column error;

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -75,6 +75,9 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(
 	if input.NumRowsIngested != nil {
 		updateRequest = updateRequest.Set("num_rows_ingested", *input.NumRowsIngested)
 	}
+	if input.Error != nil {
+		updateRequest = updateRequest.Set("error", *input.Error)
+	}
 
 	updateRequest = updateRequest.
 		Where("id = ?", input.Id).


### PR DESCRIPTION
This PR adds a new field in the UploadLog DTO, `error`, that contains the raw error that happened during ingestion so it could be displayed in the frontend (and be readable from the database).