### PR TITLE
Offloading: concurrent GCS upload to improve performance.

### DIFF
--- a/repositories/blob_repository.go
+++ b/repositories/blob_repository.go
@@ -65,10 +65,10 @@ func (repository *blobRepository) openBlobBucket(ctx context.Context, bucketUrl 
 	)
 	defer span.End()
 
-	if repository.buckets[bucketUrl] == nil {
-		repository.m.Lock()
-		defer repository.m.Unlock()
+	repository.m.Lock()
+	defer repository.m.Unlock()
 
+	if repository.buckets[bucketUrl] == nil {
 		var bucket *blob.Bucket
 		// adapt bucket url with additional values from env variables in the GCS case
 		url, err := url.Parse(bucketUrl)

--- a/usecases/task_queue.go
+++ b/usecases/task_queue.go
@@ -3,6 +3,7 @@ package usecases
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"sync"
 	"time"
@@ -178,7 +179,10 @@ func QueuesFromOrgs(ctx context.Context, appName string, orgsRepo repositories.O
 		}...)
 
 		if offloadingConfig.Enabled {
-			periodics = append(periodics, scheduled_execution.NewOffloadingPeriodicJob(org.Id, offloadingConfig.JobInterval))
+			// Undocumented debug setting to only enable offloading for a specific organization
+			if onlyOffloadOrg := os.Getenv("OFFLOADING_ONLY_ORG"); onlyOffloadOrg == "" || onlyOffloadOrg == org.Id {
+				periodics = append(periodics, scheduled_execution.NewOffloadingPeriodicJob(org.Id, offloadingConfig.JobInterval))
+			}
 		}
 
 		queues[org.Id] = river.QueueConfig{


### PR DESCRIPTION
We have seen poor performance in the initial version of the offloading job when writing to GCS serially. This PR batches decision rules to offload into batches and write each of those concurrently up to the save point size.