### PR TITLE
convoy migration is now mandatory to upgrade

### DIFF
--- a/cmd/webhook_migration.go
+++ b/cmd/webhook_migration.go
@@ -21,7 +21,6 @@ import (
 // The migration:
 // - Checks if already migrated (via metadata flag)
 // - If convoy is NOT configured, marks as migrated immediately (no feature flag needed)
-// - If Convoy IS configured, waits for feature flag before migrating
 // - Fetches all webhooks from Convoy for all organizations
 // - Creates them in the internal system with their secrets (in a transaction)
 // - Skips non-HTTPS endpoints (logs a warning)
@@ -38,12 +37,11 @@ func MigrateConvoyWebhooks(ctx context.Context, repos repositories.Repositories,
 	// If Convoy is NOT configured, mark as migrated immediately (no feature flag needed)
 	if !hasConvoyServerSetup {
 		logger.InfoContext(ctx, "Convoy not configured, marking webhook system as migrated")
-		return markWebhookSystemMigratedWithTx(ctx, repos)
-	}
-
-	// Convoy IS configured: wait for feature flag before migrating
-	if !utils.GetEnv("ENABLE_WEBHOOK_MIGRATION", false) {
-		return nil
+		return repos.ExecutorGetter.Transaction(ctx, models.DATABASE_SCHEMA_TYPE_MARBLE, nil,
+			func(tx repositories.Transaction) error {
+				return createMigrationMetadata(ctx, repos, tx)
+			},
+		)
 	}
 
 	logger.InfoContext(ctx, "Starting webhook migration from Convoy to internal system")
@@ -202,14 +200,4 @@ func createMigrationMetadata(ctx context.Context, repos repositories.Repositorie
 		Value:     "true",
 	}
 	return repos.MarbleDbRepository.CreateMetadata(ctx, tx, metadata)
-}
-
-// markWebhookSystemMigratedWithTx marks the webhook system as migrated in its own transaction.
-// Used when Convoy is not configured.
-func markWebhookSystemMigratedWithTx(ctx context.Context, repos repositories.Repositories) error {
-	return repos.ExecutorGetter.Transaction(ctx, models.DATABASE_SCHEMA_TYPE_MARBLE, nil,
-		func(tx repositories.Transaction) error {
-			return createMigrationMetadata(ctx, repos, tx)
-		},
-	)
 }


### PR DESCRIPTION
Convoy to marble webhooks migration was optional since 3 releases, now becomes mandatory.
Convoy code paths stay for a few more versions so that webhooks don't suddenly break if the migration errors (which it can).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined webhook migration control flow by removing redundant environment checks and consolidating internal helper functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->