### PR TITLE
fix: public API continous screening schema

### DIFF
--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -161,8 +161,10 @@ paths:
           in: query
           description: If monitoring the object, which configuration to use. Can be repeated multiple times.
           schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: skip_screening
           in: query
           description: If monitoring, whether to skip the initial screening of the ingested object.
@@ -219,8 +221,10 @@ paths:
           in: query
           description: If monitoring the object, which configuration to use. Can be repeated multiple times.
           schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: skip_screening
           in: query
           description: If monitoring, whether to skip the initial screening of the ingested object.
@@ -278,8 +282,10 @@ paths:
           in: query
           description: If monitoring the object, which configuration to use. Can be repeated multiple times.
           schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: skip_screening
           in: query
           description: If monitoring, whether to skip the initial screening of the ingested object.
@@ -338,8 +344,10 @@ paths:
           in: query
           description: If monitoring the object, which configuration to use. Can be repeated multiple times.
           schema:
-            type: string
-            format: uuid
+            type: array
+            items:
+              type: string
+              format: uuid
         - name: skip_screening
           in: query
           description: If monitoring, whether to skip the initial screening of the ingested object.


### PR DESCRIPTION
This pull request updates the OpenAPI schema in `pubapi/openapi/v1beta.yml` to correctly specify that certain query parameters accept arrays of UUID strings, improving the accuracy of the API documentation and client generation.

**OpenAPI schema improvements:**

* Updated the `schema` for relevant query parameters to explicitly declare them as arrays of strings with UUID format in four different endpoints. This clarifies that these parameters can accept multiple values and ensures better compatibility with OpenAPI tools. [[1]](diffhunk://#diff-21e63fd6d4b657c5408a3c8498e8a75c0b69e437442b5b411b0b22fe8bf98febR164-R165) [[2]](diffhunk://#diff-21e63fd6d4b657c5408a3c8498e8a75c0b69e437442b5b411b0b22fe8bf98febR224-R225) [[3]](diffhunk://#diff-21e63fd6d4b657c5408a3c8498e8a75c0b69e437442b5b411b0b22fe8bf98febR285-R286) [[4]](diffhunk://#diff-21e63fd6d4b657c5408a3c8498e8a75c0b69e437442b5b411b0b22fe8bf98febR347-R348)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ingestion API endpoints now support multiple monitoring configuration IDs in requests, enabling assignment of multiple configurations in a single operation across both individual and batch ingestion endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->