### PR TITLE
upgrade actions and separate job for lint

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -38,7 +38,7 @@ jobs:
 
       - name: auth github actions to GCP
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           token_format: access_token
           project_id: ${{ vars.GCP_PROJECT_ID }}
@@ -57,7 +57,7 @@ jobs:
         run: echo "MARBLE_VERSION=$(git describe --tags)" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           build-args: |
@@ -71,7 +71,7 @@ jobs:
           docker buildx imagetools create --tag ${{ env.VERSION_IMAGE }} ${{ env.COMMIT_IMAGE }}
 
       - name: Set up Cloud SDK
-        uses: "google-github-actions/setup-gcloud@v2"
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Deploy migration job
         run: |

--- a/.github/workflows/backend_test_workflow.yaml
+++ b/.github/workflows/backend_test_workflow.yaml
@@ -1,9 +1,6 @@
 name: Test back-end
 
-on:
-  workflow_call:
-    secrets:
-      README_API_KEY:
+on: workflow_call
 
 permissions:
   contents: read
@@ -15,7 +12,34 @@ jobs:
     name: Test back-end
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ./go.mod
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Generate Marble API OpenAPI as temporary file
+        run: go run pubapi/openapi/generate.go v1 > /tmp/marble-api-v1.yml
+
+      - name: Upload OpenAPI specifications as artifacts, to be downloaded and used in the production deployment workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: marble-api-openapi
+          path: /tmp/marble-api-*.yml
+          retention-days: 1
+
+  lint_backend:
+    name: Lint back-end
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -27,19 +51,3 @@ jobs:
         with:
           version: v2.5
           args: --timeout=3m
-
-      - name: Build
-        run: go build -v ./...
-
-      - name: Test
-        run: go test ./...
-
-      - name: Generate Marble API OpenAPI
-        run: go run pubapi/openapi/generate.go v1 > /tmp/marble-api-v1.yml
-
-      - name: Upload OpenAPI specifications as artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: marble-api-openapi
-          path: /tmp/marble-api-*.yml
-          retention-days: 1

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: read
       checks: write
-    
+
     services:
       postgres:
         image: postgres:17-alpine
@@ -30,15 +30,15 @@ jobs:
           --tmpfs /var/lib/postgresql/data
         ports:
           - 5432:5432
-    
+
     steps:
       - name: Checkout main branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: main
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: ./go.mod
           cache: true
@@ -56,7 +56,7 @@ jobs:
             go install github.com/pressly/goose/v3/cmd/goose@latest
           fi
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-          
+
       - name: Run migrations on main branch
         env:
           GOOSE_DRIVER: postgres
@@ -64,10 +64,10 @@ jobs:
         run: goose -dir repositories/migrations up
 
       - name: Checkout PR branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          
+
       - name: Run migrations on PR branch
         env:
           GOOSE_DRIVER: postgres
@@ -85,6 +85,4 @@ jobs:
       contents: read
       pull-requests: read
       checks: write
-    secrets:
-      README_API_KEY: ${{ secrets.README_API_KEY }}
     uses: ./.github/workflows/backend_test_workflow.yaml


### PR DESCRIPTION
- move golangci-lint to a separate job to run in parallel with tests, for faster execution
- also bump the version of all CI actions, quite a few have a new version