### PR TITLE
step 2: backfill num of matches, counterparty identifier on screenings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,6 +25,7 @@ linters:
     staticcheck:
       checks:
         - all
+        - -S1001
         - -ST1003
         - -ST1006
         - -ST1020

--- a/dto/screening_dto.go
+++ b/dto/screening_dto.go
@@ -99,7 +99,6 @@ type ScreeningMatchDto struct {
 	Status                       string                     `json:"status"`
 	ReviewedBy                   *string                    `json:"reviewer_id,omitempty"` //nolint:tagliatelle
 	Datasets                     []string                   `json:"datasets"`
-	UniqueCounterpartyIdentifier *string                    `json:"unique_counterparty_identifier"`
 	Payload                      json.RawMessage            `json:"payload"`
 	Enriched                     bool                       `json:"enriched"`
 	Comments                     []ScreeningMatchCommentDto `json:"comments"`
@@ -116,7 +115,6 @@ func AdaptScreeningMatchDto(m models.ScreeningMatch) ScreeningMatchDto {
 		Datasets:                     make([]string, 0),
 		Payload:                      m.Payload,
 		Enriched:                     m.Enriched,
-		UniqueCounterpartyIdentifier: m.UniqueCounterpartyIdentifier,
 		Comments:                     pure_utils.Map(m.Comments, AdaptScreeningMatchCommentDto),
 	}
 

--- a/models/decision.go
+++ b/models/decision.go
@@ -157,12 +157,8 @@ func MergeScreeningExecWithDefaults(decisionId, orgId uuid.UUID, counterpartyIde
 		se.OrgId = orgId
 		se.CreatedAt = time.Now()
 		se.UpdatedAt = time.Now()
-		// Set counterparty on screening and on all matches (dual-write)
 		if counterpartyIdentifier != nil {
 			se.UniqueCounterpartyIdentifier = counterpartyIdentifier
-			for i := range se.Matches {
-				se.Matches[i].UniqueCounterpartyIdentifier = counterpartyIdentifier
-			}
 		}
 		return se
 	}

--- a/models/screening.go
+++ b/models/screening.go
@@ -114,10 +114,6 @@ type Screening struct {
 	ErrorCodes                   []string
 	ErrorDetail                  error
 
-	// This field is newly stored in DB, but is not filled for all old screenings.
-	// The "GetDecisionById" and "ListScreeningsByDecision" endpoints override it with the actual number of matches if it is 0 in DB,
-	// but not all instances of models.Screening have it.
-	// It should be backfilled in a future release, once all new screenings have it written.
 	NumberOfMatches int
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
@@ -205,7 +201,6 @@ type ScreeningMatch struct {
 	Referents                    []string
 	Status                       ScreeningMatchStatus
 	QueryIds                     []string
-	UniqueCounterpartyIdentifier *string
 	Payload                      []byte
 	Enriched                     bool
 	ReviewedBy                   *string

--- a/repositories/dbmodels/db_screening_match.go
+++ b/repositories/dbmodels/db_screening_match.go
@@ -18,7 +18,6 @@ type DBScreeningMatch struct {
 	OpenSanctionEntityId string          `db:"opensanction_entity_id"`
 	Status               string          `db:"status"`
 	QueryIds             []string        `db:"query_ids"`
-	CounterpartyId       *string         `db:"counterparty_id"`
 	Payload              json.RawMessage `db:"payload"`
 	Enriched             bool            `db:"enriched"`
 	ReviewedBy           *string         `db:"reviewed_by"`
@@ -36,7 +35,6 @@ func AdaptScreeningMatch(dto DBScreeningMatch) (models.ScreeningMatch, error) {
 		Status:                       models.ScreeningMatchStatusFrom(dto.Status),
 		ReviewedBy:                   dto.ReviewedBy,
 		QueryIds:                     dto.QueryIds,
-		UniqueCounterpartyIdentifier: dto.CounterpartyId,
 		Payload:                      dto.Payload,
 		Enriched:                     dto.Enriched,
 	}

--- a/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
+++ b/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
@@ -1,29 +1,40 @@
 -- +goose Up
-
--- Backfill counterparty_id on screenings from screening_matches (all matches for a given screening have the same counterparty_id)
+-- Backfill counterparty_id and number_of_matches on screenings from screening_matches
 UPDATE screenings s
-SET counterparty_id = sub.counterparty_id
-FROM (
-    SELECT DISTINCT ON (screening_id) screening_id, counterparty_id
-    FROM screening_matches
-    WHERE counterparty_id IS NOT NULL
-) sub
-WHERE s.id = sub.screening_id
-  AND s.counterparty_id IS NULL;
-
--- Backfill number_of_matches on screenings from screening_matches count
-UPDATE screenings s
-SET number_of_matches = sub.cnt
-FROM (
-    SELECT screening_id, count(*) AS cnt
-    FROM screening_matches
-    GROUP BY screening_id
-) sub
-WHERE s.id = sub.screening_id
-  AND (s.number_of_matches IS NULL OR s.number_of_matches = 0);
+SET
+  counterparty_id = sub.counterparty_id,
+  number_of_matches = sub.cnt
+FROM
+  (
+    SELECT
+      screening_id,
+      max(counterparty_id) AS counterparty_id,
+      count(*) AS cnt
+    FROM
+      screening_matches
+    GROUP BY
+      screening_id
+  ) sub
+WHERE
+  s.id = sub.screening_id
+  AND (
+    s.counterparty_id IS NULL
+    OR s.number_of_matches IS NULL
+    OR s.number_of_matches = 0
+  );
 
 -- Drop counterparty_id from screening_matches (no longer needed)
-ALTER TABLE screening_matches DROP COLUMN counterparty_id;
+ALTER TABLE screening_matches
+DROP COLUMN counterparty_id;
+
+ALTER TABLE screenings
+ALTER COLUMN number_of_matches
+SET DEFAULT 0;
 
 -- +goose Down
-ALTER TABLE screening_matches ADD COLUMN counterparty_id text;
+ALTER TABLE screening_matches
+ADD COLUMN counterparty_id text;
+
+ALTER TABLE screenings
+ALTER COLUMN number_of_matches
+DROP DEFAULT;

--- a/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
+++ b/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+-- Backfill counterparty_id on screenings from screening_matches (all matches for a given screening have the same counterparty_id)
+UPDATE screenings s
+SET counterparty_id = sub.counterparty_id
+FROM (
+    SELECT DISTINCT ON (screening_id) screening_id, counterparty_id
+    FROM screening_matches
+    WHERE counterparty_id IS NOT NULL
+) sub
+WHERE s.id = sub.screening_id
+  AND s.counterparty_id IS NULL;
+
+-- Backfill number_of_matches on screenings from screening_matches count
+UPDATE screenings s
+SET number_of_matches = sub.cnt
+FROM (
+    SELECT screening_id, count(*) AS cnt
+    FROM screening_matches
+    GROUP BY screening_id
+) sub
+WHERE s.id = sub.screening_id
+  AND (s.number_of_matches IS NULL OR s.number_of_matches = 0);
+
+-- Drop counterparty_id from screening_matches (no longer needed)
+ALTER TABLE screening_matches DROP COLUMN counterparty_id;
+
+-- +goose Down
+ALTER TABLE screening_matches ADD COLUMN counterparty_id text;

--- a/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
+++ b/repositories/migrations/20260417120000_backfill_screening_counterparty_id_and_matches.sql
@@ -35,6 +35,13 @@ SET DEFAULT 0;
 ALTER TABLE screening_matches
 ADD COLUMN counterparty_id text;
 
+-- Copy counterparty_id back from screenings to screening_matches
+UPDATE screening_matches sm
+SET counterparty_id = s.counterparty_id
+FROM screenings s
+WHERE sm.screening_id = s.id
+  AND s.counterparty_id IS NOT NULL;
+
 ALTER TABLE screenings
 ALTER COLUMN number_of_matches
 DROP DEFAULT;

--- a/repositories/screening_repository.go
+++ b/repositories/screening_repository.go
@@ -279,11 +279,11 @@ func (*MarbleDbRepository) InsertScreening(
 
 	matchSql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_SCREENING_MATCHES).
-		Columns("id", "screening_id", "opensanction_entity_id", "query_ids", "payload", "counterparty_id")
+		Columns("id", "screening_id", "opensanction_entity_id", "query_ids", "payload")
 
 	for _, match := range screening.Matches {
 		matchSql = matchSql.Values(pure_utils.NewId(), screening.Id, match.EntityId, match.QueryIds,
-			match.Payload, match.UniqueCounterpartyIdentifier)
+			match.Payload)
 	}
 
 	return ExecBuilder(ctx, exec, matchSql)

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -133,9 +133,6 @@ func (usecase *DecisionUsecase) GetDecision(ctx context.Context, decisionId stri
 	decision.ScreeningExecutions = make([]models.ScreeningWithMatches, len(scs))
 
 	for idx, sc := range scs {
-		if sc.NumberOfMatches == 0 && len(sc.Matches) > 0 {
-			sc.NumberOfMatches = len(sc.Matches)
-		}
 		decision.ScreeningExecutions[idx] = sc
 	}
 

--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -229,9 +229,6 @@ func (e ScenarioEvaluator) evaluateScreening(
 
 			if uniqueCounterpartyIdentifier != nil {
 				result.UniqueCounterpartyIdentifier = uniqueCounterpartyIdentifier
-				for idx := range result.Matches {
-					result.Matches[idx].UniqueCounterpartyIdentifier = uniqueCounterpartyIdentifier
-				}
 			}
 
 			result.Id = scId

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -208,10 +208,6 @@ func (uc ScreeningUsecase) ListScreenings(ctx context.Context, decisionId string
 	matchIdToMatch := make(map[string]*models.ScreeningMatch)
 
 	for sidx, sc := range scs {
-		if sc.NumberOfMatches == 0 && len(sc.Matches) > 0 {
-			sc.NumberOfMatches = len(sc.Matches)
-		}
-
 		for midx, match := range sc.Matches {
 			matchIds.Insert(match.Id)
 			matchIdToMatch[match.Id] = &scs[sidx].Matches[midx]
@@ -541,10 +537,10 @@ func (uc ScreeningUsecase) UpdateMatchStatus(
 			}
 
 			if update.Status == models.ScreeningMatchStatusNoHit && update.Whitelist &&
-				data.match.UniqueCounterpartyIdentifier != nil {
+				data.sanction.UniqueCounterpartyIdentifier != nil {
 				if err := uc.CreateWhitelist(ctx, tx,
 					data.decision.OrganizationId,
-					*data.match.UniqueCounterpartyIdentifier,
+					*data.sanction.UniqueCounterpartyIdentifier,
 					data.match.EntityId, update.ReviewerId); err != nil {
 					return errors.Wrap(err, "could not whitelist match")
 				}
@@ -968,13 +964,5 @@ func mergePayloads(originalRaw, newRaw []byte) ([]byte, error) {
 }
 
 func getScreeningCounterpartyIdentifier(screening models.ScreeningWithMatches) *string {
-	// TODO: finish this migration by migrating values from Matches to the new column UniqueCounterpartyIdentifier, then remove the fallback to Matches
-	// New rows have it on the screening; old rows (pre-backfill) fall back to first match
-	if screening.UniqueCounterpartyIdentifier != nil {
-		return screening.UniqueCounterpartyIdentifier
-	}
-	if len(screening.Matches) == 0 {
-		return nil
-	}
-	return screening.Matches[0].UniqueCounterpartyIdentifier
+	return screening.UniqueCounterpartyIdentifier
 }

--- a/usecases/screening_usecase_test.go
+++ b/usecases/screening_usecase_test.go
@@ -65,7 +65,7 @@ func TestListScreeningOnDecision(t *testing.T) {
 		SELECT
 			sc.id, sc.decision_id, sc.org_id, sc.screening_config_id, sc.status, sc.search_input, sc.initial_query, sc.counterparty_id, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.error_codes, sc.number_of_matches, sc.created_at, sc.updated_at,
 			scc.id AS config_id, stable_id, scc.name, scc.datasets,
-			ARRAY_AGG(ROW(scm.id,scm.screening_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.counterparty_id,scm.payload,scm.enriched,scm.reviewed_by,scm.created_at,scm.updated_at)
+			ARRAY_AGG(ROW(scm.id,scm.screening_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.payload,scm.enriched,scm.reviewed_by,scm.created_at,scm.updated_at)
 				ORDER BY array_position(.+, scm.status), scm.payload->>'score' DESC) FILTER (WHERE scm.id IS NOT NULL)
 				AS matches
 		FROM screenings AS sc
@@ -144,7 +144,7 @@ func TestUpdateMatchStatus(t *testing.T) {
 		}))
 
 	exec.Mock.
-		ExpectQuery(`SELECT id, screening_id, opensanction_entity_id, status, query_ids, counterparty_id, payload, enriched, reviewed_by, created_at, updated_at FROM screening_matches WHERE id = \$1`).
+		ExpectQuery(`SELECT id, screening_id, opensanction_entity_id, status, query_ids, payload, enriched, reviewed_by, created_at, updated_at FROM screening_matches WHERE id = \$1`).
 		WithArgs("matchid").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectScreeningMatchesColumn).
 			AddRow(mockScmRow...),
@@ -155,20 +155,20 @@ func TestUpdateMatchStatus(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectScreeningAndConfigColumn).
 			AddRow(mockScRow...),
 		)
-	exec.Mock.ExpectQuery(`SELECT id, screening_id, opensanction_entity_id, status, query_ids, counterparty_id, payload, enriched, reviewed_by, created_at, updated_at FROM screening_matches WHERE screening_id = \$1`).
+	exec.Mock.ExpectQuery(`SELECT id, screening_id, opensanction_entity_id, status, query_ids, payload, enriched, reviewed_by, created_at, updated_at FROM screening_matches WHERE screening_id = \$1`).
 		WithArgs("screening_id").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectScreeningMatchesColumn).
 			AddRow(mockScmRow...).
 			AddRows(mockOtherScmRows...),
 		)
-	exec.Mock.ExpectQuery(`UPDATE screening_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,screening_id,opensanction_entity_id,status,query_ids,counterparty_id,payload,enriched,reviewed_by,created_at,updated_at`).
+	exec.Mock.ExpectQuery(`UPDATE screening_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,screening_id,opensanction_entity_id,status,query_ids,payload,enriched,reviewed_by,created_at,updated_at`).
 		WithArgs(&userId, models.ScreeningMatchStatusConfirmedHit, "NOW()", "matchid").
 		WillReturnRows(pgxmock.NewRows(dbmodels.SelectScreeningMatchesColumn).
 			AddRow(mockScmRow...),
 		)
 
 	for i := range 3 {
-		exec.Mock.ExpectQuery(`UPDATE screening_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,screening_id,opensanction_entity_id,status,query_ids,counterparty_id,payload,enriched,reviewed_by,created_at,updated_at`).
+		exec.Mock.ExpectQuery(`UPDATE screening_matches SET reviewed_by = \$1, status = \$2, updated_at = \$3 WHERE id = \$4 RETURNING id,screening_id,opensanction_entity_id,status,query_ids,payload,enriched,reviewed_by,created_at,updated_at`).
 			WithArgs(&userId, models.ScreeningMatchStatusSkipped, "NOW()", mockOtherScms[i].Id).
 			WillReturnRows(pgxmock.NewRows(dbmodels.SelectScreeningMatchesColumn).
 				AddRow(mockOtherScmRows[i]...),


### PR DESCRIPTION
Step two out of three to improve the data model of screenings.
Migrate "counterparty_id" from the matches table to the screenings table, and drop the field on matches (was already started writing on the new field in a previous PR, this PR finishes the backfill).
May be slightly long to run on instances with a lot of screenings with matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Restructured counterparty identifier storage: moved from individual screening matches to the screening level in the database schema and API responses.
  * Removed `unique_counterparty_identifier` field from screening match responses. Counterparty data is now accessed at the parent screening level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->