### PR TITLE
fix(billing): stop returning error when no funds for ai review

### DIFF
--- a/models/ai_case_review.go
+++ b/models/ai_case_review.go
@@ -18,6 +18,7 @@ const (
 	AiCaseReviewStatusPending
 	AiCaseReviewStatusCompleted
 	AiCaseReviewStatusFailed
+	AiCaseReviewStatusInsufficientFunds
 )
 
 func (s AiCaseReviewStatus) String() string {
@@ -28,6 +29,8 @@ func (s AiCaseReviewStatus) String() string {
 		return "completed"
 	case AiCaseReviewStatusFailed:
 		return "failed"
+	case AiCaseReviewStatusInsufficientFunds:
+		return "insufficient_funds"
 	}
 	return "unknown"
 }
@@ -40,6 +43,8 @@ func AiCaseReviewStatusFromString(s string) AiCaseReviewStatus {
 		return AiCaseReviewStatusCompleted
 	case "failed":
 		return AiCaseReviewStatusFailed
+	case "insufficient_funds":
+		return AiCaseReviewStatusInsufficientFunds
 	default:
 		return AiCaseReviewStatusUnknown
 	}

--- a/repositories/migrations/20251120160000_update_ai_case_review_status.sql
+++ b/repositories/migrations/20251120160000_update_ai_case_review_status.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE ai_case_reviews DROP CONSTRAINT status_check;
+ALTER TABLE ai_case_reviews ADD CONSTRAINT status_check CHECK (status IN ('pending', 'completed', 'failed', 'insufficient_funds'));
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+UPDATE ai_case_reviews SET status = 'failed' WHERE status = 'insufficient_funds';
+ALTER TABLE ai_case_reviews DROP CONSTRAINT status_check;
+ALTER TABLE ai_case_reviews ADD CONSTRAINT status_check CHECK (status IN ('pending', 'completed', 'failed'));
+-- +goose StatementEnd


### PR DESCRIPTION
Avoid returning an error when an AI review fails due to insufficient wallet funds. Instead, assign a dedicated status to the review for this condition, and do not retry the case review.

# Github auto summary
This pull request adds support for handling "insufficient funds" as a new status in the AI case review workflow. The changes update both the application logic and the database schema, and include a new test to ensure the new status is set correctly when funds are insufficient.

**AI Case Review Status Enhancements:**

* Added a new status `AiCaseReviewStatusInsufficientFunds` to the `AiCaseReviewStatus` enum in `models/ai_case_review.go`, updated its string representations, and parsing logic to support the new status. [[1]](diffhunk://#diff-bde228707b637441d3941ade8a490e0ffe9338b5da9e8f7dfa8a8dfd578c5687R21) [[2]](diffhunk://#diff-bde228707b637441d3941ade8a490e0ffe9338b5da9e8f7dfa8a8dfd578c5687R32-R33) [[3]](diffhunk://#diff-bde228707b637441d3941ade8a490e0ffe9338b5da9e8f7dfa8a8dfd578c5687R46-R47)
* Updated the database schema with a migration (`20251120160000_update_ai_case_review_status.sql`) to allow the new `insufficient_funds` status in the `ai_case_reviews` table, with proper up/down migration logic.

**Business Logic Updates:**

* Modified the `CaseReviewWorker` in `async_case_review.go` to check for `billing.ErrInsufficientFunds` when creating a case review. If detected, it updates the case review status to `insufficient_funds` and logs the event. [[1]](diffhunk://#diff-571d692123bf4b15af4cdea3f17b2270c05538e53fc98cc126365679057e00e7R11) [[2]](diffhunk://#diff-571d692123bf4b15af4cdea3f17b2270c05538e53fc98cc126365679057e00e7R122-R134)

**Testing:**

* Added a new test `TestWork_InsufficientFunds` in `async_case_review_test.go` to verify that the worker sets the status to `insufficient_funds` when the billing error is encountered. [[1]](diffhunk://#diff-f12759748dbd8b43405633ab30df75ba527db8b9eb83b60821c2ff9809c20f46R20) [[2]](diffhunk://#diff-f12759748dbd8b43405633ab30df75ba527db8b9eb83b60821c2ff9809c20f46R504-R536)