### PR TITLE
Add jitter to max lifetime connection close.

### DIFF
--- a/infra/postgres_connections_pool.go
+++ b/infra/postgres_connections_pool.go
@@ -48,6 +48,7 @@ func NewPostgresConnectionPool(
 		cfg.MaxConns = DEFAULT_MAX_CONNECTIONS
 	}
 	cfg.MaxConnIdleTime = MAX_CONNECTION_IDLE_TIME
+	cfg.MaxConnLifetimeJitter = 5 * time.Minute
 
 	if impersonateRole != "" {
 		cfg.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {


### PR DESCRIPTION
By default, Postgres connections have a max lifetime of one hour, meaning all opened connections will be closed after that time (and after pgx job runs). That means most **used** connections will be closed exactly at the same time.

A theory we have about why the Cloud SQL proxy sees spikes of CPU usage once in a while is that all connections are closed and reopened (if there is trafic) at the same time, incurring errors.

Note that this only impacts used connections, since unused connections will still be closed five minutes after they are idle. 