### PR TITLE
Reduce offloading GCS chunk size to avoid memory overallocation.

### DIFF
--- a/usecases/scheduled_execution/offloading_job.go
+++ b/usecases/scheduled_execution/offloading_job.go
@@ -324,6 +324,7 @@ func (w OffloadingWorker) writeBatchToBlobStorage(
 
 					if asFunc(&gcsWriter) {
 						gcsWriter.CustomTime = rule.CreatedAt
+						gcsWriter.ChunkSize = 0
 					}
 
 					return nil


### PR DESCRIPTION
As seen in:

 * https://github.com/googleapis/google-cloud-go/blob/storage/v1.55.0/storage/writer.go#L72 and
 * https://github.com/googleapis/google-api-go-client/blob/v0.251.0/googleapi/googleapi.go#L57

The GCS SDK allocates 16MB buffers for writing files to blob storage. This is optimized for largish files, but falls flat when uploading lots of very small files.

In our case, for offloading, we uploaded, in a loop and concurrently, 300 files, which immediately allocated a whopping 4.8GB.

This PR configures the `ChunkSize` on the blob writer to 0 to disable chunking, since those files are going to be a few kilobytes.