### PR TITLE
feat(license): send deployment id with the license key

### DIFF
--- a/api/handle_license.go
+++ b/api/handle_license.go
@@ -89,9 +89,22 @@ func handleValidateLicense(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		licenseKey := c.Param("license_key")
+		deploymentId := c.Query("deployment_id")
+
+		// Should we check if the deployment is an UUID if provided?
+		// if deploymentId != "" {
+		// 	if _, err := uuid.Parse(deploymentId); err != nil {
+		// 		presentError(ctx, c, errors.Wrap(models.BadParameterError, "invalid deployment_id format"))
+		// 		return
+		// 	}
+		// }
 
 		usecase := uc.NewLicenseUsecase()
-		licenseValidation, err := usecase.ValidateLicense(ctx, strings.TrimPrefix(licenseKey, "/"))
+		licenseValidation, err := usecase.ValidateLicense(
+			ctx,
+			strings.TrimPrefix(licenseKey, "/"),
+			deploymentId,
+		)
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/handle_license.go
+++ b/api/handle_license.go
@@ -91,7 +91,7 @@ func handleValidateLicense(uc usecases.Usecases) func(c *gin.Context) {
 		licenseKey := c.Param("license_key")
 		deploymentId := c.Query("deployment_id")
 
-		// Should we check if the deployment is an UUID if provided?
+		// Should we check if the deployment is an UUID if provided and return an error if not?
 		// if deploymentId != "" {
 		// 	if _, err := uuid.Parse(deploymentId); err != nil {
 		// 		presentError(ctx, c, errors.Wrap(models.BadParameterError, "invalid deployment_id format"))

--- a/cmd/batch_ingestion.go
+++ b/cmd/batch_ingestion.go
@@ -60,7 +60,7 @@ func RunBatchIngestion(apiVersion string) error {
 
 	logger := utils.NewLogger(jobConfig.loggingFormat)
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
-	license := infra.VerifyLicense(licenseConfig)
+	license := infra.VerifyLicense(licenseConfig, "")
 
 	infra.SetupSentry(jobConfig.sentryDsn, jobConfig.env, apiVersion)
 	defer sentry.Flush(3 * time.Second)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+)
+
+func GetDeploymentMetadata(ctx context.Context, repositories repositories.Repositories) (models.Metadata, error) {
+	// Get deployment ID from Marble DB
+	executor, err := repositories.ExecutorGetter.GetExecutor(
+		ctx,
+		models.DATABASE_SCHEMA_TYPE_MARBLE,
+		nil,
+	)
+	if err != nil {
+		utils.LogAndReportSentryError(ctx, err)
+		return models.Metadata{}, errors.Wrap(err, "failed to get executor from Marble DB")
+	}
+	deploymentMetadata, err := repositories.MarbleDbRepository.GetMetadata(ctx, executor, nil, models.MetadataKeyDeploymentID)
+	if err != nil {
+		utils.LogAndReportSentryError(ctx, err)
+		return models.Metadata{}, errors.Wrap(err, "failed to get deployment ID from Marble DB")
+	}
+
+	// Expect the deployment ID to be set
+	if deploymentMetadata == nil {
+		return models.Metadata{}, errors.Wrap(models.NotFoundError, "deployment ID not found")
+	}
+
+	return *deploymentMetadata, nil
+}

--- a/cmd/scheduled_executor.go
+++ b/cmd/scheduled_executor.go
@@ -61,7 +61,7 @@ func RunScheduledExecuter(apiVersion string) error {
 
 	logger := utils.NewLogger(jobConfig.loggingFormat)
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
-	license := infra.VerifyLicense(licenseConfig)
+	license := infra.VerifyLicense(licenseConfig, "")
 
 	infra.SetupSentry(jobConfig.sentryDsn, jobConfig.env, apiVersion)
 	defer sentry.Flush(3 * time.Second)

--- a/cmd/send_pending_webhook_events.go
+++ b/cmd/send_pending_webhook_events.go
@@ -59,7 +59,7 @@ func RunSendPendingWebhookEvents(apiVersion string) error {
 
 	logger := utils.NewLogger(jobConfig.loggingFormat)
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
-	license := infra.VerifyLicense(licenseConfig)
+	license := infra.VerifyLicense(licenseConfig, "")
 
 	infra.SetupSentry(jobConfig.sentryDsn, jobConfig.env, apiVersion)
 	defer sentry.Flush(3 * time.Second)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -243,19 +243,7 @@ func RunServer(config CompiledConfig) error {
 	)
 
 	deps := api.InitDependencies(ctx, apiConfig, pool, marbleJwtSigningKey)
-
-	// Get deployment ID from Marble DB
-	executor, err := repositories.ExecutorGetter.GetExecutor(
-		ctx,
-		models.DATABASE_SCHEMA_TYPE_MARBLE,
-		nil,
-	)
-	if err != nil {
-		utils.LogAndReportSentryError(ctx, err)
-		return errors.Wrap(err, "failed to get executor from Marble DB")
-	}
-	deploymentMetadata, err := repositories.MarbleDbRepository.GetMetadata(ctx, executor, nil, models.MetadataKeyDeploymentID)
-	// Should never happen, new version of the app should have the deployment ID set
+	deploymentMetadata, err := GetDeploymentMetadata(ctx, repositories)
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)
 		return errors.Wrap(err, "failed to get deployment ID from Marble DB")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -261,7 +261,6 @@ func RunServer(config CompiledConfig) error {
 		return errors.Wrap(err, "failed to get deployment ID from Marble DB")
 	}
 	license := infra.VerifyLicense(licenseConfig, deploymentMetadata.Value)
-	// license := models.NewFullLicense()
 
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -187,18 +187,8 @@ func RunTaskQueue(apiVersion string) error {
 		repositories.WithTracerProvider(telemetryRessources.TracerProvider),
 		repositories.WithOpenSanctions(openSanctionsConfig),
 	)
-	// Get deployment ID from Marble DB
-	executor, err := repositories.ExecutorGetter.GetExecutor(
-		ctx,
-		models.DATABASE_SCHEMA_TYPE_MARBLE,
-		nil,
-	)
-	if err != nil {
-		utils.LogAndReportSentryError(ctx, err)
-		return errors.Wrap(err, "failed to get executor from Marble DB")
-	}
-	deploymentMetadata, err := repositories.MarbleDbRepository.GetMetadata(ctx, executor, nil, models.MetadataKeyDeploymentID)
-	// Should never happen, new version of the app should have the deployment ID set
+
+	deploymentMetadata, err := GetDeploymentMetadata(ctx, repositories)
 	if err != nil {
 		utils.LogAndReportSentryError(ctx, err)
 		return errors.Wrap(err, "failed to get deployment ID from Marble DB")

--- a/usecases/license_usecase.go
+++ b/usecases/license_usecase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/metrics_collection"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
@@ -182,7 +183,13 @@ func (usecase *PublicLicenseUseCase) ValidateLicense(ctx context.Context, licens
 				LicenseKey:   &license.Key,
 				LicenseName:  &license.OrganizationName,
 				Metrics: []models.MetricData{
-					models.NewGlobalMetric("check_license", utils.Ptr(float64(1)), nil, time.Now(), time.Now()),
+					models.NewGlobalMetric(
+						metrics_collection.CheckLicenseMetricName,
+						utils.Ptr(float64(1)),
+						nil,
+						time.Now(),
+						time.Now(),
+					),
 				},
 			})
 			if err != nil {

--- a/usecases/metrics_collection/constant.go
+++ b/usecases/metrics_collection/constant.go
@@ -6,4 +6,5 @@ const (
 	CaseCountMetricName         = "cases.count"
 	DecisionCountMetricName     = "decisions.count"
 	ScreeningCountMetricName    = "screenings.count"
+	CheckLicenseMetricName      = "check_license.count"
 )

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -377,6 +377,7 @@ func (usecase *Usecases) NewScenarioFetcher() scenarios.ScenarioFetcher {
 func (usecases *Usecases) NewLicenseUsecase() PublicLicenseUseCase {
 	return NewPublicLicenseUsecase(
 		usecases.NewExecutorFactory(),
+		usecases.Repositories.MetricsIngestionRepository,
 		&usecases.Repositories.MarbleDbRepository,
 		usecases.license,
 	)


### PR DESCRIPTION
This pull request improves license validation by having the server and worker fetch the deployment ID and send it to the Marble SaaS for license checking. If the license is valid, Marble SaaS records a new metric. License verification now occurs at server and worker startup, immediately after repository initialization.