### PR TITLE
Deprecate Postgres keyword-style DSN, in favor of standard URLs.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os/signal"
 	"syscall"
 	"time"
@@ -104,6 +105,17 @@ func RunServer(config CompiledConfig) error {
 		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 		ImpersonateRole:    utils.GetEnv("PG_IMPERSONATE_ROLE", ""),
 	}
+	if pgConfig.ConnectionString != "" {
+		if u, err := url.Parse(pgConfig.ConnectionString); err != nil || !u.IsAbs() {
+			switch err {
+			case nil:
+				return errors.New("invalid database connection string")
+			default:
+				return errors.Wrap(err, "invalid database connection string")
+			}
+		}
+	}
+
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),
 		APIUrl:    utils.GetEnv("CONVOY_API_URL", ""),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"reflect"
@@ -47,6 +48,17 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		SslMode:            utils.GetEnv("PG_SSL_MODE", "prefer"),
 		ImpersonateRole:    utils.GetEnv("PG_IMPERSONATE_ROLE", ""),
 	}
+	if pgConfig.ConnectionString != "" {
+		if u, err := url.Parse(pgConfig.ConnectionString); err != nil || !u.IsAbs() {
+			switch err {
+			case nil:
+				return errors.New("invalid database connection string")
+			default:
+				return errors.Wrap(err, "invalid database connection string")
+			}
+		}
+	}
+
 	convoyConfiguration := infra.ConvoyConfiguration{
 		APIKey:    utils.GetEnv("CONVOY_API_KEY", ""),
 		APIUrl:    utils.GetEnv("CONVOY_API_URL", ""),

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -201,8 +201,8 @@ func (usecase *CaseUseCase) ListCases(
 	)
 }
 
-func (uc *CaseUseCase) GetCasesReferents(ctx context.Context, caseIds []string) (map[string]models.CaseReferents, error) {
-	referents, err := uc.repository.GetCaseReferents(ctx, uc.executorFactory.NewExecutor(), caseIds)
+func (usecase *CaseUseCase) GetCasesReferents(ctx context.Context, caseIds []string) (map[string]models.CaseReferents, error) {
+	referents, err := usecase.repository.GetCaseReferents(ctx, usecase.executorFactory.NewExecutor(), caseIds)
 	if err != nil {
 		return nil, err
 	}
@@ -216,25 +216,25 @@ func (uc *CaseUseCase) GetCasesReferents(ctx context.Context, caseIds []string) 
 	return referentMap, nil
 }
 
-func (uc *CaseUseCase) GetCaseComments(ctx context.Context, caseId string, paging models.PaginationAndSorting) (models.Paginated[models.CaseEvent], error) {
-	c, err := uc.GetCase(ctx, caseId)
+func (usecase *CaseUseCase) GetCaseComments(ctx context.Context, caseId string, paging models.PaginationAndSorting) (models.Paginated[models.CaseEvent], error) {
+	c, err := usecase.GetCase(ctx, caseId)
 	if err != nil {
 		return models.Paginated[models.CaseEvent]{}, errors.Wrap(err, "could not retrieve requested case")
 	}
 
-	inboxes, err := uc.getAvailableInboxIds(ctx, uc.executorFactory.NewExecutor(), c.OrganizationId)
+	inboxes, err := usecase.getAvailableInboxIds(ctx, usecase.executorFactory.NewExecutor(), c.OrganizationId)
 	if err != nil {
 		return models.Paginated[models.CaseEvent]{}, errors.Wrap(err, "could not retrieve available inboxes")
 	}
 
-	if err := uc.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), inboxes); err != nil {
+	if err := usecase.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), inboxes); err != nil {
 		return models.Paginated[models.CaseEvent]{}, err
 	}
 
 	pagingPlusOne := paging
 	pagingPlusOne.Limit += 1
 
-	comments, err := uc.repository.ListCaseEventsOfTypes(ctx, uc.executorFactory.NewExecutor(), caseId, []models.CaseEventType{models.CaseCommentAdded}, pagingPlusOne)
+	comments, err := usecase.repository.ListCaseEventsOfTypes(ctx, usecase.executorFactory.NewExecutor(), caseId, []models.CaseEventType{models.CaseCommentAdded}, pagingPlusOne)
 	if err != nil {
 		return models.Paginated[models.CaseEvent]{}, errors.Wrap(err, "could not list comment case events")
 	}
@@ -245,22 +245,22 @@ func (uc *CaseUseCase) GetCaseComments(ctx context.Context, caseId string, pagin
 	}, nil
 }
 
-func (uc *CaseUseCase) GetCaseFiles(ctx context.Context, caseId string) ([]models.CaseFile, error) {
-	c, err := uc.GetCase(ctx, caseId)
+func (usecase *CaseUseCase) GetCaseFiles(ctx context.Context, caseId string) ([]models.CaseFile, error) {
+	c, err := usecase.GetCase(ctx, caseId)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve requested case")
 	}
 
-	inboxes, err := uc.getAvailableInboxIds(ctx, uc.executorFactory.NewExecutor(), c.OrganizationId)
+	inboxes, err := usecase.getAvailableInboxIds(ctx, usecase.executorFactory.NewExecutor(), c.OrganizationId)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not retrieve available inboxes")
 	}
 
-	if err := uc.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), inboxes); err != nil {
+	if err := usecase.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), inboxes); err != nil {
 		return nil, err
 	}
 
-	caseFiles, err := uc.repository.GetCasesFileByCaseId(ctx, uc.executorFactory.NewExecutor(), caseId)
+	caseFiles, err := usecase.repository.GetCasesFileByCaseId(ctx, usecase.executorFactory.NewExecutor(), caseId)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We want to standardize on a single, canonical standard for connection strings. Postgres supported two styles: URLs and keyword-style DSNs. We now only support URLs.