### PR TITLE
fix public api doc: "after" instead of "offset_id" for pagination

### DIFF
--- a/pubapi/openapi/v1.yml
+++ b/pubapi/openapi/v1.yml
@@ -105,7 +105,7 @@ paths:
             default: "now"
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/order"
-        - $ref: "#/components/parameters/offset_id"
+        - $ref: "#/components/parameters/after"
       responses:
         "200":
           description: List of decisions
@@ -823,8 +823,8 @@ components:
       schema:
         type: string
         enum: ["ASC", "DESC"]
-    offset_id:
-      name: offset_id
+    after:
+      name: after
       description: |
         Value to start iterating from.
 

--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -70,7 +70,7 @@ paths:
             format: date-time
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/order"
-        - $ref: "#/components/parameters/offset_id"
+        - $ref: "#/components/parameters/after"
       responses:
         "200":
           description: List of cases
@@ -135,7 +135,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/order"
-        - $ref: "#/components/parameters/offset_id"
+        - $ref: "#/components/parameters/after"
       responses:
         "200":
           description: List of comments
@@ -278,8 +278,8 @@ components:
       schema:
         type: string
         enum: ["ASC", "DESC"]
-    offset_id:
-      name: offset_id
+    after:
+      name: after
       description: |
         Value to start iterating from.
 


### PR DESCRIPTION
The documentation was out of line with public API v1 (offset_id was used for the internal API and for v0 public API)