### PR TITLE
feat(continuous_screening): Remove an object from monitoring list

### DIFF
--- a/api/handle_continuous_screening.go
+++ b/api/handle_continuous_screening.go
@@ -125,11 +125,11 @@ func handleUpdateContinuousScreeningConfig(uc usecases.Usecases) func(c *gin.Con
 	}
 }
 
-func handleInsertContinuousScreeningObject(uc usecases.Usecases) func(c *gin.Context) {
+func handleCreateContinuousScreeningObject(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
-		var input dto.InsertContinuousScreeningObjectDto
+		var input dto.CreateContinuousScreeningObjectDto
 		if err := c.ShouldBindJSON(&input); err != nil {
 			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
 			return
@@ -229,5 +229,28 @@ func handleUpdateContinuousScreeningMatchStatus(uc usecases.Usecases) func(c *gi
 		}
 
 		c.JSON(http.StatusOK, dto.AdaptContinuousScreeningMatchDto(match))
+	}
+}
+
+func handleDeleteContinuousScreeningObject(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		var input dto.DeleteContinuousScreeningObjectDto
+		if err := c.ShouldBindJSON(&input); err != nil {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
+			return
+		}
+
+		uc := usecasesWithCreds(ctx, uc).NewContinuousScreeningUsecase()
+		err := uc.DeleteContinuousScreeningObject(
+			ctx,
+			dto.AdaptDeleteContinuousScreeningObjectDto(input),
+		)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.Status(http.StatusNoContent)
 	}
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -204,7 +204,9 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 		handleUpdateContinuousScreeningConfig(uc),
 	)
 	router.POST("/continuous-screenings/objects", tom,
-		handleInsertContinuousScreeningObject(uc))
+		handleCreateContinuousScreeningObject(uc))
+	router.DELETE("/continuous-screenings/objects", tom,
+		handleDeleteContinuousScreeningObject(uc))
 	router.PATCH("/continuous-screenings/matches/:id", tom,
 		handleUpdateContinuousScreeningMatchStatus(uc))
 

--- a/dto/continuous_screening_config.go
+++ b/dto/continuous_screening_config.go
@@ -148,14 +148,14 @@ func AdaptUpdateContinuousScreeningConfigDtoToModel(dto UpdateContinuousScreenin
 	}
 }
 
