### PR TITLE
feat(continuous_screening): add load-more func to fetch all screening matches

### DIFF
--- a/api/handle_continuous_screening_load_more.go
+++ b/api/handle_continuous_screening_load_more.go
@@ -1,0 +1,31 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/cockroachdb/errors"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func handleLoadMoreContinuousScreeningMatches(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		id, err := uuid.Parse(c.Param("id"))
+		if err != nil {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
+			return
+		}
+
+		uc := usecasesWithCreds(ctx, uc).NewContinuousScreeningUsecase()
+		screening, err := uc.LoadMoreContinuousScreeningMatches(ctx, id)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, dto.AdaptContinuousScreeningDto(screening))
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -212,6 +212,8 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.GET("/continuous-screenings", tom, handleListContinuousScreeningsForOrg(uc))
 	router.PATCH("/continuous-screenings/:id/dismiss", tom,
 		handleDismissContinuousScreening(uc))
+	router.POST("/continuous-screenings/:id/load-more", tom,
+		handleLoadMoreContinuousScreeningMatches(uc))
 
 	router.GET("/scenario-publications", tom, handleListScenarioPublications(uc))
 	router.POST("/scenario-publications", tom, handleCreateScenarioPublication(uc))

--- a/mocks/continuous_screening_repository.go
+++ b/mocks/continuous_screening_repository.go
@@ -231,6 +231,26 @@ func (m *ContinuousScreeningRepository) AddScreeningMatchWhitelist(
 	return args.Error(0)
 }
 
+func (m *ContinuousScreeningRepository) InsertContinuousScreeningMatches(
+	ctx context.Context,
+	exec repositories.Executor,
+	screeningId uuid.UUID,
+	matches []models.ContinuousScreeningMatch,
+) ([]models.ContinuousScreeningMatch, error) {
+	args := m.Called(ctx, exec, screeningId, matches)
+	return args.Get(0).([]models.ContinuousScreeningMatch), args.Error(1)
+}
+
+func (m *ContinuousScreeningRepository) UpdateContinuousScreening(
+	ctx context.Context,
+	exec repositories.Executor,
+	id uuid.UUID,
+	input models.UpdateContinuousScreeningInput,
+) (models.ContinuousScreening, error) {
+	args := m.Called(ctx, exec, id, input)
+	return args.Get(0).(models.ContinuousScreening), args.Error(1)
+}
+
 type ContinuousScreeningClientDbRepository struct {
 	mock.Mock
 }

--- a/models/continuous_screening.go
+++ b/models/continuous_screening.go
@@ -74,6 +74,13 @@ type ContinuousScreening struct {
 	UpdatedAt time.Time
 }
 
