### PR TITLE
chore: delete unnecessary guard in update table method

### DIFF
--- a/dto/data_model_dto.go
+++ b/dto/data_model_dto.go
@@ -245,8 +245,10 @@ type UpdateTableInput struct {
 
 func (input UpdateTableInput) AdaptToUpdateTableCompositeInput() (models.UpdateTableCompositeInput, error) {
 	result := models.UpdateTableCompositeInput{
-		Description: input.Description,
-		Metadata:    input.Metadata,
+		Description:          input.Description,
+		Metadata:             input.Metadata,
+		CaptionField:         input.CaptionField,
+		PrimaryOrderingField: input.PrimaryOrderingField,
 	}
 
 	// Table-level optional fields
@@ -277,12 +279,6 @@ func (input UpdateTableInput) AdaptToUpdateTableCompositeInput() (models.UpdateT
 		} else {
 			result.SemanticType = pure_utils.NullFromPtr[models.SemanticType](nil)
 		}
-	}
-	if input.CaptionField.Set {
-		result.CaptionField = input.CaptionField
-	}
-	if input.PrimaryOrderingField.Set {
-		result.PrimaryOrderingField = input.PrimaryOrderingField
 	}
 
 	// Parse field operations


### PR DESCRIPTION
Little PR, the if statements were unnecessary because the CaptionField and PrimaryOrderingField are of the Null type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where table metadata updates were not being applied consistently when modifying table properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->