### PR TITLE
fix: refuse percentiles above 1 (should be 0-1) and downscale legacy > 1

### DIFF
--- a/usecases/ast_eval/evaluate/evaluate_aggregator.go
+++ b/usecases/ast_eval/evaluate/evaluate_aggregator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 type AggregatorEvaluator struct {
@@ -124,6 +125,21 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 		if err != nil {
 			return MakeEvaluateError(errors.Wrap(ast.NewNamedArgumentError("percentile"),
 				"missing or invalid value for percentile"))
+		}
+
+		if a.ReturnFakeValue {
+			// Dry-run / scenario validation: reject out-of-range so the builder surfaces a clear error.
+			if arg < 0 || arg > 1 {
+				return MakeEvaluateError(errors.Wrapf(ast.NewNamedArgumentError("percentile"),
+					"percentile value %v must be between 0 and 1", arg))
+			}
+		} else if arg < 0 {
+			logger := utils.LoggerFromContext(ctx)
+			logger.WarnContext(ctx, fmt.Sprintf("percentile value %v is less than 0, setting to 0", arg))
+			arg = 0
+		} else if arg > 1 {
+			// Production runtime: auto-normalize legacy values stored on a 0-100 scale.
+			arg /= 100
 		}
 
 		options["percentile"] = arg


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved percentile argument validation in aggregator evaluation. Dry-run mode now fails fast for invalid percentile values outside the 0-1 range. Runtime mode automatically normalizes legacy percentile inputs (values greater than 1) by dividing by 100.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->