### PR TITLE
adjust logic in rule hits analytics query

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -66,7 +66,8 @@
         "match_enrichment",
         "offloading",
         "test_run_summary",
-        "case_review"
+        "case_review",
+        "analytics_export"
       ]
     }
   ]


### PR DESCRIPTION
- compute repeat hit rate by taking into account only hit rules as denominator
- order results so highest hit ratio rules display first