### PR TITLE
Abort if OIDC is set up without SSO license entitlement

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -286,6 +286,10 @@ func RunServer(config CompiledConfig) error {
 	}
 	license := infra.VerifyLicense(licenseConfig, deploymentMetadata.Value)
 
+	if apiConfig.TokenProvider == auth.TokenProviderOidc && !license.Sso {
+		return errors.New("cannot use OpenID Connect configuration without the appropriate license entitlement")
+	}
+
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),
 		usecases.WithApiVersion(config.Version),


### PR DESCRIPTION
A license check is now performed on backend startup to abort early if authentication is configured through OIDC without having the SSO entitlement.