-type InsertContinuousScreeningObjectDto struct {
+type CreateContinuousScreeningObjectDto struct {
 	ObjectType     string           `json:"object_type" binding:"required"`
 	ConfigStableId uuid.UUID        `json:"config_stable_id" binding:"required"`
 	ObjectId       *string          `json:"object_id"`
 	ObjectPayload  *json.RawMessage `json:"object_payload"`
 }
 
-func (dto InsertContinuousScreeningObjectDto) Validate() error {
+func (dto CreateContinuousScreeningObjectDto) Validate() error {
 	if dto.ObjectId == nil && dto.ObjectPayload == nil {
 		return errors.Wrap(
 			models.BadParameterError,
@@ -173,11 +173,25 @@ func (dto InsertContinuousScreeningObjectDto) Validate() error {
 	return nil
 }
 
-func AdaptInsertContinuousScreeningObjectDto(dto InsertContinuousScreeningObjectDto) models.InsertContinuousScreeningObject {
-	return models.InsertContinuousScreeningObject{
+func AdaptInsertContinuousScreeningObjectDto(dto CreateContinuousScreeningObjectDto) models.CreateContinuousScreeningObject {
+	return models.CreateContinuousScreeningObject{
 		ObjectType:     dto.ObjectType,
 		ConfigStableId: dto.ConfigStableId,
 		ObjectId:       dto.ObjectId,
 		ObjectPayload:  dto.ObjectPayload,
+	}
+}
+
+type DeleteContinuousScreeningObjectDto struct {
+	ObjectType     string    `json:"object_type" binding:"required"`
+	ObjectId       string    `json:"object_id" binding:"required"`
+	ConfigStableId uuid.UUID `json:"config_stable_id" binding:"required"`
+}
+
+func AdaptDeleteContinuousScreeningObjectDto(dto DeleteContinuousScreeningObjectDto) models.DeleteContinuousScreeningObject {
+	return models.DeleteContinuousScreeningObject{
+		ObjectType:     dto.ObjectType,
+		ObjectId:       dto.ObjectId,
+		ConfigStableId: dto.ConfigStableId,
 	}
 }

--- a/mocks/continuous_screening_repository.go
+++ b/mocks/continuous_screening_repository.go
@@ -260,6 +260,15 @@ func (m *ContinuousScreeningClientDbRepository) InsertContinuousScreeningAudit(
 	return args.Error(0)
 }
 
+func (m *ContinuousScreeningClientDbRepository) DeleteContinuousScreeningObject(
+	ctx context.Context,
+	exec repositories.Executor,
+	input models.DeleteContinuousScreeningObject,
+) error {
+	args := m.Called(ctx, exec, input)
+	return args.Error(0)
+}
+
 func (m *ContinuousScreeningClientDbRepository) ListMonitoredObjectsByObjectIds(
 	ctx context.Context,
 	exec repositories.Executor,

--- a/models/continuous_screening.go
+++ b/models/continuous_screening.go
@@ -42,11 +42,17 @@ func (stt ContinuousScreeningTriggerType) String() string {
 	return "unknown"
 }
 
-type InsertContinuousScreeningObject struct {
+type CreateContinuousScreeningObject struct {
 	ObjectType     string
 	ConfigStableId uuid.UUID
 	ObjectId       *string
 	ObjectPayload  *json.RawMessage
+}
+
+type DeleteContinuousScreeningObject struct {
+	ObjectType     string
+	ObjectId       string
+	ConfigStableId uuid.UUID
 }
 
 type ContinuousScreening struct {

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -147,6 +147,11 @@ type ContinuousScreeningClientDbRepository interface {
 		exec repositories.Executor,
 		input models.CreateContinuousScreeningAudit,
 	) error
+	DeleteContinuousScreeningObject(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.DeleteContinuousScreeningObject,
+	) error
 }
 
 type ContinuousScreeningIngestedDataReader interface {


### PR DESCRIPTION
This pull request introduces support for deleting continuous screening objects and refactors related API endpoints and data structures for clarity and consistency. The main changes include adding a new delete endpoint and associated logic, renaming "Insert" operations to "Create", and updating models and DTOs to match these changes.

**API and Endpoint Changes**
* Added a new `DELETE /continuous-screenings/objects` endpoint to allow clients to delete monitored objects from continuous screenings, including the handler `handleDeleteContinuousScreeningObject` and its associated DTO (`DeleteContinuousScreeningObjectDto`). [[1]](diffhunk://#diff-478bc9930523d2cb1072aa084f696518349c18e0db006524d4f3dfa1a413cf32R234-R256) [[2]](diffhunk://#diff-98ba00aec3a81a2ed9b83cab1c3de9ae182c63060b8d8a4a06bb443f90648e52L207-R209) [[3]](diffhunk://#diff-0ab152d9b2703ff7e9b39b59f1cdb7df88461ea0b2834021105499e4fe22b3f2L176-R197)
* Refactored the "insert" endpoint and handler to use "create" terminology (`handleCreateContinuousScreeningObject` and `CreateContinuousScreeningObjectDto`). [[1]](diffhunk://#diff-478bc9930523d2cb1072aa084f696518349c18e0db006524d4f3dfa1a413cf32L128-R132) [[2]](diffhunk://#diff-98ba00aec3a81a2ed9b83cab1c3de9ae182c63060b8d8a4a06bb443f90648e52L207-R209) [[3]](diffhunk://#diff-0ab152d9b2703ff7e9b39b59f1cdb7df88461ea0b2834021105499e4fe22b3f2L151-R158)

**Model and DTO Refactoring**
* Renamed `InsertContinuousScreeningObject` to `CreateContinuousScreeningObject` in both DTOs and models, and updated all usages throughout the codebase for consistency. [[1]](diffhunk://#diff-0ab152d9b2703ff7e9b39b59f1cdb7df88461ea0b2834021105499e4fe22b3f2L151-R158) [[2]](diffhunk://#diff-0ab152d9b2703ff7e9b39b59f1cdb7df88461ea0b2834021105499e4fe22b3f2L176-R197) [[3]](diffhunk://#diff-a8bb06ca3e933827f2abc1f193dea5bde077679081d42f5c4d49e5806500aef9L45-R57) [[4]](diffhunk://#diff-c0267b4b5598dc8a3ace2ce2e18b2354d75da50a5696ab3262df192c9f67628fL29-R29) [[5]](diffhunk://#diff-c0267b4b5598dc8a3ace2ce2e18b2354d75da50a5696ab3262df192c9f67628fL215-R215) [[6]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL179-R179) [[7]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL279-R279) [[8]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL328-R328) [[9]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL382-R382) [[10]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL442-R442) [[11]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL543-R543) [[12]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL613-R613) [[13]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL645-R645) [[14]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL767-R767) [[15]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL882-R882) [[16]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL1428-R1428)
* Added new model and DTO types for deletion operations (`DeleteContinuousScreeningObject`, `DeleteContinuousScreeningObjectDto`). [[1]](diffhunk://#diff-0ab152d9b2703ff7e9b39b59f1cdb7df88461ea0b2834021105499e4fe22b3f2L176-R197) [[2]](diffhunk://#diff-a8bb06ca3e933827f2abc1f193dea5bde077679081d42f5c4d49e5806500aef9L45-R57)

**Repository and Usecase Logic**
* Implemented repository and usecase methods to handle deletion of continuous screening objects, including validation, audit logging, and organization checks. [[1]](diffhunk://#diff-0134df6971c8344e2e9034b3753d0152e40b59e0874b31264d6d7fe09090f317R254-R284) [[2]](diffhunk://#diff-b7cb723d8520b96da2715366247f7013b202a8a3384d16178e87520015dd04baR263-R271) [[3]](diffhunk://#diff-c0267b4b5598dc8a3ace2ce2e18b2354d75da50a5696ab3262df192c9f67628fR480-R541)
* Updated test cases and mocks to use the new "create" terminology and to support the new deletion logic. [[1]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL179-R179) [[2]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL279-R279) [[3]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL328-R328) [[4]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL382-R382) [[5]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL442-R442) [[6]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL543-R543) [[7]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL613-R613) [[8]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL645-R645) [[9]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL767-R767) [[10]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL882-R882) [[11]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bL1428-R1428) [[12]](diffhunk://#diff-b7cb723d8520b96da2715366247f7013b202a8a3384d16178e87520015dd04baR263-R271)

**Other Minor Updates**
* Updated the generated API client to use the latest version of `oapi-codegen` and made a minor type change for paged response content. [[1]](diffhunk://#diff-2266d225884911e3d4c3bf221c51c4e4dcc5302ed1f2bf0989974c2d5eb34b10L3-R3) [[2]](diffhunk://#diff-2266d225884911e3d4c3bf221c51c4e4dcc5302ed1f2bf0989974c2d5eb34b10L526-R526)
* Added missing imports and minor code improvements for error handling and user ID extraction. [[1]](diffhunk://#diff-0134df6971c8344e2e9034b3753d0152e40b59e0874b31264d6d7fe09090f317R10) [[2]](diffhunk://#diff-3b346347b0776ce637da986ffc16993c77d6bda30a3ef0e96aebeac5acd9bc6bR14) [[3]](diffhunk://#diff-c0267b4b5598dc8a3ace2ce2e18b2354d75da50a5696ab3262df192c9f67628fL464-R469)

These changes collectively improve the API's capabilities and code clarity for managing continuous screening objects.