### PR TITLE
fix: change the attempt number for DB transaction in retry mechanism

### DIFF
--- a/repositories/db_executor_getter.go
+++ b/repositories/db_executor_getter.go
@@ -93,7 +93,7 @@ func (g ExecutorGetter) Transaction(
 	}
 	// Retry retryable commit errors once, immediately after failure.
 	err = retry.Do(execInTransaction,
-		retry.Attempts(1),
+		retry.Attempts(2),
 		retry.LastErrorOnly(true),
 		retry.RetryIf(func(err error) bool {
 			return IsDeadlockError(err) || IsSerializationFailureError(err)


### PR DESCRIPTION
This pull request makes a small change to the transaction retry logic in `repositories/db_executor_getter.go`. The number of retry attempts for retryable commit errors has been increased from one to two, which should improve resilience against transient database errors.