### PR TITLE
Fetch picture from IDP and update Marble user.

### DIFF
--- a/dto/user_dto.go
+++ b/dto/user_dto.go
@@ -14,6 +14,7 @@ type User struct {
 	PartnerId      *string    `json:"partner_id,omitempty"`
 	FirstName      string     `json:"first_name"`
 	LastName       string     `json:"last_name"`
+	Picture        string     `json:"picture"`
 	DeletedAt      *time.Time `json:"deleted_at,omitempty"`
 }
 
@@ -26,6 +27,7 @@ func AdaptUserDto(user models.User) User {
 		PartnerId:      user.PartnerId,
 		FirstName:      user.FirstName,
 		LastName:       user.LastName,
+		Picture:        user.Picture,
 		DeletedAt:      user.DeletedAt,
 	}
 }

--- a/mocks/postgres.go
+++ b/mocks/postgres.go
@@ -27,8 +27,8 @@ func (m *Database) GetApiKeyByHash(ctx context.Context, hash []byte) (models.Api
 	return args.Get(0).(models.ApiKey), args.Error(1)
 }
 
-func (m *Database) UpdateUser(ctx context.Context, user models.User, firstname, lastname string) (models.User, error) {
-	args := m.Called(ctx, user, firstname, lastname)
+func (m *Database) UpdateUser(ctx context.Context, user models.User, profile models.IdentityUpdatableClaims) (models.User, error) {
+	args := m.Called(ctx, user, profile)
 
 	return args.Get(0).(models.User), args.Error(1)
 }

--- a/models/identity.go
+++ b/models/identity.go
@@ -2,21 +2,30 @@ package models
 
 type IdentityClaims interface {
 	GetIssuer() string
-	GetName() (string, string, bool)
 	GetEmail() string
+	GetProfile() *IdentityUpdatableClaims
+}
+
+type IdentityUpdatableClaims struct {
+	Firstname string
+	Lastname  string
+	Picture   string
 }
 
 type FirebaseIdentity struct {
-	Issuer string
-	Email  string
+	Issuer  string
+	Email   string
+	Picture string
 }
 
 func (i FirebaseIdentity) GetIssuer() string {
 	return i.Issuer
 }
 
-func (i FirebaseIdentity) GetName() (string, string, bool) {
-	return "", "", false
+func (i FirebaseIdentity) GetProfile() *IdentityUpdatableClaims {
+	return &IdentityUpdatableClaims{
+		Picture: i.Picture,
+	}
 }
 
 func (i FirebaseIdentity) GetEmail() string {
@@ -28,18 +37,19 @@ type OidcIdentity struct {
 	Firstname string `json:"given_name"`  //nolint:tagliatelle
 	Lastname  string `json:"family_name"` //nolint:tagliatelle
 	Email     string `json:"email"`
+	Picture   string `json:"picture"`
 }
 
 func (i OidcIdentity) GetIssuer() string {
 	return i.Issuer
 }
 
-func (i OidcIdentity) GetName() (string, string, bool) {
-	if i.Firstname != "" && i.Lastname != "" {
-		return i.Firstname, i.Lastname, true
+func (i OidcIdentity) GetProfile() *IdentityUpdatableClaims {
+	return &IdentityUpdatableClaims{
+		Firstname: i.Firstname,
+		Lastname:  i.Lastname,
+		Picture:   i.Picture,
 	}
-
-	return "", "", false
 }
 
 func (c OidcIdentity) GetEmail() string {
@@ -54,8 +64,8 @@ func (i ApiKeyIdentity) GetIssuer() string {
 	return "marble"
 }
 
-func (i ApiKeyIdentity) GetName() (string, string, bool) {
-	return "", "", false
+func (i ApiKeyIdentity) GetProfile() *IdentityUpdatableClaims {
+	return nil
 }
 
 func (i ApiKeyIdentity) GetEmail() string {

--- a/models/user.go
+++ b/models/user.go
@@ -14,6 +14,7 @@ type User struct {
 	LastName        string
 	DeletedAt       *time.Time
 	AiAssistEnabled bool
+	Picture         string
 }
 
 func (u User) FullName() string {

--- a/repositories/dbmodels/db_user.go
+++ b/repositories/dbmodels/db_user.go
@@ -16,6 +16,7 @@ type DBUserResult struct {
 	LastName        pgtype.Text        `db:"last_name"`
 	DeletedAt       pgtype.Timestamptz `db:"deleted_at"`
 	AiAssistEnabled bool               `db:"ai_assist_enabled"`
+	Picture         string             `db:"picture"`
 }
 
 const TABLE_USERS = "users"
@@ -29,6 +30,7 @@ func AdaptUser(db DBUserResult) (models.User, error) {
 		Role:            models.Role(db.Role),
 		PartnerId:       db.PartnerId,
 		AiAssistEnabled: db.AiAssistEnabled,
+		Picture:         db.Picture,
 	}
 	if db.OrganizationId != nil {
 		user.OrganizationId = *db.OrganizationId

--- a/repositories/idp/firebase.go
+++ b/repositories/idp/firebase.go
@@ -47,9 +47,16 @@ func (c *FirebaseClient) VerifyToken(ctx context.Context, firebaseToken string) 
 			"unexpected firebase token content: Field email is missing")
 	}
 
+	picture := ""
+
+	if p, ok := token.Claims["picture"].(string); ok {
+		picture = p
+	}
+
 	return models.FirebaseIdentity{
-		Issuer: token.Issuer,
-		Email:  email,
+		Issuer:  token.Issuer,
+		Email:   email,
+		Picture: picture,
 	}, nil
 }
 

--- a/repositories/migrations/20251013141300_add_user_picture.sql
+++ b/repositories/migrations/20251013141300_add_user_picture.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+alter table users
+    add column picture text default '';
+
+-- +goose Down
+
+alter table users
+    drop column picture;

--- a/usecases/auth/generator.go
+++ b/usecases/auth/generator.go
@@ -14,7 +14,7 @@ type marbleRepository interface {
 	GetApiKeyByHash(ctx context.Context, hash []byte) (models.ApiKey, error)
 	GetOrganizationByID(ctx context.Context, organizationID string) (models.Organization, error)
 	UserByEmail(ctx context.Context, email string) (models.User, error)
-	UpdateUser(ctx context.Context, user models.User, firstname, lastname string) (models.User, error)
+	UpdateUser(ctx context.Context, user models.User, profile models.IdentityUpdatableClaims) (models.User, error)
 }
 
 type encoder interface {

--- a/usecases/auth/verifier.go
+++ b/usecases/auth/verifier.go
@@ -76,8 +76,8 @@ func (v MarbleVerifier) Verify(ctx context.Context, creds Credentials) (models.I
 			return nil, nil, fmt.Errorf("repository.UserByEmail error: %w", err)
 		}
 
-		if fn, ln, ok := identity.GetName(); ok {
-			user, err = v.repository.UpdateUser(ctx, user, fn, ln)
+		if p := identity.GetProfile(); p != nil {
+			user, err = v.repository.UpdateUser(ctx, user, *p)
 			if err != nil {
 				utils.LoggerFromContext(ctx).WarnContext(ctx, "could not update user's name", "error", err.Error())
 

--- a/usecases/token/verifier_test.go
+++ b/usecases/token/verifier_test.go
@@ -26,7 +26,7 @@ func TestGenerator_VerifyToken_APIKey(t *testing.T) {
 		OrganizationId: "organization_id",
 		Prefix:         "abc",
 		Role:           models.ADMIN,
-		DisplayString: "Api key abc*** of organization",
+		DisplayString:  "Api key abc*** of organization",
 	}
 
 	organization := models.Organization{
@@ -105,6 +105,8 @@ func TestGenerator_VerifyToken_FirebaseToken(t *testing.T) {
 		mockRepository.On("GetOrganizationByID", mock.Anything, "organization_id").
 			Return(models.Organization{}, nil)
 		mockRepository.On("UserByEmail", mock.Anything, firebaseIdentity.Email).
+			Return(user, nil)
+		mockRepository.On("UpdateUser", mock.Anything, user, models.IdentityUpdatableClaims{}).
 			Return(user, nil)
 
 		mockEncoder := new(mocks.JWTEncoderValidator)


### PR DESCRIPTION
Small refactor to the process of updating the user's name from the OIDC/Firebase IDP to now include the picture, if available.