### PR TITLE
fix: enqueue computation score job after the case update

### DIFF
--- a/mocks/score_computation_usecase.go
+++ b/mocks/score_computation_usecase.go
@@ -12,12 +12,6 @@ type ScoringScoreUsecase struct {
 	mock.Mock
 }
 
-func (m *ScoringScoreUsecase) EnqueueComputationForDecisions(ctx context.Context, orgId uuid.UUID, decisions []models.Decision) error {
-	args := m.Called(ctx, orgId, decisions)
-
-	return args.Error(0)
-}
-
 func (m *ScoringScoreUsecase) EnqueueComputationForIngestion(ctx context.Context, orgId uuid.UUID, recordType string, records models.IngestionResults) error {
 	args := m.Called(ctx, orgId, recordType, records)
 

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -629,7 +629,7 @@ func (usecase *CaseUseCase) UpdateCase(
 					return models.Case{}, err
 				}
 
-				if err := usecase.scoringScoreUsecase.EnqueueComputationForDecisions(ctx, c.OrganizationId, decisions); err != nil {
+				if err := usecase.scoringScoreUsecase.EnqueueComputationForDecisions(ctx, tx, c.OrganizationId, decisions); err != nil {
 					utils.LoggerFromContext(ctx).ErrorContext(ctx,
 						"could not trigger score computation job",
 						"error", err.Error())

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -100,7 +100,6 @@ type taskEnqueuer interface {
 }
 
 type scoreComputationUsecase interface {
-	EnqueueComputationForDecisions(ctx context.Context, orgId uuid.UUID, decisions []models.Decision) error
 	EnqueueComputationForIngestion(ctx context.Context, orgId uuid.UUID, recordType string, records models.IngestionResults) error
 }
 

--- a/usecases/scoring/scoring_scores_usecase.go
+++ b/usecases/scoring/scoring_scores_usecase.go
@@ -342,62 +342,60 @@ func (uc ScoringScoresUsecase) GetScoreDistribution(ctx context.Context, entityT
 	return uc.repository.GetScoreDistribution(ctx, exec, orgId, entityType)
 }
 
-func (uc ScoringScoresUsecase) EnqueueComputationForDecisions(ctx context.Context, orgId uuid.UUID, decisions []models.Decision) error {
-	return uc.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		dataModel, err := uc.dataModelRepository.GetDataModel(ctx, tx, orgId, false, false)
+func (uc ScoringScoresUsecase) EnqueueComputationForDecisions(ctx context.Context, tx repositories.Transaction, orgId uuid.UUID, decisions []models.Decision) error {
+	dataModel, err := uc.dataModelRepository.GetDataModel(ctx, tx, orgId, false, false)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range decisions {
+		exists, err := uc.scoringRulesetsUsecase.CommittedRulesetExists(ctx, orgId, d.ClientObject.TableName)
+		if err != nil {
+			utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not check if scoring ruleset exists", "error", err.Error())
+			continue
+		}
+
+		if exists {
+			err = uc.taskQueueRepository.EnqueueTriggerScoreComputation(ctx, tx, models.ScoringRecordRef{
+				OrgId:      orgId,
+				RecordType: d.ClientObject.TableName,
+				RecordId:   d.ClientObject.Data["object_id"].(string),
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		if d.PivotId == nil || d.PivotValue == nil {
+			continue
+		}
+
+		pivotMeta, err := uc.dataModelRepository.GetPivot(ctx, tx, d.PivotId.String())
 		if err != nil {
 			return err
 		}
 
-		for _, d := range decisions {
-			exists, err := uc.scoringRulesetsUsecase.CommittedRulesetExists(ctx, orgId, d.ClientObject.TableName)
-			if err != nil {
-				utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not check if scoring ruleset exists", "error", err.Error())
-				continue
-			}
+		pivot := pivotMeta.Enrich(dataModel)
 
-			if exists {
-				err = uc.taskQueueRepository.EnqueueTriggerScoreComputation(ctx, tx, models.ScoringRecordRef{
-					OrgId:      orgId,
-					RecordType: d.ClientObject.TableName,
-					RecordId:   d.ClientObject.Data["object_id"].(string),
-				})
-				if err != nil {
-					return err
-				}
-			}
+		exists, err = uc.scoringRulesetsUsecase.CommittedRulesetExists(ctx, orgId, pivot.PivotTable)
+		if err != nil {
+			utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not check if scoring ruleset exists", "error", err.Error())
+			continue
+		}
 
-			if d.PivotId == nil || d.PivotValue == nil {
-				continue
-			}
-
-			pivotMeta, err := uc.dataModelRepository.GetPivot(ctx, tx, d.PivotId.String())
+		if exists {
+			err = uc.taskQueueRepository.EnqueueTriggerScoreComputation(ctx, tx, models.ScoringRecordRef{
+				OrgId:      orgId,
+				RecordType: pivot.PivotTable,
+				RecordId:   *d.PivotValue,
+			})
 			if err != nil {
 				return err
 			}
-
-			pivot := pivotMeta.Enrich(dataModel)
-
-			exists, err = uc.scoringRulesetsUsecase.CommittedRulesetExists(ctx, orgId, pivot.PivotTable)
-			if err != nil {
-				utils.LoggerFromContext(ctx).ErrorContext(ctx, "could not check if scoring ruleset exists", "error", err.Error())
-				continue
-			}
-
-			if exists {
-				err = uc.taskQueueRepository.EnqueueTriggerScoreComputation(ctx, tx, models.ScoringRecordRef{
-					OrgId:      orgId,
-					RecordType: pivot.PivotTable,
-					RecordId:   *d.PivotValue,
-				})
-				if err != nil {
-					return err
-				}
-			}
 		}
+	}
 
-		return nil
-	})
+	return nil
 }
 
 func (uc ScoringScoresUsecase) EnqueueComputationForIngestion(ctx context.Context, orgId uuid.UUID, recordType string, records models.IngestionResults) error {


### PR DESCRIPTION
This pull request updates how database transactions are managed when enqueuing score computations for decisions. The main change is to ensure that an existing transaction is used throughout the process, improving transactional consistency and reliability.

**Transaction handling improvements:**

* Changed the `EnqueueComputationForDecisions` method in `ScoringScoresUsecase` to accept an existing `tx` (transaction) instead of internally creating a new transaction, ensuring transactional consistency when called within an existing transaction context.
* Updated the call to `EnqueueComputationForDecisions` in `CaseUseCase.UpdateCase` to pass the current transaction (`tx`) as an argument.
* Removed the internal transaction wrapper from `EnqueueComputationForDecisions`, as it now expects to be called with an existing transaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal transaction handling in score computation operations to improve consistency across the system.
  * Streamlined mock implementations to align with updated component interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->