### PR TITLE
Make Firebase API key required.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -56,7 +56,7 @@ func RunServer(config CompiledConfig) error {
 		FirebaseConfig: api.FirebaseConfig{
 			ProjectId:    utils.GetEnv("FIREBASE_PROJECT_ID", ""),
 			EmulatorHost: utils.GetEnv("FIREBASE_AUTH_EMULATOR_HOST", ""),
-			ApiKey:       utils.GetEnv("FIREBASE_API_KEY", ""),
+			ApiKey:       utils.GetRequiredEnv[string]("FIREBASE_API_KEY"),
 			AuthDomain:   utils.GetEnv("FIREBASE_AUTH_DOMAIN", ""),
 		},
 	}


### PR DESCRIPTION
Now that the Firebase config is retrieved from the backend, we are going to remove it from the frontend config, and make it required here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Require `FIREBASE_API_KEY` via `utils.GetRequiredEnv` in `cmd/server.go`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90d0be8017bfa8e2dd5422bcd19fcd63bf41416b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->