### PR TITLE
Add preprocessing option to ignore NER classification.

### DIFF
--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -76,10 +76,11 @@ type ScreeningConfig struct {
 }
 
 type ScreeningConfigPreprocessing struct {
-	UseNer        bool   `json:"use_ner,omitempty"`
-	SkipIfUnder   int    `json:"skip_if_under,omitempty"`
-	RemoveNumbers bool   `json:"remove_numbers,omitempty"`
-	IgnoreListId  string `json:"ignore_list_id,omitempty"`
+	UseNer                  bool   `json:"use_ner,omitempty"`
+	NerIgnoreClassification bool   `json:"ner_ignore_classification,omitempty"`
+	SkipIfUnder             int    `json:"skip_if_under,omitempty"`
+	RemoveNumbers           bool   `json:"remove_numbers,omitempty"`
+	IgnoreListId            string `json:"ignore_list_id,omitempty"`
 }
 
 func (cfg ScreeningConfigPreprocessing) equal(other ScreeningConfigPreprocessing) bool {

--- a/usecases/evaluate_scenario/preprocessing.go
+++ b/usecases/evaluate_scenario/preprocessing.go
@@ -180,21 +180,30 @@ func NameEntityRecognition(ctx context.Context, e ScenarioEvaluator, screeningId
 		performed = true
 
 		for _, match := range matches {
-			switch match.Type {
-			case "Person":
+			switch scc.Preprocessing.NerIgnoreClassification {
+			case false:
+				switch match.Type {
+				case "Person":
+					out = append(out, models.OpenSanctionsCheckQuery{
+						Type:    "Person",
+						Filters: models.OpenSanctionsFilter{"name": []string{match.Text}},
+					})
+
+				case "Company", "Organization":
+					out = append(out, models.OpenSanctionsCheckQuery{
+						Type:    "Organization",
+						Filters: models.OpenSanctionsFilter{"name": []string{match.Text}},
+					})
+
+				default:
+					out = append(out, query)
+				}
+
+			case true:
 				out = append(out, models.OpenSanctionsCheckQuery{
-					Type:    "Person",
+					Type:    "Thing",
 					Filters: models.OpenSanctionsFilter{"name": []string{match.Text}},
 				})
-
-			case "Company", "Organization":
-				out = append(out, models.OpenSanctionsCheckQuery{
-					Type:    "Organization",
-					Filters: models.OpenSanctionsFilter{"name": []string{match.Text}},
-				})
-
-			default:
-				out = append(out, query)
 			}
 		}
 	}


### PR DESCRIPTION
When sending labels through NER, it returns matched text with its classification. Relevant queries are performed against screening list for the classification.

This is not always wanted, where this classification could be wrong (a boat having a person's name), producing wrong tags and therefore producing false negatives.

This adds an option to ignore the detected classification (therefore only using NER as a tokenizer) and produce `Thing` queries.