### PR TITLE
Fix audit logs mixing user ID and API key ID.

### DIFF
--- a/repositories/migrations/20251121115000_fix_audit_logs.sql
+++ b/repositories/migrations/20251121115000_fix_audit_logs.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- +goose StatementBegin
+
+create or replace function global_audit() returns trigger as $$
+begin
+    if nullif(current_setting('custom.current_user_id', true), '') is null and nullif(current_setting('custom.current_api_key_id', true), '') is null then
+        return null;
+    end if;
+
+    if (TG_OP = 'DELETE') then
+        insert into audit.audit_events ("operation", "org_id", "user_id", "api_key_id", "table", "entity_id", "data", "created_at")
+        values ('DELETE', current_setting('custom.current_org_id', true)::uuid, nullif(current_setting('custom.current_user_id', true), ''), nullif(current_setting('custom.current_api_key_id', true), '')::uuid, TG_TABLE_NAME, old.id, to_jsonb(OLD), now());
+    elsif (TG_OP = 'UPDATE') then
+        insert into audit.audit_events ("operation", "org_id", "user_id", "api_key_id", "table", "entity_id", "data", "previous_data", "created_at")
+        values ('UPDATE', current_setting('custom.current_org_id', true)::uuid, nullif(current_setting('custom.current_user_id', true), ''), nullif(current_setting('custom.current_api_key_id', true), '')::uuid, TG_TABLE_NAME, new.id, to_jsonb(NEW), to_jsonb(OLD), now());
+    elsif (TG_OP = 'INSERT') then
+        insert into audit.audit_events ("operation", "org_id", "user_id", "api_key_id", "table", "entity_id", "data", "created_at")
+        values ('INSERT', current_setting('custom.current_org_id', true)::uuid, nullif(current_setting('custom.current_user_id', true), ''), nullif(current_setting('custom.current_api_key_id', true), '')::uuid, TG_TABLE_NAME, new.id, to_jsonb(NEW), now());
+    end if;
+    return null;
+end;
+$$ language plpgsql;
+
+-- +goose StatementEnd
+
+-- +goose Down

--- a/repositories/utils.go
+++ b/repositories/utils.go
@@ -51,25 +51,28 @@ func injectDbSessionConfig(ctx context.Context, exec executor, query string) (pg
 		}
 	}
 
-	cmds := make([]auditCommands, 0)
+	cmds := []auditCommands{
+		{"set_config($1, null, false)", []any{postgres_audit_user_id_parameter}},
+		{"set_config($2, null, false)", []any{postgres_audit_api_key_id_parameter}},
+	}
 
 	if creds, ok := utils.CredentialsFromCtx(ctx); ok {
 		switch {
 		case creds.ActorIdentity.UserId != "":
-			cmds = append(cmds, auditCommands{"SET_CONFIG($1, $2, false)", []any{
+			cmds = append(cmds, auditCommands{"SET_CONFIG($3, $4, false)", []any{
 				postgres_audit_user_id_parameter, creds.ActorIdentity.UserId,
 			}})
 		case creds.ActorIdentity.ApiKeyId != "":
-			cmds = append(cmds, auditCommands{"SET_CONFIG($1, $2, false)", []any{
+			cmds = append(cmds, auditCommands{"SET_CONFIG($3, $4, false)", []any{
 				postgres_audit_api_key_id_parameter, creds.ActorIdentity.ApiKeyId,
 			}})
 		default:
 			// We need to select dummy values so we simplify the arguments logic
-			cmds = append(cmds, auditCommands{"$1, $2", []any{0, 0}})
+			cmds = append(cmds, auditCommands{"$3, $4", []any{0, 0}})
 		}
 
 		if creds.OrganizationId != "" {
-			cmds = append(cmds, auditCommands{"SET_CONFIG($3, $4, false)", []any{
+			cmds = append(cmds, auditCommands{"SET_CONFIG($5, $6, false)", []any{
 				postgres_audit_org_id_parameter, creds.OrganizationId,
 			}})
 		}


### PR DESCRIPTION
A race was present in the code setting the variables for user and API key ID in the SQL session. We did not clear the previous values.

The blast radius should be quite limited, since we do not expose writeable, public API endpoints yet, but we should check the data.

---

Still performing some tests.