### PR TITLE
feat(case): get related case by object attributes (for continuous screening) 

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -293,7 +293,9 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.POST("/cases/review_decision", tom, handleReviewCaseDecisions(uc))
 	router.GET("/cases/:case_id/annotations", tom, handleGetAnnotationByCase(uc))
 	router.GET("/cases/:case_id/pivot_objects", tom, handleReadCasePivotObjects(uc))
-	router.GET("/cases/related/pivot/:pivotValue", tom, handleGetRelatedCases(uc))
+	router.GET("/cases/related/pivot/:pivotValue", tom, handleGetRelatedCasesByPivotValue(uc))
+	router.GET("/cases/related/object_type/:objectType/object_id/:objectId", tom,
+		handleGetRelatedContinuousScreeningCasesByObjectAttr(uc))
 	router.GET("/cases/:case_id/sar", tom, handleListSuspiciousActivityReports(uc))
 	router.POST("/cases/:case_id/sar", tom, handleCreateSuspiciousActivityReport(uc))
 	router.PATCH("/cases/:case_id/sar/:reportId", tom, handleUpdateSuspiciousActivityReport(uc))


### PR DESCRIPTION
This pull request adds a new way to fetch related cases by object attributes necessary for continuous screening, in addition to the existing pivot value method. The API, usecase, and repository layers are updated to support querying related cases using an object's type and ID. Route and handler names have been clarified to distinguish between the two methods.

### API changes

* Added the route `/cases/related/object_type/:objectType/object_id/:objectId` and its handler `handleGetRelatedCasesByObjectAttr`, allowing clients to fetch related cases by object type and object ID. [[1]](diffhunk://#diff-98ba00aec3a81a2ed9b83cab1c3de9ae182c63060b8d8a4a06bb443f90648e52L297-R298) [[2]](diffhunk://#diff-621be274d14c4c93d448372cb2c6645021ccc0ff693eb4f00ec168dff294c6aaR566-R587)
* Renamed the existing handler and route for fetching related cases by pivot value to `handleGetRelatedCasesByPivotValue` and `/cases/related/pivot/:pivotValue` for clarity. [[1]](diffhunk://#diff-621be274d14c4c93d448372cb2c6645021ccc0ff693eb4f00ec168dff294c6aaL544-R544) [[2]](diffhunk://#diff-98ba00aec3a81a2ed9b83cab1c3de9ae182c63060b8d8a4a06bb443f90648e52L297-R298)

### Usecase layer changes

* Added `GetRelatedCasesByObjectAttr` method to the `CaseUseCase` class, which enforces security and returns allowed cases for the organization, object type, and object ID.
* Renamed the previous `GetRelatedCases` method to `GetRelatedCasesByPivotValue` for consistency.
* Updated the `CaseUseCaseRepository` interface to include the new repository method for object attribute queries.

### Repository layer changes

* Added the `GetCasesWithObjectAttr` method to `MarbleDbRepository`, which queries cases related to a given object type and object ID.
* Minor formatting improvements to SQL query construction for readability. [[1]](diffhunk://#diff-038ad1ce25a23db928a1e9a3df6193dedb2df8f08d7a0a5b0556cc33b674f5aeL208-R213) [[2]](diffhunk://#diff-038ad1ce25a23db928a1e9a3df6193dedb2df8f08d7a0a5b0556cc33b674f5aeL118-R120)