### PR TITLE
chore: group river update in one PR

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,7 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: chore
+    groups:
+      riverqueue:
+        patterns:
+          - "github.com/riverqueue/river*"


### PR DESCRIPTION
Change dependabot configuration to group river updates in the same PR

ex: https://github.com/checkmarble/marble-backend/pull/1346 & https://github.com/checkmarble/marble-backend/pull/1344