### PR TITLE
fix decision workflow execution data model get

### DIFF
--- a/usecases/decision_workflows/worker.go
+++ b/usecases/decision_workflows/worker.go
@@ -106,7 +106,7 @@ func (w *DecisionWorkflowsWorker) Work(ctx context.Context, job *river.Job[model
 		ctx,
 		exec,
 		decision.OrganizationId.String(),
-		true,
+		false,
 		true,
 	)
 	if err != nil {


### PR DESCRIPTION
Large volumes of decision workflows were taking more than seconds because it was getting repeatedly the data model with enum values, creating loads of unnecessary requests.
I could (and will) fix this for now on the managed worker, but I want to include this in the hotfix branch before we release OS.