### PR TITLE
make ENV optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,6 @@
 # REQUIRED SETTINGS
 #
 
-# MUST be set to 'production' when not testing. In which case HTTPS will be assumed.
-ENV=development
 PORT=8080
 
 # Set this to the full url used by your users to access Marble's frontend
@@ -113,6 +111,9 @@ LOGGING_FORMAT=text
 #
 # OPTIONAL SETTINGS
 #
+
+# MUST be set to a value other than 'development' (or not set at all) when in production, or unsafe CORS settings will apply.
+ENV=development
 
 # Uncomment this line if you are using the Firebase emulator for testing.
 # FIREBASE_AUTH_EMULATOR_HOST="localhost:9099"

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -46,7 +46,7 @@ func RunServer(config CompiledConfig) error {
 
 	// This is where we read the environment variables and set up the configuration for the application.
 	apiConfig := api.Configuration{
-		Env:                 utils.GetEnv("ENV", "development"),
+		Env:                 utils.GetEnv("ENV", "production"),
 		AppName:             "marble-backend",
 		MarbleApiUrl:        utils.GetEnv("MARBLE_API_URL", ""),
 		MarbleAppUrl:        utils.GetEnv("MARBLE_APP_URL", ""),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -83,7 +83,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 
 	workerConfig := WorkerConfig{
 		appName:                     "marble-backend-worker",
-		env:                         utils.GetEnv("ENV", "development"),
+		env:                         utils.GetEnv("ENV", "production"),
 		failedWebhooksRetryPageSize: utils.GetEnv("FAILED_WEBHOOKS_RETRY_PAGE_SIZE", 1000),
 		ingestionBucketUrl:          utils.GetRequiredEnv[string]("INGESTION_BUCKET_URL"),
 		loggingFormat:               utils.GetEnv("LOGGING_FORMAT", "text"),


### PR DESCRIPTION
No more useless, mandatory env vars for end users: use reasonable production values, opt-in for unsafe development values.

Setting ENV to "develoment" allows CORS for a. series of localhost ports, and sets to test not release mode.