### PR TITLE
fix license server: some features were not returned

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -44,9 +44,9 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	r.GET("/config", tom, handleGetConfig(uc, conf))
 	r.GET("/is-sso-available", tom, handleIsSSOEnabled(uc))
 	r.GET("/signup-status", tom, handleSignupStatus(uc))
+	r.GET("/validate-license/*license_key", tom, handleValidateLicense(uc))
 
 	if infra.IsMarbleSaasProject() {
-		r.GET("/validate-license/*license_key", tom, handleValidateLicense(uc))
 		r.POST("/metrics", tom, handleMetricsIngestion(uc))
 	}
 

--- a/repositories/dbmodels/db_license.go
+++ b/repositories/dbmodels/db_license.go
@@ -26,6 +26,7 @@ type DBLicense struct {
 	RuleSnoozes          bool               `db:"rule_snoozes"`
 	TestRun              bool               `db:"test_run"`
 	Sanctions            bool               `db:"sanctions"`
+	AutoAssignment       bool               `db:"auto_assignment"`
 }
 
 const TABLE_LICENSES = "licenses"
@@ -51,6 +52,7 @@ func AdaptLicense(db DBLicense) (models.License, error) {
 			RuleSnoozes:    db.RuleSnoozes,
 			TestRun:        db.TestRun,
 			Sanctions:      db.Sanctions,
+			CaseAutoAssign: db.AutoAssignment,
 		},
 	}, nil
 }

--- a/repositories/license_repository.go
+++ b/repositories/license_repository.go
@@ -66,7 +66,6 @@ func (repo *MarbleDbRepository) CreateLicense(ctx context.Context, exec Executor
 			Columns(
 				"id",
 				"key",
-				"created_at",
 				"expiration_date",
 				"name",
 				"description",
@@ -78,11 +77,12 @@ func (repo *MarbleDbRepository) CreateLicense(ctx context.Context, exec Executor
 				"webhooks",
 				"rule_snoozes",
 				"test_run",
+				"sanctions",
+				"auto_assignment",
 			).
 			Values(
 				license.Id,
 				license.Key,
-				license.CreatedAt,
 				license.ExpirationDate,
 				license.OrganizationName,
 				license.Description,
@@ -94,6 +94,8 @@ func (repo *MarbleDbRepository) CreateLicense(ctx context.Context, exec Executor
 				license.LicenseEntitlements.Webhooks,
 				license.LicenseEntitlements.RuleSnoozes,
 				license.LicenseEntitlements.TestRun,
+				license.LicenseEntitlements.Sanctions,
+				license.LicenseEntitlements.CaseAutoAssign,
 			),
 	)
 	return err
@@ -132,6 +134,8 @@ func (repo *MarbleDbRepository) UpdateLicense(ctx context.Context, exec Executor
 		query = query.Set("webhooks", licenseEntitlements.Webhooks)
 		query = query.Set("rule_snoozes", licenseEntitlements.RuleSnoozes)
 		query = query.Set("test_run", licenseEntitlements.TestRun)
+		query = query.Set("sanctions", licenseEntitlements.Sanctions)
+		query = query.Set("auto_assignment", licenseEntitlements.CaseAutoAssign)
 	}
 
 	err := ExecBuilder(


### PR DESCRIPTION
The license server was not returning the auto_assign feature access (rather, it was not being properly read from the DB, so that the API would always return "false" by default).
Also, the license server API did not properly take into account some input, which was less problematic because we are not really using the API for that (I'm creating licenses directly in db)