### PR TITLE
rename env var for tracing config, update .env.example, change default telemetry exporter to otlp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,12 +129,34 @@ FIREBASE_API_KEY=dummy
 # For example, Cloud Run requires all services to process liveness checks to keep running.
 # CLOUD_RUN_PROBE_PORT=9000
 
+# Authenticate with OpenID Connect SSO
+# See the configuration steps on https://docs.checkmarble.com/update/docs/sso-openid-connect#/
+
+# optional configuration for API and worker profiling
+# DEBUG_ENABLE_PROFILING=true
+# mandatory Bearer token to authenticate the utilitary /debug/pprof/* endpoints
+# DEBUG_PROFILING_TOKEN=replaceme
+
+
+# 'liveness' (only log liveness requests) || 'all' (log all requests) || any other value for no request logs (for example if the infrastructure layer already logs all requests)
+REQUEST_LOGGING_LEVEL=all
+# 'json' || 'text' (default) || 'gcp' (adapted logging keys for Stackdriver-compatible structured logging)
+LOGGING_FORMAT=text
+
+#####
 # Configure various external integrations.
-# Send traces to aither an OpenTelemetry-compatible GRPC collector (otlp, default) or to Google Cloud Platform (gcp) (see https://cloud.google.com/trace/docs/setup/go-ot).
+#####
+
+# Send traces to either an OpenTelemetry-compatible GRPC collector (otlp, default) or to Google Cloud Platform (gcp) (see https://cloud.google.com/trace/docs/setup/go-ot).
 # The GCP collector requires Application Default Credentials.
