### PR TITLE
chore: add in vscode, new job to run manually

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,7 +92,13 @@
         "webhook_retry",
         "webhook_dispatch",
         "webhook_delivery",
-        "webhook_cleanup"
+        "webhook_cleanup",
+        "triggered_score_computation",
+        "async_decision_execution",
+        "async_decision_execution_cleanup",
+        "score_computation",
+        "scoring_initial_insertion",
+        "scoring_initial_computation"
       ]
     },
     {


### PR DESCRIPTION
This pull request updates the `.vscode/launch.json` file to add several new tasks to the debug configuration. These changes ensure that developers can easily run and debug new background jobs related to scoring and asynchronous decision execution from within VS Code.

Debug configuration updates:

* Added support for the following jobs: `triggered_score_computation`, `async_decision_execution`, `async_decision_execution_cleanup`, `score_computation`, `scoring_initial_insertion`, and `scoring_initial_computation` to the list of available debug tasks.