### PR TITLE
bubble up nil value on fuzzy match filter

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
+++ b/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options.go
@@ -17,6 +17,13 @@ var allowedFuzzyMatchAlgorithms = []string{
 }
 
 func (f FuzzyMatchOptionsEvaluator) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
+	// "value" input comes from payload or DB, can be null and should not fail.
+	// Bubble up nil so the parent Filter evaluator can handle it (returns Filter{Value: nil},
+	// which the Aggregator then treats as a no-op filter and returns the default value).
+	if arguments.NamedArgs["value"] == nil {
+		return nil, nil
+	}
+
 	algorithm, err := AdaptNamedArgument(arguments.NamedArgs, "algorithm", adaptArgumentToString)
 	if err != nil {
 		return nil, []error{err}

--- a/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_fuzzy_match_options_test.go
@@ -15,7 +15,7 @@ func TestFuzzyMatchOptionsEvaluator_Evaluate(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     ast.Arguments
-		want     ast.FuzzyMatchOptions
+		want     any
 		wantErrs bool
 	}{
 		{
@@ -95,7 +95,8 @@ func TestFuzzyMatchOptionsEvaluator_Evaluate(t *testing.T) {
 					"threshold": 75,
 				},
 			},
-			wantErrs: true,
+			want:     nil,
+			wantErrs: false,
 		},
 	}
 


### PR DESCRIPTION
All other operators pass a nil value up the chain, but the fuzzy match option operator for aggregate filters did not, so that decisions would end up with a 500 status / 6 retries then stop in batch mode.
This fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced fuzzy matching functionality with improved handling of missing required arguments. The system now performs early validation checks for value parameters, returning appropriate results without unnecessary processing steps when required arguments are absent. This ensures more predictable and efficient behavior when handling edge cases in fuzzy matching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->