### PR TITLE
feat: add DecisionWorkflowsWorker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,7 @@
       "args": [
         "--worker",
         "--worker-only=${input:jobName}",
-        "--worker-args=${input:jobArgs}",
+        "--worker-args=${input:jobArgs}"
       ],
       "console": "integratedTerminal"
     }
@@ -49,7 +49,7 @@
       "id": "jobArgs",
       "description": "Job arguments",
       "type": "promptString",
-      "default": "{\"org_id\": \"\"}",
+      "default": "{\"org_id\": \"\"}"
     },
     {
       "id": "jobName",
@@ -68,6 +68,6 @@
         "test_run_summary",
         "case_review"
       ]
-    },
+    }
   ]
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -276,6 +276,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	river.AddWorker(workers, adminUc.NewMatchEnrichmentWorker())
 	river.AddWorker(workers, adminUc.NewCaseReviewWorker(workerConfig.caseReviewTimeout))
 	river.AddWorker(workers, adminUc.NewAutoAssignmentWorker())
+	river.AddWorker(workers, adminUc.NewDecisionWorkflowsWorker())
 
 	if offloadingConfig.Enabled {
 		river.AddWorker(workers, adminUc.NewOffloadingWorker())
@@ -443,6 +444,9 @@ func singleJobRun(ctx context.Context, uc usecases.UsecasesWithCreds, jobName, j
 	case "case_review":
 		return uc.NewCaseReviewWorker(time.Hour).Work(ctx,
 			singleJobCreate[models.CaseReviewArgs](ctx, jobArgs))
+	case "decision_workflows":
+		return uc.NewDecisionWorkflowsWorker().Work(ctx,
+			singleJobCreate[models.DecisionWorkflowArgs](ctx, jobArgs))
 	default:
 		return errors.Newf("unknown job %s", jobName)
 	}

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -116,7 +116,8 @@ func TestMain(m *testing.M) {
 	}
 
 	// Need to declare this after the migrations, to have the correct search path
-	dbPool, err := infra.NewPostgresConnectionPool(ctx, "marble-test", pgConfig.GetConnectionString(), nil, pgConfig.MaxPoolConnections)
+	dbPool, err := infra.NewPostgresConnectionPool(ctx, "marble-test",
+		pgConfig.GetConnectionString(), nil, pgConfig.MaxPoolConnections)
 	if err != nil {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}
@@ -167,6 +168,7 @@ func TestMain(m *testing.M) {
 	river.AddWorker(workers, adminUc.NewIndexCreationWorker())
 	river.AddWorker(workers, adminUc.NewIndexCreationStatusWorker())
 	river.AddWorker(workers, adminUc.NewCaseReviewWorker(10*time.Second))
+	river.AddWorker(workers, adminUc.NewDecisionWorkflowsWorker())
 
 	if err := riverClient.Start(ctx); err != nil {
 		log.Fatalln("Could not start river client:", err)

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -496,6 +496,9 @@ func createDecisions(
 	assert.Equal(t, models.Decline, declineDecision.Outcome,
 		"Expected decision to be Decline, got %s", declineDecision.Outcome)
 
+	// Let river process the scenario workflow after the decision creation
+	time.Sleep(1 * time.Second)
+
 	// Create a second decision with the same account_id to check their cases [Decline]
 	declineDecision2 := createAndTestDecision(ctx, t, transactionPayloadJson, table, decisionUsecase,
 		organizationId, scenarioId, 111)

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -502,10 +502,18 @@ func createDecisions(
 	assert.Equal(t, models.Decline, declineDecision2.Outcome,
 		"Expected decision to be Decline, got %s", declineDecision2.Outcome)
 
+	// Let river process the scenario workflow after the decision creation
+	time.Sleep(1 * time.Second)
+
+	declineDecision_after, err := decisionUsecase.GetDecision(ctx, declineDecision.DecisionId.String())
+	assert.NoError(t, err)
+	declineDecision2_after, err := decisionUsecase.GetDecision(ctx, declineDecision2.DecisionId.String())
+	assert.NoError(t, err)
+
 	// Check that the two decisions on tx with account_id "{account_id_decline}" are both in a case - the same
-	assert.NotNil(t, declineDecision.Case, "Decision is in a case")
-	assert.NotNil(t, declineDecision2.Case, "Decision is in a case")
-	assert.Equal(t, declineDecision.Case.Id, declineDecision2.Case.Id,
+	assert.NotNil(t, declineDecision_after.Case, "Decision is in a case")
+	assert.NotNil(t, declineDecision2_after.Case, "Decision is in a case")
+	assert.Equal(t, declineDecision_after.Case.Id, declineDecision2_after.Case.Id,
 		"The two decisions are in the same case")
 
 	// Create a decision [APPROVE]
@@ -597,7 +605,7 @@ func createDecisions(
 	}
 	// Now snooze the rules and rerun the decision in Decline status
 	ruleSnoozeUsecase := usecasesWithUserCreds.NewRuleSnoozeUsecase()
-	_, err := ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
+	_, err = ruleSnoozeUsecase.SnoozeDecision(ctx, models.SnoozeDecisionInput{
 		Comment:        "this is a test snooze",
 		DecisionId:     declineDecision.DecisionId.String(),
 		Duration:       "500ms", // snooze for 0.5 sec, after this wait for the snooze to end before moving on

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -82,3 +82,12 @@ func (m *TaskQueueRepository) EnqueueAutoAssignmentTask(
 ) error {
 	return m.Called(ctx, tx, orgId, inboxId).Error(0)
 }
+
+func (m *TaskQueueRepository) EnqueueDecisionWorkflowTask(
+	ctx context.Context,
+	tx repositories.Transaction,
+	organizationId string,
+	decisionId string,
+) error {
+	return m.Called(ctx, tx, organizationId, decisionId).Error(0)
+}

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -78,7 +78,8 @@ func (m *TaskQueueRepository) EnqueueCaseReviewTask(
 func (m *TaskQueueRepository) EnqueueAutoAssignmentTask(
 	ctx context.Context,
 	tx repositories.Transaction,
-	orgId string, inboxId uuid.UUID,
+	orgId string,
+	inboxId uuid.UUID,
 ) error {
 	return m.Called(ctx, tx, orgId, inboxId).Error(0)
 }
@@ -86,8 +87,8 @@ func (m *TaskQueueRepository) EnqueueAutoAssignmentTask(
 func (m *TaskQueueRepository) EnqueueDecisionWorkflowTask(
 	ctx context.Context,
 	tx repositories.Transaction,
-	organizationId string,
+	orgId string,
 	decisionId string,
 ) error {
-	return m.Called(ctx, tx, organizationId, decisionId).Error(0)
+	return m.Called(ctx, tx, orgId, decisionId).Error(0)
 }

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -84,11 +84,7 @@ type AutoAssignmentArgs struct {
 func (AutoAssignmentArgs) Kind() string { return "auto_assignment" }
 
 type DecisionWorkflowArgs struct {
-	DecisionId         string `json:"decision_id"`
-	ScenarioId         string `json:"scenario_id"`
-	ObjectId           string `json:"object_id"`
-	TriggerObjectTable string `json:"trigger_object_table"`
-	OrganizationId     string `json:"organization_id"`
+	DecisionId string `json:"decision_id"`
 }
 
 func (DecisionWorkflowArgs) Kind() string { return "decision_workflow" }

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -82,3 +82,13 @@ type AutoAssignmentArgs struct {
 }
 
 func (AutoAssignmentArgs) Kind() string { return "auto_assignment" }
+
+type DecisionWorkflowArgs struct {
+	DecisionId         string `json:"decision_id"`
+	ScenarioId         string `json:"scenario_id"`
+	ObjectId           string `json:"object_id"`
+	TriggerObjectTable string `json:"trigger_object_table"`
+	OrganizationId     string `json:"organization_id"`
+}
+
+func (DecisionWorkflowArgs) Kind() string { return "decision_workflow" }

--- a/repositories/dbmodels/db_decision_rule.go
+++ b/repositories/dbmodels/db_decision_rule.go
@@ -19,6 +19,7 @@ type DbDecisionRule struct {
 	RuleId         string             `db:"rule_id"`
 	RuleEvaluation []byte             `db:"rule_evaluation"`
 	Outcome        string             `db:"outcome"`
+	StableRuleId   string             `db:"stable_rule_id"`
 }
 
 const TABLE_DECISION_RULES = "decision_rules"
@@ -47,9 +48,10 @@ func AdaptRuleExecution(db DbDecisionRule) (models.RuleExecution, error) {
 		Result:              db.Result,
 		ResultScoreModifier: db.ScoreModifier,
 		Rule: models.Rule{
-			Id:          db.RuleId,
-			Name:        db.Name,
-			Description: db.Description,
+			Id:           db.RuleId,
+			Name:         db.Name,
+			Description:  db.Description,
+			StableRuleId: db.StableRuleId,
 		},
 	}, nil
 }

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -624,7 +624,7 @@ func (repo *MarbleDbRepository) rulesOfDecisions(
 		return nil, err
 	}
 
-	columns := "d.id, d.org_id, d.decision_id, r.name, r.description, d.score_modifier, d.result, d.error_code, d.rule_id, d.outcome"
+	columns := "d.id, d.org_id, d.decision_id, r.name, r.description, d.score_modifier, d.result, d.error_code, d.rule_id, d.outcome, r.stable_rule_id"
 	if withEvaluation {
 		columns += ", d.rule_evaluation"
 	}
@@ -650,6 +650,7 @@ func (repo *MarbleDbRepository) rulesOfDecisions(
 				&r.ErrorCode,
 				&r.RuleId,
 				&r.Outcome,
+				&r.StableRuleId,
 			}
 			if withEvaluation {
 				fields = append(fields, &r.RuleEvaluation)

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -62,16 +62,14 @@ type TaskQueueRepository interface {
 	EnqueueAutoAssignmentTask(
 		ctx context.Context,
 		tx Transaction,
-		orgId string, inboxId uuid.UUID,
+		orgId string,
+		inboxId uuid.UUID,
 	) error
 	EnqueueDecisionWorkflowTask(
 		ctx context.Context,
 		tx Transaction,
-		organizationId string,
+		orgId string,
 		decisionId string,
-		scenarioId string,
-		objectId string,
-		triggerObjectTable string,
 	) error
 }
 
@@ -254,7 +252,8 @@ func (r riverRepository) EnqueueCaseReviewTask(
 func (r riverRepository) EnqueueAutoAssignmentTask(
 	ctx context.Context,
 	tx Transaction,
-	orgId string, inboxId uuid.UUID,
+	orgId string,
+	inboxId uuid.UUID,
 ) error {
 	res, err := r.client.InsertTx(
 		ctx,
@@ -284,24 +283,17 @@ func (r riverRepository) EnqueueAutoAssignmentTask(
 func (r riverRepository) EnqueueDecisionWorkflowTask(
 	ctx context.Context,
 	tx Transaction,
-	organizationId string,
+	orgId string,
 	decisionId string,
-	scenarioId string,
-	objectId string,
-	triggerObjectTable string,
 ) error {
 	res, err := r.client.InsertTx(
 		ctx,
 		tx.RawTx(),
 		models.DecisionWorkflowArgs{
-			DecisionId:         decisionId,
-			ScenarioId:         scenarioId,
-			ObjectId:           objectId,
-			TriggerObjectTable: triggerObjectTable,
-			OrganizationId:     organizationId,
+			DecisionId: decisionId,
 		},
 		&river.InsertOpts{
-			Queue: organizationId,
+			Queue: orgId,
 		},
 	)
 	if err != nil {

--- a/usecases/decision_workflows/worker.go
+++ b/usecases/decision_workflows/worker.go
@@ -85,7 +85,6 @@ func NewDecisionWorkflowsWorker(
 }
 
 func (w *DecisionWorkflowsWorker) Timeout(job *river.Job[models.DecisionWorkflowArgs]) time.Duration {
-	// TODO: Need to change?
 	return 10 * time.Second
 }
 
@@ -125,7 +124,7 @@ func (w *DecisionWorkflowsWorker) Work(ctx context.Context, job *river.Job[model
 		return errors.Wrap(err, "error getting workflows for scenario")
 	}
 
-	// Create transaction just for ProcessDecisionWorkflows because all function in there expect a transaction
+	// Create transaction just for ProcessDecisionWorkflows because all functions in there expect a transaction
 	workflowExecutions, err := executor_factory.TransactionReturnValue(ctx, w.transactionFactory, func(
 		tx repositories.Transaction,
 	) (models.WorkflowExecution, error) {

--- a/usecases/decision_workflows/worker.go
+++ b/usecases/decision_workflows/worker.go
@@ -119,7 +119,11 @@ func (w *DecisionWorkflowsWorker) Work(ctx context.Context, job *river.Job[model
 		DataModel:    dataModel,
 	}
 
-	workflowRules, err := w.decisionWorkflowsWorkerRepository.ListWorkflowsForScenario(ctx, exec, uuid.MustParse(scenario.Id))
+	scenarioUUID, err := uuid.Parse(scenario.Id)
+	if err != nil {
+		return errors.Wrap(err, "invalid scenario ID: not a valid UUID")
+	}
+	workflowRules, err := w.decisionWorkflowsWorkerRepository.ListWorkflowsForScenario(ctx, exec, scenarioUUID)
 	if err != nil {
 		return errors.Wrap(err, "error getting workflows for scenario")
 	}

--- a/usecases/decision_workflows/worker.go
+++ b/usecases/decision_workflows/worker.go
@@ -1,0 +1,153 @@
+package decision_workflows
+
+import (
+	"context"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/evaluate_scenario"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/riverqueue/river"
+)
+
+type decisionWorkflowsUsecase interface {
+	ProcessDecisionWorkflows(
+		ctx context.Context,
+		tx repositories.Transaction,
+		rules []models.Workflow,
+		scenario models.Scenario,
+		decision models.DecisionWithRuleExecutions,
+		evalParams evaluate_scenario.ScenarioEvaluationParameters,
+	) (models.WorkflowExecution, error)
+}
+
+type webhookEventsUsecase interface {
+	SendWebhookEventAsync(ctx context.Context, webhookEventId string)
+}
+
+type decisionWorkflowsWorkerRepository interface {
+	DecisionWithRuleExecutionsById(
+		ctx context.Context,
+		exec repositories.Executor,
+		decisionId string,
+	) (models.DecisionWithRuleExecutions, error)
+	GetScenarioById(ctx context.Context, exec repositories.Executor, scenarioId string) (models.Scenario, error)
+	ListWorkflowsForScenario(ctx context.Context, exec repositories.Executor, scenarioId uuid.UUID) ([]models.Workflow, error)
+}
+
+type dataModelRepository interface {
+	GetDataModel(ctx context.Context, exec repositories.Executor, organizationID string,
+		fetchEnumValues bool, useCache bool) (models.DataModel, error)
+}
+
+type ingestedDataReadRepository interface {
+	QueryIngestedObject(
+		ctx context.Context,
+		exec repositories.Executor,
+		table models.Table,
+		objectId string,
+	) ([]models.DataModelObject, error)
+}
+
+type DecisionWorkflowsWorker struct {
+	river.WorkerDefaults[models.DecisionWorkflowArgs]
+
+	executorFactory                   executor_factory.ExecutorFactory
+	transactionFactory                executor_factory.TransactionFactory
+	decisionWorkflowsUsecase          decisionWorkflowsUsecase
+	dataModelRepository               dataModelRepository
+	ingestedDataReadRepository        ingestedDataReadRepository
+	decisionWorkflowsWorkerRepository decisionWorkflowsWorkerRepository
+	webhookEventsUsecase              webhookEventsUsecase
+}
+
+func NewDecisionWorkflowsWorker(
+	executorFactory executor_factory.ExecutorFactory,
+	transactionFactory executor_factory.TransactionFactory,
+	decisionWorkflowsUsecase decisionWorkflowsUsecase,
+	dataModelRepository dataModelRepository,
+	ingestedDataReadRepository ingestedDataReadRepository,
+	decisionWorkflowsWorkerRepository decisionWorkflowsWorkerRepository,
+	webhookEventsUsecase webhookEventsUsecase,
+) *DecisionWorkflowsWorker {
+	return &DecisionWorkflowsWorker{
+		executorFactory:                   executorFactory,
+		transactionFactory:                transactionFactory,
+		decisionWorkflowsUsecase:          decisionWorkflowsUsecase,
+		dataModelRepository:               dataModelRepository,
+		ingestedDataReadRepository:        ingestedDataReadRepository,
+		decisionWorkflowsWorkerRepository: decisionWorkflowsWorkerRepository,
+		webhookEventsUsecase:              webhookEventsUsecase,
+	}
+}
+
+func (w *DecisionWorkflowsWorker) Timeout(job *river.Job[models.DecisionWorkflowArgs]) time.Duration {
+	// TODO: Need to change?
+	return 10 * time.Second
+}
+
+func (w *DecisionWorkflowsWorker) Work(ctx context.Context, job *river.Job[models.DecisionWorkflowArgs]) error {
+	exec := w.executorFactory.NewExecutor()
+	// Build data for decision workflows
+	decision, err := w.decisionWorkflowsWorkerRepository.DecisionWithRuleExecutionsById(ctx, exec, job.Args.DecisionId)
+	if err != nil {
+		return errors.Wrap(err, "error getting decision with rule executions")
+	}
+	scenario, err := w.decisionWorkflowsWorkerRepository.GetScenarioById(ctx, exec, job.Args.ScenarioId)
+	if err != nil {
+		return errors.Wrap(err, "error getting scenario")
+	}
+	dataModel, err := w.dataModelRepository.GetDataModel(ctx, exec, job.Args.OrganizationId, true, true)
+	if err != nil {
+		return errors.Wrap(err, "error getting data model")
+	}
+
+	table := dataModel.Tables[job.Args.TriggerObjectTable]
+	objectMap, err := w.ingestedDataReadRepository.QueryIngestedObject(ctx, exec, table, job.Args.ObjectId)
+	if err != nil {
+		return errors.Wrap(err, "error getting ingested object")
+	}
+	clientObject := models.ClientObject{TableName: table.Name, Data: objectMap[0].Data}
+
+	evalParams := evaluate_scenario.ScenarioEvaluationParameters{
+		Scenario:     scenario,
+		ClientObject: clientObject,
+		DataModel:    dataModel,
+	}
+
+	workflowRules, err := w.decisionWorkflowsWorkerRepository.ListWorkflowsForScenario(ctx, exec, uuid.MustParse(scenario.Id))
+	if err != nil {
+		return errors.Wrap(err, "error getting workflows for scenario")
+	}
+
+	// Create transaction just for ProcessDecisionWorkflows because all function in there expect a transaction
+	workflowExecutions, err := executor_factory.TransactionReturnValue(ctx, w.transactionFactory, func(
+		tx repositories.Transaction,
+	) (models.WorkflowExecution, error) {
+		workflowExecutions, err := w.decisionWorkflowsUsecase.ProcessDecisionWorkflows(
+			ctx,
+			tx,
+			workflowRules,
+			scenario,
+			decision,
+			evalParams,
+		)
+		if err != nil {
+			return models.WorkflowExecution{}, errors.Wrap(err, "error processing decision workflows")
+		}
+
+		return workflowExecutions, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "error processing decision workflows")
+	}
+
+	for _, webhookId := range workflowExecutions.WebhookIds {
+		w.webhookEventsUsecase.SendWebhookEventAsync(ctx, webhookId)
+	}
+
+	return nil
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -733,3 +733,15 @@ func (uc *UsecasesWithCreds) NewUserSettingsUsecase() UserSettingsUsecase {
 		repository:      uc.Repositories.MarbleDbRepository,
 	}
 }
+
+func (uc *UsecasesWithCreds) NewDecisionWorkflowsWorker() *decision_workflows.DecisionWorkflowsWorker {
+	return decision_workflows.NewDecisionWorkflowsWorker(
+		uc.NewExecutorFactory(),
+		uc.NewTransactionFactory(),
+		uc.NewDecisionWorkflows(),
+		uc.Repositories.MarbleDbRepository,
+		uc.Repositories.IngestedDataReadRepository,
+		uc.Repositories.MarbleDbRepository,
+		uc.NewWebhookEventsUsecase(),
+	)
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -119,7 +119,6 @@ func (usecases *UsecasesWithCreds) NewDecisionUsecase() DecisionUsecase {
 		dataModelRepository:       usecases.Repositories.MarbleDbRepository,
 		repository:                usecases.Repositories.MarbleDbRepository,
 		screeningRepository:       usecases.Repositories.MarbleDbRepository,
-		decisionWorkflows:         usecases.NewDecisionWorkflows(),
 		webhookEventsSender:       usecases.NewWebhookEventsUsecase(),
 		phantomUseCase:            usecases.NewPhantomDecisionUseCase(),
 		scenarioTestRunRepository: usecases.Repositories.MarbleDbRepository,


### PR DESCRIPTION
- Introduced a new worker for processing decision workflows
- Updated task queue repository to support enqueuing decision workflow tasks.
- Implemented logic for handling decision workflows in the usecases layer by replacing the process by enqueue function
- The behavior for creating decisions asynchronously in batch mode remains unchanged.