### PR TITLE
rename some auth things

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -60,13 +60,13 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 		pubapi.InitPublicApi()
 
 		pubapiv1.Routes(cfg, "v1", r.Group("/v1"),
-			auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken), uc)
 
 		// Mount both the v1 and new v1beta routes under /v1beta for backward compatibility
 		pubapiv1.Routes(cfg, "v1beta", r.Group("/v1beta"),
-			auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken), uc)
 		pubapiv1.BetaRoutes(cfg, r.Group("/v1beta"),
-			auth.AuthedBy(utils.PublicApiKey, utils.BearerToken), uc)
+			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken), uc)
 	}
 
 	router := r.Use(auth.AuthedBy(utils.FederatedBearerToken, utils.PublicApiKey),

--- a/usecases/token/validator.go
+++ b/usecases/token/validator.go
@@ -38,7 +38,7 @@ func (v *Validator) fromAPIKey(ctx context.Context, key string) (models.Credenti
 	return credentials, nil
 }
 
-func (v *Validator) Validate(ctx context.Context, marbleToken, apiKey string) (models.Credentials, error) {
+func (v *Validator) ValidateTokenOrKey(ctx context.Context, marbleToken, apiKey string) (models.Credentials, error) {
 	if apiKey != "" {
 		return v.fromAPIKey(ctx, apiKey)
 	}

--- a/usecases/token/validator_test.go
+++ b/usecases/token/validator_test.go
@@ -51,7 +51,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		credentials, err := v.Validate(ctx, "", key)
+		credentials, err := v.ValidateTokenOrKey(ctx, "", key)
 		assert.NoError(t, err)
 		assert.Equal(t, creds, credentials)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
@@ -66,7 +66,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		_, err := v.Validate(ctx, "", key)
+		_, err := v.ValidateTokenOrKey(ctx, "", key)
 		assert.Error(t, err)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
 	})
@@ -82,7 +82,7 @@ func TestValidator_Validate_APIKey(t *testing.T) {
 			getter: mockKeyAndOrganizationGetter,
 		}
 
-		_, err := v.Validate(ctx, "", key)
+		_, err := v.ValidateTokenOrKey(ctx, "", key)
 		assert.Error(t, err)
 		mockKeyAndOrganizationGetter.AssertExpectations(t)
 	})
@@ -109,7 +109,7 @@ func TestValidator_Validate_Token(t *testing.T) {
 			validator: mockValidator,
 		}
 
-		credentials, err := v.Validate(context.Background(), token, "")
+		credentials, err := v.ValidateTokenOrKey(context.Background(), token, "")
 		assert.NoError(t, err)
 		assert.Equal(t, creds, credentials)
 		mockValidator.AssertExpectations(t)
@@ -124,7 +124,7 @@ func TestValidator_Validate_Token(t *testing.T) {
 			validator: mockValidator,
 		}
 
-		_, err := v.Validate(context.Background(), token, "")
+		_, err := v.ValidateTokenOrKey(context.Background(), token, "")
 		assert.Error(t, err)
 		mockValidator.AssertExpectations(t)
 	})


### PR DESCRIPTION
Simple renaming of things, for all the times I had to search "Validate()" in the codebase and didn't find the ones I wanted