### PR TITLE
fix: add missing field in public openapi

### DIFF
--- a/pubapi/openapi/v1.yml
+++ b/pubapi/openapi/v1.yml
@@ -1158,6 +1158,8 @@ components:
               type: string
             birthDate:
               type: string
+            nationality:
+              type: string
             passportNumber:
               type: string
             address:
@@ -1174,6 +1176,8 @@ components:
           minProperties: 1
           properties:
             name:
+              type: string
+            country:
               type: string
             registrationNumber:
               type: string


### PR DESCRIPTION
This pull request updates the OpenAPI schema to include missing fields: **nationality** for Person and **country** for Company. These fields are already supported by the endpoint.