### PR TITLE
fix error (newly normalized field read) on test run summary job

### DIFF
--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -106,17 +106,18 @@ func (repo *MarbleDbRepository) DecisionsByOutcomeAndScore(
 	begin, end time.Time,
 ) ([]models.DecisionsByVersionByOutcome, error) {
 	decisionQuery := squirrel.StatementBuilder.
-		Select("outcome, scenario_version, score").
-		From(dbmodels.TABLE_DECISIONS).
+		Select("outcome, si.version as scenario_version, score").
+		From(dbmodels.TABLE_DECISIONS + " AS d").
+		InnerJoin(dbmodels.TABLE_SCENARIO_ITERATIONS + " AS si ON si.id = d.scenario_iteration_id").
 		Where(squirrel.GtOrEq{
-			"created_at": begin,
+			"d.created_at": begin,
 		}).
 		Where(squirrel.LtOrEq{
-			"created_at": end,
+			"d.created_at": end,
 		}).
 		Where(squirrel.Eq{
-			"org_id":      organizationId,
-			"scenario_id": scenarioId,
+			"d.org_id":      organizationId,
+			"d.scenario_id": scenarioId,
 		})
 	phantomDecisionQuery := squirrel.StatementBuilder.
 		Select("outcome, scenario_version, score").


### PR DESCRIPTION
I broke this when I stopped writing the denormalized scenario_version on decisions.
I'll also hotfix this one on v0.54.