### PR TITLE
more precise glob matching for perf in analytics

### DIFF
--- a/usecases/analytics_metadata_usecase.go
+++ b/usecases/analytics_metadata_usecase.go
@@ -23,8 +23,11 @@ type AnalyticsMetadataUsecase struct {
 	scenarioRepository repositories.ScenarioUsecaseRepository
 }
 
-func (uc AnalyticsMetadataUsecase) GetAvailableFilters(ctx context.Context, req dto.AnalyticsAvailableFiltersRequest) ([]models.AnalyticsFilter, error) {
-	scenario, err := uc.scenarioRepository.GetScenarioById(ctx, uc.executorFactory.NewExecutor(), req.ScenarioId.String())
+func (uc AnalyticsMetadataUsecase) GetAvailableFilters(ctx context.Context,
+	req dto.AnalyticsAvailableFiltersRequest,
+) ([]models.AnalyticsFilter, error) {
+	scenario, err := uc.scenarioRepository.GetScenarioById(ctx,
+		uc.executorFactory.NewExecutor(), req.ScenarioId.String())
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +40,10 @@ func (uc AnalyticsMetadataUsecase) GetAvailableFilters(ctx context.Context, req 
 		return nil, err
 	}
 
-	inner := squirrel.Select("*").From(uc.analyticsFactory.BuildTarget("decisions"))
-	inner = uc.analyticsFactory.BuildPushdownFilter(inner, uc.enforceSecurity.OrgId(), req.Start, req.End, scenario.TriggerObjectType)
+	inner := squirrel.Select("*").From(uc.analyticsFactory.BuildTarget("decisions",
+		scenario.OrganizationId, scenario.TriggerObjectType))
+	inner = uc.analyticsFactory.BuildPushdownFilter(inner, uc.enforceSecurity.OrgId(),
+		req.Start, req.End, scenario.TriggerObjectType)
 
 	innerSql, innerArgs, _ := inner.ToSql()
 
@@ -67,7 +72,7 @@ func (uc AnalyticsMetadataUsecase) GetAvailableFilters(ctx context.Context, req 
 			) i
 			on i.name = o.column_name;
 		`,
-		uc.analyticsFactory.BuildTarget("decisions"),
+		uc.analyticsFactory.BuildTarget("decisions", scenario.OrganizationId, scenario.TriggerObjectType),
 		innerSql,
 	), innerArgs...)
 	if err != nil {
@@ -85,7 +90,8 @@ func (uc AnalyticsMetadataUsecase) GetAvailableFilters(ctx context.Context, req 
 			return nil, err
 		}
 
-		if strings.HasPrefix(tmp.Name, analytics.TriggerObjectFieldPrefix) || strings.HasPrefix(tmp.Name, analytics.DatabaseFieldPrefix) {
+		if strings.HasPrefix(tmp.Name, analytics.TriggerObjectFieldPrefix) ||
+			strings.HasPrefix(tmp.Name, analytics.DatabaseFieldPrefix) {
 			filters = append(filters, tmp)
 		}
 	}

--- a/usecases/scheduled_execution/analytics_export_job.go
+++ b/usecases/scheduled_execution/analytics_export_job.go
@@ -247,7 +247,7 @@ func (w AnalyticsExportWorker) exportDecisions(
 	var id uuid.UUID
 	id, startWatermark, err = repositories.AnalyticsGetLatestRow(ctx, exec,
 		req.OrgId, req.TriggerObject,
-		w.analyticsFactory.BuildTarget("decisions"))
+		w.analyticsFactory.BuildTarget("decisions", req.OrgId, req.TriggerObject))
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get latest exported row")
 	}
@@ -276,7 +276,7 @@ func (w AnalyticsExportWorker) exportDecisionRules(
 	var id uuid.UUID
 	id, startWatermark, err = repositories.AnalyticsGetLatestRow(ctx, exec,
 		req.OrgId, req.TriggerObject,
-		w.analyticsFactory.BuildTarget("decision_rules"))
+		w.analyticsFactory.BuildTarget("decision_rules", req.OrgId, req.TriggerObject))
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get latest exported row")
 	}
@@ -305,7 +305,7 @@ func (w AnalyticsExportWorker) exportScreenings(
 	var id uuid.UUID
 	id, startWatermark, err = repositories.AnalyticsGetLatestRow(ctx, exec,
 		req.OrgId, req.TriggerObject,
-		w.analyticsFactory.BuildTarget("screenings"))
+		w.analyticsFactory.BuildTarget("screenings", req.OrgId, req.TriggerObject))
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to get latest exported row")
 	}


### PR DESCRIPTION
Pushdown filters on duckdb are only applied after the glob matching - it the latter is too imprecise, we have a bottlened on listing files & reading headers. Esp at end of month with many orgs.