### PR TITLE
Set up optional pprof endpoint on the worker.

### DIFF
--- a/api/configuration.go
+++ b/api/configuration.go
@@ -10,6 +10,7 @@ import (
 type Configuration struct {
 	Env                 string
 	AppName             string
+	AppVersion          string
 	Port                string
 	MarbleApiUrl        string
 	MarbleAppUrl        string
@@ -29,6 +30,7 @@ type Configuration struct {
 	FirebaseConfig FirebaseConfig
 	OidcConfig     infra.OidcConfig
 
+	GcpConfig      infra.GcpConfig
 	MetabaseConfig infra.MetabaseConfiguration
 }
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/checkmarble/marble-backend/infra"
@@ -53,6 +54,10 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	}
 
 	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	if os.Getenv("DEBUG_ENABLE_PROFILING") == "1" {
+		utils.SetupProfilerEndpoints(r, "marble-backend", conf.AppVersion, conf.GcpConfig.ProjectId)
+	}
 
 	if infra.IsMarbleSaasProject() {
 		r.POST("/metrics", tom, handleMetricsIngestion(uc))

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	cloud.google.com/go/firestore v1.18.0 // indirect
 	cloud.google.com/go/longrunning v0.6.7 // indirect
 	cloud.google.com/go/monitoring v1.24.2 // indirect
+	cloud.google.com/go/profiler v0.4.3 // indirect
 	cloud.google.com/go/trace v1.11.6 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.1 // indirect
@@ -183,6 +184,7 @@ require (
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20250602020802-c6617b811d0e // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/google/wire v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/longrunning v0.6.7 h1:IGtfDWHhQCgCjwQjV9iiLnUta9LBCo8R9QmAFs
 cloud.google.com/go/longrunning v0.6.7/go.mod h1:EAFV3IZAKmM56TyiE6VAP3VoTzhZzySwI/YI1s/nRsY=
 cloud.google.com/go/monitoring v1.24.2 h1:5OTsoJ1dXYIiMiuL+sYscLc9BumrL3CarVLL7dd7lHM=
 cloud.google.com/go/monitoring v1.24.2/go.mod h1:x7yzPWcgDRnPEv3sI+jJGBkwl5qINf+6qY4eq0I9B4U=
+cloud.google.com/go/profiler v0.4.3 h1:IY3QNKlr8VbXwGWHcZbJQsMA/83ZTH6uAHf8jYyj7OI=
+cloud.google.com/go/profiler v0.4.3/go.mod h1:3xFodugWfPIQZWFcXdUmfa+yTiiyQ8fWrdT+d2Sg4J0=
 cloud.google.com/go/storage v1.57.0 h1:4g7NB7Ta7KetVbOMpCqy89C+Vg5VE8scqlSHUPm7Rds=
 cloud.google.com/go/storage v1.57.0/go.mod h1:329cwlpzALLgJuu8beyJ/uvQznDHpa2U5lGjWednkzg=
 cloud.google.com/go/trace v1.11.6 h1:2O2zjPzqPYAHrn3OKl029qlqG6W8ZdYaOWRyr8NgMT4=
@@ -320,6 +322,8 @@ github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
+github.com/google/pprof v0.0.0-20250602020802-c6617b811d0e h1:FJta/0WsADCe1r9vQjdHbd3KuiLPu7Y9WlyLGwMUNyE=
+github.com/google/pprof v0.0.0-20250602020802-c6617b811d0e/go.mod h1:5hDyRhoBCxViHszMt12TnOpEI4VVi+U8Gm9iphldiMA=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=

--- a/utils/profiling.go
+++ b/utils/profiling.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+
+	"cloud.google.com/go/profiler"
+	"github.com/gin-gonic/gin"
+)
+
+func SetupProfilerEndpoints(r *gin.Engine, serviceName, serviceVersion, gcpProjectId string) {
+	switch key := os.Getenv("DEBUG_PROFILING_MODE"); key {
+	case "gcp":
+		cfg := profiler.Config{
+			ProjectID:      gcpProjectId,
+			Service:        serviceName,
+			ServiceVersion: serviceVersion,
+		}
+
+		if err := profiler.Start(cfg); err != nil {
+			fmt.Println(err)
+		}
+
+	case "http":
+		pp := r.Group("/debug/pprof")
+		pp.Use(func(c *gin.Context) {
+			if c.Request.Header.Get("authorization") != "Bearer "+os.Getenv("DEBUG_PROFILING_TOKEN") {
+				c.AbortWithStatus(http.StatusUnauthorized)
+			}
+		})
+
+		pp.GET("/profile", gin.WrapF(pprof.Profile))
+		pp.GET("/goroutine", gin.WrapH(pprof.Handler("goroutine")))
+		pp.GET("/heap", gin.WrapH(pprof.Handler("heap")))
+		pp.GET("/threadcreate", gin.WrapH(pprof.Handler("threadcreate")))
+		pp.GET("/block", gin.WrapH(pprof.Handler("block")))
+		pp.GET("/mutex", gin.WrapH(pprof.Handler("mutex")))
+	}
+}


### PR DESCRIPTION
This introduces _(yet again...)_ three environment variables used to enabled `pprof` on both the backend and the worker:

 * `DEBUG_ENABLE_PROFILING`
 * `DEBUG_PROFILING_MODE` (`http` or `gcp`)
 * `DEBUG_PROFILING_TOKEN` (used with the `http` mode to protect the debug endpoints)

In the `http` mode, relevant `pprof` endpoints are mounted at `/debug/pprof` and exposed through both the backend's API and the worker's probe server.

In the `gcp` mode, the Cloud Profiler library is used to periodically send profiling data to GCP's profiler. It uses the default Google Project configured on Marble, and categorizes profile data with the binary and its version.