-ENABLE_GCP_TRACING=false
-# TRACING_EXPORTER=otlp
+ENABLE_TRACING=false
+# TRACING_EXPORTER=gcp|otlp
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# TRACING_SAMPLING_RATES={"/decisions": 0.05...} (json map of span names and sampling rates)
+
+# Collect prometheus metrics on decisions, ingestion, etc (full list is subject to change).
+# If enabled, the metrics can be pulled on the **unauthenticated** /metrics endpoint. We advise not to expose it on public networks.
+# ENABLE_PROMETHEUS=true
 
 SEGMENT_WRITE_KEY=
 DISABLE_SEGMENT=false

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,6 +23,7 @@ type ServerConfig struct {
 	telemetryExporter                string
 	otelSamplingRates                string
 	similarityThreshold              float64
+	enableTracing                    bool
 }
 
 func (config ServerConfig) Validate() error {
@@ -46,4 +47,5 @@ type WorkerConfig struct {
 	telemetryExporter           string
 	otelSamplingRates           string
 	enablePrometheus            bool
+	enableTracing               bool
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,7 +49,6 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		ctx,
 		utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 		utils.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""),
-		utils.GetEnv("ENABLE_GCP_TRACING", false),
 	)
 	if err != nil {
 		return err
@@ -192,6 +191,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		telemetryExporter:                utils.GetEnv("TRACING_EXPORTER", "otlp"),
 		otelSamplingRates:                utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 		similarityThreshold:              utils.GetEnv("SIMILARITY_THRESHOLD", models.DEFAULT_SIMILARITY_THRESHOLD),
+		enableTracing:                    utils.GetEnv("ENABLE_TRACING", false),
 	}
 	if err := serverConfig.Validate(); err != nil {
 		utils.LogAndReportSentryError(ctx, err)
@@ -229,7 +229,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 
 	tracingConfig := infra.TelemetryConfiguration{
 		ApplicationName: apiConfig.AppName,
-		Enabled:         gcpConfig.EnableTracing,
+		Enabled:         serverConfig.enableTracing,
 		ProjectID:       gcpConfig.ProjectId,
 		Exporter:        serverConfig.telemetryExporter,
 		SamplingMap:     infra.NewTelemetrySamplingMap(ctx, serverConfig.otelSamplingRates),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -97,16 +97,16 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		telemetryExporter:           utils.GetEnv("TRACING_EXPORTER", "otlp"),
 		otelSamplingRates:           utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 		enablePrometheus:            utils.GetEnv("ENABLE_PROMETHEUS", false),
+		enableTracing:               utils.GetEnv("ENABLE_TRACING", false),
 	}
 
 	logger := utils.NewLogger(workerConfig.loggingFormat)
 	ctx := utils.StoreLoggerInContext(context.Background(), logger)
 
 	gcpConfig, err := infra.NewGcpConfig(
-		context.Background(),
+		ctx,
 		utils.GetEnv("GOOGLE_CLOUD_PROJECT", ""),
 		utils.GetEnv("GOOGLE_APPLICATION_CREDENTIALS", ""),
-		utils.GetEnv("ENABLE_GCP_TRACING", false),
 	)
 	if err != nil {
 		logger.WarnContext(ctx, "could not initialize GCP config", "error", err.Error())
@@ -158,7 +158,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 
 	tracingConfig := infra.TelemetryConfiguration{
 		ApplicationName: workerConfig.appName,
-		Enabled:         gcpConfig.EnableTracing,
+		Enabled:         workerConfig.enableTracing,
 		ProjectID:       gcpConfig.ProjectId,
 		Exporter:        workerConfig.telemetryExporter,
 		SamplingMap:     infra.NewTelemetrySamplingMap(ctx, workerConfig.otelSamplingRates),

--- a/infra/config.go
+++ b/infra/config.go
@@ -24,10 +24,9 @@ type GcpConfig struct {
 	ProjectId                    string
 	PrincipalEmail               string
 	GoogleApplicationCredentials string
-	EnableTracing                bool
 }
 
-func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCredentials string, enableTracing bool) (GcpConfig, error) {
+func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCredentials string) (GcpConfig, error) {
 	// Errors to validate GCP credentials do not have to be a hard fail.
 	// They are common when trying out the product with the emulator (no service account required).
 	// So long as the GCP project is defined in the configuration, most things will work.
@@ -70,7 +69,6 @@ func NewGcpConfig(ctx context.Context, gcpProjectId string, googleApplicationCre
 		ProjectId:                    projectId,
 		PrincipalEmail:               adcPrincipal,
 		GoogleApplicationCredentials: googleApplicationCredentials,
-		EnableTracing:                enableTracing,
 	}
 
 	return cfg, nil

--- a/infra/tracing.go
+++ b/infra/tracing.go
@@ -44,15 +44,7 @@ func InitTelemetry(configuration TelemetryConfiguration, apiVersion string) (Tel
 	var exporter sdktrace.SpanExporter
 
 	switch configuration.Exporter {
-	case "otlp":
-		otlpExporter, err := otlptracegrpc.New(context.Background())
-		if err != nil {
-			return TelemetryRessources{}, fmt.Errorf("otlptracegrpc.New error: %w", err)
-		}
-
-		exporter = otlpExporter
-
-	default:
+	case "gcp":
 		gcpExporter, err := texporter.New(
 			texporter.WithProjectID(configuration.ProjectID), // If empty (env variable GOOGLE_CLOUD_PROJECT not set), it will try to determine the project id from the GCP metadata server
 			texporter.WithTraceClientOptions([]option.ClientOption{option.WithTelemetryDisabled()}),
@@ -62,6 +54,14 @@ func InitTelemetry(configuration TelemetryConfiguration, apiVersion string) (Tel
 		}
 
 		exporter = gcpExporter
+
+	default: // "otlp"
+		otlpExporter, err := otlptracegrpc.New(context.Background())
+		if err != nil {
+			return TelemetryRessources{}, fmt.Errorf("otlptracegrpc.New error: %w", err)
+		}
+
+		exporter = otlpExporter
 	}
 
 	res, err := resource.New(context.Background(),


### PR DESCRIPTION
1. Use otlp trace exporter by default (our GCP now has the non-default env var set)
2. Rename env var to activate tracing from ENABLE_GCP_TRACING to ENABLE_TRACING
3. Update the marble-backend repo "doc" in .env.example

To include and backport into hotfix/v0.54.

Update full list of env vars doc accordingly on https://docs.checkmarble.com/update/docs/technical-configuration#/.
I definitely abandoned the idea to also keep a complete list in the marble repo ".env.example" file, it was getting out of hand.