### PR TITLE
proposed improvement for string similarity matching on cases list

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -9,10 +9,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-const (
-	DEFAULT_SIMILARITY_THRESHOLD = 0.3
-)
-
 func GetDeploymentMetadata(ctx context.Context, repositories repositories.Repositories) (models.Metadata, error) {
 	// Get deployment ID from Marble DB
 	executor, err := repositories.ExecutorGetter.GetExecutor(

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -152,7 +152,7 @@ func RunServer(config CompiledConfig) error {
 		transferCheckEnrichmentBucketUrl: utils.GetEnv("TRANSFER_CHECK_ENRICHMENT_BUCKET_URL", ""), // required for transfercheck
 		telemetryExporter:                utils.GetEnv("TRACING_EXPORTER", "otlp"),
 		otelSamplingRates:                utils.GetEnv("TRACING_SAMPLING_RATES", ""),
-		similarityThreshold:              utils.GetEnv("SIMILARITY_THRESHOLD", DEFAULT_SIMILARITY_THRESHOLD),
+		similarityThreshold:              utils.GetEnv("SIMILARITY_THRESHOLD", models.DEFAULT_SIMILARITY_THRESHOLD),
 	}
 	if err := serverConfig.Validate(); err != nil {
 		utils.LogAndReportSentryError(ctx, err)

--- a/models/case.go
+++ b/models/case.go
@@ -136,6 +136,10 @@ type CaseFilters struct {
 	AssigneeId      UserId
 }
 
+const (
+	DEFAULT_SIMILARITY_THRESHOLD = 0.5
+)
+
 type CaseListPage struct {
 	Cases       []Case
 	HasNextPage bool

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -63,7 +63,11 @@ func (repo *MarbleDbRepository) ListOrganizationCases(
 		query = query.Where(squirrel.Eq{"c.inbox_id": filters.InboxIds})
 	}
 	if filters.Name != "" {
-		query = query.Where("similarity(c.name, ?) > ?", filters.Name, repo.similarityThreshold)
+		// Straight from the Postgres doc,
+		// "Same as word_similarity, but forces extent boundaries to match word boundaries. Since we don't have cross-word trigrams,
+		// this function actually returns greatest similarity between first string and any continuous extent of words of the second string."
+		// Hence, the (presumably shorter) string received as input should be used as the first argument.
+		query = query.Where("word_similarity(?, c.name) > ?", filters.Name, repo.similarityThreshold)
 	}
 	if !filters.IncludeSnoozed {
 		query = query.Where(squirrel.Or{

--- a/repositories/marble_db_repository.go
+++ b/repositories/marble_db_repository.go
@@ -1,11 +1,17 @@
 package repositories
 
+import "github.com/checkmarble/marble-backend/models"
+
 type MarbleDbRepository struct {
 	withCache           bool
 	similarityThreshold float64
 }
 
 func NewMarbleDbRepository(withCache bool, similarityThreshold float64) *MarbleDbRepository {
+	if similarityThreshold == 0 {
+		similarityThreshold = models.DEFAULT_SIMILARITY_THRESHOLD
+	}
+
 	return &MarbleDbRepository{
 		withCache:           withCache,
 		similarityThreshold: similarityThreshold,


### PR DESCRIPTION
Using 
```sql
with words as (
    select 'case' as w
)
select name, w as match,
       similarity(name, w) as sim_bad, word_similarity(name,w) as sim2_bad, strict_word_similarity(name, w) as sim3_bad,
       similarity(w,name) as sim4_bad, word_similarity(w,name) as sim5_good, strict_word_similarity(w,name) as sim6_good
       --, 1-levenshtein(name, w)::float8/GREATEST(LENGTH(name), LENGTH(w)) as lev1
from cases
inner join words on(true)
where org_id='e617f1de-a1ba-4a08-8202-e2a810367a31'
and assigned_to='d14e8e4e-b844-409b-8422-2ab9a1772091'
order by 4 desc;
```

we get this 
<img width="1626" height="271" alt="Capture d’écran 2025-09-29 à 16 37 19" src="https://github.com/user-attachments/assets/9ef2331d-8453-4573-be3e-271c54b29a56" />
or this 
<img width="1638" height="379" alt="Capture d’écran 2025-09-29 à 16 37 03" src="https://github.com/user-attachments/assets/eef06ded-b653-4a6d-be58-3ca162ecc938" />

Long story short, `word_similarity` is better aligned with our usecase, and the shorter string should be the first argument (when there is an obvious candidate for shorter string, which is the case here - otherwise we may need to compute both permutations).