### PR TITLE
add migration for created_at on decision_rules

### DIFF
--- a/repositories/migrations/20250903212000_created_at_on_dec_rules.sql
+++ b/repositories/migrations/20250903212000_created_at_on_dec_rules.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+alter table decision_rules
+add column created_at timestamp with time zone not null default now();
+
+-- +goose StatementEnd
+-- +goose Down
+-- +goose StatementBegin
+alter table decision_rules
+drop column created_at;
+
+-- +goose StatementEnd


### PR DESCRIPTION
It's a pain not to have this denormalized.
Won't be usable before we do a full rewrite of decision_rules (ouch).
But we might as well start writing them for new rows.