### PR TITLE
Ingest stable_rule_id in analytics bucket, and group by it.

### DIFF
--- a/repositories/analytics_export_repository.go
+++ b/repositories/analytics_export_repository.go
@@ -138,6 +138,7 @@ func AnalyticsCopyDecisionRules(ctx context.Context, exec AnalyticsExecutor, req
 			"dr.result",
 			"dr.outcome",
 			"dr.rule_id",
+			"sir.stable_rule_id as stable_rule_id",
 			"sir.name as rule_name",
 			"d.pivot_id", "d.pivot_value",
 			"s.id as scenario_id",

--- a/usecases/analytics_query_usecase.go
+++ b/usecases/analytics_query_usecase.go
@@ -129,7 +129,7 @@ func (uc AnalyticsQueryUsecase) RuleVsDecisionOutcome(ctx context.Context, filte
 		InnerJoin(uc.analyticsFactory.BuildTarget("decisions", "d")+" on d.id = dr.decision_id").
 		Where("d.created_at between ? and ?", filters.Start, filters.End).
 		Where("rule_name is not null and dr.outcome = 'hit'").
-		GroupBy("rule_id", "rule_name", "d.outcome")
+		GroupBy("stable_rule_id", "rule_name", "d.outcome")
 
 	query, err = uc.analyticsFactory.ApplyFilters(query, scenario, filters, "dr")
 	if err != nil {


### PR DESCRIPTION
In the "decision count per rule", we grouped by rule ID so had several rows for the same rule across multiple iteration versions.

This PR ingests the stable rule ID and group by it during query.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `stable_rule_id` to `decision_rules` analytics export and groups RuleVsDecisionOutcome by `stable_rule_id` to aggregate across rule iterations.
> 
> - **Analytics export**:
>   - `repositories/analytics_export_repository.go`:
>     - Include `sir.stable_rule_id as stable_rule_id` in `AnalyticsCopyDecisionRules` select.
> - **Analytics queries**:
>   - `usecases/analytics_query_usecase.go`:
>     - `RuleVsDecisionOutcome`: change `GROUP BY` from `rule_id` to `stable_rule_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e148bf15921e3a0bf85e4d074d8b07f4605f09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->