### PR TITLE
Allow changing the email attribute to another claim.

### DIFF
--- a/api/dependencies.go
+++ b/api/dependencies.go
@@ -68,7 +68,7 @@ func InitDependencies(
 			return dependencies{}, err
 		}
 
-		idpTokenVerifier = idp.NewOidcClient(oidcConfig.Provider, oidcConfig.Issuer, oidcConfig.Verifier)
+		idpTokenVerifier = idp.NewOidcClient(oidcConfig, oidcConfig.Provider, oidcConfig.Issuer, oidcConfig.Verifier)
 		tokenIssuer = idpTokenVerifier.Issuer()
 	}
 

--- a/infra/oidc.go
+++ b/infra/oidc.go
@@ -17,6 +17,7 @@ type OidcConfig struct {
 	RedirectUri  string
 	Scopes       []string
 	ExtraParams  map[string]string
+	EmailClaim   string
 
 	AllowedDomains []string
 
@@ -59,6 +60,7 @@ func InitializeOidc(ctx context.Context, marbleAppUrl string) (OidcConfig, error
 		Scopes:       strings.Split(utils.GetEnv("AUTH_OIDC_SCOPE", ""), ","),
 		RedirectUri:  fmt.Sprintf("%s/oidc/callback", marbleAppUrl),
 		ExtraParams:  extraParams,
+		EmailClaim:   utils.GetEnv("AUTH_OIDC_EMAIL_CLAIM", ""),
 
 		AllowedDomains: allowedDomains,
 

--- a/models/identity.go
+++ b/models/identity.go
@@ -39,6 +39,8 @@ type OidcIdentity struct {
 	Email         string `json:"email"`
 	EmailVerified bool   `json:"email_verified"`
 	Picture       string `json:"picture"`
+
+	SkipEmailVerify bool `json:"-"`
 }
 
 func (i OidcIdentity) GetIssuer() string {
@@ -54,7 +56,7 @@ func (i OidcIdentity) GetProfile() *IdentityUpdatableClaims {
 }
 
 func (i OidcIdentity) GetEmail() string {
-	if !i.EmailVerified {
+	if !i.SkipEmailVerify && !i.EmailVerified {
 		return ""
 	}
 	return i.Email

--- a/repositories/idp/oidc.go
+++ b/repositories/idp/oidc.go
@@ -2,9 +2,10 @@ package idp
 
 import (
 	"context"
-	"errors"
 
+	"github.com/checkmarble/marble-backend/infra"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/cockroachdb/errors"
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
@@ -14,13 +15,15 @@ type oidcTokenVerifier interface {
 }
 
 type OidcClient struct {
+	config   infra.OidcConfig
 	issuer   string
 	verifier oidcTokenVerifier
 	provider *oidc.Provider
 }
 
-func NewOidcClient(provider *oidc.Provider, issuer string, verifier *oidc.IDTokenVerifier) *OidcClient {
+func NewOidcClient(cfg infra.OidcConfig, provider *oidc.Provider, issuer string, verifier *oidc.IDTokenVerifier) *OidcClient {
 	return &OidcClient{
+		config:   cfg,
 		issuer:   issuer,
 		verifier: verifier,
 		provider: provider,
@@ -39,6 +42,15 @@ func (c *OidcClient) VerifyToken(ctx context.Context, idToken, accessToken strin
 		return models.OidcIdentity{}, err
 	}
 
+	// If we were configured to lookup the user's email address from another claim,
+	// unmarshal the claims into a map and parse it as a string.
+	if c.config.EmailClaim != "" {
+		claims, err = c.extractCustomEmailClaim(token, claims)
+		if err != nil {
+			return models.OidcIdentity{}, err
+		}
+	}
+
 	if claims.GetEmail() == "" {
 		userinfo, err := c.provider.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken}))
 		if err != nil {
@@ -49,9 +61,16 @@ func (c *OidcClient) VerifyToken(ctx context.Context, idToken, accessToken strin
 			return models.OidcIdentity{}, err
 		}
 
-		if claims.GetEmail() == "" {
-			return models.OidcIdentity{}, errors.New("oidc claims do not contain the principal's email or it is not verified")
+		if c.config.EmailClaim != "" {
+			claims, err = c.extractCustomEmailClaim(userinfo, claims)
+			if err != nil {
+				return models.OidcIdentity{}, err
+			}
 		}
+	}
+
+	if claims.GetEmail() == "" {
+		return models.OidcIdentity{}, errors.New("oidc claims do not contain the principal's email or it is not verified")
 	}
 
 	return claims, nil
@@ -59,4 +78,30 @@ func (c *OidcClient) VerifyToken(ctx context.Context, idToken, accessToken strin
 
 func (c *OidcClient) Issuer() string {
 	return c.issuer
+}
+
+type claimExtracter interface {
+	Claims(any) error
+}
+
+func (c *OidcClient) extractCustomEmailClaim(extractor claimExtracter, claims models.OidcIdentity) (models.OidcIdentity, error) {
+	var rawClaims map[string]any
+
+	if err := extractor.Claims(&rawClaims); err != nil {
+		return models.OidcIdentity{}, err
+	}
+
+	value, ok := rawClaims[c.config.EmailClaim]
+	if !ok {
+		return models.OidcIdentity{}, errors.Newf("oidc claims do not contain the principal's '%s' claim", c.config.EmailClaim)
+	}
+	email, ok := value.(string)
+	if !ok || email == "" {
+		return models.OidcIdentity{}, errors.Newf("oidc claims contain '%s' but it is not a string", c.config.EmailClaim)
+	}
+
+	claims.Email = email
+	claims.SkipEmailVerify = true
+
+	return claims, nil
 }


### PR DESCRIPTION
This adds a configuration parameter to instruct us to look for the user's email address from a different claim as `email`. When this is set, we will not check for the `email_verified` claim either.

This is useful for identity providers that either do not expose the email, or do not guarantee it is verified.

---

OIDC can now be configured with `AUTH_OIDC_EMAIL_CLAIM` set to another claim name. If the claim does not exist or is not a string, authentication will fail. Otherwise, it will replace the `email` claim, as far as we are using it.