### PR TITLE
feat(screening_monitoring): Do Screening before inserting new object in monitoring list

### DIFF
--- a/api/handle_screening_monitoring.go
+++ b/api/handle_screening_monitoring.go
@@ -132,14 +132,16 @@ func handleInsertScreeningMonitoringObject(uc usecases.Usecases) func(c *gin.Con
 		}
 
 		uc := usecasesWithCreds(ctx, uc).NewScreeningMonitoringUsecase()
-		err := uc.InsertScreeningMonitoringObject(
+		screeningResponse, err := uc.InsertScreeningMonitoringObject(
 			ctx,
-			dto.AdaptInsertScreeningMonitoringObjectDtoToModel(input),
+			dto.AdaptInsertScreeningMonitoringObjectDto(input),
 		)
 		if presentError(ctx, c, err) {
 			return
 		}
 
-		c.Status(http.StatusCreated)
+		c.JSON(http.StatusCreated, dto.AdaptScreeningDto(
+			screeningResponse,
+		))
 	}
 }

--- a/dto/screening_monitoring_config.go
+++ b/dto/screening_monitoring_config.go
@@ -148,7 +148,7 @@ func (dto InsertScreeningMonitoringObjectDto) Validate() error {
 	return nil
 }
 
-func AdaptInsertScreeningMonitoringObjectDtoToModel(dto InsertScreeningMonitoringObjectDto) models.InsertScreeningMonitoringObject {
+func AdaptInsertScreeningMonitoringObjectDto(dto InsertScreeningMonitoringObjectDto) models.InsertScreeningMonitoringObject {
 	return models.InsertScreeningMonitoringObject{
 		ObjectType:    dto.ObjectType,
 		ConfigId:      dto.ConfigId,

--- a/mocks/screening_monitoring_repository.go
+++ b/mocks/screening_monitoring_repository.go
@@ -94,3 +94,18 @@ func (m *ScreeningMonitoringClientDbRepository) InsertScreeningMonitoringObject(
 	args := m.Called(ctx, exec, tableName, objectId, configId)
 	return args.Error(0)
 }
+
+type ScreeningMonitoringScreeningProvider struct {
+	mock.Mock
+}
+
+func (m *ScreeningMonitoringScreeningProvider) Search(
+	ctx context.Context,
+	query models.OpenSanctionsQuery,
+) (models.ScreeningRawSearchResponseWithMatches, error) {
+	args := m.Called(ctx, query)
+	if args.Get(0) == nil {
+		return models.ScreeningRawSearchResponseWithMatches{}, args.Error(1)
+	}
+	return args.Get(0).(models.ScreeningRawSearchResponseWithMatches), args.Error(1)
+}

--- a/usecases/screening_monitoring/object_monitoring_operation.go
+++ b/usecases/screening_monitoring/object_monitoring_operation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
@@ -18,37 +19,37 @@ import (
 //
 // If the object already ingested and it is a new version, we will ignore the conflict error and consider the object as a new one and force the screening on the updated object.
 // The updated object should be ingested, we check if the object has been ingested before resume the screening monitoring operation.
-// TODO: Do a screening on the object before inserting it into the list.
 func (uc *ScreeningMonitoringUsecase) InsertScreeningMonitoringObject(
 	ctx context.Context,
 	input models.InsertScreeningMonitoringObject,
-) error {
+) (models.ScreeningWithMatches, error) {
 	exec := uc.executorFactory.NewExecutor()
 
 	// Check if the config exists
 	config, err := uc.repository.GetScreeningMonitoringConfig(ctx, exec, input.ConfigId)
 	if err != nil {
-		return err
+		return models.ScreeningWithMatches{}, err
 	}
 
 	if err := uc.enforceSecurity.WriteMonitoredObject(config.OrgId); err != nil {
-		return err
+		return models.ScreeningWithMatches{}, err
 	}
 
 	// Get Data Model Table
 	dataModel, err := uc.repository.GetDataModel(ctx, exec, config.OrgId, false, false)
 	if err != nil {
-		return err
+		return models.ScreeningWithMatches{}, err
 	}
-
 	table, ok := dataModel.Tables[input.ObjectType]
 	if !ok {
-		return errors.Wrapf(models.NotFoundError, "table %s not found in data model", input.ObjectType)
+		return models.ScreeningWithMatches{},
+			errors.Wrapf(models.BadParameterError, "table %s not found in data model", input.ObjectType)
 	}
 
-	// Check if data model table and fields are well configured for screening monitoring
-	if err := checkDataModelTableAndFieldsConfiguration(table); err != nil {
-		return err
+	// Check if data model table and fields are well configured for screening monitoring and fetch the mapping
+	dataModelMapping, err := buildDataModelMapping(table)
+	if err != nil {
+		return models.ScreeningWithMatches{}, errors.Wrap(models.BadParameterError, err.Error())
 	}
 
 	var objectId string
@@ -57,24 +58,21 @@ func (uc *ScreeningMonitoringUsecase) InsertScreeningMonitoringObject(
 
 	// Ingest the object if provided
 	if input.ObjectPayload != nil {
-		nb, err := uc.ingestionUsecase.IngestObject(ctx, config.OrgId, input.ObjectType, *input.ObjectPayload)
+		objectId, err = uc.ingestObject(ctx, config.OrgId, input)
 		if err != nil {
-			return err
-		}
-		if nb == 0 {
-			return errors.New("no object ingested")
-		}
-		objectId, err = extractObjectIDFromPayload(*input.ObjectPayload)
-		if err != nil {
-			return err
+			return models.ScreeningWithMatches{}, err
 		}
 		ignoreConflictError = true
 	} else if input.ObjectId != nil {
 		objectId = *input.ObjectId
 	} else {
 		// Should never happen if the input is validated
-		return errors.New("object_id or object_payload is required")
+		return models.ScreeningWithMatches{},
+			errors.New("object_id or object_payload is required")
 	}
+
+	var screeningResponse models.ScreeningRawSearchResponseWithMatches
+	var query models.OpenSanctionsQuery
 
 	// Check if the object exists in ingested data then insert it into screening monitoring table
 	// Create if not exists the screening monitoring table and index
@@ -96,6 +94,16 @@ func (uc *ScreeningMonitoringUsecase) InsertScreeningMonitoringObject(
 			return err
 		}
 
+		// Do screening on the object
+		query, err = prepareOpenSanctionsQuery(ingestedObjects[0], dataModelMapping.Entity, dataModelMapping.Properties, config)
+		if err != nil {
+			return err
+		}
+		screeningResponse, err = uc.screeningProvider.Search(ctx, query)
+		if err != nil {
+			return err
+		}
+
 		return uc.clientDbRepository.InsertScreeningMonitoringObject(
 			ctx,
 			tx,
@@ -105,28 +113,128 @@ func (uc *ScreeningMonitoringUsecase) InsertScreeningMonitoringObject(
 		)
 	})
 
-	if repositories.IsUniqueViolationError(err) && ignoreConflictError {
-		return nil
+	// Unique violation error is handled below
+	if err != nil && !repositories.IsUniqueViolationError(err) {
+		return models.ScreeningWithMatches{}, err
 	}
+
+	screeningWithMatches := screeningResponse.AdaptScreeningFromSearchResponse(query)
+
+	// If the object already exists in the screening monitoring table, we can ignore the conflict error
+	// in case of ingestion. Consider the object as a new one and force the screening on the updated object.
 	if repositories.IsUniqueViolationError(err) {
-		return errors.Wrap(
+		if ignoreConflictError {
+			return screeningWithMatches, nil
+		}
+		return models.ScreeningWithMatches{}, errors.Wrap(
 			models.ConflictError,
 			"object already exists in screening monitored objects table",
 		)
 	}
-	return err
+	return screeningWithMatches, nil
 }
 
 type payloadObjectID struct {
 	ObjectID string `json:"object_id"`
 }
 
+// From payload, extract the object ID which is a mandatory field
+// Need this ID to retrieve the object, the ingestion doesn't return the object after ingestion
 func extractObjectIDFromPayload(payload json.RawMessage) (string, error) {
 	var objectID payloadObjectID
 	if err := json.Unmarshal(payload, &objectID); err != nil {
 		return "", err
 	}
 	return objectID.ObjectID, nil
+}
+
+// Call screening provider to perform the screening
+func (uc *ScreeningMonitoringUsecase) doScreening(
+	ctx context.Context,
+	query models.OpenSanctionsQuery,
+) (models.ScreeningRawSearchResponseWithMatches, error) {
+	return uc.screeningProvider.Search(ctx, query)
+}
+
+// Ingest the object from payload and return the object ID from payload
+func (uc *ScreeningMonitoringUsecase) ingestObject(
+	ctx context.Context,
+	orgId string,
+	input models.InsertScreeningMonitoringObject,
+) (string, error) {
+	// Ingestion doesn't return the object after operation.
+	nb, err := uc.ingestionUsecase.IngestObject(ctx, orgId, input.ObjectType, *input.ObjectPayload)
+	if err != nil {
+		return "", err
+	}
+	if nb == 0 {
+		// Can happen if the payload defines a previous version of the ingested object based on updated_at
+		return "", errors.New("no object ingested")
+	}
+	return extractObjectIDFromPayload(*input.ObjectPayload)
+}
+
+func stringRepresentation(value any) string {
+	timestampVal, ok := value.(time.Time)
+	if ok {
+		return timestampVal.Format(time.RFC3339)
+	}
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", value)
+}
+
+// Based on data model field mapping, prepare the OpenSanctions Filters
+// For each data model field defined with a follow the money property, put them in the OpenSanctions Filters
+func prepareScreeningFilters(
+	ingestedObject models.DataModelObject,
+	dataModelMapping map[string]string,
+) (models.OpenSanctionsFilter, error) {
+	filters := models.OpenSanctionsFilter{}
+	for modelField, property := range dataModelMapping {
+		if value, ok := ingestedObject.Data[modelField]; ok {
+			filters[property] = append(filters[property], stringRepresentation(value))
+		} else {
+			return nil, errors.Newf("field %s not found in ingested object", modelField)
+		}
+	}
+
+	return filters, nil
+}
+
+// Build the OpenSanctions Query
+func prepareOpenSanctionsQuery(
+	ingestedObject models.DataModelObject,
+	dataModelEntityType string,
+	dataModelMapping map[string]string,
+	config models.ScreeningMonitoringConfig,
+) (models.OpenSanctionsQuery, error) {
+	screeningFilters, err := prepareScreeningFilters(ingestedObject, dataModelMapping)
+	if err != nil {
+		return models.OpenSanctionsQuery{}, err
+	}
+
+	return models.OpenSanctionsQuery{
+		OrgConfig: models.OrganizationOpenSanctionsConfig{
+			MatchThreshold: config.MatchThreshold,
+			MatchLimit:     config.MatchLimit,
+		},
+		Config: models.ScreeningConfig{
+			Datasets: config.Datasets,
+		},
+		Queries: []models.OpenSanctionsCheckQuery{
+			{
+				Type:    dataModelEntityType,
+				Filters: screeningFilters,
+			},
+		},
+	}, nil
+}
+
+type dataModelMapping struct {
+	Entity     string
+	Properties map[string]string
 }
 
 func checkDataModelTableAndFieldsConfiguration(table models.Table) error {
@@ -152,4 +260,23 @@ func checkDataModelTableAndFieldsConfiguration(table models.Table) error {
 	}
 
 	return nil
+}
+
+// Suppose table is configured with a FTM entity and at least one field with a FTM property
+func buildDataModelMapping(table models.Table) (dataModelMapping, error) {
+	// Check if the table is configured correctly
+	if err := checkDataModelTableAndFieldsConfiguration(table); err != nil {
+		return dataModelMapping{}, err
+	}
+	// At this point, table has a FTM entity and at least one field with a FTM property
+	properties := make(map[string]string)
+	for _, field := range table.Fields {
+		if field.FTMProperty != nil {
+			properties[field.Name] = field.FTMProperty.String()
+		}
+	}
+	return dataModelMapping{
+		Entity:     table.FTMEntity.String(),
+		Properties: properties,
+	}, nil
 }

--- a/usecases/screening_monitoring/object_monitoring_operation_test.go
+++ b/usecases/screening_monitoring/object_monitoring_operation_test.go
@@ -3,7 +3,9 @@ package screening_monitoring
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"testing"
+	"time"
 
 	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
@@ -24,6 +26,7 @@ type ScreeningMonitoringUsecaseTestSuite struct {
 	organizationSchemaRepository *mocks.OrganizationSchemaRepository
 	ingestedDataReader           *mocks.ScreeningMonitoringIngestedDataReader
 	ingestionUsecase             *mocks.ScreeningMonitoringIngestionUsecase
+	screeningProvider            *mocks.ScreeningMonitoringScreeningProvider
 	executorFactory              executor_factory.ExecutorFactoryStub
 	transactionFactory           executor_factory.TransactionFactoryStub
 
@@ -41,6 +44,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) SetupTest() {
 	suite.organizationSchemaRepository = new(mocks.OrganizationSchemaRepository)
 	suite.ingestedDataReader = new(mocks.ScreeningMonitoringIngestedDataReader)
 	suite.ingestionUsecase = new(mocks.ScreeningMonitoringIngestionUsecase)
+	suite.screeningProvider = new(mocks.ScreeningMonitoringScreeningProvider)
 
 	suite.executorFactory = executor_factory.NewExecutorFactoryStub()
 	suite.transactionFactory = executor_factory.NewTransactionFactoryStub(suite.executorFactory)
@@ -62,6 +66,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) makeUsecase() *ScreeningMonito
 		organizationSchemaRepository: suite.organizationSchemaRepository,
 		ingestedDataReader:           suite.ingestedDataReader,
 		ingestionUsecase:             suite.ingestionUsecase,
+		screeningProvider:            suite.screeningProvider,
 	}
 }
 
@@ -73,6 +78,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) AssertExpectations() {
 	suite.organizationSchemaRepository.AssertExpectations(t)
 	suite.ingestedDataReader.AssertExpectations(t)
 	suite.ingestionUsecase.AssertExpectations(t)
+	suite.screeningProvider.AssertExpectations(t)
 }
 
 func TestScreeningMonitoringUsecase(t *testing.T) {
@@ -122,6 +128,13 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 	suite.organizationSchemaRepository.On("CreateSchemaIfNotExists", suite.ctx, mock.Anything).Return(nil)
 	suite.clientDbRepository.On("CreateInternalScreeningMonitoringTable", suite.ctx,
 		mock.Anything, suite.objectType).Return(nil)
+	suite.screeningProvider.On("Search", suite.ctx, mock.MatchedBy(func(query models.OpenSanctionsQuery) bool {
+		return len(query.Queries) > 0
+	})).Return(models.ScreeningRawSearchResponseWithMatches{
+		SearchInput:       []byte("{}"),
+		InitialHasMatches: false,
+		Matches:           []models.ScreeningMatch{},
+	}, nil)
 	suite.clientDbRepository.On("InsertScreeningMonitoringObject", suite.ctx, mock.Anything,
 		suite.objectType, suite.objectId, suite.configId).Return(nil)
 
@@ -133,10 +146,11 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectId:   &suite.objectId,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	result, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert
 	suite.NoError(err)
+	suite.NotNil(result)
 	suite.AssertExpectations()
 }
 
@@ -190,6 +204,13 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 	suite.organizationSchemaRepository.On("CreateSchemaIfNotExists", suite.ctx, mock.Anything).Return(nil)
 	suite.clientDbRepository.On("CreateInternalScreeningMonitoringTable", suite.ctx,
 		mock.Anything, suite.objectType).Return(nil)
+	suite.screeningProvider.On("Search", suite.ctx, mock.MatchedBy(func(query models.OpenSanctionsQuery) bool {
+		return len(query.Queries) > 0
+	})).Return(models.ScreeningRawSearchResponseWithMatches{
+		SearchInput:       []byte("{}"),
+		InitialHasMatches: false,
+		Matches:           []models.ScreeningMatch{},
+	}, nil)
 	suite.clientDbRepository.On("InsertScreeningMonitoringObject", suite.ctx, mock.Anything,
 		suite.objectType, suite.objectId, suite.configId).Return(nil)
 
@@ -201,10 +222,11 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectPayload: &payload,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	result, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert
 	suite.NoError(err)
+	suite.NotNil(result)
 	suite.AssertExpectations()
 }
 
@@ -244,7 +266,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectId:   &suite.objectId,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	_, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert
 	suite.Error(err)
@@ -293,7 +315,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectId:   &suite.objectId,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	_, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert
 	suite.Error(err)
@@ -347,7 +369,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectPayload: &payload,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	_, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert
 	suite.Error(err)
@@ -405,6 +427,13 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 	suite.organizationSchemaRepository.On("CreateSchemaIfNotExists", suite.ctx, mock.Anything).Return(nil)
 	suite.clientDbRepository.On("CreateInternalScreeningMonitoringTable", suite.ctx,
 		mock.Anything, suite.objectType).Return(nil)
+	suite.screeningProvider.On("Search", suite.ctx, mock.MatchedBy(func(query models.OpenSanctionsQuery) bool {
+		return len(query.Queries) > 0
+	})).Return(models.ScreeningRawSearchResponseWithMatches{
+		SearchInput:       []byte("{}"),
+		InitialHasMatches: false,
+		Matches:           []models.ScreeningMatch{},
+	}, nil)
 	// Return a unique violation error
 	suite.clientDbRepository.On("InsertScreeningMonitoringObject", suite.ctx, mock.Anything,
 		suite.objectType, suite.objectId, suite.configId).Return(&pgconn.PgError{
@@ -419,10 +448,11 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectPayload: &payload,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	result, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert - should not error when ignoreConflictError is true and unique violation occurs
 	suite.NoError(err)
+	suite.NotNil(result)
 	suite.AssertExpectations()
 }
 
@@ -469,6 +499,13 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 	suite.organizationSchemaRepository.On("CreateSchemaIfNotExists", suite.ctx, mock.Anything).Return(nil)
 	suite.clientDbRepository.On("CreateInternalScreeningMonitoringTable", suite.ctx,
 		mock.Anything, suite.objectType).Return(nil)
+	suite.screeningProvider.On("Search", suite.ctx, mock.MatchedBy(func(query models.OpenSanctionsQuery) bool {
+		return len(query.Queries) > 0
+	})).Return(models.ScreeningRawSearchResponseWithMatches{
+		SearchInput:       []byte("{}"),
+		InitialHasMatches: false,
+		Matches:           []models.ScreeningMatch{},
+	}, nil)
 	// Return a unique violation error
 	suite.clientDbRepository.On("InsertScreeningMonitoringObject", suite.ctx, mock.Anything,
 		suite.objectType, suite.objectId, suite.configId).Return(&pgconn.PgError{
@@ -483,7 +520,7 @@ func (suite *ScreeningMonitoringUsecaseTestSuite) TestInsertScreeningMonitoringO
 		ObjectId:   &suite.objectId,
 	}
 
-	err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
+	_, err := uc.InsertScreeningMonitoringObject(suite.ctx, input)
 
 	// Assert - should error when ignoreConflictError is false and unique violation occurs
 	suite.Error(err)
@@ -597,6 +634,488 @@ func TestCheckDataModelTableAndFieldsConfiguration(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStringRepresentation(t *testing.T) {
+	// Test with time.Time
+	testTime := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	result := stringRepresentation(testTime)
+	assert.Equal(t, "2024-01-15T10:30:45Z", result)
+
+	// Test with nil
+	result = stringRepresentation(nil)
+	assert.Equal(t, "", result)
+
+	// Test with string
+	result = stringRepresentation("test-string")
+	assert.Equal(t, "test-string", result)
+
+	// Test with integer
+	result = stringRepresentation(42)
+	assert.Equal(t, "42", result)
+
+	// Test with float
+	result = stringRepresentation(3.14)
+	assert.Equal(t, "3.14", result)
+
+	// Test with boolean
+	result = stringRepresentation(true)
+	assert.Equal(t, "true", result)
+}
+
+func sortOpenSanctionsFilter(filter models.OpenSanctionsFilter) models.OpenSanctionsFilter {
+	sorted := make(models.OpenSanctionsFilter)
+	for key, values := range filter {
+		sortedValues := make([]string, len(values))
+		copy(sortedValues, values)
+		sort.Strings(sortedValues)
+		sorted[key] = sortedValues
+	}
+	return sorted
+}
+
+func TestPrepareScreeningFilters(t *testing.T) {
+	tests := []struct {
+		name             string
+		ingestedObject   models.DataModelObject
+		dataModelMapping map[string]string
+		expectedFilters  models.OpenSanctionsFilter
+		wantError        bool
+		errorContains    string
+	}{
+		{
+			name: "single field mapping",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"name": "John Doe",
+				},
+			},
+			dataModelMapping: map[string]string{
+				"name": "name",
+			},
+			expectedFilters: models.OpenSanctionsFilter{
+				"name": []string{"John Doe"},
+			},
+			wantError: false,
+		},
+		{
+			name: "multiple fields with different properties",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"first_name": "John",
+					"country":    "US",
+				},
+			},
+			dataModelMapping: map[string]string{
+				"first_name": "name",
+				"country":    "country",
+			},
+			expectedFilters: models.OpenSanctionsFilter{
+				"name":    []string{"John"},
+				"country": []string{"US"},
+			},
+			wantError: false,
+		},
+		{
+			name: "multiple fields mapping to same property",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"first_name": "John",
+					"last_name":  "Doe",
+					"email":      "john@example.com",
+				},
+			},
+			dataModelMapping: map[string]string{
+				"first_name": "name",
+				"last_name":  "name",
+				"email":      "email",
+			},
+			expectedFilters: models.OpenSanctionsFilter{
+				"name":  []string{"John", "Doe"},
+				"email": []string{"john@example.com"},
+			},
+			wantError: false,
+		},
+		{
+			name: "with nil value",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"name": nil,
+				},
+			},
+			dataModelMapping: map[string]string{
+				"name": "name",
+			},
+			expectedFilters: models.OpenSanctionsFilter{
+				"name": []string{""},
+			},
+			wantError: false,
+		},
+		{
+			name: "with timestamp value",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"created_at": time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC),
+				},
+			},
+			dataModelMapping: map[string]string{
+				"created_at": "date",
+			},
+			expectedFilters: models.OpenSanctionsFilter{
+				"date": []string{"2024-01-15T10:30:45Z"},
+			},
+			wantError: false,
+		},
+		{
+			name: "missing field in ingested data",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"name": "John",
+				},
+			},
+			dataModelMapping: map[string]string{
+				"name":    "name",
+				"country": "country",
+			},
+			wantError:     true,
+			errorContains: "field country not found in ingested object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := prepareScreeningFilters(tt.ingestedObject, tt.dataModelMapping)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, sortOpenSanctionsFilter(tt.expectedFilters), sortOpenSanctionsFilter(result))
+			}
+		})
+	}
+}
+
+func TestPrepareOpenSanctionsQuery(t *testing.T) {
+	tests := []struct {
+		name                string
+		ingestedObject      models.DataModelObject
+		dataModelEntityType string
+		dataModelMapping    map[string]string
+		config              models.ScreeningMonitoringConfig
+		expectedQuery       models.OpenSanctionsQuery
+		wantError           bool
+		errorContains       string
+	}{
+		{
+			name: "valid query with single filter",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"name": "John Doe",
+				},
+			},
+			dataModelEntityType: "Person",
+			dataModelMapping: map[string]string{
+				"name": "name",
+			},
+			config: models.ScreeningMonitoringConfig{
+				MatchThreshold: 75,
+				MatchLimit:     10,
+				Datasets:       []string{"default"},
+			},
+			expectedQuery: models.OpenSanctionsQuery{
+				OrgConfig: models.OrganizationOpenSanctionsConfig{
+					MatchThreshold: 75,
+					MatchLimit:     10,
+				},
+				Config: models.ScreeningConfig{
+					Datasets: []string{"default"},
+				},
+				Queries: []models.OpenSanctionsCheckQuery{
+					{
+						Type: "Person",
+						Filters: models.OpenSanctionsFilter{
+							"name": []string{"John Doe"},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "valid query with multiple filters",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"first_name": "John",
+					"last_name":  "Doe",
+					"country":    "US",
+				},
+			},
+			dataModelEntityType: "Person",
+			dataModelMapping: map[string]string{
+				"first_name": "name",
+				"last_name":  "name",
+				"country":    "country",
+			},
+			config: models.ScreeningMonitoringConfig{
+				MatchThreshold: 80,
+				MatchLimit:     20,
+				Datasets:       []string{"default", "custom"},
+			},
+			expectedQuery: models.OpenSanctionsQuery{
+				OrgConfig: models.OrganizationOpenSanctionsConfig{
+					MatchThreshold: 80,
+					MatchLimit:     20,
+				},
+				Config: models.ScreeningConfig{
+					Datasets: []string{"default", "custom"},
+				},
+				Queries: []models.OpenSanctionsCheckQuery{
+					{
+						Type: "Person",
+						Filters: models.OpenSanctionsFilter{
+							"name":    []string{"John", "Doe"},
+							"country": []string{"US"},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "entity type Company",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"company_name": "Acme Corp",
+				},
+			},
+			dataModelEntityType: "Company",
+			dataModelMapping: map[string]string{
+				"company_name": "name",
+			},
+			config: models.ScreeningMonitoringConfig{
+				MatchThreshold: 70,
+				MatchLimit:     5,
+				Datasets:       []string{"default"},
+			},
+			expectedQuery: models.OpenSanctionsQuery{
+				OrgConfig: models.OrganizationOpenSanctionsConfig{
+					MatchThreshold: 70,
+					MatchLimit:     5,
+				},
+				Config: models.ScreeningConfig{
+					Datasets: []string{"default"},
+				},
+				Queries: []models.OpenSanctionsCheckQuery{
+					{
+						Type: "Company",
+						Filters: models.OpenSanctionsFilter{
+							"name": []string{"Acme Corp"},
+						},
+					},
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "missing field in ingested data",
+			ingestedObject: models.DataModelObject{
+				Data: map[string]any{
+					"name": "John",
+				},
+			},
+			dataModelEntityType: "Person",
+			dataModelMapping: map[string]string{
+				"name":    "name",
+				"country": "country",
+			},
+			config: models.ScreeningMonitoringConfig{
+				MatchThreshold: 75,
+				MatchLimit:     10,
+				Datasets:       []string{"default"},
+			},
+			wantError:     true,
+			errorContains: "field country not found in ingested object",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := prepareOpenSanctionsQuery(tt.ingestedObject,
+				tt.dataModelEntityType, tt.dataModelMapping, tt.config)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedQuery.OrgConfig, result.OrgConfig)
+				assert.Equal(t, tt.expectedQuery.Config.Datasets, result.Config.Datasets)
+				assert.Equal(t, len(tt.expectedQuery.Queries), len(result.Queries))
+				if len(result.Queries) > 0 {
+					assert.Equal(t, tt.expectedQuery.Queries[0].Type, result.Queries[0].Type)
+					assert.Equal(t, tt.expectedQuery.Queries[0].Filters, result.Queries[0].Filters)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildDataModelMapping(t *testing.T) {
+	ftmEntity := models.FollowTheMoneyEntityPerson
+	ftmEntityCompany := models.FollowTheMoneyEntityCompany
+	ftmPropertyName := models.FollowTheMoneyPropertyName
+	ftmPropertyCountry := models.FollowTheMoneyPropertyCountry
+	ftmPropertyAddress := models.FollowTheMoneyPropertyAddress
+
+	tests := []struct {
+		name            string
+		table           models.Table
+		expectedMapping dataModelMapping
+		wantError       bool
+		errorMsg        string
+	}{
+		{
+			name: "single field with FTM property",
+			table: models.Table{
+				Name:      "customers",
+				FTMEntity: &ftmEntity,
+				Fields: map[string]models.Field{
+					"customer_name": {
+						Name:        "customer_name",
+						FTMProperty: &ftmPropertyName,
+					},
+				},
+			},
+			expectedMapping: dataModelMapping{
+				Entity: "Person",
+				Properties: map[string]string{
+					"customer_name": "name",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "multiple fields with different FTM properties",
+			table: models.Table{
+				Name:      "customers",
+				FTMEntity: &ftmEntity,
+				Fields: map[string]models.Field{
+					"first_name": {
+						Name:        "first_name",
+						FTMProperty: &ftmPropertyName,
+					},
+					"country_code": {
+						Name:        "country_code",
+						FTMProperty: &ftmPropertyCountry,
+					},
+				},
+			},
+			expectedMapping: dataModelMapping{
+				Entity: "Person",
+				Properties: map[string]string{
+					"first_name":   "name",
+					"country_code": "country",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "Company entity with address property",
+			table: models.Table{
+				Name:      "companies",
+				FTMEntity: &ftmEntityCompany,
+				Fields: map[string]models.Field{
+					"company_name": {
+						Name:        "company_name",
+						FTMProperty: &ftmPropertyName,
+					},
+					"company_address": {
+						Name:        "company_address",
+						FTMProperty: &ftmPropertyAddress,
+					},
+				},
+			},
+			expectedMapping: dataModelMapping{
+				Entity: "Company",
+				Properties: map[string]string{
+					"company_name":    "name",
+					"company_address": "address",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "fields with and without FTM property (only mapped fields included)",
+			table: models.Table{
+				Name:      "customers",
+				FTMEntity: &ftmEntity,
+				Fields: map[string]models.Field{
+					"customer_name": {
+						Name:        "customer_name",
+						FTMProperty: &ftmPropertyName,
+					},
+					"email": {
+						Name:        "email",
+						FTMProperty: nil,
+					},
+				},
+			},
+			expectedMapping: dataModelMapping{
+				Entity: "Person",
+				Properties: map[string]string{
+					"customer_name": "name",
+				},
+			},
+			wantError: false,
+		},
+		{
+			name: "missing FTM entity",
+			table: models.Table{
+				Name:      "customers",
+				FTMEntity: nil,
+				Fields: map[string]models.Field{
+					"customer_name": {
+						Name:        "customer_name",
+						FTMProperty: &ftmPropertyName,
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "table is not configured for the use case",
+		},
+		{
+			name: "no fields with FTM property",
+			table: models.Table{
+				Name:      "customers",
+				FTMEntity: &ftmEntity,
+				Fields: map[string]models.Field{
+					"email": {
+						Name:        "email",
+						FTMProperty: nil,
+					},
+				},
+			},
+			wantError: true,
+			errorMsg:  "table's fields are not configured for the use case",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := buildDataModelMapping(tt.table)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedMapping.Entity, result.Entity)
+				assert.Equal(t, tt.expectedMapping.Properties, result.Properties)
 			}
 		})
 	}

--- a/usecases/screening_monitoring/usecase.go
+++ b/usecases/screening_monitoring/usecase.go
@@ -76,6 +76,11 @@ type ScreeningMonitoringIngestionUsecase interface {
 	) (int, error)
 }
 
+type ScreeningMonitoringScreeningProvider interface {
+	Search(ctx context.Context, query models.OpenSanctionsQuery) (
+		models.ScreeningRawSearchResponseWithMatches, error)
+}
+
 type ScreeningMonitoringUsecase struct {
 	executorFactory    executor_factory.ExecutorFactory
 	transactionFactory executor_factory.TransactionFactory
@@ -86,6 +91,7 @@ type ScreeningMonitoringUsecase struct {
 	organizationSchemaRepository repositories.OrganizationSchemaRepository
 	ingestedDataReader           ScreeningMonitoringIngestedDataReader
 	ingestionUsecase             ScreeningMonitoringIngestionUsecase
+	screeningProvider            ScreeningMonitoringScreeningProvider
 }
 
 func NewScreeningMonitoringUsecase(
@@ -97,6 +103,7 @@ func NewScreeningMonitoringUsecase(
 	organizationSchemaRepository repositories.OrganizationSchemaRepository,
 	ingestedDataReader ScreeningMonitoringIngestedDataReader,
 	ingestionUsecase ScreeningMonitoringIngestionUsecase,
+	screeningProvider ScreeningMonitoringScreeningProvider,
 ) ScreeningMonitoringUsecase {
 	return ScreeningMonitoringUsecase{
 		executorFactory:              executorFactory,
@@ -107,5 +114,6 @@ func NewScreeningMonitoringUsecase(
 		organizationSchemaRepository: organizationSchemaRepository,
 		ingestedDataReader:           ingestedDataReader,
 		ingestionUsecase:             ingestionUsecase,
+		screeningProvider:            screeningProvider,
 	}
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -814,5 +814,6 @@ func (usecases *UsecasesWithCreds) NewScreeningMonitoringUsecase() screening_mon
 		usecases.Repositories.OrganizationSchemaRepository,
 		usecases.Repositories.IngestedDataReadRepository,
 		utils.Ptr(usecases.NewIngestionUseCase()),
+		usecases.Repositories.OpenSanctionsRepository,
 	)
 }


### PR DESCRIPTION
Perform screening before adding an object to the monitoring list, and return the screening result in the query response.

This PR will merge into https://github.com/checkmarble/marble-backend/pull/1283 to streamline the review.

~~This PR remains a draft until the data model mapping PR is merged. I need that mapping to resolve field equivalences between the data model and the Follow the Money entities and properties.~~ ✅ 

# TODO
- [x] Unit test
- [x] Fetch Data model mapping from DB and check if correctly configured