### PR TITLE
Remove analytics feature flag.

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -391,12 +391,10 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.GET("/settings/ai", tom, HandleGetAiSettingForOrganization(uc))
 	router.PUT("/settings/ai", tom, HandlePutAiSettingForOrganization(uc))
 
-	if conf.AnalyticsEnabled {
-		if conf.AnalyticsProxyApiUrl == "" {
-			addAnalyticsRoutes(router, conf, uc)
-		} else {
-			addAnalyticsProxyRoutes(router, conf)
-		}
+	if conf.AnalyticsProxyApiUrl == "" {
+		addAnalyticsRoutes(router, conf, uc)
+	} else {
+		addAnalyticsProxyRoutes(router, conf)
 	}
 }
 

--- a/infra/analytics.go
+++ b/infra/analytics.go
@@ -44,8 +44,7 @@ func InitAnalyticsConfig(pgConfig PgConfig, bucket string) (AnalyticsConfig, err
 	}
 
 	cfg := AnalyticsConfig{
-		Enabled: utils.GetEnv("ANALYTICS_ONLY_ORG", "") != "",
-		// TODO: during QA phase, analytics is only enabled if we set it for a single organization
+		Enabled:         !utils.GetEnv("DISABLE_ANALYTICS", false),
 		JobInterval:     utils.GetEnvDuration("ANALYTICS_JOB_INTERVAL", time.Hour),
 		ExportBatchSize: utils.GetEnv("ANALYTICS_BATCH_SIZE", 10000),
 		Bucket:          bucket,

--- a/usecases/task_queue.go
+++ b/usecases/task_queue.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/scheduled_execution"
 	"github.com/checkmarble/marble-backend/utils"
-	"github.com/google/uuid"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
@@ -190,18 +188,7 @@ func QueuesFromOrgs(ctx context.Context, appName string,
 		}
 
 		if analyticsConfig.Enabled {
-			enabledOrgIds := make([]string, 0)
-
-			// TODO: during QA, only run on specified org IDs, skip errors because this is for production
-			for analyticsOrgId := range strings.SplitSeq(os.Getenv("ANALYTICS_ONLY_ORG"), ",") {
-				if _, err := uuid.Parse(analyticsOrgId); err == nil {
-					enabledOrgIds = append(enabledOrgIds, analyticsOrgId)
-				}
-			}
-
-			if slices.Contains(enabledOrgIds, org.Id) {
-				periodics = append(periodics, scheduled_execution.NewAnalyticsExportJob(org.Id, analyticsConfig.JobInterval))
-			}
+			periodics = append(periodics, scheduled_execution.NewAnalyticsExportJob(org.Id, analyticsConfig.JobInterval))
 		}
 
 		queues[org.Id] = river.QueueConfig{


### PR DESCRIPTION
The list of allowlisted organizations for ananlytics is not replaced by a global switch to turn it off (defaults to enabled). It only impacts export without disabling the API.