### PR TITLE
dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,5 @@ updates:
       riverqueue:
         patterns:
           - "github.com/riverqueue/river*"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Cf inspiration here https://checkmarble.slack.com/archives/C05AZK54GSC/p1763760106876979

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a 14-day cooldown to Dependabot gomod updates in .github/dependabot.yaml.
> 
> - **Dependabot config**: Add `cooldown.default-days: 14` for `gomod` updates in `.github/dependabot.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb0703a2c7413e36005b600c1f8f7c84314b28ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->