### PR TITLE
Various analytics improvements

### DIFF
--- a/repositories/migrations/20251003090300_create_analytics_export_index.sql
+++ b/repositories/migrations/20251003090300_create_analytics_export_index.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+create index concurrently if not exists idx_analytics_export
+on decisions (org_id, trigger_object_type, created_at desc, id desc);
+
+-- +goose Down
+
+drop index idx_analytics_export;

--- a/usecases/analytics_query_usecase.go
+++ b/usecases/analytics_query_usecase.go
@@ -20,6 +20,7 @@ type AnalyticsQueryUsecase struct {
 	executorFactory  executor_factory.ExecutorFactory
 	analyticsFactory executor_factory.AnalyticsExecutorFactory
 
+	license            models.LicenseValidation
 	scenarioRepository repositories.ScenarioUsecaseRepository
 }
 
@@ -54,6 +55,10 @@ func (uc AnalyticsQueryUsecase) DecisionOutcomePerDay(ctx context.Context, filte
 }
 
 func (uc AnalyticsQueryUsecase) DecisionsScoreDistribution(ctx context.Context, filters dto.AnalyticsQueryFilters) ([]analytics.DecisionsScoreDistribution, error) {
+	if !uc.license.Analytics {
+		return []analytics.DecisionsScoreDistribution{}, nil
+	}
+
 	scenario, exec, err := uc.getExecutor(ctx, filters.ScenarioId)
 	if err != nil {
 		return nil, err
@@ -74,6 +79,10 @@ func (uc AnalyticsQueryUsecase) DecisionsScoreDistribution(ctx context.Context, 
 }
 
 func (uc AnalyticsQueryUsecase) RuleHitTable(ctx context.Context, filters dto.AnalyticsQueryFilters) ([]analytics.RuleHitTable, error) {
+	if !uc.license.Analytics {
+		return []analytics.RuleHitTable{}, nil
+	}
+
 	scenario, exec, err := uc.getExecutor(ctx, filters.ScenarioId)
 	if err != nil {
 		return nil, err
@@ -101,6 +110,10 @@ func (uc AnalyticsQueryUsecase) RuleHitTable(ctx context.Context, filters dto.An
 }
 
 func (uc AnalyticsQueryUsecase) RuleVsDecisionOutcome(ctx context.Context, filters dto.AnalyticsQueryFilters) ([]analytics.RuleVsDecisionOutcome, error) {
+	if !uc.license.Analytics {
+		return []analytics.RuleVsDecisionOutcome{}, nil
+	}
+
 	scenario, exec, err := uc.getExecutor(ctx, filters.ScenarioId)
 	if err != nil {
 		return nil, err
@@ -127,6 +140,10 @@ func (uc AnalyticsQueryUsecase) RuleVsDecisionOutcome(ctx context.Context, filte
 }
 
 func (uc AnalyticsQueryUsecase) RuleCoOccurenceMatrix(ctx context.Context, filters dto.AnalyticsQueryFilters) ([]analytics.RuleCoOccurence, error) {
+	if !uc.license.Analytics {
+		return []analytics.RuleCoOccurence{}, nil
+	}
+
 	scenario, exec, err := uc.getExecutor(ctx, filters.ScenarioId)
 	if err != nil {
 		return nil, err
@@ -161,6 +178,10 @@ func (uc AnalyticsQueryUsecase) RuleCoOccurenceMatrix(ctx context.Context, filte
 }
 
 func (uc AnalyticsQueryUsecase) ScreeningHits(ctx context.Context, filters dto.AnalyticsQueryFilters) ([]analytics.ScreeningHits, error) {
+	if !uc.license.Analytics {
+		return []analytics.ScreeningHits{}, nil
+	}
+
 	scenario, exec, err := uc.getExecutor(ctx, filters.ScenarioId)
 	if err != nil {
 		return nil, err

--- a/usecases/analytics_query_usecase.go
+++ b/usecases/analytics_query_usecase.go
@@ -30,7 +30,7 @@ func (uc AnalyticsQueryUsecase) DecisionOutcomePerDay(ctx context.Context, filte
 		return nil, err
 	}
 
-	subquery := squirrel.Select("time_bucket('1 day', created_at) as date, outcome, count() as decisions").
+	subquery := squirrel.Select(fmt.Sprintf("time_bucket('1 day', created_at, '%s') as date, outcome, count() as decisions", filters.Timezone)).
 		From(uc.analyticsFactory.BuildTarget("decisions", &scenario.TriggerObjectType)).
 		Where("created_at between ? and ?", filters.Start, filters.End).
 		GroupBy("date", "outcome")

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -656,6 +656,7 @@ func (usecases UsecasesWithCreds) NewAnalyticsExportWorker() *scheduled_executio
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
 		usecases.NewAnalyticsExecutorFactory(),
+		usecases.license,
 		usecases.Repositories.MarbleDbRepository,
 		usecases.analyticsConfig,
 	)
@@ -768,6 +769,7 @@ func (uc *UsecasesWithCreds) NewAnalyticsQueryUsecase() AnalyticsQueryUsecase {
 		enforceSecurity:    uc.NewEnforceScenarioSecurity(),
 		executorFactory:    uc.NewExecutorFactory(),
 		analyticsFactory:   uc.NewAnalyticsExecutorFactory(),
+		license:            uc.license,
 		scenarioRepository: uc.Repositories.MarbleDbRepository,
 	}
 }


### PR DESCRIPTION
* Guard decision rules and screenings behind a license entitlement
* Guard most graph generation behind a license entitlement
* Create specialized index to efficiently export decisions (`(org_id, trigger_object_type, created_at, id)`)
* Take client timezone into account for time bucketing
* _[work in progress]_