### PR TITLE
small tracing improvements

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -79,7 +79,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	}
 
 	workerConfig := WorkerConfig{
-		appName:                     "marble-backend",
+		appName:                     "marble-backend-worker",
 		env:                         utils.GetEnv("ENV", "development"),
 		failedWebhooksRetryPageSize: utils.GetEnv("FAILED_WEBHOOKS_RETRY_PAGE_SIZE", 1000),
 		ingestionBucketUrl:          utils.GetRequiredEnv[string]("INGESTION_BUCKET_URL"),
@@ -460,7 +460,8 @@ func singleJobRun(ctx context.Context, uc usecases.UsecasesWithCreds, jobName, j
 		return uc.NewDecisionWorkflowsWorker().Work(ctx,
 			singleJobCreate[models.DecisionWorkflowArgs](ctx, jobArgs))
 	case "analytics_export":
-		return uc.NewAnalyticsExportWorker().Work(ctx, singleJobCreate[models.AnalyticsExportArgs](ctx, jobArgs))
+		return uc.NewAnalyticsExportWorker().Work(ctx,
+			singleJobCreate[models.AnalyticsExportArgs](ctx, jobArgs))
 	default:
 		return errors.Newf("unknown job %s", jobName)
 	}

--- a/infra/tracing.go
+++ b/infra/tracing.go
@@ -111,9 +111,10 @@ const (
 
 var (
 	defaultSpanNamesSampling = map[string]float64{
-		"async_decision":   0.05,
-		"match_enrichment": 0.05,
-		"test_run_summary": 0.05,
+		"async_decision":    0.05,
+		"match_enrichment":  0.05,
+		"test_run_summary":  0.05,
+		"decision_workflow": 0.05,
 	}
 
 	defaultRoutePrefixSampling = map[string]float64{
@@ -204,6 +205,10 @@ rates:
 		}
 		if ratio, ok := defaultSpanNamesSampling[p.Name]; ok {
 			prob = ratio
+			break rates
+		}
+		if p.Name == "pool.acquire" {
+			prob = 0.0
 			break rates
 		}
 


### PR DESCRIPTION
- don't create spans for bucket blob opening (unless requested by debug env var)
- lower default sampling for decision workflows (now dominant in traces)
- don't sample "pool.acquire" (one third of our traces, done every time we do a query outside of a transaction
- rename app name for worker so we can filter traces by api or worker