### PR TITLE
Short-circuit bag of words ot return 0 on empty input.

### DIFF
--- a/pure_utils/strings.go
+++ b/pure_utils/strings.go
@@ -120,6 +120,11 @@ func BagOfWordsSimilarity(s1, s2 string) int {
 	s1 = cleanseString(s1)
 	s2 = cleanseString(s2)
 
+	// If one of the string is empty (after cleanup), short-circuit and return no similarity
+	if (len(s1) == 0 && len(s2) > 0) || (len(s1) > 0 && len(s2) == 0) {
+		return 0
+	}
+
 	set1 := stringToSet(s1)
 	set2 := stringToSet(s2)
 

--- a/pure_utils/strings_test.go
+++ b/pure_utils/strings_test.go
@@ -21,6 +21,9 @@ func TestBagOfWordsSimilarity(t *testing.T) {
 		{"the dog was walking on the sidewalk", "the d og as walkin' on the side alk", 72},
 		{"Mr Mrs John Jane OR Doe Smith	", "John Doe", 100},
 		{"ça, c'est une théière", "la theier a une typo", 65},
+		{"🇨🇦", "anything", 0},
+		{"❤️", "this is a heart", 0},
+		{"🏴󠁧󠁢󠁳󠁣󠁴󠁿", "28-byte long emoji (Scotland flag)", 0},
 	}
 
 	for _, example := range examples {


### PR DESCRIPTION
Especially useful if a string only contains grapheme clusters that are cleaned out (such as emojis), the previous function would return 100% match.