+type UpdateContinuousScreeningInput struct {
+	Status          *ScreeningStatus
+	IsPartial       *bool
+	NumberOfMatches *int
+	CaseId          *uuid.UUID
+}
+
 type ContinuousScreeningMatch struct {
 	Id                    uuid.UUID
 	ContinuousScreeningId uuid.UUID

--- a/usecases/continuous_screening/screening.go
+++ b/usecases/continuous_screening/screening.go
@@ -2,6 +2,7 @@ package continuous_screening
 
 import (
 	"context"
+	"slices"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
@@ -10,6 +11,9 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 )
+
+// cf: https://api.opensanctions.org/#tag/Matching/operation/match_match__dataset__post
+const MaxScreeningCandidates = 500
 
 // UpdateContinuousScreeningMatchStatus updates the status of a continuous screening match
 // (e.g., marking it as confirmed_hit or no_hit) and triggers related actions.
@@ -338,6 +342,159 @@ func (uc *ContinuousScreeningUsecase) DismissContinuousScreening(ctx context.Con
 		if err != nil {
 			return err
 		}
+		return nil
+	})
+	if err != nil {
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
+	return continuousScreening, nil
+}
+
+// LoadMoreContinuousScreeningMatches fetches additional screening matches for a continuous screening that has partial results.
+//
+// 1. Validates that the continuous screening exists, is in "in_review" status and has partial results
+// 2. Verifies permissions: requires WriteContinuousScreeningHit permission
+// 3. Fetches the screening configuration and data model mapping for the object type
+// 4. Retrieves the ingested data for the monitored object
+// 5. Re-runs the screening with MatchLimit set to MaxScreeningCandidates (500)
+// 6. Filters out matches that already exist in the screening to avoid duplicates
+// 7. Inserts only the new matches into the database
+// 8. Updates the screening's IsPartial and NumberOfMatches fields:
+//   - IsPartial is set to false if the full result set is now loaded
+//   - NumberOfMatches is incremented with the new matches count
+//
+// 9. Returns the updated ContinuousScreeningWithMatches containing all matches (existing + new)
+//
+// Returns the updated ContinuousScreeningWithMatches containing all matches (existing + newly loaded)
+//
+// For now, we ignore the case where the new matches don't contains existing matches.
+func (uc *ContinuousScreeningUsecase) LoadMoreContinuousScreeningMatches(
+	ctx context.Context,
+	continuousScreeningId uuid.UUID,
+) (models.ContinuousScreeningWithMatches, error) {
+	logger := utils.LoggerFromContext(ctx)
+	var continuousScreening models.ContinuousScreeningWithMatches
+
+	err := uc.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		// Fetch the continuous screening with matches
+		var err error
+		continuousScreening, err = uc.repository.GetContinuousScreeningWithMatchesById(ctx, tx, continuousScreeningId)
+		if err != nil {
+			return err
+		}
+
+		clientDbExec, err := uc.executorFactory.NewClientDbExecutor(ctx, continuousScreening.OrgId.String())
+		if err != nil {
+			return err
+		}
+
+		if err := uc.enforceSecurity.WriteContinuousScreeningHit(continuousScreening.OrgId); err != nil {
+			return err
+		}
+
+		// Check if the continuous screening is in review and is Partial
+		if continuousScreening.Status != models.ScreeningStatusInReview {
+			return errors.Wrap(
+				models.UnprocessableEntityError,
+				"continuous screening is not in review, can't load more results",
+			)
+		}
+		if !continuousScreening.IsPartial {
+			return errors.Wrap(
+				models.UnprocessableEntityError,
+				"continuous screening is not partial, can't load more results",
+			)
+		}
+
+		// Fetch the configuration
+		config, err := uc.repository.GetContinuousScreeningConfigByStableId(ctx, tx,
+			continuousScreening.ContinuousScreeningConfigStableId)
+		if err != nil {
+			return err
+		}
+
+		// Have the data model table and mapping
+		table, mapping, err := uc.GetDataModelTableAndMapping(ctx, tx, config, continuousScreening.ObjectType)
+		if err != nil {
+			return err
+		}
+
+		// Fetch the ingested Data
+		ingestedObject, _, err := uc.GetIngestedObject(ctx, clientDbExec, table, continuousScreening.ObjectId)
+		if err != nil {
+			return err
+		}
+
+		// Override configuration max candidates to MAX_SCREENING_CANDIDATES
+		config.MatchLimit = MaxScreeningCandidates
+
+		// Do the screening
+		screeningWithMatches, err := uc.DoScreening(
+			ctx,
+			tx,
+			ingestedObject,
+			mapping,
+			config,
+			continuousScreening.ObjectType,
+			continuousScreening.ObjectId,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Filter matches to keep only new matches compared to the existing ones
+		newMatches := utils.Filter(screeningWithMatches.Matches, func(m models.ScreeningMatch) bool {
+			return !slices.ContainsFunc(
+				continuousScreening.Matches,
+				func(csm models.ContinuousScreeningMatch) bool {
+					return csm.OpenSanctionEntityId == m.EntityId
+				},
+			)
+		})
+
+		if len(newMatches) == 0 {
+			logger.InfoContext(
+				ctx,
+				"No new matches found in load more",
+				"continuous_screening_id", continuousScreeningId,
+			)
+		}
+
+		// Insert new matches
+		insertedMatches, err := uc.repository.InsertContinuousScreeningMatches(
+			ctx,
+			tx,
+			continuousScreeningId,
+			pure_utils.Map(newMatches, func(m models.ScreeningMatch) models.ContinuousScreeningMatch {
+				return models.ContinuousScreeningMatch{
+					OpenSanctionEntityId: m.EntityId,
+					Payload:              m.Payload,
+				}
+			}),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Update the continuous screening fields
+		continuousScreening.NumberOfMatches += len(insertedMatches)
+		continuousScreening.IsPartial = screeningWithMatches.Partial
+		continuousScreening.Matches = append(continuousScreening.Matches, insertedMatches...)
+
+		_, err = uc.repository.UpdateContinuousScreening(
+			ctx,
+			tx,
+			continuousScreeningId,
+			models.UpdateContinuousScreeningInput{
+				NumberOfMatches: utils.Ptr(continuousScreening.NumberOfMatches),
+				IsPartial:       utils.Ptr(continuousScreening.IsPartial),
+			},
+		)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -79,6 +79,12 @@ type ContinuousScreeningUsecaseRepository interface {
 		id uuid.UUID,
 		newStatus models.ScreeningStatus,
 	) (models.ContinuousScreening, error)
+	UpdateContinuousScreening(
+		ctx context.Context,
+		exec repositories.Executor,
+		id uuid.UUID,
+		input models.UpdateContinuousScreeningInput,
+	) (models.ContinuousScreening, error)
 
 	// Continuous screening matches
 	GetContinuousScreeningMatch(
@@ -99,6 +105,12 @@ type ContinuousScreeningUsecaseRepository interface {
 		ids []uuid.UUID,
 		status models.ScreeningMatchStatus,
 		reviewerId *uuid.UUID,
+	) ([]models.ContinuousScreeningMatch, error)
+	InsertContinuousScreeningMatches(
+		ctx context.Context,
+		exec repositories.Executor,
+		screeningId uuid.UUID,
+		matches []models.ContinuousScreeningMatch,
 	) ([]models.ContinuousScreeningMatch, error)
 
 	// Cases:


### PR DESCRIPTION
This PR implements a "load more" feature for continuous screening results that allows users to retrieve additional matches beyond the initial batch. When a screening returns partial results, users can now trigger a re-screening with a higher match limit (up to 500 cf: Yente match documentation) to get more results from Open Sanctions.

- Validates that the screening is in InReview status and marked as partial
- Re-runs the screening against Open Sanctions with MAX_SCREENING_CANDIDATES (500) as the match limit
- Filters out previously found matches using deduplication by OpenSanctionEntityId
- Inserts only the new matches into the database
- Updates the continuous screening record with the new match count and partial status


# Github auto summary
This pull request introduces a new "load more matches" feature for continuous screenings, allowing users to fetch additional screening matches when the initial results are partial. The main changes span the API, use case layer, models, repositories, and tests, ensuring the feature is robust, deduplicates matches, and updates screening metadata accordingly.

**Feature implementation:**

* Added a new API endpoint `POST /continuous-screenings/:id/load-more` and handler `handleLoadMoreContinuousScreeningMatches` to trigger loading more matches for a continuous screening. [[1]](diffhunk://#diff-60bbc7bb2b9e52c75e571f9f356d5b00341ca46ce052eafc45b07a67ea43b8f6R1-R31) [[2]](diffhunk://#diff-98ba00aec3a81a2ed9b83cab1c3de9ae182c63060b8d8a4a06bb443f90648e52R215-R216)
* Implemented `LoadMoreContinuousScreeningMatches` in the use case layer, which fetches the screening, performs additional matching (with a higher candidate limit), deduplicates new matches, inserts them, and updates the screening status and match count. [[1]](diffhunk://#diff-21539c8d3fafaa3774cb1dfe6a6c478d859b6f2f8dafe0c7136652eca1981334R353-R487) [[2]](diffhunk://#diff-21539c8d3fafaa3774cb1dfe6a6c478d859b6f2f8dafe0c7136652eca1981334R15-R17)

**Repository and model changes:**

* Added repository methods `InsertContinuousScreeningMatches` and `UpdateContinuousScreening` to support batch insertion of new matches and updating screening metadata. Also introduced the `UpdateContinuousScreeningInput` model for flexible updates. [[1]](diffhunk://#diff-39633c2fb9f730ec8165dc6efe467c7ec8a39a5f5c5fd5c096237104c4f99847R251-R276) [[2]](diffhunk://#diff-39633c2fb9f730ec8165dc6efe467c7ec8a39a5f5c5fd5c096237104c4f99847R535-R574) [[3]](diffhunk://#diff-b7cb723d8520b96da2715366247f7013b202a8a3384d16178e87520015dd04baR234-R253) [[4]](diffhunk://#diff-a8bb06ca3e933827f2abc1f193dea5bde077679081d42f5c4d49e5806500aef9R77-R83) [[5]](diffhunk://#diff-4477cb6ab44ee61b7feb332da87d6f6e8a660ef81159ca3c50ede03d36c8a2a8R82-R87) [[6]](diffhunk://#diff-4477cb6ab44ee61b7feb332da87d6f6e8a660ef81159ca3c50ede03d36c8a2a8R109-R114)

**Testing:**

* Added comprehensive unit tests for the new "load more matches" flow, covering deduplication, insertion, and metadata updates.

**Miscellaneous:**

* Minor import and constant additions for improved code clarity and configuration. [[1]](diffhunk://#diff-21539c8d3fafaa3774cb1dfe6a6c478d859b6f2f8dafe0c7136652eca1981334R5) [[2]](diffhunk://#diff-21539c8d3fafaa3774cb1dfe6a6c478d859b6f2f8dafe0c7136652eca1981334R15-R17)