### PR TITLE
Support plain IP addresses for allowed network and audit trail

### DIFF
--- a/repositories/migrations/20250905153700_allowed_network_trail.sql
+++ b/repositories/migrations/20250905153700_allowed_network_trail.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+
+create or replace trigger audit
+after update of allowed_networks
+on organizations
+for each row execute function global_audit();
+
+-- +goose Down
+
+drop trigger if exists audit on organizations;


### PR DESCRIPTION
This adds two items to our allowed network feature:

 * Modification of the allowed networks will be logged into the audit trail.
 * Plain IP address (without a CIDR mask) are now allowed. They still need to be valid addresses for their family and will be suffixed with `/32` or `/128` depending on it.