### PR TITLE
Add optional domain allowlist for OIDC authentication.

### DIFF
--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -77,7 +77,7 @@ func InitDependencies(
 
 	tokenHandler := auth.NewTokenHandler(
 		auth.DefaultExtractor(),
-		auth.NewVerifier(conf.TokenProvider, idpTokenVerifier, database),
+		auth.NewVerifier(conf.TokenProvider, idpTokenVerifier, database, conf.OidcConfig.AllowedDomains),
 		auth.NewGenerator(database, jwtRepository, time.Hour, clock.New()),
 	)
 

--- a/api/handle_post_firebase_id_token.go
+++ b/api/handle_post_firebase_id_token.go
@@ -29,7 +29,7 @@ func (t *TokenHandler) GenerateToken(c *gin.Context) {
 	token, err := t.handler.GetToken(ctx, c.Request)
 
 	if err != nil {
-		utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not verify token", "error", err)
+		utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not verify token", "error", err.Error())
 
 		_ = c.Error(fmt.Errorf("generator.GenerateToken error: %w", err))
 

--- a/infra/oidc.go
+++ b/infra/oidc.go
@@ -17,6 +17,8 @@ type OidcConfig struct {
 	Scopes       []string
 	ExtraParams  map[string]string
 
+	AllowedDomains []string
+
 	Provider *oidc.Provider
 	Verifier *oidc.IDTokenVerifier
 }
@@ -39,6 +41,16 @@ func InitializeOidc(ctx context.Context) (OidcConfig, error) {
 		return OidcConfig{}, err
 	}
 
+	var allowedDomains []string
+
+	if domains := utils.GetEnv("AUTH_OIDC_ALLOWED_DOMAINS", ""); domains != "" {
+		allowedDomains = strings.Split(domains, ",")
+	}
+
+	for idx, domain := range allowedDomains {
+		allowedDomains[idx] = "@" + domain
+	}
+
 	return OidcConfig{
 		Issuer:       issuer,
 		ClientId:     clientId,
@@ -46,6 +58,8 @@ func InitializeOidc(ctx context.Context) (OidcConfig, error) {
 		Scopes:       strings.Split(utils.GetEnv("AUTH_OIDC_SCOPE", ""), ","),
 		RedirectUri:  utils.GetEnv("AUTH_OIDC_REDIRECT_URI", ""),
 		ExtraParams:  extraParams,
+
+		AllowedDomains: allowedDomains,
 
 		Provider: provider,
 		Verifier: provider.Verifier(&oidc.Config{

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -210,7 +210,7 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	apiKeyVerifier = auth.NewVerifier(auth.TokenProviderFirebase, firebaseClient, database)
+	apiKeyVerifier = auth.NewVerifier(auth.TokenProviderFirebase, firebaseClient, database, nil)
 	tokenGenerator = auth.NewGenerator(database, jwtRepository, time.Minute, clock.New())
 
 	// we need to create a first marble admin user, otherwise we can't use the API (chicken and egg)

--- a/usecases/token/verifier_test.go
+++ b/usecases/token/verifier_test.go
@@ -45,7 +45,7 @@ func TestGenerator_VerifyToken_APIKey(t *testing.T) {
 		mockRepository.On("GetOrganizationByID", ctx, "organization_id").
 			Return(organization, nil)
 
-		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository)
+		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository, nil)
 		intoCreds, _, err := verifier.Verify(ctx, auth.Credentials{Type: auth.CredentialsApiKey, Value: key})
 
 		assert.NoError(t, err)
@@ -58,7 +58,7 @@ func TestGenerator_VerifyToken_APIKey(t *testing.T) {
 		mockRepository.On("GetApiKeyByHash", ctx, keyHash).
 			Return(models.ApiKey{}, assert.AnError)
 
-		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository)
+		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository, nil)
 		_, _, err := verifier.Verify(ctx, auth.Credentials{Type: auth.CredentialsApiKey, Value: key})
 
 		assert.Error(t, err)
@@ -73,7 +73,7 @@ func TestGenerator_VerifyToken_APIKey(t *testing.T) {
 		mockRepository.On("GetOrganizationByID", ctx, "organization_id").
 			Return(models.Organization{}, assert.AnError)
 
-		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository)
+		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository, nil)
 		_, _, err := verifier.Verify(ctx, auth.Credentials{Type: auth.CredentialsApiKey, Value: key})
 
 		assert.Error(t, err)
@@ -120,7 +120,7 @@ func TestGenerator_VerifyToken_FirebaseToken(t *testing.T) {
 		}).
 			Return(token, nil)
 
-		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository)
+		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository, nil)
 		generator := auth.NewGenerator(
 			mockRepository,
 			mockEncoder,
@@ -162,7 +162,7 @@ func TestGenerator_VerifyToken_FirebaseToken(t *testing.T) {
 		mockRepository.On("UserByEmail", mock.Anything, firebaseIdentity.Email).
 			Return(models.User{}, assert.AnError)
 
-		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository)
+		verifier := auth.NewVerifier(auth.TokenProviderFirebase, idpTokenVerifier, mockRepository, nil)
 		generator := auth.NewGenerator(
 			mockRepository,
 			nil,


### PR DESCRIPTION
This adds a new configuration setting for OIDC: a list of allowed domains that can authenticate into Marble.

This is mainly useful for when a single IDP can manage several domains (enterprise users, or users using public IDP (e.g. Google), so they can enforce that only users from specific domains can log into Marble.