### PR TITLE
DuckDB: re-enable index scan.

### DIFF
--- a/usecases/executor_factory/analytics_executor_factory.go
+++ b/usecases/executor_factory/analytics_executor_factory.go
@@ -76,7 +76,7 @@ func (f AnalyticsExecutorFactory) GetExecutorWithSource(ctx context.Context, ali
 		if _, err = exportDb.ExecContext(ctx, f.buildUpstreamAttachStatement(alias)); err != nil {
 			return
 		}
-		if _, err = exportDb.ExecContext(ctx, fmt.Sprintf(`set threads to 1; call postgres_execute('%[1]s', 'set enable_seqscan = 0'); call postgres_execute('%[1]s', 'set enable_indexscan = 0');`, alias)); err != nil {
+		if _, err = exportDb.ExecContext(ctx, fmt.Sprintf(`set threads to 1; call postgres_execute('%[1]s', 'set enable_seqscan = 0');`, alias)); err != nil {
 			return
 		}
 	})

--- a/usecases/scheduled_execution/analytics_merge_job.go
+++ b/usecases/scheduled_execution/analytics_merge_job.go
@@ -21,13 +21,13 @@ import (
 
 func NewAnalyticsMergeJob() *river.PeriodicJob {
 	return river.NewPeriodicJob(
-		river.PeriodicInterval(time.Minute),
+		river.PeriodicInterval(time.Hour),
 		func() (river.JobArgs, *river.InsertOpts) {
 			return models.AnalyticsMergeArgs{}, &river.InsertOpts{
 				Queue: "analytics_merge",
 				UniqueOpts: river.UniqueOpts{
 					ByQueue:  true,
-					ByPeriod: time.Minute,
+					ByPeriod: time.Hour,
 				},
 			}
 		},
@@ -149,8 +149,8 @@ func (w AnalyticsMergeWorker) merge(
 	dbExec repositories.Executor,
 	exec repositories.AnalyticsExecutor,
 	watermarkType models.WatermarkType,
-	kind, tableName string) error {
-
+	kind, tableName string,
+) error {
 	logger := utils.LoggerFromContext(ctx).With("org_id", orgId, "kind", kind, "trigger_object_type", tableName)
 
 	// Let's find the first partition (e.g. month) that can be merged. The eligible partition is the first month:


### PR DESCRIPTION
ALso: Enable filter for analytics export on multiple orgs.