### PR TITLE
fix: missing rule evaluations cause errors if offloading is not enabled on server

### DIFF
--- a/usecases/offloaded_reader.go
+++ b/usecases/offloaded_reader.go
@@ -29,7 +29,9 @@ type OffloadedReader struct {
 	offloadingBucketUrl string
 }
 
-func (uc OffloadedReader) MutateWithOffloadedDecisionRules(ctx context.Context, orgId string,
+func (uc OffloadedReader) MutateWithOffloadedDecisionRules(
+	ctx context.Context,
+	orgId string,
 	decision models.DecisionWithRuleExecutions,
 ) error {
 	offloadingWatermark, err := uc.repository.GetWatermark(ctx,
@@ -42,6 +44,9 @@ func (uc OffloadedReader) MutateWithOffloadedDecisionRules(ctx context.Context, 
 		return nil
 	}
 	if decision.CreatedAt.After(offloadingWatermark.WatermarkTime) {
+		return nil
+	}
+	if uc.offloadingBucketUrl == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Error seen in Creacard instance: if some decision rules have a missing rule evaluation, this causes an error if offloading bucket url is empty on the server: `Unexpected Error: failed to open bucket : open blob.Bucket: no scheme in URL ""`