### PR TITLE
allow to migrate down without manual goose command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,7 +26,7 @@
       "envFile": "${workspaceFolder}/.env",
       "args": [
         "--migrations",
-        "--down"
+        "--down-to=${input:migrateDownTo}"
       ],
       "console": "integratedTerminal"
     },
@@ -82,6 +82,12 @@
         "case_review",
         "analytics_export"
       ]
+    },
+    {
+      "id": "migrateDownTo",
+      "description": "Migrate down to a specific version",
+      "type": "promptString",
+      "default": "-1"
     }
   ]
 }

--- a/cmd/migrations.go
+++ b/cmd/migrations.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func RunMigrations(apiVersion string, migrateDown bool) error {
+func RunMigrations(apiVersion string, migrateDownTo *int64) error {
 	pgConfig := infra.PgConfig{
 		ConnectionString: utils.GetEnv("PG_CONNECTION_STRING", ""),
 		Database:         utils.GetEnv("PG_DATABASE", "marble"),
@@ -41,11 +41,7 @@ func RunMigrations(apiVersion string, migrateDown bool) error {
 
 	migrater := repositories.NewMigrater(pgConfig)
 
-	direction := repositories.MigrationUp
-	if migrateDown {
-		direction = repositories.MigrationDown
-	}
-	if err := migrater.Run(ctx, direction); err != nil {
+	if err := migrater.Run(ctx, migrateDownTo); err != nil {
 		logger.ErrorContext(ctx, fmt.Sprintf("error running migrations: %v", err))
 		return err
 	}

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -112,7 +112,7 @@ func TestMain(m *testing.M) {
 	logger := utils.NewLogger("text")
 	ctx = utils.StoreLoggerInContext(ctx, logger)
 
-	err = migrater.Run(ctx)
+	err = migrater.Run(ctx, nil)
 	if err != nil {
 		log.Fatalf("Could not run migrations: %s", err)
 	}

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -89,7 +89,7 @@ func setupPostgres(t *testing.T, ctx context.Context) *postgres.PostgresContaine
 	pgConfig := infra.PgConfig{ConnectionString: dsn}
 	migrator := repositories.NewMigrater(pgConfig)
 
-	if err = migrator.Run(ctx); err != nil {
+	if err = migrator.Run(ctx, nil); err != nil {
 		log.Fatal(err)
 	}
 
@@ -125,7 +125,10 @@ func setupApi(t *testing.T, ctx context.Context, dsn string) string {
 		log.Fatalf("Could not create connection pool: %s", err)
 	}
 
-	cfg := api.Configuration{Env: "development", MarbleAppUrl: "http://x", DefaultTimeout: 5 * time.Second, TokenProvider: auth.TokenProviderFirebase}
+	cfg := api.Configuration{
+		Env: "development", MarbleAppUrl: "http://x",
+		DefaultTimeout: 5 * time.Second, TokenProvider: auth.TokenProviderFirebase,
+	}
 	key, err := rsa.GenerateKey(rand.Reader, 128)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Allows to migrate down by passing `--migrations --down`. No-op on river migrations.
Should be convenient for the occasional staging "down" before migration rewrite, and for prod incidents.