### PR TITLE
change default scenario thresholds + small refactor of dtos

### DIFF
--- a/dto/scenario_iterations.go
+++ b/dto/scenario_iterations.go
@@ -123,14 +123,14 @@ func AdaptUpdateScenarioIterationInput(input UpdateScenarioIterationBody, iterat
 // Create iteration DTO
 type CreateScenarioIterationBody struct {
 	ScenarioId string `json:"scenario_id"`
-	Body       *struct {
+	Body       struct {
 		TriggerConditionAstExpression *NodeDto              `json:"trigger_condition_ast_expression"`
 		Rules                         []CreateRuleInputBody `json:"rules"`
 		ScoreReviewThreshold          *int                  `json:"score_review_threshold,omitempty"`
 		ScoreBlockAndReviewThreshold  *int                  `json:"score_block_and_review_threshold,omitempty"`
 		ScoreDeclineThreshold         *int                  `json:"score_decline_threshold,omitempty"`
 		Schedule                      string                `json:"schedule"`
-	} `json:"body,omitempty"`
+	} `json:"body"`
 }
 
 func AdaptCreateScenarioIterationInput(input CreateScenarioIterationBody, organizationId string) (models.CreateScenarioIterationInput, error) {
@@ -138,33 +138,31 @@ func AdaptCreateScenarioIterationInput(input CreateScenarioIterationBody, organi
 		ScenarioId: input.ScenarioId,
 	}
 
-	if input.Body != nil {
-		createScenarioIterationInput.Body = &models.CreateScenarioIterationBody{
-			ScoreReviewThreshold:         input.Body.ScoreReviewThreshold,
-			ScoreBlockAndReviewThreshold: input.Body.ScoreBlockAndReviewThreshold,
-			ScoreDeclineThreshold:        input.Body.ScoreDeclineThreshold,
-			Schedule:                     input.Body.Schedule,
-			Rules:                        make([]models.CreateRuleInput, len(input.Body.Rules)),
-		}
-
-		for i, rule := range input.Body.Rules {
-			var err error
-			createScenarioIterationInput.Body.Rules[i], err =
-				AdaptCreateRuleInput(rule, organizationId)
-			if err != nil {
-				return models.CreateScenarioIterationInput{}, err
-			}
-		}
-
-		if input.Body.TriggerConditionAstExpression != nil {
-			trigger, err := AdaptASTNode(*input.Body.TriggerConditionAstExpression)
-			if err != nil {
-				return models.CreateScenarioIterationInput{},
-					errors.Wrap(models.BadParameterError, "invalid trigger")
-			}
-			createScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
-		}
-
+	createScenarioIterationInput.Body = models.CreateScenarioIterationBody{
+		ScoreReviewThreshold:         input.Body.ScoreReviewThreshold,
+		ScoreBlockAndReviewThreshold: input.Body.ScoreBlockAndReviewThreshold,
+		ScoreDeclineThreshold:        input.Body.ScoreDeclineThreshold,
+		Schedule:                     input.Body.Schedule,
+		Rules:                        make([]models.CreateRuleInput, len(input.Body.Rules)),
 	}
+
+	for i, rule := range input.Body.Rules {
+		var err error
+		createScenarioIterationInput.Body.Rules[i], err =
+			AdaptCreateRuleInput(rule, organizationId)
+		if err != nil {
+			return models.CreateScenarioIterationInput{}, err
+		}
+	}
+
+	if input.Body.TriggerConditionAstExpression != nil {
+		trigger, err := AdaptASTNode(*input.Body.TriggerConditionAstExpression)
+		if err != nil {
+			return models.CreateScenarioIterationInput{},
+				errors.Wrap(models.BadParameterError, "invalid trigger")
+		}
+		createScenarioIterationInput.Body.TriggerConditionAstExpression = &trigger
+	}
+
 	return createScenarioIterationInput, nil
 }

--- a/integration_test/scenario_flow_test.go
+++ b/integration_test/scenario_flow_test.go
@@ -312,7 +312,7 @@ func setupScenarioAndPublish(
 	scenarioIteration, err := scenarioIterationUsecase.CreateScenarioIteration(
 		ctx, organizationId, models.CreateScenarioIterationInput{
 			ScenarioId: scenarioId,
-			Body: &models.CreateScenarioIterationBody{
+			Body: models.CreateScenarioIterationBody{
 				Rules: rules,
 				TriggerConditionAstExpression: &ast.Node{
 					Function: ast.FUNC_AND,

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -32,7 +32,7 @@ type GetScenarioIterationFilters struct {
 
 type CreateScenarioIterationInput struct {
 	ScenarioId string
-	Body       *CreateScenarioIterationBody
+	Body       CreateScenarioIterationBody
 }
 
 type CreateScenarioIterationBody struct {
@@ -111,7 +111,8 @@ func (scc ScreeningConfig) HasSameQuery(other ScreeningConfig) bool {
 		return false
 	}
 
-	if (scc.Threshold == nil && other.Threshold != nil) || (scc.Threshold != nil && other.Threshold == nil) {
+	if (scc.Threshold == nil && other.Threshold != nil) ||
+		(scc.Threshold != nil && other.Threshold == nil) {
 		return false
 	}
 	if scc.Threshold != nil && other.Threshold != nil {
@@ -120,7 +121,8 @@ func (scc ScreeningConfig) HasSameQuery(other ScreeningConfig) bool {
 		}
 	}
 
-	if (scc.TriggerRule == nil && other.TriggerRule != nil) || (scc.TriggerRule != nil && other.TriggerRule == nil) {
+	if (scc.TriggerRule == nil && other.TriggerRule != nil) ||
+		(scc.TriggerRule != nil && other.TriggerRule == nil) {
 		return false
 	}
 	if scc.TriggerRule != nil && other.TriggerRule != nil {
@@ -129,7 +131,8 @@ func (scc ScreeningConfig) HasSameQuery(other ScreeningConfig) bool {
 		}
 	}
 
-	if (scc.CounterpartyIdExpression == nil && other.CounterpartyIdExpression != nil) || (scc.CounterpartyIdExpression != nil && other.CounterpartyIdExpression == nil) {
+	if (scc.CounterpartyIdExpression == nil && other.CounterpartyIdExpression != nil) ||
+		(scc.CounterpartyIdExpression != nil && other.CounterpartyIdExpression == nil) {
 		return false
 	}
 	if scc.CounterpartyIdExpression != nil && other.CounterpartyIdExpression != nil {
@@ -143,7 +146,8 @@ func (scc ScreeningConfig) HasSameQuery(other ScreeningConfig) bool {
 	}
 
 	// If the queries do not target the same fields, we are not equal
-	if !set.From(slices.Collect(maps.Keys(other.Query))).Equal(set.From(slices.Collect(maps.Keys(scc.Query)))) {
+	if !set.From(slices.Collect(maps.Keys(other.Query))).Equal(
+		set.From(slices.Collect(maps.Keys(scc.Query)))) {
 		return false
 	}
 


### PR DESCRIPTION
Mainly, do the improvement [here](https://linear.app/marble-eu/issue/MAR-1256/small-fixes-on-decision-threshold-settings), so that we are not in the (in retrospect) strange edge case where one outcome is not possible on the default scenario.
While I'm at it, small rationalization of some dto/models and their nullable fields.