### PR TITLE
Add CLI arguments to run one-off jobs with arguments.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,46 @@
         "--worker"
       ],
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Launch single worker job (.env)",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/.",
+      "envFile": "${workspaceFolder}/.env",
+      "args": [
+        "--worker",
+        "--worker-only=${input:jobName}",
+        "--worker-args=${input:jobArgs}",
+      ],
+      "console": "integratedTerminal"
     }
+  ],
+  "inputs": [
+    {
+      "id": "jobArgs",
+      "description": "Job arguments",
+      "type": "promptString",
+      "default": "{\"org_id\": \"\"}",
+    },
+    {
+      "id": "jobName",
+      "description": "Job to run",
+      "type": "pickString",
+      "options": [
+        "async_decision",
+        "scheduled_exec_status",
+        "auto_assignment",
+        "index_cleanup",
+        "index_creation",
+        "index_creation_status",
+        "index_deletion",
+        "match_enrichment",
+        "offloading",
+        "test_run_summary",
+        "case_review"
+      ]
+    },
   ]
 }

--- a/jobs/middlewares.go
+++ b/jobs/middlewares.go
@@ -31,6 +31,8 @@ type LoggerMiddleware struct {
 	errorCountLock *sync.Mutex
 }
 
+func (m LoggerMiddleware) IsMiddleware() bool { return true }
+
 func (m LoggerMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
 	logger := m.l.With(
 		"job_id", job.ID,
@@ -88,6 +90,8 @@ func NewLoggerMiddleware(l *slog.Logger) LoggerMiddleware {
 
 type RecovererMiddleware struct{}
 
+func (m RecovererMiddleware) IsMiddleware() bool { return true }
+
 func (m RecovererMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) (err error) {
 	defer utils.RecoverAndReportSentryError(ctx, "RecovererMiddleware.Work")
 	return doInner(ctx)
@@ -102,6 +106,8 @@ func NewRecoveredMiddleware() RecovererMiddleware {
 type TracingMiddleware struct {
 	tracer trace.Tracer
 }
+
+func (m TracingMiddleware) IsMiddleware() bool { return true }
 
 func (m TracingMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
 	ctx, span := m.tracer.Start(
@@ -129,6 +135,8 @@ func NewTracingMiddleware(tracer trace.Tracer) TracingMiddleware {
 // Sentry middleware
 
 type SentryMiddleware struct{}
+
+func (m SentryMiddleware) IsMiddleware() bool { return true }
 
 func (m SentryMiddleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
 	hub := sentry.GetHubFromContext(ctx)


### PR DESCRIPTION
This PR adds a way for developers to run one-off jobs from the worker, without running the whole river setup. This is helpful to prevent other jobs from cluttering the output while iterating, or having to comment them out, deleting entries from `river_job` to have job rerun or temporarily changing the interval.

```shell
$ go run . -worker -worker-only index_deletion -worker-args '{"org_id":"2ff0718a-5c00-42eb-bf93-b98c882ca746"}'
```

Note that right now, we won't get the full job behavior as we would through river. Notably, there is no timeout enforcement. While we might add that (and maybe we will), this is enough for a first draft.