### PR TITLE
Custom APIv1 output DateTime type to customize formatting.

### DIFF
--- a/pubapi/params.go
+++ b/pubapi/params.go
@@ -1,8 +1,10 @@
 package pubapi
 
 import (
+	"encoding/json"
 	"time"
 
+	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -16,6 +18,8 @@ func UuidParam(c *gin.Context, param string) (*uuid.UUID, error) {
 
 	return &parsed, nil
 }
+
+const outputDateFormat = "2006-01-02T15:04:05.000Z07:00"
 
 var dateFormats = []string{
 	"2006-01-02T15:04:05Z",
@@ -40,9 +44,21 @@ func (b *DateTime) UnmarshalParam(param string) error {
 	return errors.WithDetailf(ErrInvalidPayload, "invalid datetime format, use yyyy-mm-ddThh:mm:ss+zz:zz")
 }
 
+func (b DateTime) MarshalJSON() ([]byte, error) {
+	return json.Marshal(time.Time(b).UTC().Format(outputDateFormat))
+}
+
 func (b *DateTime) IsZero() bool {
 	if b == nil {
 		return true
 	}
 	return time.Time(*b).IsZero()
+}
+
+func ThenDateTime(value *time.Time) *DateTime {
+	if value == nil {
+		return nil
+	}
+
+	return utils.Ptr(DateTime(*value))
 }

--- a/pubapi/tests/specs/v1/batch_executions.go
+++ b/pubapi/tests/specs/v1/batch_executions.go
@@ -19,7 +19,7 @@ func batchExecutions(t *testing.T, e *httpexpect.Expect) {
 		HasValue("id", "11111111-1111-1111-1111-111111111111").
 		HasValue("manual", true).
 		HasValue("status", "processing").
-		HasValue("created_at", "2025-01-01T10:00:00Z").
+		HasValue("created_at", "2025-01-01T10:00:00.000Z").
 		Path("$.scenario").Object().
 		HasValue("id", "11111111-1111-1111-1111-111111111111").
 		HasValue("iteration_id", "11111111-1111-1111-1111-111111111111").
@@ -30,8 +30,8 @@ func batchExecutions(t *testing.T, e *httpexpect.Expect) {
 		HasValue("manual", false).
 		HasValue("status", "success").
 		HasValue("decisions_created", 42).
-		HasValue("created_at", "2025-01-01T08:00:00Z").
-		HasValue("finished_at", "2025-01-01T09:00:00Z").
+		HasValue("created_at", "2025-01-01T08:00:00.000Z").
+		HasValue("finished_at", "2025-01-01T09:00:00.000Z").
 		Path("$.scenario").Object().
 		HasValue("id", "22222222-2222-2222-2222-222222222222").
 		HasValue("iteration_id", "22222222-2222-2222-2222-222222222222").

--- a/pubapi/v1/dto/batch_executions.go
+++ b/pubapi/v1/dto/batch_executions.go
@@ -1,9 +1,8 @@
 package dto
 
 import (
-	"time"
-
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
 )
 
 type ScheduledExecution struct {
@@ -12,8 +11,8 @@ type ScheduledExecution struct {
 	Manual           bool             `json:"manual"`
 	Status           string           `json:"status"`
 	DecisionsCreated int              `json:"decisions_created"`
-	CreatedAt        time.Time        `json:"created_at"`
-	FinishedAt       *time.Time       `json:"finished_at"`
+	CreatedAt        pubapi.DateTime  `json:"created_at"`
+	FinishedAt       *pubapi.DateTime `json:"finished_at"`
 }
 
 func AdaptScheduledExecution(model models.ScheduledExecution) ScheduledExecution {
@@ -27,7 +26,7 @@ func AdaptScheduledExecution(model models.ScheduledExecution) ScheduledExecution
 		Manual:           model.Manual,
 		Status:           model.Status.String(),
 		DecisionsCreated: model.NumberOfCreatedDecisions,
-		CreatedAt:        model.StartedAt,
-		FinishedAt:       model.FinishedAt,
+		CreatedAt:        pubapi.DateTime(model.StartedAt),
+		FinishedAt:       pubapi.ThenDateTime(model.FinishedAt),
 	}
 }

--- a/pubapi/v1/dto/decision.go
+++ b/pubapi/v1/dto/decision.go
@@ -2,10 +2,10 @@ package dto
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
@@ -15,7 +15,7 @@ type Decision struct {
 	Id               uuid.UUID        `json:"id"`
 	BatchExecutionId *string          `json:"batch_execution_id,omitempty"`
 	Case             *Case            `json:"case,omitempty"`
-	CreatedAt        time.Time        `json:"created_at"`
+	CreatedAt        pubapi.DateTime  `json:"created_at"`
 	TriggerObject    map[string]any   `json:"trigger_object"`
 	Outcome          string           `json:"outcome"`
 	ReviewStatus     *string          `json:"review_status"`
@@ -50,7 +50,7 @@ func AdaptDecision(includeRules bool, ruleExecutions []models.RuleExecution,
 	return func(model models.Decision) Decision {
 		d := Decision{
 			Id:               model.DecisionId,
-			CreatedAt:        model.CreatedAt,
+			CreatedAt:        pubapi.DateTime(model.CreatedAt),
 			TriggerObject:    model.ClientObject.Data,
 			Outcome:          model.Outcome.String(),
 			ReviewStatus:     model.ReviewStatus,

--- a/pubapi/v1/dto/screening.go
+++ b/pubapi/v1/dto/screening.go
@@ -2,9 +2,9 @@ package dto
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
 	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
@@ -18,8 +18,8 @@ type Screening struct {
 	MatchCount int              `json:"match_count"`
 	Matches    []ScreeningMatch `json:"matches,omitzero"`
 
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	CreatedAt pubapi.DateTime `json:"created_at"`
+	UpdatedAt pubapi.DateTime `json:"updated_at"`
 }
 
 type ScreeningMatch struct {
@@ -38,8 +38,8 @@ func AdaptScreening(includeMatches bool) func(models.ScreeningWithMatches) Scree
 			InitialQuery: model.InitialQuery,
 			Partial:      model.Partial,
 			MatchCount:   len(model.Matches),
-			CreatedAt:    model.CreatedAt,
-			UpdatedAt:    model.UpdatedAt,
+			CreatedAt:    pubapi.DateTime(model.CreatedAt),
+			UpdatedAt:    pubapi.DateTime(model.UpdatedAt),
 		}
 
 		if includeMatches {
@@ -64,15 +64,15 @@ func AdaptScreeningMatch(model models.ScreeningMatch) ScreeningMatch {
 }
 
 type ScreeningWhitelist struct {
-	Counterparty string    `json:"counterparty"`
-	EntityId     string    `json:"entity_id"`
-	CreatedAt    time.Time `json:"created_at"`
+	Counterparty string          `json:"counterparty"`
+	EntityId     string          `json:"entity_id"`
+	CreatedAt    pubapi.DateTime `json:"created_at"`
 }
 
 func AdaptScreeningWhitelist(model models.ScreeningWhitelist) ScreeningWhitelist {
 	return ScreeningWhitelist{
 		Counterparty: model.CounterpartyId,
 		EntityId:     model.EntityId,
-		CreatedAt:    model.CreatedAt,
+		CreatedAt:    pubapi.DateTime(model.CreatedAt),
 	}
 }


### PR DESCRIPTION
Use a custom type for output timestamps all across the API v1 so we can override the format string to something very specific.