### PR TITLE
feat(ai_setting): add custom instructions field to KYC enrichment settings

### DIFF
--- a/dto/ai_setting_dto.go
+++ b/dto/ai_setting_dto.go
@@ -6,10 +6,11 @@ import (
 )
 
 type KYCEnrichmentSettingDto struct {
-	Model             *string                             `json:"model"`
-	DomainFilter      []string                            `json:"domain_filter"`
-	SearchContextSize *models.PerplexitySearchContextSize `json:"search_context_size"`
-	Enabled           bool                                `json:"enabled"`
+	Model              *string                             `json:"model"`
+	DomainFilter       []string                            `json:"domain_filter"`
+	SearchContextSize  *models.PerplexitySearchContextSize `json:"search_context_size"`
+	CustomInstructions *string                             `json:"custom_instructions"`
+	Enabled            bool                                `json:"enabled"`
 }
 
 func (dto KYCEnrichmentSettingDto) Validate() error {
@@ -18,19 +19,21 @@ func (dto KYCEnrichmentSettingDto) Validate() error {
 
 func AdaptKYCEnrichmentSettingDto(setting models.KYCEnrichmentSetting) KYCEnrichmentSettingDto {
 	return KYCEnrichmentSettingDto{
-		Model:             setting.Model,
-		DomainFilter:      setting.DomainFilter,
-		SearchContextSize: setting.SearchContextSize,
-		Enabled:           setting.Enabled,
+		Model:              setting.Model,
+		DomainFilter:       setting.DomainFilter,
+		SearchContextSize:  setting.SearchContextSize,
+		CustomInstructions: setting.CustomInstructions,
+		Enabled:            setting.Enabled,
 	}
 }
 
 func AdaptKYCEnrichmentSetting(setting KYCEnrichmentSettingDto) models.KYCEnrichmentSetting {
 	return models.KYCEnrichmentSetting{
-		Model:             setting.Model,
-		DomainFilter:      setting.DomainFilter,
-		SearchContextSize: setting.SearchContextSize,
-		Enabled:           setting.Enabled,
+		Model:              setting.Model,
+		DomainFilter:       setting.DomainFilter,
+		SearchContextSize:  setting.SearchContextSize,
+		CustomInstructions: setting.CustomInstructions,
+		Enabled:            setting.Enabled,
 	}
 }
 

--- a/models/ai_setting.go
+++ b/models/ai_setting.go
@@ -33,9 +33,10 @@ type AiSettingEntity interface {
 
 // Json tag for json serialization into JSONB column
 type KYCEnrichmentSetting struct {
-	Model             *string                      `json:"model"`
-	DomainFilter      []string                     `json:"domain_filter"`
-	SearchContextSize *PerplexitySearchContextSize `json:"search_context_size"`
+	Model              *string                      `json:"model"`
+	DomainFilter       []string                     `json:"domain_filter"`
+	SearchContextSize  *PerplexitySearchContextSize `json:"search_context_size"`
+	CustomInstructions *string                      `json:"custom_instructions"`
 
 	// Opt-in, the user should explicitly enable it
 	Enabled bool `json:"enabled"`

--- a/repositories/dbmodels/db_ai_setting.go
+++ b/repositories/dbmodels/db_ai_setting.go
@@ -9,6 +9,9 @@ import (
 	"github.com/google/uuid"
 )
 
+// DBAiSetting is the database model for the AI setting
+// For a given organization, there can be multiple settings for different AI usecases
+// Value of each usecase setting is stored in the Value field as a JSONB column, need to parse it to the correct type
 type DBAiSetting struct {
 	Id        uuid.UUID      `db:"id"`
 	OrgId     string         `db:"org_id"`
@@ -81,6 +84,10 @@ func adaptKYCEnrichmentFromJSONB(value map[string]any) (models.KYCEnrichmentSett
 	if searchContextStr, ok := value["search_context_size"].(string); ok && searchContextStr != "" {
 		searchContext := models.PerplexitySearchContextSizeFromString(searchContextStr)
 		setting.SearchContextSize = &searchContext
+	}
+
+	if customInstructions, ok := value["custom_instructions"].(string); ok && customInstructions != "" {
+		setting.CustomInstructions = &customInstructions
 	}
 
 	if enabled, ok := value["enabled"].(bool); ok {

--- a/usecases/ai_agent/ai_enrichment.go
+++ b/usecases/ai_agent/ai_enrichment.go
@@ -131,7 +131,8 @@ func (uc *AiAgentUsecase) enrichData(
 			"failed to convert language to english")
 	}
 	instruction, err := preparePrompt(INSTRUCTION_PATH, map[string]any{
-		"language": language,
+		"language":            language,
+		"custom_instructions": aiSetting.KYCEnrichmentSetting.CustomInstructions,
 	})
 	if err != nil {
 		return models.AiEnrichmentKYC{}, errors.Wrap(err, "failed to read instruction")


### PR DESCRIPTION
This pull request introduces support for custom instructions in the KYC enrichment AI settings. The changes ensure that custom instructions can be stored, retrieved, and used throughout the data flow, from database models to DTOs and business logic.

### Support for custom instructions in KYC enrichment settings

* Added a `CustomInstructions` field to the `KYCEnrichmentSetting` model (`models/ai_setting.go`) and the corresponding DTO (`dto/ai_setting_dto.go`). [[1]](diffhunk://#diff-393f376dcf3a108ae5967212c39da396ef41ffa7256531248c94ecba2ef0d946R39) [[2]](diffhunk://#diff-d8485b7e6b8f10374364bec2623294f7f1574b679eacbcc2842d54a0a68e51ebR12)
* Updated the adaptation functions to include the new `CustomInstructions` field when converting between models and DTOs (`dto/ai_setting_dto.go`). [[1]](diffhunk://#diff-d8485b7e6b8f10374364bec2623294f7f1574b679eacbcc2842d54a0a68e51ebR25) [[2]](diffhunk://#diff-d8485b7e6b8f10374364bec2623294f7f1574b679eacbcc2842d54a0a68e51ebR35)

### Database model and parsing enhancements

* Improved parsing logic in `adaptKYCEnrichmentFromJSONB` to extract and assign the `custom_instructions` value from the JSONB column, ensuring it is properly set in the model (`repositories/dbmodels/db_ai_setting.go`).
* Added clarifying comments to the `DBAiSetting` struct to explain its purpose and usage for different AI use cases (`repositories/dbmodels/db_ai_setting.go`).

### Business logic integration

* Updated the enrichment process to pass the `CustomInstructions` from the AI setting into the prompt preparation step, enabling the use of custom instructions in AI agent operations (`usecases/ai_agent/ai_enrichment.go`).