### PR TITLE
Add an entrypoint to run a standalone analytics server.

### DIFF
--- a/.github/workflows/backend_deploy_workflow.yaml
+++ b/.github/workflows/backend_deploy_workflow.yaml
@@ -89,6 +89,13 @@ jobs:
             --image=${{ env.VERSION_IMAGE }} \
             --region="europe-west1"
 
+      - name: Deploy server
+        run: |
+          gcloud run deploy marble-analytics-backend \
+            --quiet \
+            --image=${{ env.VERSION_IMAGE }} \
+            --region="europe-west1"
+
       - name: Deploy execute async worker service
         run: |
           gcloud run deploy marble-backend-worker \

--- a/api/configuration.go
+++ b/api/configuration.go
@@ -7,10 +7,18 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/auth"
 )
 
+type ServerMode int
+
+const (
+	ServerModeDefault ServerMode = iota
+	ServerModeAnalytics
+)
+
 type Configuration struct {
 	Env                 string
 	AppName             string
 	AppVersion          string
+	ServerMode          ServerMode
 	Port                string
 	MarbleApiUrl        string
 	MarbleAppUrl        string
@@ -23,8 +31,9 @@ type Configuration struct {
 	DecisionTimeout     time.Duration
 	DefaultTimeout      time.Duration
 
-	AnalyticsEnabled bool
-	AnalyticsTimeout time.Duration
+	AnalyticsEnabled     bool
+	AnalyticsTimeout     time.Duration
+	AnalyticsProxyApiUrl string
 
 	TokenProvider  auth.TokenProvider
 	FirebaseConfig FirebaseConfig

--- a/api/http_server.go
+++ b/api/http_server.go
@@ -47,7 +47,15 @@ func NewServer(
 ) *http.Server {
 	o := applyOptions(opts)
 
-	addRoutes(router, conf, uc, auth, tokenHandler, logger)
+	addDefaultRoutes(router, conf, uc)
+
+	switch conf.ServerMode {
+	case ServerModeAnalytics:
+		runStandaloneAnalyticsRoutes(router, conf, uc, auth)
+
+	default:
+		addRoutes(router, conf, uc, auth, tokenHandler, logger)
+	}
 
 	var host string
 	if o.localTest {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"log/slog"
 
+	"github.com/checkmarble/marble-backend/api"
 	"github.com/checkmarble/marble-backend/cmd"
 	"github.com/checkmarble/marble-backend/utils"
 )
@@ -60,7 +61,13 @@ func main() {
 	}
 
 	if *shouldRunServer {
-		err := cmd.RunServer(compiledConfig)
+		err := cmd.RunServer(compiledConfig, api.ServerModeDefault)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	if *shouldRunAnalyticsServer {
+		err := cmd.RunServer(compiledConfig, api.ServerModeAnalytics)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
This server will initialize the same way as the backend, but will only mount misc. routes (healthchecks, version) and the analytics routes.

A new environment variable, on the regular backend, can indicate the base URL to that analytics server, and will proxy analytics requests to that URL. All relevant elements from the source requests are copied (path, query, headers). The reponse will experience the same treatment, where the status, header and body will be copied as is.