### PR TITLE
feat: can disable continuous screening by env

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -157,6 +157,14 @@ func (w *ApplyDeltaFileWorker) Timeout(job *river.Job[models.ContinuousScreening
 // Could be slow, need to monitor the time process and see if we need to parallelize it
 func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.ContinuousScreeningApplyDeltaFileArgs]) error {
 	logger := utils.LoggerFromContext(ctx)
+
+	if utils.GetEnv("DISABLE_CONTINUOUS_SCREENING_APPLY_DELTA_FILE", false) {
+		logger.InfoContext(ctx, "Continuous screening apply delta file is disabled, skipping job",
+			"update_id", job.Args.UpdateId,
+			"org_id", job.Args.OrgId)
+		return nil
+	}
+
 	exec := w.executorFactory.NewExecutor()
 
 	// Log error if job has been retried many times


### PR DESCRIPTION
This pull request introduces a feature flag to allow disabling the "apply delta file" step in the continuous screening workflow. This is implemented by checking the `DISABLE_CONTINUOUS_SCREENING_APPLY_DELTA_FILE` environment variable at the start of the worker's `Work` method.

Feature flag for continuous screening:

* [`usecases/continuous_screening/worker_apply_delta_file.go`](diffhunk://#diff-28858045fe86a2105225a7874022f8c02864ed98e0f506fae621ae42936cdd1bR160-R167): Added a check for the `DISABLE_CONTINUOUS_SCREENING_APPLY_DELTA_FILE` environment variable to conditionally skip processing jobs and log when the feature is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added operational control to disable continuous screening delta-file processing via environment variable configuration when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->