### PR TITLE
fix: remove unused function

### DIFF
--- a/usecases/screening_monitoring/object_monitoring_operation.go
+++ b/usecases/screening_monitoring/object_monitoring_operation.go
@@ -148,14 +148,6 @@ func extractObjectIDFromPayload(payload json.RawMessage) (string, error) {
 	return objectID.ObjectID, nil
 }
 
-// Call screening provider to perform the screening
-func (uc *ScreeningMonitoringUsecase) doScreening(
-	ctx context.Context,
-	query models.OpenSanctionsQuery,
-) (models.ScreeningRawSearchResponseWithMatches, error) {
-	return uc.screeningProvider.Search(ctx, query)
-}
-
 // Ingest the object from payload and return the object ID from payload
 func (uc *ScreeningMonitoringUsecase) ingestObject(
 	ctx context.Context,


### PR DESCRIPTION
I merged a change that implemented an unused function, and the linter failed because of it.