### PR TITLE
Fall back to userinfo endpoint if ID token does not contain necessary claims

### DIFF
--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -63,12 +63,12 @@ func InitDependencies(
 		idpTokenVerifier = idp.NewFirebaseClient(conf.FirebaseConfig.ProjectId, optTokenVerifier[0])
 		tokenIssuer = idpTokenVerifier.Issuer()
 	case auth.TokenProviderOidc:
-		oidcConfig, err := infra.InitializeOidc(ctx)
+		oidcConfig, err := infra.InitializeOidc(ctx, conf.MarbleAppUrl)
 		if err != nil {
 			return dependencies{}, err
 		}
 
-		idpTokenVerifier = idp.NewOidcClient(oidcConfig.Issuer, oidcConfig.Verifier)
+		idpTokenVerifier = idp.NewOidcClient(oidcConfig.Provider, oidcConfig.Issuer, oidcConfig.Verifier)
 		tokenIssuer = idpTokenVerifier.Issuer()
 	}
 

--- a/api/handle_config.go
+++ b/api/handle_config.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/checkmarble/marble-backend/dto"
@@ -38,7 +37,7 @@ func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Contex
 			oidcConfig = &dto.ConfigAuthOidcDto{
 				Issuer:      cfg.OidcConfig.Issuer,
 				ClientId:    cfg.OidcConfig.ClientId,
-				RedirectUri: fmt.Sprintf("%s/oidc/callback", cfg.MarbleAppUrl),
+				RedirectUri: cfg.OidcConfig.RedirectUri,
 				Scopes:      cfg.OidcConfig.Scopes,
 				ExtraParams: cfg.OidcConfig.ExtraParams,
 			}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -31,12 +31,13 @@ func RunServer(config CompiledConfig) error {
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
 
 	isMarbleSaasProject := infra.IsMarbleSaasProject()
+	marbleAppUrl := utils.GetEnv("MARBLE_APP_URL", "")
 
 	authProvider := auth.ParseTokenProvider(utils.GetEnv("AUTH_PROVIDER", "firebase"))
 	oidcProvider := infra.OidcConfig{}
 
 	if authProvider == auth.TokenProviderOidc {
-		oidc, err := infra.InitializeOidc(ctx)
+		oidc, err := infra.InitializeOidc(ctx, marbleAppUrl)
 		if err != nil {
 			return err
 		}
@@ -49,7 +50,7 @@ func RunServer(config CompiledConfig) error {
 		Env:                 utils.GetEnv("ENV", "production"),
 		AppName:             "marble-backend",
 		MarbleApiUrl:        utils.GetEnv("MARBLE_API_URL", ""),
-		MarbleAppUrl:        utils.GetEnv("MARBLE_APP_URL", ""),
+		MarbleAppUrl:        marbleAppUrl,
 		MarbleBackofficeUrl: utils.GetEnv("MARBLE_BACKOFFICE_URL", ""),
 		Port:                utils.GetRequiredEnv[string]("PORT"),
 		RequestLoggingLevel: utils.GetEnv("REQUEST_LOGGING_LEVEL", "all"),

--- a/infra/oidc.go
+++ b/infra/oidc.go
@@ -2,6 +2,7 @@ package infra
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -23,7 +24,7 @@ type OidcConfig struct {
 	Verifier *oidc.IDTokenVerifier
 }
 
-func InitializeOidc(ctx context.Context) (OidcConfig, error) {
+func InitializeOidc(ctx context.Context, marbleAppUrl string) (OidcConfig, error) {
 	issuer := utils.GetEnv("AUTH_OIDC_ISSUER", "")
 	clientId := utils.GetEnv("AUTH_OIDC_CLIENT_ID", "")
 	extraParams := map[string]string{}
@@ -56,7 +57,7 @@ func InitializeOidc(ctx context.Context) (OidcConfig, error) {
 		ClientId:     clientId,
 		ClientSecret: utils.GetEnv("AUTH_OIDC_CLIENT_SECRET", ""),
 		Scopes:       strings.Split(utils.GetEnv("AUTH_OIDC_SCOPE", ""), ","),
-		RedirectUri:  utils.GetEnv("AUTH_OIDC_REDIRECT_URI", ""),
+		RedirectUri:  fmt.Sprintf("%s/oidc/callback", marbleAppUrl),
 		ExtraParams:  extraParams,
 
 		AllowedDomains: allowedDomains,

--- a/mocks/token.go
+++ b/mocks/token.go
@@ -54,6 +54,6 @@ func (e StaticIdpTokenVerifier) Issuer() string {
 	return e.issuer
 }
 
-func (e StaticIdpTokenVerifier) VerifyToken(ctx context.Context, idToken string) (models.IdentityClaims, error) {
+func (e StaticIdpTokenVerifier) VerifyToken(ctx context.Context, idToken, accessToken string) (models.IdentityClaims, error) {
 	return e.claims, nil
 }

--- a/repositories/idp/auth.go
+++ b/repositories/idp/auth.go
@@ -8,5 +8,5 @@ import (
 
 type TokenRepository interface {
 	Issuer() string
-	VerifyToken(ctx context.Context, firebaseToken string) (models.IdentityClaims, error)
+	VerifyToken(ctx context.Context, idToken, accessToken string) (models.IdentityClaims, error)
 }

--- a/repositories/idp/firebase.go
+++ b/repositories/idp/firebase.go
@@ -31,7 +31,7 @@ func (c *FirebaseClient) verifyTokenOrCookie(ctx context.Context, firebaseToken 
 	return token, nil
 }
 
-func (c *FirebaseClient) VerifyToken(ctx context.Context, firebaseToken string) (models.IdentityClaims, error) {
+func (c *FirebaseClient) VerifyToken(ctx context.Context, firebaseToken, _accessToken string) (models.IdentityClaims, error) {
 	token, err := c.verifyTokenOrCookie(ctx, firebaseToken)
 	if err != nil {
 		return models.FirebaseIdentity{}, fmt.Errorf("firebaseVerifyToken error: %w", err)

--- a/repositories/idp/firebase_test.go
+++ b/repositories/idp/firebase_test.go
@@ -39,7 +39,7 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 
 		c := NewFirebaseClient("project", mockVerifier)
 
-		identity, err := c.VerifyToken(context.Background(), "token")
+		identity, err := c.VerifyToken(context.Background(), "token", "")
 		assert.NoError(t, err)
 		assert.Equal(t, models.FirebaseIdentity{
 			Issuer: infra.MockFirebaseIssuer,
@@ -55,7 +55,7 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 
 		c := NewFirebaseClient("project", mockVerifier)
 
-		_, err := c.VerifyToken(context.Background(), "token")
+		_, err := c.VerifyToken(context.Background(), "token", "")
 		assert.Error(t, err)
 		mockVerifier.AssertExpectations(t)
 	})
@@ -67,7 +67,7 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 
 		c := NewFirebaseClient("project", mockVerifier)
 
-		_, err := c.VerifyToken(context.Background(), "token")
+		_, err := c.VerifyToken(context.Background(), "token", "")
 		assert.Error(t, err)
 		mockVerifier.AssertExpectations(t)
 	})
@@ -87,7 +87,7 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 
 		c := NewFirebaseClient("project", mockVerifier)
 
-		_, err := c.VerifyToken(context.Background(), "token")
+		_, err := c.VerifyToken(context.Background(), "token", "")
 		assert.Error(t, err)
 		mockVerifier.AssertExpectations(t)
 	})
@@ -107,7 +107,7 @@ func TestClient_VerifyFirebaseToken(t *testing.T) {
 
 		c := NewFirebaseClient("project", mockVerifier)
 
-		_, err := c.VerifyToken(context.Background(), "token")
+		_, err := c.VerifyToken(context.Background(), "token", "")
 		assert.Error(t, err)
 		mockVerifier.AssertExpectations(t)
 	})

--- a/repositories/idp/oidc.go
+++ b/repositories/idp/oidc.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
 )
 
 type oidcTokenVerifier interface {
@@ -15,16 +16,18 @@ type oidcTokenVerifier interface {
 type OidcClient struct {
 	issuer   string
 	verifier oidcTokenVerifier
+	provider *oidc.Provider
 }
 
-func NewOidcClient(issuer string, verifier *oidc.IDTokenVerifier) *OidcClient {
+func NewOidcClient(provider *oidc.Provider, issuer string, verifier *oidc.IDTokenVerifier) *OidcClient {
 	return &OidcClient{
 		issuer:   issuer,
 		verifier: verifier,
+		provider: provider,
 	}
 }
 
-func (c *OidcClient) VerifyToken(ctx context.Context, idToken string) (models.IdentityClaims, error) {
+func (c *OidcClient) VerifyToken(ctx context.Context, idToken, accessToken string) (models.IdentityClaims, error) {
 	token, err := c.verifier.Verify(ctx, idToken)
 	if err != nil {
 		return models.OidcIdentity{}, err
@@ -35,8 +38,20 @@ func (c *OidcClient) VerifyToken(ctx context.Context, idToken string) (models.Id
 	if err := token.Claims(&claims); err != nil {
 		return models.OidcIdentity{}, err
 	}
+
 	if claims.GetEmail() == "" {
-		return models.OidcIdentity{}, errors.New("oidc claims do not contain the principal's email or it is not verified")
+		userinfo, err := c.provider.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken}))
+		if err != nil {
+			return models.OidcIdentity{}, err
+		}
+
+		if err := userinfo.Claims(&claims); err != nil {
+			return models.OidcIdentity{}, err
+		}
+
+		if claims.GetEmail() == "" {
+			return models.OidcIdentity{}, errors.New("oidc claims do not contain the principal's email or it is not verified")
+		}
 	}
 
 	return claims, nil

--- a/usecases/auth/extractor.go
+++ b/usecases/auth/extractor.go
@@ -19,8 +19,9 @@ type Extractor interface {
 }
 
 type Credentials struct {
-	Type  CredentialsType
-	Value string
+	Type     CredentialsType
+	Value    string
+	Fallback string
 }
 
 type MarbleExtractor struct{}
@@ -31,11 +32,11 @@ func DefaultExtractor() Extractor {
 
 func (e MarbleExtractor) Extract(r *http.Request) (Credentials, error) {
 	if header := r.Header.Get("x-api-key"); header != "" {
-		return Credentials{CredentialsApiKey, header}, nil
+		return Credentials{CredentialsApiKey, header, ""}, nil
 	}
 
 	if header := r.Header.Get("authorization"); header != "" && strings.HasPrefix(header, "Bearer ") {
-		return Credentials{CredentialsBearer, strings.TrimPrefix(header, "Bearer ")}, nil
+		return Credentials{CredentialsBearer, strings.TrimPrefix(header, "Bearer "), r.Header.Get("x-oidc-access-token")}, nil
 	}
 
 	return Credentials{}, errors.New("missing credentials in headers")

--- a/usecases/auth/verifier.go
+++ b/usecases/auth/verifier.go
@@ -66,7 +66,7 @@ func NewVerifier(flavor TokenProvider, verifier idp.TokenRepository, repository 
 func (v MarbleVerifier) Verify(ctx context.Context, creds Credentials) (models.IntoCredentials, models.IdentityClaims, error) {
 	switch creds.Type {
 	case CredentialsBearer:
-		identity, err := v.verifier.VerifyToken(ctx, creds.Value)
+		identity, err := v.verifier.VerifyToken(ctx, creds.Value, creds.Fallback)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
We can now fallback to retrieving claims from userinfo endpoint if ID token does not contain the necessary claims to establish a session. Some IDPs (hello Okta) do emit what they call a "thin" ID token that does not contain any of the claims we require. Here, the only way for us to get them is to use the access token to call the userinfo endpoint.

Also, always use built redirect URI from Marble App URL instead of using envvar.