### PR TITLE
backfill field semantic if configured as caption field

### DIFF
--- a/repositories/migrations/20260420000000_backfill_caption_field_semantic_type_name.sql
+++ b/repositories/migrations/20260420000000_backfill_caption_field_semantic_type_name.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+UPDATE data_model_fields f
+SET semantic_type = 'name'
+FROM data_model_tables t
+WHERE f.table_id = t.id
+  AND t.caption_field <> ''
+  AND f.name = t.caption_field
+  AND f.semantic_type = '';
+
+-- +goose Down
+-- No rollback


### PR DESCRIPTION
This pull request introduces a migration to backfill the `semantic_type` field for certain data model fields. Specifically, it updates the `semantic_type` to `'name'` for fields that match the `caption_field` of their respective tables, provided the `semantic_type` is currently empty.

**Database migration:**

* Adds a migration (`20260420000000_backfill_caption_field_semantic_type_name.sql`) that updates the `semantic_type` of fields to `'name'` where the field's name matches the table's `caption_field` and the `semantic_type` is currently empty.
* The migration does not include a rollback step.