### PR TITLE
Pascal/mar 1321 avoid write then read on decisions create all usecase

### DIFF
--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -573,9 +573,7 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 	decisions = make([]models.DecisionWithRuleExecutions, len(items))
 	sendWebhookEventIds := make([]string, 0)
 	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		ids := make([]string, len(items))
 		for i, item := range items {
-			ids[i] = item.decision.DecisionId.String()
 			storageStart := time.Now()
 
 			if err = usecase.repository.StoreDecision(


### PR DESCRIPTION
Avoid to write-then-read the decisions, decisions rules and screenings on the /decisions/all path, which is wasteful and not needed (and possibly a cause of P99 latency on Swan)

This does make me want to clean out some dtos, it's quite hard to follow in some paths. But in a future PR outside the hotfix.

I'd like to try this one as a hotfix to see what result it gives on swan's decisions.