### PR TITLE
Relax mandatory "field" argument on Switch.

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_switch.go
+++ b/usecases/ast_eval/evaluate/evaluate_switch.go
@@ -15,33 +15,27 @@ func (p Switch) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []e
 	if len(arguments.Args) == 0 {
 		errs = append(errs, errors.Wrap(ast.ErrWrongNumberOfArgument, "Switch should have at least one branch"))
 	}
-	field, ok := arguments.NamedArgs["field"]
-	if !ok {
-		errs = append(errs, errors.Wrap(ast.ErrMissingNamedArgument, "Switch should have a `field` named argument"))
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	nodes, err := adaptArgumentToListOfThings[ast.ScoreComputationResult](arguments.Args)
+	if err != nil {
+		errs = append(errs, err)
 	}
 
 	if len(errs) > 0 {
 		return nil, errs
 	}
 
-	if field != nil {
-		nodes, err := adaptArgumentToListOfThings[ast.ScoreComputationResult](arguments.Args)
-		if err != nil {
-			errs = append(errs, err)
-		}
+	for idx, node := range nodes {
+		if node.Triggered {
+			node.Fallback = false
+			node.Default = false
+			node.Branch = new(idx)
 
-		if len(errs) > 0 {
-			return nil, errs
-		}
-
-		for idx, node := range nodes {
-			if node.Triggered {
-				node.Fallback = false
-				node.Default = false
-				node.Branch = new(idx)
-
-				return node, nil
-			}
+			return node, nil
 		}
 	}
 

--- a/usecases/ast_eval/evaluate_ast_scoring_test.go
+++ b/usecases/ast_eval/evaluate_ast_scoring_test.go
@@ -188,7 +188,7 @@ func TestSwitchErrorOnNoCaseExecuted(t *testing.T) {
 		Children: []ast.Node{
 			{
 				Function: ast.FUNC_SCORE_COMPUTATION,
-				Children: []ast.Node{{Constant: false}},
+				Children: []ast.Node{},
 				NamedChildren: map[string]ast.Node{
 					"modifier": {Constant: 42},
 					"floor":    {Constant: 9000},


### PR DESCRIPTION
Initially, `Switch` was supposed to only be used with a `field` arguments. Some filters now do not have this restriction, hence this PR relaxing this requirement.

`field` is now only a frontend metadata helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to simplify logic flow and enhance maintainability.

**Note:** This release contains no new user-facing features or bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->