### PR TITLE
fix: prevent seqscan for offloading query

### DIFF
--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -740,7 +740,8 @@ func (repo *MarbleDbRepository) GetOffloadableDecisionRules(
 	}
 
 	// In this query, the query planner may choose a hash join, which is about guaranteed to never complete on this large table.
-	_, err := tx.Exec(ctx, "SET local enable_hashjoin = off;")
+	// Also, in some cases where there is very little data to fetch, it arbitrarily chooses a sequential scan, for no clear reason.
+	_, err := tx.Exec(ctx, "SET local enable_hashjoin = off; SET local enable_seqscan = OFF;")
 	if err != nil {
 		return models.ChannelOfModels[models.OffloadableDecisionRule]{}, err
 	}


### PR DESCRIPTION
Because postgres is dump, and will apply the correct plan on a "count" query, will apply the correct plan on the query with an org/watermark where the query will return "limit" rows, but will arbitrarily seq scan the decisions table if I want fields from one row of decisions and rules 🤷 