### PR TITLE
Add whether the backend runs an outdated version in /config.

### DIFF
--- a/api/handle_config.go
+++ b/api/handle_config.go
@@ -6,10 +6,13 @@ import (
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/usecases/auth"
+	"github.com/checkmarble/marble-backend/utils"
 	"github.com/gin-gonic/gin"
 )
 
 func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Context) {
+	go utils.RunCheckOutdated(cfg.AppVersion)
+
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
@@ -45,6 +48,7 @@ func handleGetConfig(uc usecases.Usecases, cfg Configuration) func(c *gin.Contex
 
 		out := dto.ConfigDto{
 			Version:         versionUsecase.ApiVersion,
+			Outdated:        utils.IsOutdatedVersion.Load(),
 			IsManagedMarble: licenseUsecase.IsManagedMarble(),
 			Status: dto.ConfigStatusDto{
 				Migrations: migrationsRunForOrgs && migrationsRunForUsers,

--- a/dto/config_dto.go
+++ b/dto/config_dto.go
@@ -22,6 +22,7 @@ func (s NullString) MarshalJSON() ([]byte, error) {
 
 type ConfigDto struct {
 	Version         string            `json:"version"`
+	Outdated        bool              `json:"outdated"`
 	Status          ConfigStatusDto   `json:"status"`
 	Urls            ConfigUrlsDto     `json:"urls"`
 	Auth            ConfigAuthDto     `json:"auth"`

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	firebase.google.com/go/v4 v4.14.1
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.29.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.53.0
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/TwiN/deepmerge v0.2.2
 	github.com/adhocore/gronx v1.19.6

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.53.0/go.mod h1:cSgYe11MCNYunTnRXrKiR/tHc0eoKjICUuWpNZoVCOo=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.53.0 h1:RAHqDHJmNMLe6JvDoRIlXmb72w+62Ue/k5p/qP9yfAg=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/propagator v0.53.0/go.mod h1:dtCRwgvytbGKWdlrjMOg9geBoRwRpCYWIOM/JhVsDIc=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=
 github.com/Masterminds/squirrel v1.5.4/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/MicahParks/keyfunc v1.9.0 h1:lhKd5xrFHLNOWrDc4Tyb/Q1AJ4LCzQ48GVJyVIID3+o=

--- a/utils/outdated.go
+++ b/utils/outdated.go
@@ -1,0 +1,118 @@
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"github.com/Masterminds/semver"
+)
+
+type GithubRelease struct {
+	TagName     string    `json:"tag_name"`
+	Prerelease  bool      `json:"prerelease"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+const (
+	GithubReleaseUrl            = "https://api.github.com/repos/checkmarble/marble-backend/releases?per_page=100"
+	GithubReleaseMaxMinorSpread = 2
+	GithubReleaseGracePeriod    = 30 * 24 * time.Hour
+)
+
+var IsOutdatedVersion atomic.Bool
+
+func RunCheckOutdated(appVersion string) {
+	for {
+		IsOutdatedVersion.Store(checkOutdated(context.Background(), appVersion))
+		time.Sleep(time.Hour)
+	}
+}
+
+func checkOutdated(ctx context.Context, appVersion string) (isOutdated bool) {
+	// No outdated notion for development builds
+	if appVersion == "dev" {
+		return
+	}
+
+	currentSv, err := semver.NewVersion(appVersion)
+	if err != nil {
+		return
+	}
+	withoutPrerelease, _ := currentSv.SetPrerelease("")
+	currentSv = &withoutPrerelease
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, GithubReleaseUrl, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+
+	defer resp.Body.Close()
+
+	dec := json.NewDecoder(resp.Body)
+
+	var (
+		releases       []GithubRelease
+		currentRelease *GithubRelease
+		minorsSince    = 1
+	)
+
+	// In case we cannot retrieve releases or the list is empty, bail out.
+	if err := dec.Decode(&releases); err != nil {
+		return
+	}
+	if len(releases) == 0 {
+		return
+	}
+
+	latest := releases[0]
+	latestSv, err := semver.NewVersion(latest.TagName)
+	if err != nil {
+		return
+	}
+
+	// Keep the latest unique minor version found, so we can count them.
+	var seenMinor *semver.Version
+
+	for _, r := range releases {
+		if r.TagName == currentSv.Original() {
+			currentRelease = &r
+			break
+		}
+
+		// Let's only count real releases
+		if !r.Prerelease {
+			if sv, err := semver.NewVersion(r.TagName); err == nil {
+				// If this is a different minor version from the last one seen, let's bump the minor counter.
+				// Here, [1.2.0, 1.2.1, 1.3.1] counts for two versions (spread of `1`).
+				if seenMinor != nil && (sv.Major() != seenMinor.Major() || sv.Minor() != seenMinor.Minor()) {
+					minorsSince += 1
+				}
+
+				seenMinor = sv
+			}
+		}
+	}
+
+	// Edge case, if we did not find the current version in the release list, if
+	// means we are outdated by more than 100 releases or we are in a weird state.
+	if currentRelease == nil {
+		isOutdated = true
+		return
+	}
+
+	// Two conditions must be true for the version be considered obsolete:
+	//  * Be at least two minors away from the latest
+	//  * Be at least a month old
+	if minorsSince > GithubReleaseMaxMinorSpread &&
+		latestSv.GreaterThan(currentSv) &&
+		latest.PublishedAt.Sub(currentRelease.PublishedAt) > GithubReleaseGracePeriod {
+
+		isOutdated = true
+	}
+
+	return
+}

--- a/utils/outdated_test.go
+++ b/utils/outdated_test.go
@@ -1,0 +1,81 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOudatedVersion(t *testing.T) {
+	defer gock.Off()
+
+	releases := []GithubRelease{
+		{"v0.10.0", false, time.Now().Add(-7 * 24 * time.Hour)},
+		{"v0.9.2", false, time.Now().Add(-31 * 24 * time.Hour)},
+		{"v0.9.1", false, time.Now().Add(-32 * 24 * time.Hour)},
+		{"v0.9.0", false, time.Now().Add(-33 * 24 * time.Hour)},
+		{"v0.6.0", false, time.Now().Add(-90 * 24 * time.Hour)},
+		{"v0.5.0", false, time.Now().Add(-90 * 24 * time.Hour)},
+		{"v0.4.0", false, time.Now().Add(-15 * 24 * time.Hour)},
+		{"v0.1.0", false, time.Now().Add(-90 * 24 * time.Hour)},
+	}
+
+	gock.New("https://api.github.com").Persist().
+		Get("/repos/checkmarble/marble-backend/releases").
+		MatchParam("per_page", "100").
+		Reply(http.StatusOK).
+		JSON(releases)
+
+	tts := []struct {
+		version  string
+		expected bool
+	}{
+		{"dev", false},                 // Development version
+		{"v0.100.0", true},             // Unknown version
+		{"v0.10.0", false},             // Latest version
+		{"v0.10.0-10-abcd1234", false}, // Ahead of latest version
+		{"v0.6.0", false},              // Old version, within minor spread tolerance
+		{"v0.4.0", false},              // Old version, within grace period
+		{"v0.5.0", true},               // Outdated version
+		{"v0.1.0", true},               // Outdated version
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.version, func(t *testing.T) {
+			assert.False(t, gock.HasUnmatchedRequest())
+			assert.Equal(t, tt.expected, checkOutdated(t.Context(), tt.version))
+		})
+	}
+}
+
+func TestOudatedVersionError(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.github.com").Persist().
+		Get("/repos/checkmarble/marble-backend/releases").
+		MatchParam("per_page", "100").
+		Reply(http.StatusUnavailableForLegalReasons)
+
+	tts := []struct {
+		version  string
+		expected bool
+	}{
+		{"dev", false},      // Development version
+		{"v0.100.0", false}, // Unknown version
+		{"v0.10.0", false},  // Latest version
+		{"v0.6.0", false},   // Old version, within minor spread tolerance
+		{"v0.4.0", false},   // Old version, within grace period
+		{"v0.5.0", false},   // Outdated version
+		{"v0.1.0", false},   // Outdated version
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.version, func(t *testing.T) {
+			assert.False(t, gock.HasUnmatchedRequest())
+			assert.Equal(t, tt.expected, checkOutdated(t.Context(), tt.version))
+		})
+	}
+}


### PR DESCRIPTION
This fetched the list of Github releases for the backend in the background and populates whether we are outdated according to the following heuristic:

 - The current and latest releases are more than two minors apart AND
 - The current and latest releases are more than a month apart.

---

Let's discuss what we consider is an outdated version to pinpoint the lofic.