### PR TITLE
fix: ingestion with continuous screening, delta tack was ignored

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -400,6 +400,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	river.AddWorker(workers, adminUc.NewDecisionWorkflowsWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningDoScreeningWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningRegisterObjectWorker())
+	river.AddWorker(workers, adminUc.NewContinuousScreeningVerifyDeltaTrackExistenceWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningApplyDeltaFileWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningScanDatasetUpdatesWorker())
 	river.AddWorker(workers, adminUc.NewCsvIngestionWorker())
@@ -638,6 +639,9 @@ func singleJobRun(ctx context.Context, uc usecases.UsecasesWithCreds, apiVersion
 	case "continuous_screening_register_object":
 		return uc.NewContinuousScreeningRegisterObjectWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningRegisterObjectArgs](ctx, jobArgs))
+	case "continuous_screening_verify_delta_track_existence":
+		return uc.NewContinuousScreeningVerifyDeltaTrackExistenceWorker().Work(ctx,
+			singleJobCreate[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs](ctx, jobArgs))
 	case "continuous_screening_scan_dataset_updates":
 		return uc.NewContinuousScreeningScanDatasetUpdatesWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningScanDatasetUpdatesArgs](ctx, jobArgs))

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -399,6 +399,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	river.AddWorker(workers, adminUc.NewAutoAssignmentWorker())
 	river.AddWorker(workers, adminUc.NewDecisionWorkflowsWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningDoScreeningWorker())
+	river.AddWorker(workers, adminUc.NewContinuousScreeningRegisterObjectWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningApplyDeltaFileWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningScanDatasetUpdatesWorker())
 	river.AddWorker(workers, adminUc.NewCsvIngestionWorker())
@@ -634,6 +635,9 @@ func singleJobRun(ctx context.Context, uc usecases.UsecasesWithCreds, apiVersion
 	case "continuous_screening_do_screening":
 		return uc.NewContinuousScreeningDoScreeningWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningDoScreeningArgs](ctx, jobArgs))
+	case "continuous_screening_register_object":
+		return uc.NewContinuousScreeningRegisterObjectWorker().Work(ctx,
+			singleJobCreate[models.ContinuousScreeningRegisterObjectArgs](ctx, jobArgs))
 	case "continuous_screening_scan_dataset_updates":
 		return uc.NewContinuousScreeningScanDatasetUpdatesWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningScanDatasetUpdatesArgs](ctx, jobArgs))

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -400,7 +400,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	river.AddWorker(workers, adminUc.NewDecisionWorkflowsWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningDoScreeningWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningRegisterObjectWorker())
-	river.AddWorker(workers, adminUc.NewContinuousScreeningVerifyDeltaTrackExistenceWorker())
+	river.AddWorker(workers, adminUc.NewContinuousScreeningEnsureDeltaTrackWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningApplyDeltaFileWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningScanDatasetUpdatesWorker())
 	river.AddWorker(workers, adminUc.NewCsvIngestionWorker())
@@ -639,9 +639,9 @@ func singleJobRun(ctx context.Context, uc usecases.UsecasesWithCreds, apiVersion
 	case "continuous_screening_register_object":
 		return uc.NewContinuousScreeningRegisterObjectWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningRegisterObjectArgs](ctx, jobArgs))
-	case "continuous_screening_verify_delta_track_existence":
-		return uc.NewContinuousScreeningVerifyDeltaTrackExistenceWorker().Work(ctx,
-			singleJobCreate[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs](ctx, jobArgs))
+	case "continuous_screening_ensure_delta_track":
+		return uc.NewContinuousScreeningEnsureDeltaTrackWorker().Work(ctx,
+			singleJobCreate[models.ContinuousScreeningEnsureDeltaTrackArgs](ctx, jobArgs))
 	case "continuous_screening_scan_dataset_updates":
 		return uc.NewContinuousScreeningScanDatasetUpdatesWorker().Work(ctx,
 			singleJobCreate[models.ContinuousScreeningScanDatasetUpdatesArgs](ctx, jobArgs))

--- a/mocks/continuous_screening_repository.go
+++ b/mocks/continuous_screening_repository.go
@@ -451,10 +451,12 @@ func (m *ContinuousScreeningClientDbRepository) InsertContinuousScreeningObject(
 	tableName string,
 	objectId string,
 	configStableId uuid.UUID,
-	ignoreConflicts bool,
-) error {
-	args := m.Called(ctx, exec, tableName, objectId, configStableId, ignoreConflicts)
-	return args.Error(0)
+) (uuid.UUID, error) {
+	args := m.Called(ctx, exec, tableName, objectId, configStableId)
+	if id, ok := args.Get(0).(uuid.UUID); ok {
+		return id, args.Error(1)
+	}
+	return uuid.Nil, args.Error(1)
 }
 
 func (m *ContinuousScreeningClientDbRepository) InsertContinuousScreeningAudit(

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -120,6 +120,13 @@ func (m *TaskQueueRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
 	return args.Error(0)
 }
 
+func (m *TaskQueueRepository) EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+	ctx context.Context,
+	args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+) error {
+	return m.Called(ctx, args).Error(0)
+}
+
 func (m *TaskQueueRepository) EnqueueContinuousScreeningMatchEnrichmentTask(
 	ctx context.Context,
 	tx repositories.Transaction,

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -108,6 +108,18 @@ func (m *TaskQueueRepository) EnqueueContinuousScreeningDoScreeningTaskMany(
 	return args.Error(0)
 }
 
+func (m *TaskQueueRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
+	ctx context.Context,
+	tx repositories.Transaction,
+	orgId uuid.UUID,
+	objectType string,
+	tasks []models.ContinuousScreeningRegisterObjectTask,
+	shouldScreen bool,
+) error {
+	args := m.Called(ctx, tx, orgId, objectType, tasks, shouldScreen)
+	return args.Error(0)
+}
+
 func (m *TaskQueueRepository) EnqueueContinuousScreeningMatchEnrichmentTask(
 	ctx context.Context,
 	tx repositories.Transaction,

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -120,9 +120,9 @@ func (m *TaskQueueRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
 	return args.Error(0)
 }
 
-func (m *TaskQueueRepository) EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+func (m *TaskQueueRepository) EnqueueContinuousScreeningEnsureDeltaTrackTask(
 	ctx context.Context,
-	args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+	args models.ContinuousScreeningEnsureDeltaTrackArgs,
 ) error {
 	return m.Called(ctx, args).Error(0)
 }

--- a/models/continuous_screening.go
+++ b/models/continuous_screening.go
@@ -262,6 +262,14 @@ type ContinuousScreeningEnqueueObjectUpdateTask struct {
 	NewInternalId      string
 }
 
+type ContinuousScreeningRegisterObjectTask struct {
+	ObjectId       string
+	ConfigStableId uuid.UUID
+	NewInternalId  string
+	UserId         *string
+	ApiKeyId       *string
+}
+
 type DeltaTrackOperation int
 
 const (

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -160,6 +160,20 @@ func (ContinuousScreeningRegisterObjectArgs) Kind() string {
 	return "continuous_screening_register_object"
 }
 
+type ContinuousScreeningVerifyDeltaTrackExistenceArgs struct {
+	OrgId             uuid.UUID           `json:"org_id"`
+	ObjectType        string              `json:"object_type"`
+	ObjectId          string              `json:"object_id"`
+	ObjectInternalId  uuid.UUID           `json:"object_internal_id"`
+	EntityId          string              `json:"entity_id"`
+	MonitoredObjectId uuid.UUID           `json:"monitored_object_id"`
+	Operation         DeltaTrackOperation `json:"operation"`
+}
+
+func (ContinuousScreeningVerifyDeltaTrackExistenceArgs) Kind() string {
+	return "continuous_screening_verify_delta_track_existence"
+}
+
 type ContinuousScreeningEvaluateNeedArgs struct {
 	OrgId      uuid.UUID `json:"org_id"`
 	ObjectType string    `json:"object_type"`

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -145,6 +145,21 @@ func (ContinuousScreeningDoScreeningArgs) Kind() string {
 	return "continuous_screening_do_screening"
 }
 
+type ContinuousScreeningRegisterObjectArgs struct {
+	OrgId          uuid.UUID `json:"org_id"`
+	ObjectType     string    `json:"object_type"`
+	ObjectId       string    `json:"object_id"`
+	ConfigStableId uuid.UUID `json:"config_stable_id"`
+	NewInternalId  string    `json:"new_internal_id"`
+	ShouldScreen   bool      `json:"should_screen"`
+	UserId         *string   `json:"user_id,omitempty"`
+	ApiKeyId       *string   `json:"api_key_id,omitempty"`
+}
+
+func (ContinuousScreeningRegisterObjectArgs) Kind() string {
+	return "continuous_screening_register_object"
+}
+
 type ContinuousScreeningEvaluateNeedArgs struct {
 	OrgId      uuid.UUID `json:"org_id"`
 	ObjectType string    `json:"object_type"`

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -160,7 +160,7 @@ func (ContinuousScreeningRegisterObjectArgs) Kind() string {
 	return "continuous_screening_register_object"
 }
 
-type ContinuousScreeningVerifyDeltaTrackExistenceArgs struct {
+type ContinuousScreeningEnsureDeltaTrackArgs struct {
 	OrgId             uuid.UUID           `json:"org_id"`
 	ObjectType        string              `json:"object_type"`
 	ObjectId          string              `json:"object_id"`
@@ -170,8 +170,8 @@ type ContinuousScreeningVerifyDeltaTrackExistenceArgs struct {
 	Operation         DeltaTrackOperation `json:"operation"`
 }
 
-func (ContinuousScreeningVerifyDeltaTrackExistenceArgs) Kind() string {
-	return "continuous_screening_verify_delta_track_existence"
+func (ContinuousScreeningEnsureDeltaTrackArgs) Kind() string {
+	return "continuous_screening_ensure_delta_track"
 }
 
 type ContinuousScreeningEvaluateNeedArgs struct {

--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -52,8 +52,8 @@ paths:
               required:
                 - trigger_objects
               anyOf:
-                - required: [ trigger_object_type ]
-                - required: [ scenario_id ]
+                - required: [trigger_object_type]
+                - required: [scenario_id]
               properties:
                 trigger_object_type:
                   description: |
@@ -159,14 +159,16 @@ paths:
             type: boolean
         - name: monitoring_config_id
           in: query
-          description: If monitoring the object, which configuration to use. Can be
+          description:
+            If monitoring the object, which configuration to use. Can be
             repeated multiple times.
           schema:
             type: string
             format: uuid
         - name: skip_screening
           in: query
-          description: If monitoring, whether to skip the initial screening of the
+          description:
+            If monitoring, whether to skip the initial screening of the
             ingested object.
           schema:
             type: boolean
@@ -219,14 +221,16 @@ paths:
             type: boolean
         - name: monitoring_config_id
           in: query
-          description: If monitoring the object, which configuration to use. Can be
+          description:
+            If monitoring the object, which configuration to use. Can be
             repeated multiple times.
           schema:
             type: string
             format: uuid
         - name: skip_screening
           in: query
-          description: If monitoring, whether to skip the initial screening of the
+          description:
+            If monitoring, whether to skip the initial screening of the
             ingested object.
           schema:
             type: boolean
@@ -280,14 +284,16 @@ paths:
             type: boolean
         - name: monitoring_config_id
           in: query
-          description: If monitoring the object, which configuration to use. Can be
+          description:
+            If monitoring the object, which configuration to use. Can be
             repeated multiple times.
           schema:
             type: string
             format: uuid
         - name: skip_screening
           in: query
-          description: If monitoring, whether to skip the initial screening of the
+          description:
+            If monitoring, whether to skip the initial screening of the
             ingested object.
           schema:
             type: boolean
@@ -342,14 +348,16 @@ paths:
             type: boolean
         - name: monitoring_config_id
           in: query
-          description: If monitoring the object, which configuration to use. Can be
+          description:
+            If monitoring the object, which configuration to use. Can be
             repeated multiple times.
           schema:
             type: string
             format: uuid
         - name: skip_screening
           in: query
-          description: If monitoring, whether to skip the initial screening of the
+          description:
+            If monitoring, whether to skip the initial screening of the
             ingested object.
           schema:
             type: boolean
@@ -411,7 +419,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: [ pending, investigating, closed ]
+            enum: [pending, investigating, closed]
         - name: assigned_to
           description: List cases assigned to the specified user
           in: query
@@ -486,7 +494,8 @@ paths:
                   type: string
                   format: email
                 decisions:
-                  description: List of decision_ids to attach to this case. Must not already be
+                  description:
+                    List of decision_ids to attach to this case. Must not already be
                     assigned to a case.
                   type: array
                   items:
@@ -577,7 +586,7 @@ paths:
                 outcome:
                   description: Outcome of the case
                   type: string
-                  enum: [ unset confirmed_risk valuable_alert false_positive ]
+                  enum: [unset confirmed_risk valuable_alert false_positive]
 
       responses:
         "200":
@@ -625,7 +634,7 @@ paths:
                 outcome:
                   description: Final outcome of the case
                   type: string
-                  enum: [ unset confirmed_risk valuable_alert false_positive ]
+                  enum: [unset confirmed_risk valuable_alert false_positive]
                   default: unset
       responses:
         "200":
@@ -1060,7 +1069,7 @@ paths:
           in: query
           schema:
             type: string
-            enum: [ case, object ]
+            enum: [case, object]
         - $ref: "#/components/parameters/limit"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/after"
@@ -1170,6 +1179,10 @@ paths:
   /continuous-screenings/objects:
     post:
       summary: Add an object under continuous screening with given configuration
+      description: |
+        This endpoint is idempotent. If the object is already under monitoring, the call succeeds and
+        re-runs the screening, returning the latest result. It is safe to retry this call to retrieve
+        an up-to-date screening result.
       operationId: addContinuousScreeningObject
       security:
         - BearerTokenAuth: []
@@ -1197,11 +1210,12 @@ paths:
                 skip_screen:
                   type: boolean
                   default: false
-                  description: Whether to skip screening the object immediately. If true, the API
+                  description:
+                    Whether to skip screening the object immediately. If true, the API
                     returns 201 Created without data.
       responses:
         "201":
-          description: Monitored object created. Includes screening result if screening was performed, empty body if skipped.
+          description: Monitored object added or already existed. Returns the latest screening result if screening was performed, or an empty response if screening was skipped.
           content:
             application/json:
               schema:
@@ -1210,8 +1224,6 @@ paths:
           $ref: "#/components/responses/400"
         "403":
           $ref: "#/components/responses/403"
-        "409":
-          $ref: "#/components/responses/409"
 
     delete:
       summary: Remove an object from continuous screening
@@ -1475,7 +1487,7 @@ paths:
           application/json:
             schema:
               type: object
-              required: [ ids ]
+              required: [ids]
               properties:
                 ids:
                   type: array
@@ -1508,16 +1520,18 @@ components:
           schema:
             type: string
             format: url
-            description: The download URL of the file. If your HTTP client follows
+            description:
+              The download URL of the file. If your HTTP client follows
               redirects, it will be downloaded directly.
       content:
         application/json:
           schema:
             type: object
-            required: [ redirect_to ]
+            required: [redirect_to]
             properties:
               redirect_to:
-                description: The download URL of the file. Can be used if your HTTP client does
+                description:
+                  The download URL of the file. Can be used if your HTTP client does
                   not follows redirects.
                 type: string
                 format: url
@@ -1530,7 +1544,8 @@ components:
     "401":
       description: Credentials are missing or invalid
     "403":
-      description: The provided credentials are missing the required permissions for
+      description:
+        The provided credentials are missing the required permissions for
         the requested action
     "404":
       description: The requested resource does not exist
@@ -1573,7 +1588,7 @@ components:
       in: query
       schema:
         type: string
-        enum: [ "ASC", "DESC" ]
+        enum: ["ASC", "DESC"]
     after:
       name: after
       description: |
@@ -1649,7 +1664,7 @@ components:
             - `completed`: all decisions have been created successfully
             - `failed`: execution failed (see `error_message` for details)
           type: string
-          enum: [ pending, ingested, completed, failed ]
+          enum: [pending, ingested, completed, failed]
         decision_ids:
           description: IDs of decisions created by this execution (populated on completion)
           type: array
@@ -1709,7 +1724,8 @@ components:
           format: uuid
         name:
           type: string
-          description: Optional name for the referenced object, not all references will
+          description:
+            Optional name for the referenced object, not all references will
             have it.
 
     Tag:
@@ -1727,7 +1743,7 @@ components:
           type: string
         target:
           type: string
-          enum: [ case, object ]
+          enum: [case, object]
 
     Case:
       title: Case
@@ -1754,10 +1770,10 @@ components:
           $ref: "#/components/schemas/Ref"
         status:
           type: string
-          enum: [ pending, investigating, closed ]
+          enum: [pending, investigating, closed]
         outcome:
           type: string
-          enum: [ unset, confirmed_risk, valuable_alert, false_positive ]
+          enum: [unset, confirmed_risk, valuable_alert, false_positive]
         contributors:
           type: array
           items:
@@ -1772,7 +1788,7 @@ components:
         review_level:
           anyOf:
             - type: string
-              enum: [ probable_false_positive, investigate, escalate ]
+              enum: [probable_false_positive, investigate, escalate]
             - type: "null"
           description: |
             The review level from AI review.
@@ -1837,11 +1853,11 @@ components:
           format: uuid
         status:
           type: string
-          enum: [ pending, completed, failed, insufficient_funds ]
+          enum: [pending, completed, failed, insufficient_funds]
         reaction:
           anyOf:
             - type: string
-              enum: [ ok, ko ]
+              enum: [ok, ko]
             - type: "null"
         created_at:
           type: string
@@ -1875,7 +1891,7 @@ components:
       properties:
         version:
           type: string
-          enum: [ v1 ]
+          enum: [v1]
         output:
           description: The main case review text produced by the AI
           type: string
@@ -2091,7 +2107,7 @@ components:
           description: Client-side ID of the annotated object
         annotation_type:
           type: string
-          enum: [ comment, tag, risk_tag, file ]
+          enum: [comment, tag, risk_tag, file]
         payload:
           type: object
           description: |
@@ -2121,7 +2137,7 @@ components:
         - $ref: "#/components/schemas/CreateAnnotationBase"
         - properties:
             type:
-              enum: [ comment ]
+              enum: [comment]
             payload:
               required:
                 - text
@@ -2136,7 +2152,7 @@ components:
         - $ref: "#/components/schemas/CreateAnnotationBase"
         - properties:
             type:
-              enum: [ tag ]
+              enum: [tag]
             payload:
               required:
                 - tag_id
@@ -2152,7 +2168,7 @@ components:
         - $ref: "#/components/schemas/CreateAnnotationBase"
         - properties:
             type:
-              enum: [ risk_tag ]
+              enum: [risk_tag]
             payload:
               required:
                 - tag
@@ -2160,7 +2176,7 @@ components:
                 tag:
                   type: string
                   description: Risk tag identifier
-                  enum: [ sanctions, peps, adverse-media, third-parties ]
+                  enum: [sanctions, peps, adverse-media, third-parties]
                 reason:
                   type: string
                   description: Human-readable reason for applying the risk tag

--- a/repositories/continuous_screening_client_repository.go
+++ b/repositories/continuous_screening_client_repository.go
@@ -121,25 +121,21 @@ func (repo *ClientDbRepository) InsertContinuousScreeningObject(
 	objectType string,
 	objectId string,
 	configStableId uuid.UUID,
-	ignoreConflicts bool,
-) error {
+) (uuid.UUID, error) {
 	if err := validateClientDbExecutor(exec); err != nil {
-		return err
-	}
-
-	sql := "INSERT INTO %s (id, object_type, object_id, config_stable_id) VALUES ($1, $2, $3, $4)"
-
-	if ignoreConflicts {
-		sql += " ON CONFLICT DO NOTHING"
+		return uuid.Nil, err
 	}
 
 	query := fmt.Sprintf(
-		sql,
+		"INSERT INTO %s (id, object_type, object_id, config_stable_id) VALUES ($1, $2, $3, $4)",
 		sanitizedTableName(exec, dbmodels.TABLE_CONTINUOUS_SCREENING_MONITORED_OBJECTS),
 	)
 
-	_, err := exec.Exec(ctx, query, pure_utils.NewId(), objectType, objectId, configStableId)
-	return err
+	id := pure_utils.NewId()
+	if _, err := exec.Exec(ctx, query, id, objectType, objectId, configStableId); err != nil {
+		return uuid.Nil, err
+	}
+	return id, nil
 }
 
 // Table schema

--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -903,6 +903,29 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningDeltaTrack(
 	return ExecBuilder(ctx, exec, query)
 }
 
+// Returns the most recent delta track for (orgId, objectType, objectId), or nil if none exists.
+func (repo *MarbleDbRepository) GetLatestContinuousScreeningDeltaTrack(
+	ctx context.Context,
+	exec Executor,
+	orgId uuid.UUID,
+	objectType, objectId string,
+) (*models.ContinuousScreeningDeltaTrack, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return nil, err
+	}
+
+	query := NewQueryBuilder().
+		Select(dbmodels.SelectContinuousScreeningDeltaTrackColumn...).
+		From(dbmodels.TABLE_CONTINUOUS_SCREENING_DELTA_TRACKS).
+		Where(squirrel.Eq{"org_id": orgId}).
+		Where(squirrel.Eq{"object_type": objectType}).
+		Where(squirrel.Eq{"object_id": objectId}).
+		OrderBy("created_at DESC").
+		Limit(1)
+
+	return SqlToOptionalModel(ctx, exec, query, dbmodels.AdaptContinuousScreeningDeltaTrack)
+}
+
 // Fetch entity IDs which have been changed and not processed yet.
 // Only fetch the last change for each entity ID, and consider previous changes have been processed in the same version.
 // CursorEntityId is the entity ID of the last change that has been processed.

--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -898,7 +898,8 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningDeltaTrack(
 			input.ObjectInternalId,
 			input.EntityId,
 			input.Operation.String(),
-		)
+		).
+		Suffix("ON CONFLICT DO NOTHING")
 
 	return ExecBuilder(ctx, exec, query)
 }

--- a/repositories/migrations/20260427160000_add_unique_constraint_cs_delta_tracks.sql
+++ b/repositories/migrations/20260427160000_add_unique_constraint_cs_delta_tracks.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- +goose StatementBegin
+DELETE FROM continuous_screening_delta_tracks a
+USING continuous_screening_delta_tracks b
+WHERE a.operation IN ('add', 'update')
+  AND b.operation IN ('add', 'update')
+  AND a.org_id = b.org_id
+  AND a.object_type = b.object_type
+  AND a.object_id = b.object_id
+  AND a.object_internal_id = b.object_internal_id
+  AND (a.created_at < b.created_at OR (a.created_at = b.created_at AND a.id < b.id));
+
+CREATE UNIQUE INDEX idx_cs_delta_tracks_unique_add_update
+ON continuous_screening_delta_tracks (org_id, object_type, object_id, object_internal_id)
+WHERE operation IN ('add', 'update');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX idx_cs_delta_tracks_unique_add_update;
+-- +goose StatementEnd

--- a/repositories/migrations/20260427160000_add_unique_constraint_cs_delta_tracks.sql
+++ b/repositories/migrations/20260427160000_add_unique_constraint_cs_delta_tracks.sql
@@ -1,5 +1,7 @@
 -- +goose Up
 -- +goose StatementBegin
+LOCK TABLE continuous_screening_delta_tracks IN SHARE MODE;
+
 DELETE FROM continuous_screening_delta_tracks a
 USING continuous_screening_delta_tracks b
 WHERE a.operation IN ('add', 'update')

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -85,6 +85,14 @@ type TaskQueueRepository interface {
 		enqueueObjectUpdateTasks []models.ContinuousScreeningEnqueueObjectUpdateTask,
 		triggerType models.ContinuousScreeningTriggerType,
 	) error
+	EnqueueContinuousScreeningRegisterObjectTaskMany(
+		ctx context.Context,
+		tx Transaction,
+		orgId uuid.UUID,
+		objectType string,
+		tasks []models.ContinuousScreeningRegisterObjectTask,
+		shouldScreen bool,
+	) error
 	EnqueueContinuousScreeningApplyDeltaFileTask(
 		ctx context.Context,
 		tx Transaction,
@@ -490,6 +498,48 @@ func (r riverRepository) EnqueueContinuousScreeningDoScreeningTaskMany(
 
 	logger := utils.LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "Enqueued continuous screening do screening tasks", "nb_tasks", res)
+	return nil
+}
+
+func (r riverRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
+	ctx context.Context,
+	tx Transaction,
+	orgId uuid.UUID,
+	objectType string,
+	tasks []models.ContinuousScreeningRegisterObjectTask,
+	shouldScreen bool,
+) error {
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	params := make([]river.InsertManyParams, len(tasks))
+	for i, task := range tasks {
+		params[i] = river.InsertManyParams{
+			Args: models.ContinuousScreeningRegisterObjectArgs{
+				OrgId:          orgId,
+				ObjectType:     objectType,
+				ObjectId:       task.ObjectId,
+				ConfigStableId: task.ConfigStableId,
+				NewInternalId:  task.NewInternalId,
+				ShouldScreen:   shouldScreen,
+				UserId:         task.UserId,
+				ApiKeyId:       task.ApiKeyId,
+			},
+			InsertOpts: &river.InsertOpts{
+				Queue:    orgId.String(),
+				Priority: 4,
+			},
+		}
+	}
+
+	res, err := r.client.InsertManyFastTx(ctx, tx.RawTx(), params)
+	if err != nil {
+		return err
+	}
+
+	logger := utils.LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "Enqueued continuous screening register object tasks", "nb_tasks", res)
 	return nil
 }
 

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -93,6 +93,10 @@ type TaskQueueRepository interface {
 		tasks []models.ContinuousScreeningRegisterObjectTask,
 		shouldScreen bool,
 	) error
+	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+		ctx context.Context,
+		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+	) error
 	EnqueueContinuousScreeningApplyDeltaFileTask(
 		ctx context.Context,
 		tx Transaction,
@@ -540,6 +544,30 @@ func (r riverRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
 
 	logger := utils.LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "Enqueued continuous screening register object tasks", "nb_tasks", res)
+	return nil
+}
+
+// EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask enqueues a delayed verification job
+// that re-creates a missing Add delta track if the original RegisterObjectWorker failed to
+// commit it. The enqueue runs against the marble pool directly (no client tx participation):
+// callers should invoke it inside the client-DB tx that creates the monitored_object so a
+// failed enqueue rolls back the registration.
+func (r riverRepository) EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+	ctx context.Context,
+	args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+) error {
+	res, err := r.client.Insert(ctx, args, &river.InsertOpts{
+		Queue:       args.OrgId.String(),
+		Priority:    4,
+		ScheduledAt: time.Now().Add(5 * time.Minute),
+	})
+	if err != nil {
+		return err
+	}
+
+	logger := utils.LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "Enqueued continuous screening verify delta track existence task",
+		"job_id", res.Job.ID, "monitored_object_id", args.MonitoredObjectId)
 	return nil
 }
 

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -93,9 +93,9 @@ type TaskQueueRepository interface {
 		tasks []models.ContinuousScreeningRegisterObjectTask,
 		shouldScreen bool,
 	) error
-	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+	EnqueueContinuousScreeningEnsureDeltaTrackTask(
 		ctx context.Context,
-		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+		args models.ContinuousScreeningEnsureDeltaTrackArgs,
 	) error
 	EnqueueContinuousScreeningApplyDeltaFileTask(
 		ctx context.Context,
@@ -547,14 +547,13 @@ func (r riverRepository) EnqueueContinuousScreeningRegisterObjectTaskMany(
 	return nil
 }
 
-// EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask enqueues a delayed verification job
-// that re-creates a missing Add delta track if the original RegisterObjectWorker failed to
-// commit it. The enqueue runs against the marble pool directly (no client tx participation):
-// callers should invoke it inside the client-DB tx that creates the monitored_object so a
-// failed enqueue rolls back the registration.
-func (r riverRepository) EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+// EnqueueContinuousScreeningEnsureDeltaTrackTask enqueues a delayed job that creates a missing
+// Add delta track if the original RegisterObjectWorker failed to commit it. The enqueue runs
+// against the marble pool directly (no client tx participation): callers should invoke it inside
+// the client-DB tx that creates the monitored_object so a failed enqueue rolls back the registration.
+func (r riverRepository) EnqueueContinuousScreeningEnsureDeltaTrackTask(
 	ctx context.Context,
-	args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+	args models.ContinuousScreeningEnsureDeltaTrackArgs,
 ) error {
 	res, err := r.client.Insert(ctx, args, &river.InsertOpts{
 		Queue:       args.OrgId.String(),

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -112,13 +112,12 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 
 	var objectMonitoredInOtherConfigs bool
 	err = uc.transactionFactory.TransactionInOrgSchema(ctx, config.OrgId, func(tx repositories.Transaction) error {
-		if err := uc.clientDbRepository.InsertContinuousScreeningObject(
+		if _, err := uc.clientDbRepository.InsertContinuousScreeningObject(
 			ctx,
 			tx,
 			table.Name,
 			objectId,
 			input.ConfigStableId,
-			false,
 		); err != nil {
 			return err
 		}

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -54,8 +54,6 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		apiKeyId = &parsed
 	}
 
-	triggerType := models.ContinuousScreeningTriggerTypeObjectAdded
-
 	// Check if the config exists
 	config, err := uc.repository.GetContinuousScreeningConfigByStableId(ctx, exec, input.ConfigStableId)
 	if err != nil {
@@ -95,10 +93,6 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 	}
 
 	objectId := input.ObjectId
-	// Ignore the unique violation error in case of ingestion.
-	// The payload can be an updated object and we will force the screening again on the updated object.
-	// Without recording the object ID in the continuous screening table.
-	ignoreUniqueViolationError := false
 
 	ingestedObject, ingestedObjectInternalId, err := uc.GetIngestedObject(
 		ctx,
@@ -110,15 +104,29 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 
-	var objectMonitoredInOtherConfigs bool
+	var skipDeltaTrack bool
 	err = uc.transactionFactory.TransactionInOrgSchema(ctx, config.OrgId, func(tx repositories.Transaction) error {
-		if _, err := uc.clientDbRepository.InsertContinuousScreeningObject(
+		// Check if the object is monitored in other configs
+		// If yes, don't create the ADD track
+		monitoredObjects, err := uc.clientDbRepository.ListMonitoredObjectsByObjectIds(
+			ctx,
+			tx,
+			table.Name,
+			[]string{objectId},
+		)
+		if err != nil {
+			return err
+		}
+		skipDeltaTrack = len(monitoredObjects) > 0
+
+		monitoredObjectId, err := uc.clientDbRepository.InsertContinuousScreeningObject(
 			ctx,
 			tx,
 			table.Name,
 			objectId,
 			input.ConfigStableId,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
 
@@ -138,37 +146,38 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 			return err
 		}
 
-		// Check if the object is monitored in other configs
-		// If yes, don't create the ADD track
-		monitoredObjects, err := uc.clientDbRepository.ListMonitoredObjectsByObjectIds(
-			ctx,
-			tx,
-			table.Name,
-			[]string{objectId},
-		)
-		if err != nil {
-			return err
+		// Enqueue verify ONLY when a delta track is owed for this fresh registration.
+		// The enqueue runs against the marble pool; calling it before this client-DB tx
+		// commits gives us atomicity-on-success: a failed enqueue rolls back the registration
+		// and the caller sees an error.
+		if !skipDeltaTrack {
+			if err := uc.taskQueueRepository.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+				ctx,
+				models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
+					OrgId:             config.OrgId,
+					ObjectType:        input.ObjectType,
+					ObjectId:          objectId,
+					ObjectInternalId:  ingestedObjectInternalId,
+					EntityId:          pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
+					MonitoredObjectId: monitoredObjectId,
+					Operation:         models.DeltaTrackOperationAdd,
+				},
+			); err != nil {
+				return err
+			}
 		}
-		// > 1 because the object is already monitored in this config, check if it is monitored in other configs
-		objectMonitoredInOtherConfigs = len(monitoredObjects) > 1
 		return nil
 	})
-	// Unique violation error is handled below
 	if err != nil {
-		if repositories.IsUniqueViolationError(err) && ignoreUniqueViolationError {
-			// Do nothing, normal case
-			// That means the object is already in monitoring list and we updated the object data
-			triggerType = models.ContinuousScreeningTriggerTypeObjectUpdated
-		} else if repositories.IsUniqueViolationError(err) {
+		if repositories.IsUniqueViolationError(err) {
 			return models.ContinuousScreeningWithMatches{}, errors.WithDetail(errors.Wrap(
 				models.ConflictError,
 				"object is already monitored with this configuration",
 			),
 				"object is already monitored with this configuration",
 			)
-		} else {
-			return models.ContinuousScreeningWithMatches{}, err
 		}
+		return models.ContinuousScreeningWithMatches{}, err
 	}
 
 	var screeningWithMatches models.ScreeningWithMatches
@@ -184,15 +193,9 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		ctx,
 		uc.transactionFactory,
 		func(tx repositories.Transaction) (models.ContinuousScreeningWithMatches, error) {
-			deltaTrackOperation := models.DeltaTrackOperationAdd
-			if triggerType == models.ContinuousScreeningTriggerTypeObjectUpdated {
-				deltaTrackOperation = models.DeltaTrackOperationUpdate
-			}
-
-			// Check if we should record this activity in the delta tracks
-			isNewMonitoring := deltaTrackOperation == models.DeltaTrackOperationAdd && !objectMonitoredInOtherConfigs
-			isUpdate := deltaTrackOperation == models.DeltaTrackOperationUpdate
-			if isNewMonitoring || isUpdate {
+			// Skip the Add delta track when the object is already tracked by another config
+			// (the indexer already knows about this entity).
+			if !skipDeltaTrack {
 				err = uc.repository.CreateContinuousScreeningDeltaTrack(
 					ctx,
 					tx,
@@ -202,7 +205,7 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 						ObjectId:         objectId,
 						ObjectInternalId: &ingestedObjectInternalId,
 						EntityId:         pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
-						Operation:        deltaTrackOperation,
+						Operation:        models.DeltaTrackOperationAdd,
 					},
 				)
 				if err != nil {
@@ -220,7 +223,7 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 						ObjectType:       &input.ObjectType,
 						ObjectId:         &objectId,
 						ObjectInternalId: &ingestedObjectInternalId,
-						TriggerType:      triggerType,
+						TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
 					},
 				)
 				if err != nil {

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -104,21 +104,7 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 
-	var skipDeltaTrack bool
 	err = uc.transactionFactory.TransactionInOrgSchema(ctx, config.OrgId, func(tx repositories.Transaction) error {
-		// Check if the object is monitored in other configs
-		// If yes, don't create the ADD track
-		monitoredObjects, err := uc.clientDbRepository.ListMonitoredObjectsByObjectIds(
-			ctx,
-			tx,
-			table.Name,
-			[]string{objectId},
-		)
-		if err != nil {
-			return err
-		}
-		skipDeltaTrack = len(monitoredObjects) > 0
-
 		monitoredObjectId, err := uc.clientDbRepository.InsertContinuousScreeningObject(
 			ctx,
 			tx,
@@ -130,7 +116,7 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 			return err
 		}
 
-		err = uc.clientDbRepository.InsertContinuousScreeningAudit(
+		if err = uc.clientDbRepository.InsertContinuousScreeningAudit(
 			ctx,
 			tx,
 			models.CreateContinuousScreeningAudit{
@@ -141,32 +127,24 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 				UserId:         userId,
 				ApiKeyId:       apiKeyId,
 			},
-		)
-		if err != nil {
+		); err != nil {
 			return err
 		}
 
-		// Enqueue verify ONLY when a delta track is owed for this fresh registration.
-		// The enqueue runs against the marble pool; calling it before this client-DB tx
-		// commits gives us atomicity-on-success: a failed enqueue rolls back the registration
-		// and the caller sees an error.
-		if !skipDeltaTrack {
-			if err := uc.taskQueueRepository.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
-				ctx,
-				models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
-					OrgId:             config.OrgId,
-					ObjectType:        input.ObjectType,
-					ObjectId:          objectId,
-					ObjectInternalId:  ingestedObjectInternalId,
-					EntityId:          pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
-					MonitoredObjectId: monitoredObjectId,
-					Operation:         models.DeltaTrackOperationAdd,
-				},
-			); err != nil {
-				return err
-			}
-		}
-		return nil
+		// Enqueue a delayed verification job as a safety net: if the delta track insert below
+		// commits but the client-DB tx rolled back (or vice versa), the verify worker repairs it.
+		return uc.taskQueueRepository.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+			ctx,
+			models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
+				OrgId:             config.OrgId,
+				ObjectType:        input.ObjectType,
+				ObjectId:          objectId,
+				ObjectInternalId:  ingestedObjectInternalId,
+				EntityId:          pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
+				MonitoredObjectId: monitoredObjectId,
+				Operation:         models.DeltaTrackOperationAdd,
+			},
+		)
 	})
 	if err != nil {
 		if repositories.IsUniqueViolationError(err) {
@@ -177,6 +155,22 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 				"object is already monitored with this configuration",
 			)
 		}
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
+	// ON CONFLICT DO NOTHING — idempotent if the object is already tracked by another config.
+	if err := uc.repository.CreateContinuousScreeningDeltaTrack(
+		ctx,
+		exec,
+		models.CreateContinuousScreeningDeltaTrack{
+			OrgId:            config.OrgId,
+			ObjectType:       input.ObjectType,
+			ObjectId:         objectId,
+			ObjectInternalId: &ingestedObjectInternalId,
+			EntityId:         pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
+			Operation:        models.DeltaTrackOperationAdd,
+		},
+	); err != nil {
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 
@@ -193,26 +187,6 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		ctx,
 		uc.transactionFactory,
 		func(tx repositories.Transaction) (models.ContinuousScreeningWithMatches, error) {
-			// Skip the Add delta track when the object is already tracked by another config
-			// (the indexer already knows about this entity).
-			if !skipDeltaTrack {
-				err = uc.repository.CreateContinuousScreeningDeltaTrack(
-					ctx,
-					tx,
-					models.CreateContinuousScreeningDeltaTrack{
-						OrgId:            config.OrgId,
-						ObjectType:       input.ObjectType,
-						ObjectId:         objectId,
-						ObjectInternalId: &ingestedObjectInternalId,
-						EntityId:         pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
-						Operation:        models.DeltaTrackOperationAdd,
-					},
-				)
-				if err != nil {
-					return models.ContinuousScreeningWithMatches{}, err
-				}
-			}
-
 			if !input.SkipScreen {
 				continuousScreeningWithMatches, err := uc.repository.InsertContinuousScreening(
 					ctx,

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -133,9 +133,9 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 
 		// Enqueue a delayed verification job as a safety net: if the delta track insert below
 		// commits but the client-DB tx rolled back (or vice versa), the verify worker repairs it.
-		return uc.taskQueueRepository.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+		return uc.taskQueueRepository.EnqueueContinuousScreeningEnsureDeltaTrackTask(
 			ctx,
-			models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
+			models.ContinuousScreeningEnsureDeltaTrackArgs{
 				OrgId:             config.OrgId,
 				ObjectType:        input.ObjectType,
 				ObjectId:          objectId,

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -146,31 +146,9 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 			},
 		)
 	})
-	if err != nil {
-		if repositories.IsUniqueViolationError(err) {
-			return models.ContinuousScreeningWithMatches{}, errors.WithDetail(errors.Wrap(
-				models.ConflictError,
-				"object is already monitored with this configuration",
-			),
-				"object is already monitored with this configuration",
-			)
-		}
-		return models.ContinuousScreeningWithMatches{}, err
-	}
-
-	// ON CONFLICT DO NOTHING — idempotent if the object is already tracked by another config.
-	if err := uc.repository.CreateContinuousScreeningDeltaTrack(
-		ctx,
-		exec,
-		models.CreateContinuousScreeningDeltaTrack{
-			OrgId:            config.OrgId,
-			ObjectType:       input.ObjectType,
-			ObjectId:         objectId,
-			ObjectInternalId: &ingestedObjectInternalId,
-			EntityId:         pure_utils.MarbleEntityIdBuilder(input.ObjectType, objectId),
-			Operation:        models.DeltaTrackOperationAdd,
-		},
-	); err != nil {
+	// Ignore unique violation errors, let the screening proceed
+	// Multiple call to this function is idempotent
+	if err != nil && !repositories.IsUniqueViolationError(err) {
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -18,14 +18,10 @@ import (
 	"github.com/google/uuid"
 )
 
-// Before inserting an object into continuous screening table, we need to check if the table exists, create if not exists the continuous screening table and index
-// then insert the object into the list with the monitoring config ID.
-// 2 modes:
-//   - Provide the object ID of an ingested object and add it into the continuous screening list
-//   - Provide the object payload and ingest the object first then add it into the continuous screening list
-//
-// If the object already ingested and it is a new version, we will ignore the conflict error and consider the object as a new one and force the screening on the updated object.
-// The updated object should be ingested, we check if the object has been ingested before resume the continuous screening operation.
+// Add an already-ingested object to continuous screening under the given config (idempotent).
+// Registers it in the monitoring list within a client-DB transaction. An EnsureDeltaTrack job is enqueued in the same
+// transaction as a safety net against partial state between the two databases. Optionally runs an
+// immediate OpenSanctions screening
 func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 	ctx context.Context,
 	input models.CreateContinuousScreeningObject,

--- a/usecases/continuous_screening/monitored_object_test.go
+++ b/usecases/continuous_screening/monitored_object_test.go
@@ -176,7 +176,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		Matches:           []models.ScreeningMatch{},
 	}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
@@ -391,7 +391,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.ingestedDataReader.On("QueryIngestedObject", mock.Anything, mock.Anything, table,
 		suite.objectId, mock.Anything).Return(ingestedObjects, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(&pgconn.PgError{
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.Nil, &pgconn.PgError{
 		Code: pgerrcode.UniqueViolation,
 	})
 
@@ -521,7 +521,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		},
 	}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
@@ -666,7 +666,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		},
 	}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
@@ -1247,7 +1247,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	}, nil)
 
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
@@ -1482,7 +1482,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		Matches:           []models.ScreeningMatch{},
 	}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
@@ -1581,7 +1581,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	// Note: screeningProvider.Search and repository.InsertContinuousScreening should NOT be called since SkipScreen is true
 
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
-		suite.objectType, suite.objectId, suite.configStableId, false).Return(nil)
+		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,

--- a/usecases/continuous_screening/monitored_object_test.go
+++ b/usecases/continuous_screening/monitored_object_test.go
@@ -179,7 +179,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
@@ -388,7 +388,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.Nil, &pgconn.PgError{
 		Code: pgerrcode.UniqueViolation,
 	})
-	// InsertContinuousScreeningAudit and EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask
+	// InsertContinuousScreeningAudit and EnqueueContinuousScreeningEnsureDeltaTrackTask
 	// are NOT called because the transaction fails at InsertContinuousScreeningObject.
 	suite.repository.On("SearchScreeningMatchWhitelist", mock.Anything, mock.Anything,
 		suite.orgId, mock.Anything, mock.Anything).Return([]models.ScreeningWhitelist{}, nil)
@@ -545,7 +545,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
 		mock.Anything).Return(models.ContinuousScreeningWithMatches{
@@ -684,7 +684,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
@@ -1262,7 +1262,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
 		suite.objectType, []string{suite.objectId}).Return(
 		[]models.ContinuousScreeningMonitoredObject{}, nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
@@ -1495,7 +1495,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 	continuousScreeningId := pure_utils.NewId()
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
@@ -1592,7 +1592,7 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningEnsureDeltaTrackTask",
 		mock.Anything, mock.Anything).Return(nil)
 
 	// Execute

--- a/usecases/continuous_screening/monitored_object_test.go
+++ b/usecases/continuous_screening/monitored_object_test.go
@@ -179,9 +179,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return(
-		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
 		mock.Anything, mock.Anything).Return(nil)
 
@@ -200,10 +197,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningMatchEnrichmentTask", mock.Anything, mock.Anything,
 		suite.orgId, continuousScreeningId).Return(nil)
-	suite.repository.On("CreateContinuousScreeningDeltaTrack", mock.Anything, mock.Anything,
-		mock.MatchedBy(func(input models.CreateContinuousScreeningDeltaTrack) bool {
-			return input.Operation == models.DeltaTrackOperationAdd
-		})).Return(nil)
 
 	// Execute
 	uc := suite.makeUsecase()
@@ -337,8 +330,8 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.AssertExpectations()
 }
 
-func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningObject_UniqueViolationWithoutIgnoreConflictError() {
-	// Setup test data - object ID, which will NOT set ignoreConflictError
+func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningObject_UniqueViolation_IgnoredAndScreeningProceeds() {
+	// Setup test data - unique violation on insert is ignored and screening proceeds
 	config := models.ContinuousScreeningConfig{
 		Id:          suite.configId,
 		StableId:    suite.configStableId,
@@ -391,13 +384,37 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.repository.On("GetDataModel", mock.Anything, mock.Anything, suite.orgId, false, false).Return(dataModel, nil)
 	suite.ingestedDataReader.On("QueryIngestedObject", mock.Anything, mock.Anything, table,
 		suite.objectId, mock.Anything).Return(ingestedObjects, nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return(
-		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.Nil, &pgconn.PgError{
 		Code: pgerrcode.UniqueViolation,
 	})
+	// InsertContinuousScreeningAudit and EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask
+	// are NOT called because the transaction fails at InsertContinuousScreeningObject.
+	suite.repository.On("SearchScreeningMatchWhitelist", mock.Anything, mock.Anything,
+		suite.orgId, mock.Anything, mock.Anything).Return([]models.ScreeningWhitelist{}, nil)
+	suite.screeningProvider.On("Search", mock.Anything, mock.MatchedBy(func(query models.OpenSanctionsQuery) bool {
+		return len(query.Queries) > 0
+	})).Return(models.ScreeningRawSearchResponseWithMatches{
+		SearchInput:       []byte("{}"),
+		InitialHasMatches: false,
+		Matches:           []models.ScreeningMatch{},
+	}, nil)
+
+	continuousScreeningId := pure_utils.NewId()
+	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
+		mock.Anything).Return(models.ContinuousScreeningWithMatches{
+		ContinuousScreening: models.ContinuousScreening{
+			Id:                                continuousScreeningId,
+			OrgId:                             suite.orgId,
+			ContinuousScreeningConfigId:       suite.configId,
+			ContinuousScreeningConfigStableId: suite.configStableId,
+			ObjectType:                        utils.Ptr(suite.objectType),
+			ObjectId:                          utils.Ptr(suite.objectId),
+		},
+		Matches: []models.ContinuousScreeningMatch{},
+	}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningMatchEnrichmentTask", mock.Anything, mock.Anything,
+		suite.orgId, continuousScreeningId).Return(nil)
 
 	// Execute
 	uc := suite.makeUsecase()
@@ -408,11 +425,11 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		SkipScreen:     false,
 	}
 
-	_, err := uc.CreateContinuousScreeningObject(suite.ctx, input)
+	result, err := uc.CreateContinuousScreeningObject(suite.ctx, input)
 
-	// Assert - should error when ignoreConflictError is false and unique violation occurs
-	suite.Error(err)
-	suite.True(errors.Is(err, models.ConflictError), "error should be ConflictError")
+	// Assert - unique violation is ignored and screening proceeds
+	suite.NoError(err)
+	suite.NotNil(result)
 	suite.AssertExpectations()
 }
 
@@ -528,9 +545,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return(
-		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
 		mock.Anything, mock.Anything).Return(nil)
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
@@ -554,10 +568,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningMatchEnrichmentTask", mock.Anything, mock.Anything,
 		suite.orgId, continuousScreeningId).Return(nil)
-	suite.repository.On("CreateContinuousScreeningDeltaTrack", mock.Anything, mock.Anything,
-		mock.MatchedBy(func(input models.CreateContinuousScreeningDeltaTrack) bool {
-			return input.Operation == models.DeltaTrackOperationAdd
-		})).Return(nil)
 
 	// Mock case creation
 	caseId := pure_utils.NewId()
@@ -674,9 +684,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return(
-		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
 		mock.Anything, mock.Anything).Return(nil)
 
@@ -702,10 +709,6 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningMatchEnrichmentTask", mock.Anything, mock.Anything,
 		suite.orgId, continuousScreeningId).Return(nil)
-	suite.repository.On("CreateContinuousScreeningDeltaTrack", mock.Anything, mock.Anything,
-		mock.MatchedBy(func(input models.CreateContinuousScreeningDeltaTrack) bool {
-			return input.Operation == models.DeltaTrackOperationAdd
-		})).Return(nil)
 
 	// Mock case creation to fail
 	suite.caseEditor.On("CreateCase", mock.Anything, mock.Anything, "", mock.MatchedBy(func(
@@ -1492,10 +1495,8 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{}, {},
-	}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 	continuousScreeningId := pure_utils.NewId()
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
 		mock.Anything).Return(models.ContinuousScreeningWithMatches{
@@ -1591,16 +1592,8 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.New(), nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
-	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return(
-		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
 		mock.Anything, mock.Anything).Return(nil)
-
-	suite.repository.On("CreateContinuousScreeningDeltaTrack", mock.Anything, mock.Anything,
-		mock.MatchedBy(func(input models.CreateContinuousScreeningDeltaTrack) bool {
-			return input.Operation == models.DeltaTrackOperationAdd
-		})).Return(nil)
 
 	// Execute
 	uc := suite.makeUsecase()

--- a/usecases/continuous_screening/monitored_object_test.go
+++ b/usecases/continuous_screening/monitored_object_test.go
@@ -180,9 +180,10 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{},
-	}, nil)
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
@@ -390,6 +391,9 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.repository.On("GetDataModel", mock.Anything, mock.Anything, suite.orgId, false, false).Return(dataModel, nil)
 	suite.ingestedDataReader.On("QueryIngestedObject", mock.Anything, mock.Anything, table,
 		suite.objectId, mock.Anything).Return(ingestedObjects, nil)
+	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
 	suite.clientDbRepository.On("InsertContinuousScreeningObject", mock.Anything, mock.Anything,
 		suite.objectType, suite.objectId, suite.configStableId).Return(uuid.Nil, &pgconn.PgError{
 		Code: pgerrcode.UniqueViolation,
@@ -525,9 +529,10 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{},
-	}, nil)
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
 		mock.Anything).Return(models.ContinuousScreeningWithMatches{
 		ContinuousScreening: models.ContinuousScreening{
@@ -670,9 +675,10 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{},
-	}, nil)
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
@@ -1251,9 +1257,10 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{},
-	}, nil)
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 
 	continuousScreeningId := pure_utils.NewId()
 	suite.repository.On("InsertContinuousScreening", mock.Anything, mock.Anything,
@@ -1585,9 +1592,10 @@ func (suite *ContinuousScreeningUsecaseTestSuite) TestInsertContinuousScreeningO
 	suite.clientDbRepository.On("InsertContinuousScreeningAudit", mock.Anything, mock.Anything,
 		mock.Anything).Return(nil)
 	suite.clientDbRepository.On("ListMonitoredObjectsByObjectIds", mock.Anything, mock.Anything,
-		suite.objectType, []string{suite.objectId}).Return([]models.ContinuousScreeningMonitoredObject{
-		{},
-	}, nil)
+		suite.objectType, []string{suite.objectId}).Return(
+		[]models.ContinuousScreeningMonitoredObject{}, nil)
+	suite.taskQueueRepository.On("EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask",
+		mock.Anything, mock.Anything).Return(nil)
 
 	suite.repository.On("CreateContinuousScreeningDeltaTrack", mock.Anything, mock.Anything,
 		mock.MatchedBy(func(input models.CreateContinuousScreeningDeltaTrack) bool {

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -187,6 +187,10 @@ type continuousScreeningTaskQueueRepository interface {
 		organizationId uuid.UUID,
 		continuousScreeningId uuid.UUID,
 	) error
+	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+		ctx context.Context,
+		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+	) error
 }
 
 type inboxReader interface {

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -187,9 +187,9 @@ type continuousScreeningTaskQueueRepository interface {
 		organizationId uuid.UUID,
 		continuousScreeningId uuid.UUID,
 	) error
-	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+	EnqueueContinuousScreeningEnsureDeltaTrackTask(
 		ctx context.Context,
-		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+		args models.ContinuousScreeningEnsureDeltaTrackArgs,
 	) error
 }
 

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -246,8 +246,7 @@ type ContinuousScreeningClientDbRepository interface {
 		objectType string,
 		objectId string,
 		configStableId uuid.UUID,
-		ignoreConflicts bool,
-	) error
+	) (uuid.UUID, error)
 	InsertContinuousScreeningAudit(
 		ctx context.Context,
 		exec repositories.Executor,

--- a/usecases/continuous_screening/worker_ensure_delta_track.go
+++ b/usecases/continuous_screening/worker_ensure_delta_track.go
@@ -13,7 +13,7 @@ import (
 	"github.com/riverqueue/river"
 )
 
-type verifyDeltaTrackExistenceWorkerRepository interface {
+type ensureDeltaTrackWorkerRepository interface {
 	GetLatestContinuousScreeningDeltaTrack(
 		ctx context.Context,
 		exec repositories.Executor,
@@ -27,7 +27,7 @@ type verifyDeltaTrackExistenceWorkerRepository interface {
 	) error
 }
 
-type verifyDeltaTrackExistenceWorkerClientDbRepository interface {
+type ensureDeltaTrackWorkerClientDbRepository interface {
 	GetMonitoredObject(
 		ctx context.Context,
 		exec repositories.Executor,
@@ -35,27 +35,27 @@ type verifyDeltaTrackExistenceWorkerClientDbRepository interface {
 	) (models.ContinuousScreeningMonitoredObject, error)
 }
 
-// VerifyDeltaTrackExistenceWorker is the safety net for RegisterObjectWorker. It runs ~5 min
-// after a registration and re-creates the Add delta track if the original cross-DB sequence
+// EnsureDeltaTrackWorker is the safety net for RegisterObjectWorker. It runs ~5 min
+// after a registration and creates the Add delta track if the original cross-DB sequence
 // (client-DB monitored_object insert + marble-DB delta track insert) committed the first half
 // but failed the second half. The marble-DB read of the latest delta track and the recovery
 // insert run in a single transaction so a concurrent writer can't slip in between.
-type VerifyDeltaTrackExistenceWorker struct {
-	river.WorkerDefaults[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs]
+type EnsureDeltaTrackWorker struct {
+	river.WorkerDefaults[models.ContinuousScreeningEnsureDeltaTrackArgs]
 	executorFactory    executor_factory.ExecutorFactory
 	transactionFactory executor_factory.TransactionFactory
 
-	repo         verifyDeltaTrackExistenceWorkerRepository
-	clientDbRepo verifyDeltaTrackExistenceWorkerClientDbRepository
+	repo         ensureDeltaTrackWorkerRepository
+	clientDbRepo ensureDeltaTrackWorkerClientDbRepository
 }
 
-func NewVerifyDeltaTrackExistenceWorker(
+func NewEnsureDeltaTrackWorker(
 	executorFactory executor_factory.ExecutorFactory,
 	transactionFactory executor_factory.TransactionFactory,
-	repo verifyDeltaTrackExistenceWorkerRepository,
-	clientDbRepo verifyDeltaTrackExistenceWorkerClientDbRepository,
-) *VerifyDeltaTrackExistenceWorker {
-	return &VerifyDeltaTrackExistenceWorker{
+	repo ensureDeltaTrackWorkerRepository,
+	clientDbRepo ensureDeltaTrackWorkerClientDbRepository,
+) *EnsureDeltaTrackWorker {
+	return &EnsureDeltaTrackWorker{
 		executorFactory:    executorFactory,
 		transactionFactory: transactionFactory,
 		repo:               repo,
@@ -63,13 +63,13 @@ func NewVerifyDeltaTrackExistenceWorker(
 	}
 }
 
-func (w *VerifyDeltaTrackExistenceWorker) Timeout(_ *river.Job[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs]) time.Duration {
+func (w *EnsureDeltaTrackWorker) Timeout(_ *river.Job[models.ContinuousScreeningEnsureDeltaTrackArgs]) time.Duration {
 	return time.Minute
 }
 
-func (w *VerifyDeltaTrackExistenceWorker) Work(
+func (w *EnsureDeltaTrackWorker) Work(
 	ctx context.Context,
-	job *river.Job[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs],
+	job *river.Job[models.ContinuousScreeningEnsureDeltaTrackArgs],
 ) error {
 	logger := utils.LoggerFromContext(ctx)
 
@@ -106,7 +106,7 @@ func (w *VerifyDeltaTrackExistenceWorker) Work(
 			return nil
 		}
 
-		logger.WarnContext(ctx, "Continuous Screening - verify: delta track missing, recreating",
+		logger.DebugContext(ctx, "Continuous Screening - verify: delta track missing, recreating",
 			"org_id", job.Args.OrgId,
 			"object_type", job.Args.ObjectType,
 			"object_id", job.Args.ObjectId,

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -39,6 +39,10 @@ type registerObjectWorkerTaskQueueRepository interface {
 		organizationId uuid.UUID,
 		continuousScreeningId uuid.UUID,
 	) error
+	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+		ctx context.Context,
+		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
+	) error
 }
 
 type registerObjectWorkerClientDbRepository interface {
@@ -48,8 +52,7 @@ type registerObjectWorkerClientDbRepository interface {
 		objectType string,
 		objectId string,
 		configStableId uuid.UUID,
-		ignoreConflicts bool,
-	) error
+	) (uuid.UUID, error)
 	InsertContinuousScreeningAudit(
 		ctx context.Context,
 		exec repositories.Executor,
@@ -141,11 +144,15 @@ func (w *RegisterObjectWorker) Timeout(_ *river.Job[models.ContinuousScreeningRe
 // Work registers a newly ingested object under continuous screening monitoring.
 // The flow has three independent steps, each of which is safe to retry:
 //  1. Registration (client DB transaction): if the (objectId, configId) pair is not already
-//     in the monitoring table, insert it and create an audit entry. Idempotent — a second run
-//     detects the existing entry and skips to step 3.
+//     in the monitoring table, insert it and create an audit entry. The same client-DB
+//     transaction also enqueues a delayed verification job (against the marble pool) — see
+//     VerifyDeltaTrackExistenceWorker — so a failure of step 2 below can be self-healed.
+//     The verify enqueue runs before the client-DB commit: if the enqueue fails, the
+//     monitored_object insertion is rolled back and the worker errors for River to retry.
 //  2. Delta track (marble DB): record an Add operation so the object is included in the next
 //     dataset rebuild. Skipped on retry (alreadyRegistered) and skipped when the object is
-//     already tracked by another config (no new entry needed in the index).
+//     already tracked by another config (no new entry needed in the index). If this step
+//     fails, the queued verify job (5 min later) creates the missing track.
 //  3. Screening (marble DB transaction, only if ShouldScreen): query OpenSanctions, persist
 //     the result, enqueue match enrichment, and create a case if the result is in-review.
 //     This step is always attempted — even on retry — so a failed screening transaction does
@@ -209,6 +216,8 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 
 	// Check if already registered, insert if not, create audit, and determine whether an Add
 	// delta track is needed (skip if object is already monitored under another config).
+	// In the same transaction (before commit), enqueue a delayed verification job — this
+	// gives atomicity-on-success: a failed enqueue rolls back the registration so River retries.
 	var (
 		alreadyRegistered             bool
 		objectMonitoredInOtherConfigs bool
@@ -221,7 +230,12 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 			return err
 		}
 
-		// Any existing entry means this object is tracked by at least one other config.
+		// Any existing entry means this object is already tracked (by another config, or by
+		// us on retry). When we reach the enqueue step below we know we're in a fresh-insert
+		// path — the alreadyRegistered branch returns early — so this flag specifically
+		// distinguishes "first registration overall" (false → enqueue verify, owe a delta
+		// track) from "first registration under this config but another already covers the
+		// indexer" (true → no delta track owed, no verify needed).
 		objectMonitoredInOtherConfigs = len(monitoredObjects) > 0
 
 		// If the object is already monitored with the same configuration, don't insert it again.
@@ -232,21 +246,45 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 			}
 		}
 
-		if err := w.clientDbRepo.InsertContinuousScreeningObject(
-			ctx, tx, table.Name, job.Args.ObjectId, job.Args.ConfigStableId, false,
-		); err != nil {
+		monitoredObjectId, err := w.clientDbRepo.InsertContinuousScreeningObject(
+			ctx, tx, table.Name, job.Args.ObjectId, job.Args.ConfigStableId,
+		)
+		if err != nil {
 			return err
 		}
 
-		// TODO: Add a async job with a delay to check if the insert continuous object is correctly inserted and if the DeltraTrack is created on the object
-		return w.clientDbRepo.InsertContinuousScreeningAudit(ctx, tx, models.CreateContinuousScreeningAudit{
+		if err := w.clientDbRepo.InsertContinuousScreeningAudit(ctx, tx, models.CreateContinuousScreeningAudit{
 			ObjectType:     table.Name,
 			ObjectId:       job.Args.ObjectId,
 			ConfigStableId: job.Args.ConfigStableId,
 			Action:         models.ContinuousScreeningAuditActionAdd,
 			UserId:         userId,
 			ApiKeyId:       apiKeyId,
-		})
+		}); err != nil {
+			return err
+		}
+
+		// Enqueue verify ONLY when a delta track is owed for this fresh registration.
+		// The enqueue runs against the marble pool; calling it before this client-DB tx
+		// commits gives us atomicity-on-success: a failed enqueue rolls back the registration
+		// and the worker retries from scratch.
+		if !objectMonitoredInOtherConfigs {
+			if err := w.taskQueueRepo.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
+				ctx,
+				models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
+					OrgId:             config.OrgId,
+					ObjectType:        job.Args.ObjectType,
+					ObjectId:          job.Args.ObjectId,
+					ObjectInternalId:  newObjectInternalId,
+					EntityId:          pure_utils.MarbleEntityIdBuilder(job.Args.ObjectType, job.Args.ObjectId),
+					MonitoredObjectId: monitoredObjectId,
+					Operation:         models.DeltaTrackOperationAdd,
+				},
+			); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	if err != nil {
 		return err

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -39,10 +39,6 @@ type registerObjectWorkerTaskQueueRepository interface {
 		organizationId uuid.UUID,
 		continuousScreeningId uuid.UUID,
 	) error
-	EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
-		ctx context.Context,
-		args models.ContinuousScreeningVerifyDeltaTrackExistenceArgs,
-	) error
 }
 
 type registerObjectWorkerClientDbRepository interface {
@@ -142,17 +138,13 @@ func (w *RegisterObjectWorker) Timeout(_ *river.Job[models.ContinuousScreeningRe
 }
 
 // Work registers a newly ingested object under continuous screening monitoring.
-// The flow has three independent steps, each of which is safe to retry:
+// The flow has two independent steps, each of which is safe to retry:
 //  1. Registration (client DB transaction): if the (objectId, configId) pair is not already
-//     in the monitoring table, insert it and create an audit entry. The same client-DB
-//     transaction also enqueues a delayed verification job (against the marble pool) — see
-//     VerifyDeltaTrackExistenceWorker — so a failure of step 2 below can be self-healed.
-//     The verify enqueue runs before the client-DB commit: if the enqueue fails, the
-//     monitored_object insertion is rolled back and the worker errors for River to retry.
+//     in the monitoring table, insert it and create an audit entry.
 //  2. Delta track (marble DB): record an Add operation so the object is included in the next
-//     dataset rebuild. Skipped on retry (alreadyRegistered) and skipped when the object is
-//     already tracked by another config (no new entry needed in the index). If this step
-//     fails, the queued verify job (5 min later) creates the missing track.
+//     dataset rebuild. Always attempted — ON CONFLICT DO NOTHING makes it idempotent, so
+//     retries and concurrent jobs for the same object are handled by the unique constraint on
+//     (org_id, object_type, object_id, object_internal_id) for add/update operations.
 //  3. Screening (marble DB transaction, only if ShouldScreen): query OpenSanctions, persist
 //     the result, enqueue match enrichment, and create a case if the result is in-review.
 //     This step is always attempted — even on retry — so a failed screening transaction does
@@ -214,14 +206,7 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 		return err
 	}
 
-	// Check if already registered, insert if not, create audit, and determine whether an Add
-	// delta track is needed (skip if object is already monitored under another config).
-	// In the same transaction (before commit), enqueue a delayed verification job — this
-	// gives atomicity-on-success: a failed enqueue rolls back the registration so River retries.
-	var (
-		alreadyRegistered             bool
-		objectMonitoredInOtherConfigs bool
-	)
+	// Check if already registered, insert if not, create audit.
 	err = w.transactionFactory.TransactionInOrgSchema(ctx, job.Args.OrgId, func(tx repositories.Transaction) error {
 		monitoredObjects, err := w.clientDbRepo.ListMonitoredObjectsByObjectIds(
 			ctx, tx, table.Name, []string{job.Args.ObjectId},
@@ -230,79 +215,42 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 			return err
 		}
 
-		// Any existing entry means this object is already tracked (by another config, or by
-		// us on retry). When we reach the enqueue step below we know we're in a fresh-insert
-		// path — the alreadyRegistered branch returns early — so this flag specifically
-		// distinguishes "first registration overall" (false → enqueue verify, owe a delta
-		// track) from "first registration under this config but another already covers the
-		// indexer" (true → no delta track owed, no verify needed).
-		objectMonitoredInOtherConfigs = len(monitoredObjects) > 0
-
-		// If the object is already monitored with the same configuration, don't insert it again.
 		for _, mo := range monitoredObjects {
 			if mo.ConfigStableId == job.Args.ConfigStableId {
-				alreadyRegistered = true
 				return nil
 			}
 		}
 
-		monitoredObjectId, err := w.clientDbRepo.InsertContinuousScreeningObject(
+		if _, err := w.clientDbRepo.InsertContinuousScreeningObject(
 			ctx, tx, table.Name, job.Args.ObjectId, job.Args.ConfigStableId,
-		)
-		if err != nil {
+		); err != nil {
 			return err
 		}
 
-		if err := w.clientDbRepo.InsertContinuousScreeningAudit(ctx, tx, models.CreateContinuousScreeningAudit{
+		return w.clientDbRepo.InsertContinuousScreeningAudit(ctx, tx, models.CreateContinuousScreeningAudit{
 			ObjectType:     table.Name,
 			ObjectId:       job.Args.ObjectId,
 			ConfigStableId: job.Args.ConfigStableId,
 			Action:         models.ContinuousScreeningAuditActionAdd,
 			UserId:         userId,
 			ApiKeyId:       apiKeyId,
-		}); err != nil {
-			return err
-		}
-
-		// Enqueue verify ONLY when a delta track is owed for this fresh registration.
-		// The enqueue runs against the marble pool; calling it before this client-DB tx
-		// commits gives us atomicity-on-success: a failed enqueue rolls back the registration
-		// and the worker retries from scratch.
-		if !objectMonitoredInOtherConfigs {
-			if err := w.taskQueueRepo.EnqueueContinuousScreeningVerifyDeltaTrackExistenceTask(
-				ctx,
-				models.ContinuousScreeningVerifyDeltaTrackExistenceArgs{
-					OrgId:             config.OrgId,
-					ObjectType:        job.Args.ObjectType,
-					ObjectId:          job.Args.ObjectId,
-					ObjectInternalId:  newObjectInternalId,
-					EntityId:          pure_utils.MarbleEntityIdBuilder(job.Args.ObjectType, job.Args.ObjectId),
-					MonitoredObjectId: monitoredObjectId,
-					Operation:         models.DeltaTrackOperationAdd,
-				},
-			); err != nil {
-				return err
-			}
-		}
-		return nil
+		})
 	})
 	if err != nil {
 		return err
 	}
 
-	// Create the delta track independently of screening — only on first registration.
-	// On retry (alreadyRegistered=true), this is skipped since it was committed on the first attempt.
-	if !alreadyRegistered && !objectMonitoredInOtherConfigs {
-		if err := w.repo.CreateContinuousScreeningDeltaTrack(ctx, exec, models.CreateContinuousScreeningDeltaTrack{
-			OrgId:            config.OrgId,
-			ObjectType:       job.Args.ObjectType,
-			ObjectId:         job.Args.ObjectId,
-			ObjectInternalId: &newObjectInternalId,
-			EntityId:         pure_utils.MarbleEntityIdBuilder(job.Args.ObjectType, job.Args.ObjectId),
-			Operation:        models.DeltaTrackOperationAdd,
-		}); err != nil {
-			return err
-		}
+	// Always attempt the delta track insert — ON CONFLICT DO NOTHING makes it idempotent.
+	// This handles retries (alreadyRegistered) and concurrent jobs for the same object.
+	if err := w.repo.CreateContinuousScreeningDeltaTrack(ctx, exec, models.CreateContinuousScreeningDeltaTrack{
+		OrgId:            config.OrgId,
+		ObjectType:       job.Args.ObjectType,
+		ObjectId:         job.Args.ObjectId,
+		ObjectInternalId: &newObjectInternalId,
+		EntityId:         pure_utils.MarbleEntityIdBuilder(job.Args.ObjectType, job.Args.ObjectId),
+		Operation:        models.DeltaTrackOperationAdd,
+	}); err != nil {
+		return err
 	}
 
 	if !job.Args.ShouldScreen {

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -1,0 +1,316 @@
+package continuous_screening
+
+import (
+	"context"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+)
+
+type registerObjectWorkerRepository interface {
+	GetContinuousScreeningConfigByStableId(
+		ctx context.Context,
+		exec repositories.Executor,
+		stableId uuid.UUID,
+	) (models.ContinuousScreeningConfig, error)
+	InsertContinuousScreening(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.CreateContinuousScreening,
+	) (models.ContinuousScreeningWithMatches, error)
+	CreateContinuousScreeningDeltaTrack(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.CreateContinuousScreeningDeltaTrack,
+	) error
+}
+
+type registerObjectWorkerTaskQueueRepository interface {
+	EnqueueContinuousScreeningMatchEnrichmentTask(
+		ctx context.Context,
+		tx repositories.Transaction,
+		organizationId uuid.UUID,
+		continuousScreeningId uuid.UUID,
+	) error
+}
+
+type registerObjectWorkerClientDbRepository interface {
+	InsertContinuousScreeningObject(
+		ctx context.Context,
+		exec repositories.Executor,
+		objectType string,
+		objectId string,
+		configStableId uuid.UUID,
+		ignoreConflicts bool,
+	) error
+	InsertContinuousScreeningAudit(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.CreateContinuousScreeningAudit,
+	) error
+	ListMonitoredObjectsByObjectIds(
+		ctx context.Context,
+		exec repositories.Executor,
+		objectType string,
+		objectIds []string,
+	) ([]models.ContinuousScreeningMonitoredObject, error)
+}
+
+type registerObjectWorkerIngestedDataReader interface {
+	QueryIngestedObjectByInternalId(
+		ctx context.Context,
+		exec repositories.Executor,
+		table models.Table,
+		internalObjectId uuid.UUID,
+		metadataFields ...string,
+	) (models.DataModelObject, error)
+}
+
+type registerObjectWorkerCSUsecase interface {
+	GetDataModelTableAndMapping(
+		ctx context.Context,
+		exec repositories.Executor,
+		config models.ContinuousScreeningConfig,
+		objectType string,
+	) (models.Table, models.ContinuousScreeningDataModelMapping, error)
+	DoScreening(
+		ctx context.Context,
+		exec repositories.Executor,
+		ingestedObject models.DataModelObject,
+		mapping models.ContinuousScreeningDataModelMapping,
+		config models.ContinuousScreeningConfig,
+		objectType string,
+		objectId string,
+	) (models.ScreeningWithMatches, error)
+	HandleCaseCreation(
+		ctx context.Context,
+		tx repositories.Transaction,
+		config models.ContinuousScreeningConfig,
+		caseName string,
+		continuousScreeningWithMatches models.ContinuousScreeningWithMatches,
+	) (models.Case, error)
+	CheckFeatureAccess(ctx context.Context, orgId uuid.UUID) error
+}
+
+// RegisterObjectWorker handles newly monitored objects coming through the ingestion path.
+// It inserts the object into the monitoring table, creates an audit entry, records an Add
+// delta track, and optionally performs the initial screening.
+type RegisterObjectWorker struct {
+	river.WorkerDefaults[models.ContinuousScreeningRegisterObjectArgs]
+	executorFactory    executor_factory.ExecutorFactory
+	transactionFactory executor_factory.TransactionFactory
+
+	repo               registerObjectWorkerRepository
+	taskQueueRepo      registerObjectWorkerTaskQueueRepository
+	clientDbRepo       registerObjectWorkerClientDbRepository
+	ingestedDataReader registerObjectWorkerIngestedDataReader
+	usecase            registerObjectWorkerCSUsecase
+}
+
+func NewRegisterObjectWorker(
+	executorFactory executor_factory.ExecutorFactory,
+	transactionFactory executor_factory.TransactionFactory,
+	repo registerObjectWorkerRepository,
+	taskQueueRepo registerObjectWorkerTaskQueueRepository,
+	clientDbRepo registerObjectWorkerClientDbRepository,
+	ingestedDataReader registerObjectWorkerIngestedDataReader,
+	uc registerObjectWorkerCSUsecase,
+) *RegisterObjectWorker {
+	return &RegisterObjectWorker{
+		executorFactory:    executorFactory,
+		transactionFactory: transactionFactory,
+		repo:               repo,
+		taskQueueRepo:      taskQueueRepo,
+		clientDbRepo:       clientDbRepo,
+		ingestedDataReader: ingestedDataReader,
+		usecase:            uc,
+	}
+}
+
+func (w *RegisterObjectWorker) Timeout(_ *river.Job[models.ContinuousScreeningRegisterObjectArgs]) time.Duration {
+	return time.Minute
+}
+
+// Work registers a newly ingested object under continuous screening monitoring.
+// The flow has three independent steps, each of which is safe to retry:
+//  1. Registration (client DB transaction): if the (objectId, configId) pair is not already
+//     in the monitoring table, insert it and create an audit entry. Idempotent — a second run
+//     detects the existing entry and skips to step 3.
+//  2. Delta track (marble DB): record an Add operation so the object is included in the next
+//     dataset rebuild. Skipped on retry (alreadyRegistered) and skipped when the object is
+//     already tracked by another config (no new entry needed in the index).
+//  3. Screening (marble DB transaction, only if ShouldScreen): query OpenSanctions, persist
+//     the result, enqueue match enrichment, and create a case if the result is in-review.
+//     This step is always attempted — even on retry — so a failed screening transaction does
+//     not leave the object permanently unscreened.
+func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.ContinuousScreeningRegisterObjectArgs]) error {
+	exec := w.executorFactory.NewExecutor()
+	logger := utils.LoggerFromContext(ctx)
+
+	var userId *uuid.UUID
+	if job.Args.UserId != nil {
+		parsed, err := uuid.Parse(*job.Args.UserId)
+		if err != nil {
+			logger.WarnContext(ctx, "could not parse user_id", "user_id", *job.Args.UserId)
+			return nil
+		}
+		userId = &parsed
+	}
+	var apiKeyId *uuid.UUID
+	if job.Args.ApiKeyId != nil {
+		parsed, err := uuid.Parse(*job.Args.ApiKeyId)
+		if err != nil {
+			logger.WarnContext(ctx, "could not parse api_key_id", "api_key", *job.Args.ApiKeyId)
+			return nil
+		}
+		apiKeyId = &parsed
+	}
+
+	if err := w.usecase.CheckFeatureAccess(ctx, job.Args.OrgId); err != nil {
+		logger.WarnContext(ctx, "Continuous Screening - feature access not allowed, skipping registration", "error", err)
+		return nil
+	}
+
+	newObjectInternalId, err := uuid.Parse(job.Args.NewInternalId)
+	if err != nil {
+		logger.WarnContext(ctx, "Continuous Screening - could not parse new internal id, skipping registration", "error", err)
+		return nil
+	}
+
+	config, err := w.repo.GetContinuousScreeningConfigByStableId(ctx, exec, job.Args.ConfigStableId)
+	if err != nil {
+		return err
+	}
+
+	table, mapping, err := w.usecase.GetDataModelTableAndMapping(ctx, exec, config, job.Args.ObjectType)
+	if err != nil {
+		return err
+	}
+
+	clientDbExec, err := w.executorFactory.NewClientDbExecutor(ctx, job.Args.OrgId)
+	if err != nil {
+		return err
+	}
+
+	// Check if the ingested object exists
+	newObjectData, err := w.ingestedDataReader.QueryIngestedObjectByInternalId(
+		ctx, clientDbExec, table, newObjectInternalId, "id", "valid_from",
+	)
+	if err != nil {
+		if errors.Is(err, models.NotFoundError) {
+			logger.WarnContext(ctx, "Continuous Screening - ingested object not found", "new_internal_id", newObjectInternalId)
+		}
+		return err
+	}
+
+	// Check if already registered, insert if not, create audit, and determine whether an Add
+	// delta track is needed (skip if object is already monitored under another config).
+	var (
+		alreadyRegistered             bool
+		objectMonitoredInOtherConfigs bool
+	)
+	err = w.transactionFactory.TransactionInOrgSchema(ctx, job.Args.OrgId, func(tx repositories.Transaction) error {
+		monitoredObjects, err := w.clientDbRepo.ListMonitoredObjectsByObjectIds(
+			ctx, tx, table.Name, []string{job.Args.ObjectId},
+		)
+		if err != nil {
+			return err
+		}
+
+		// Any existing entry means this object is tracked by at least one other config.
+		objectMonitoredInOtherConfigs = len(monitoredObjects) > 0
+
+		// If the object is already monitored with the same configuration, don't insert it again.
+		for _, mo := range monitoredObjects {
+			if mo.ConfigStableId == job.Args.ConfigStableId {
+				alreadyRegistered = true
+				return nil
+			}
+		}
+
+		if err := w.clientDbRepo.InsertContinuousScreeningObject(
+			ctx, tx, table.Name, job.Args.ObjectId, job.Args.ConfigStableId, false,
+		); err != nil {
+			return err
+		}
+
+		// TODO: Add a async job with a delay to check if the insert continuous object is correctly inserted and if the DeltraTrack is created on the object
+		return w.clientDbRepo.InsertContinuousScreeningAudit(ctx, tx, models.CreateContinuousScreeningAudit{
+			ObjectType:     table.Name,
+			ObjectId:       job.Args.ObjectId,
+			ConfigStableId: job.Args.ConfigStableId,
+			Action:         models.ContinuousScreeningAuditActionAdd,
+			UserId:         userId,
+			ApiKeyId:       apiKeyId,
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	// Create the delta track independently of screening — only on first registration.
+	// On retry (alreadyRegistered=true), this is skipped since it was committed on the first attempt.
+	if !alreadyRegistered && !objectMonitoredInOtherConfigs {
+		if err := w.repo.CreateContinuousScreeningDeltaTrack(ctx, exec, models.CreateContinuousScreeningDeltaTrack{
+			OrgId:            config.OrgId,
+			ObjectType:       job.Args.ObjectType,
+			ObjectId:         job.Args.ObjectId,
+			ObjectInternalId: &newObjectInternalId,
+			EntityId:         pure_utils.MarbleEntityIdBuilder(job.Args.ObjectType, job.Args.ObjectId),
+			Operation:        models.DeltaTrackOperationAdd,
+		}); err != nil {
+			return err
+		}
+	}
+
+	if !job.Args.ShouldScreen {
+		return nil
+	}
+
+	screeningWithMatches, err := w.usecase.DoScreening(
+		ctx, exec, newObjectData, mapping, config, job.Args.ObjectType, job.Args.ObjectId,
+	)
+	if err != nil {
+		return err
+	}
+
+	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		continuousScreeningWithMatches, err := w.repo.InsertContinuousScreening(ctx, tx, models.CreateContinuousScreening{
+			Screening:        screeningWithMatches,
+			Config:           config,
+			ObjectType:       &job.Args.ObjectType,
+			ObjectId:         &job.Args.ObjectId,
+			ObjectInternalId: &newObjectInternalId,
+			TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
+		})
+		if err != nil {
+			return err
+		}
+
+		if err := w.taskQueueRepo.EnqueueContinuousScreeningMatchEnrichmentTask(
+			ctx, tx, config.OrgId, continuousScreeningWithMatches.Id,
+		); err != nil {
+			return err
+		}
+
+		if screeningWithMatches.Status == models.ScreeningStatusInReview {
+			caseName, err := buildCaseName(newObjectData, mapping)
+			if err != nil {
+				logger.WarnContext(ctx, "Continuous Screening - error building case name, falling back to object_id", "error", err)
+				caseName = job.Args.ObjectId
+			}
+			if _, err = w.usecase.HandleCaseCreation(ctx, tx, config, caseName, continuousScreeningWithMatches); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+}

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -158,8 +158,7 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 	if job.Args.UserId != nil {
 		parsed, err := uuid.Parse(*job.Args.UserId)
 		if err != nil {
-			logger.WarnContext(ctx, "could not parse user_id", "user_id", *job.Args.UserId)
-			return nil
+			return river.JobCancel(errors.New("could not parse user_id"))
 		}
 		userId = &parsed
 	}
@@ -167,8 +166,7 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 	if job.Args.ApiKeyId != nil {
 		parsed, err := uuid.Parse(*job.Args.ApiKeyId)
 		if err != nil {
-			logger.WarnContext(ctx, "could not parse api_key_id", "api_key", *job.Args.ApiKeyId)
-			return nil
+			return river.JobCancel(errors.New("could not parse api_key_id"))
 		}
 		apiKeyId = &parsed
 	}
@@ -180,8 +178,7 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 
 	newObjectInternalId, err := uuid.Parse(job.Args.NewInternalId)
 	if err != nil {
-		logger.WarnContext(ctx, "Continuous Screening - could not parse new internal id, skipping registration", "error", err)
-		return nil
+		return river.JobCancel(errors.New("could not parse new internal id"))
 	}
 
 	config, err := w.repo.GetContinuousScreeningConfigByStableId(ctx, exec, job.Args.ConfigStableId)

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -2,6 +2,7 @@ package continuous_screening
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -183,6 +184,12 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 	config, err := w.repo.GetContinuousScreeningConfigByStableId(ctx, exec, job.Args.ConfigStableId)
 	if err != nil {
 		return err
+	}
+
+	if !slices.Contains(config.ObjectTypes, job.Args.ObjectType) {
+		return river.JobCancel(errors.Newf(
+			"continuous screening config %s is not configured for object type %s",
+			job.Args.ConfigStableId, job.Args.ObjectType))
 	}
 
 	table, mapping, err := w.usecase.GetDataModelTableAndMapping(ctx, exec, config, job.Args.ObjectType)

--- a/usecases/continuous_screening/worker_verify_delta_track_existence.go
+++ b/usecases/continuous_screening/worker_verify_delta_track_existence.go
@@ -1,0 +1,124 @@
+package continuous_screening
+
+import (
+	"context"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+)
+
+type verifyDeltaTrackExistenceWorkerRepository interface {
+	GetLatestContinuousScreeningDeltaTrack(
+		ctx context.Context,
+		exec repositories.Executor,
+		orgId uuid.UUID,
+		objectType, objectId string,
+	) (*models.ContinuousScreeningDeltaTrack, error)
+	CreateContinuousScreeningDeltaTrack(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.CreateContinuousScreeningDeltaTrack,
+	) error
+}
+
+type verifyDeltaTrackExistenceWorkerClientDbRepository interface {
+	GetMonitoredObject(
+		ctx context.Context,
+		exec repositories.Executor,
+		id uuid.UUID,
+	) (models.ContinuousScreeningMonitoredObject, error)
+}
+
+// VerifyDeltaTrackExistenceWorker is the safety net for RegisterObjectWorker. It runs ~5 min
+// after a registration and re-creates the Add delta track if the original cross-DB sequence
+// (client-DB monitored_object insert + marble-DB delta track insert) committed the first half
+// but failed the second half. The marble-DB read of the latest delta track and the recovery
+// insert run in a single transaction so a concurrent writer can't slip in between.
+type VerifyDeltaTrackExistenceWorker struct {
+	river.WorkerDefaults[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs]
+	executorFactory    executor_factory.ExecutorFactory
+	transactionFactory executor_factory.TransactionFactory
+
+	repo         verifyDeltaTrackExistenceWorkerRepository
+	clientDbRepo verifyDeltaTrackExistenceWorkerClientDbRepository
+}
+
+func NewVerifyDeltaTrackExistenceWorker(
+	executorFactory executor_factory.ExecutorFactory,
+	transactionFactory executor_factory.TransactionFactory,
+	repo verifyDeltaTrackExistenceWorkerRepository,
+	clientDbRepo verifyDeltaTrackExistenceWorkerClientDbRepository,
+) *VerifyDeltaTrackExistenceWorker {
+	return &VerifyDeltaTrackExistenceWorker{
+		executorFactory:    executorFactory,
+		transactionFactory: transactionFactory,
+		repo:               repo,
+		clientDbRepo:       clientDbRepo,
+	}
+}
+
+func (w *VerifyDeltaTrackExistenceWorker) Timeout(_ *river.Job[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs]) time.Duration {
+	return time.Minute
+}
+
+func (w *VerifyDeltaTrackExistenceWorker) Work(
+	ctx context.Context,
+	job *river.Job[models.ContinuousScreeningVerifyDeltaTrackExistenceArgs],
+) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	clientDbExec, err := w.executorFactory.NewClientDbExecutor(ctx, job.Args.OrgId)
+	if err != nil {
+		return err
+	}
+
+	monitoredObject, err := w.clientDbRepo.GetMonitoredObject(ctx, clientDbExec, job.Args.MonitoredObjectId)
+	if errors.Is(err, models.NotFoundError) {
+		// The monitored_object row referenced by args is absent. Either the client-DB tx that
+		// scheduled us rolled back after the enqueue committed, or the object was un-monitored
+		// after the original registration. Nothing to repair.
+		logger.DebugContext(ctx, "Continuous Screening - verify: monitored object not found, nothing to do",
+			"monitored_object_id", job.Args.MonitoredObjectId)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		latest, err := w.repo.GetLatestContinuousScreeningDeltaTrack(
+			ctx, tx, job.Args.OrgId, job.Args.ObjectType, job.Args.ObjectId,
+		)
+		if err != nil {
+			return err
+		}
+
+		// A delta track at least as recent as our specific registration row means either the
+		// original Add committed, or a subsequent Update/Delete has advanced state for this
+		// entity. In both cases the indexer is already informed — don't override.
+		if latest != nil && !latest.CreatedAt.Before(monitoredObject.CreatedAt) {
+			return nil
+		}
+
+		logger.WarnContext(ctx, "Continuous Screening - verify: delta track missing, recreating",
+			"org_id", job.Args.OrgId,
+			"object_type", job.Args.ObjectType,
+			"object_id", job.Args.ObjectId,
+			"operation", job.Args.Operation.String(),
+		)
+		return w.repo.CreateContinuousScreeningDeltaTrack(ctx, tx, models.CreateContinuousScreeningDeltaTrack{
+			OrgId:            job.Args.OrgId,
+			ObjectType:       job.Args.ObjectType,
+			ObjectId:         job.Args.ObjectId,
+			ObjectInternalId: &job.Args.ObjectInternalId,
+			EntityId:         job.Args.EntityId,
+			Operation:        job.Args.Operation,
+		})
+	})
+}

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -60,14 +60,6 @@ type continuousScreeningClientDbRepository interface {
 		objectType string,
 		objectIds []string,
 	) ([]models.ContinuousScreeningMonitoredObject, error)
-	InsertContinuousScreeningObject(
-		ctx context.Context,
-		exec repositories.Executor,
-		objectType string,
-		objectId string,
-		configStableId uuid.UUID,
-		ignoreConflicts bool,
-	) error
 	IsContinuousScreeningSetup(ctx context.Context, exec repositories.Executor) (bool, error)
 }
 
@@ -79,6 +71,14 @@ type taskEnqueuer interface {
 		objectType string,
 		enqueueObjectUpdateTasks []models.ContinuousScreeningEnqueueObjectUpdateTask,
 		triggerType models.ContinuousScreeningTriggerType,
+	) error
+	EnqueueContinuousScreeningRegisterObjectTaskMany(
+		ctx context.Context,
+		tx repositories.Transaction,
+		orgId uuid.UUID,
+		objectType string,
+		tasks []models.ContinuousScreeningRegisterObjectTask,
+		shouldScreen bool,
 	) error
 	EnqueueCsvIngestionTask(
 		ctx context.Context,
@@ -379,7 +379,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 
 	for name, field := range table.Fields {
 		if !field.Nullable {
-			if !containsString(headers, name) {
+			if !slices.Contains(headers, name) {
 				if len(headers) == 1 && strings.Contains(headers[0], ";") {
 					return models.UploadLog{}, fmt.Errorf("missing required field %s in CSV (%w), you might be using semicolons (;) instead of commas (,)", name, models.BadParameterError)
 				}
@@ -630,7 +630,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 	// first, check presence of all required fields in the csv
 	for name, field := range table.Fields {
 		if !field.Nullable {
-			if !containsString(firstRow, name) {
+			if !slices.Contains(firstRow, name) {
 				return ingestionResult{
 					err: fmt.Errorf("missing required field %s in CSV", name),
 				}
@@ -723,11 +723,14 @@ func (usecase *IngestionUseCase) enqueueObjectsNeedScreeningTaskIfNeeded(
 		return err
 	}
 
+	// Get all ingested object IDs to check which ones need to be monitored or re-screened.
 	objectIds := make([]string, 0, len(ingestionResults))
 	for objectId := range ingestionResults {
 		objectIds = append(objectIds, objectId)
 	}
 
+	// Fetch objects already under monitoring (across all configs).
+	// If CS tables don't exist yet and we're not asked to monitor, nothing to do.
 	continuousScreeningSetup, err := usecase.continuousScreeningClientRepository.IsContinuousScreeningSetup(ctx, clientDbExec)
 	if err != nil {
 		return err
@@ -746,14 +749,14 @@ func (usecase *IngestionUseCase) enqueueObjectsNeedScreeningTaskIfNeeded(
 		return err
 	}
 
-	if len(monitoredObjects) == 0 {
-		// No monitored objects found, no need to enqueue the task
+	// If no ingested object are currently under monitoring and no new object needs to be monitored, we can exit early
+	if len(monitoredObjects) == 0 && !ingestionOptions.ShouldMonitor {
 		return nil
 	}
 
-	enqueueAddedObjectUpdateTasks := make([]models.ContinuousScreeningEnqueueObjectUpdateTask, 0, len(monitoredObjects))
+	// Update path: already-monitored objects that have a new version need re-screening.
+	// PreviousInternalId indicates the ingested object has been updated
 	enqueueUpdatedObjectUpdateTasks := make([]models.ContinuousScreeningEnqueueObjectUpdateTask, 0, len(monitoredObjects))
-
 	for _, monitoredObject := range monitoredObjects {
 		if ingestionResults[monitoredObject.ObjectId].PreviousInternalId != "" {
 			enqueueUpdatedObjectUpdateTasks = append(enqueueUpdatedObjectUpdateTasks, models.ContinuousScreeningEnqueueObjectUpdateTask{
@@ -762,46 +765,48 @@ func (usecase *IngestionUseCase) enqueueObjectsNeedScreeningTaskIfNeeded(
 				NewInternalId:      ingestionResults[monitoredObject.ObjectId].NewInternalId,
 			})
 		}
+	}
 
-		if ingestionResults[monitoredObject.ObjectId].PreviousInternalId == "" && ingestionOptions.ShouldScreen {
-			enqueueAddedObjectUpdateTasks = append(enqueueAddedObjectUpdateTasks, models.ContinuousScreeningEnqueueObjectUpdateTask{
-				MonitoringId:       monitoredObject.Id,
-				PreviousInternalId: ingestionResults[monitoredObject.ObjectId].PreviousInternalId,
-				NewInternalId:      ingestionResults[monitoredObject.ObjectId].NewInternalId,
-			})
+	// Register path: (objectId, configId) pairs not yet in the monitoring table.
+	var enqueueRegisterTasks []models.ContinuousScreeningRegisterObjectTask
+	if ingestionOptions.ShouldMonitor {
+		type monitoredKey struct {
+			objectId       string
+			configStableId uuid.UUID
+		}
+		monitoredSet := make(map[monitoredKey]struct{}, len(monitoredObjects))
+		for _, mo := range monitoredObjects {
+			monitoredSet[monitoredKey{mo.ObjectId, mo.ConfigStableId}] = struct{}{}
+		}
+
+		for objectId, result := range ingestionResults {
+			for _, configId := range ingestionOptions.ContinuousScreeningIds {
+				if _, alreadyMonitored := monitoredSet[monitoredKey{objectId, configId}]; !alreadyMonitored {
+					enqueueRegisterTasks = append(enqueueRegisterTasks, models.ContinuousScreeningRegisterObjectTask{
+						ObjectId:       objectId,
+						ConfigStableId: configId,
+						NewInternalId:  result.NewInternalId,
+						UserId:         usecase.enforceSecurity.UserId(),
+						ApiKeyId:       usecase.enforceSecurity.ApiKeyId(),
+					})
+				}
+			}
 		}
 	}
 
 	return usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
 		errUpdated := usecase.taskEnqueuer.EnqueueContinuousScreeningDoScreeningTaskMany(
-			ctx,
-			tx,
-			organizationId,
-			table.Name,
+			ctx, tx, organizationId, table.Name,
 			enqueueUpdatedObjectUpdateTasks,
 			models.ContinuousScreeningTriggerTypeObjectUpdated,
 		)
-
-		errAdded := usecase.taskEnqueuer.EnqueueContinuousScreeningDoScreeningTaskMany(
-			ctx,
-			tx,
-			organizationId,
-			table.Name,
-			enqueueAddedObjectUpdateTasks,
-			models.ContinuousScreeningTriggerTypeObjectAdded,
+		errRegister := usecase.taskEnqueuer.EnqueueContinuousScreeningRegisterObjectTaskMany(
+			ctx, tx, organizationId, table.Name,
+			enqueueRegisterTasks,
+			ingestionOptions.ShouldScreen,
 		)
-
-		return errors.Join(errUpdated, errAdded)
+		return errors.Join(errUpdated, errRegister)
 	})
-}
-
-func containsString(arr []string, s string) bool {
-	for _, a := range arr {
-		if a == s {
-			return true
-		}
-	}
-	return false
 }
 
 func parseStringValuesToMap(headers []string, values []string, table models.Table,
@@ -934,28 +939,7 @@ func (usecase *IngestionUseCase) insertEnumValuesAndIngest(
 	var err error
 	err = usecase.transactionFactory.TransactionInOrgSchema(ctx, organizationId, func(tx repositories.Transaction) error {
 		ingestionResults, err = usecase.ingestionRepository.IngestObjects(ctx, tx, payloads, table)
-		if err != nil {
-			return err
-		}
-
-		if ingestionOptions.ShouldMonitor {
-			for _, object := range payloads {
-				for _, configId := range ingestionOptions.ContinuousScreeningIds {
-					if err := usecase.continuousScreeningClientRepository.InsertContinuousScreeningObject(
-						ctx,
-						tx,
-						table.Name,
-						object.Data["object_id"].(string),
-						configId,
-						true,
-					); err != nil {
-						return err
-					}
-				}
-			}
-		}
-
-		return nil
+		return err
 	})
 	if err != nil {
 		return nil, err

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -165,9 +165,8 @@ func (usecase *IngestionUseCase) IngestObject(
 			return 0, err
 		}
 
-		if len(continuousScreeningConfigs) != len(ingestionOptions.ContinuousScreeningIds) {
-			return 0, errors.WithDetail(models.BadParameterError,
-				"not all provided continuous screening IDs exist")
+		if err := validateContinuousScreeningConfigs(continuousScreeningConfigs, ingestionOptions.ContinuousScreeningIds, table.Name); err != nil {
+			return 0, err
 		}
 	}
 
@@ -259,9 +258,8 @@ func (usecase *IngestionUseCase) IngestObjects(
 			return 0, err
 		}
 
-		if len(continuousScreeningConfigs) != len(ingestionOptions.ContinuousScreeningIds) {
-			return 0, errors.WithDetail(models.BadParameterError,
-				"not all provided continuous screening IDs exist")
+		if err := validateContinuousScreeningConfigs(continuousScreeningConfigs, ingestionOptions.ContinuousScreeningIds, table.Name); err != nil {
+			return 0, err
 		}
 	}
 
@@ -649,11 +647,8 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 			}
 		}
 
-		if len(continuousScreeningConfigs) != len(ingestionOptions.ContinuousScreeningIds) {
-			return ingestionResult{
-				err: errors.WithDetail(models.BadParameterError,
-					"not all provided continuous screening IDs exist"),
-			}
+		if err := validateContinuousScreeningConfigs(continuousScreeningConfigs, ingestionOptions.ContinuousScreeningIds, table.Name); err != nil {
+			return ingestionResult{err: err}
 		}
 	}
 
@@ -988,6 +983,20 @@ func (usecase *IngestionUseCase) insertEnumValuesAndIngest(
 	}()
 
 	return ingestionResults, nil
+}
+
+func validateContinuousScreeningConfigs(configs []models.ContinuousScreeningConfig, configRequestedIds []uuid.UUID, objectType string) error {
+	if len(configs) != len(configRequestedIds) {
+		return errors.WithDetail(models.BadParameterError, "not all provided continuous screening IDs exist")
+	}
+	for _, cfg := range configs {
+		if !slices.Contains(cfg.ObjectTypes, objectType) {
+			return errors.WithDetailf(models.BadParameterError,
+				"continuous screening config %s is not configured for object type %s",
+				cfg.StableId, objectType)
+		}
+	}
+	return nil
 }
 
 func buildEnumValuesContainersFromTable(table models.Table) models.EnumValues {

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -924,6 +924,15 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningRegisterObjectWorker() 
 	)
 }
 
+func (usecases *UsecasesWithCreds) NewContinuousScreeningVerifyDeltaTrackExistenceWorker() *continuous_screening.VerifyDeltaTrackExistenceWorker {
+	return continuous_screening.NewVerifyDeltaTrackExistenceWorker(
+		usecases.NewExecutorFactory(),
+		usecases.NewTransactionFactory(),
+		usecases.Repositories.MarbleDbRepository,
+		&usecases.Repositories.ClientDbRepository,
+	)
+}
+
 func (usecases *UsecasesWithCreds) NewContinuousScreeningApplyDeltaFileWorker() *continuous_screening.ApplyDeltaFileWorker {
 	return continuous_screening.NewApplyDeltaFileWorker(
 		usecases.NewExecutorFactory(),

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -924,8 +924,8 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningRegisterObjectWorker() 
 	)
 }
 
-func (usecases *UsecasesWithCreds) NewContinuousScreeningVerifyDeltaTrackExistenceWorker() *continuous_screening.VerifyDeltaTrackExistenceWorker {
-	return continuous_screening.NewVerifyDeltaTrackExistenceWorker(
+func (usecases *UsecasesWithCreds) NewContinuousScreeningEnsureDeltaTrackWorker() *continuous_screening.EnsureDeltaTrackWorker {
+	return continuous_screening.NewEnsureDeltaTrackWorker(
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
 		usecases.Repositories.MarbleDbRepository,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -912,6 +912,18 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningDoScreeningWorker() *co
 	)
 }
 
+func (usecases *UsecasesWithCreds) NewContinuousScreeningRegisterObjectWorker() *continuous_screening.RegisterObjectWorker {
+	return continuous_screening.NewRegisterObjectWorker(
+		usecases.NewExecutorFactory(),
+		usecases.NewTransactionFactory(),
+		usecases.Repositories.MarbleDbRepository,
+		usecases.Repositories.TaskQueueRepository,
+		&usecases.Repositories.ClientDbRepository,
+		usecases.Repositories.IngestedDataReadRepository,
+		usecases.NewContinuousScreeningUsecase(),
+	)
+}
+
 func (usecases *UsecasesWithCreds) NewContinuousScreeningApplyDeltaFileWorker() *continuous_screening.ApplyDeltaFileWorker {
 	return continuous_screening.NewApplyDeltaFileWorker(
 		usecases.NewExecutorFactory(),


### PR DESCRIPTION
## Problem

When objects were added to monitoring via the ingestion endpoint, two bugs existed:

1. **Wrong delta track operation**: new objects always produced an \`Update\` delta track instead of an \`Add\` delta track in the screening worker (only when initial screening was requested).
2. **Missing delta track for non-screened objects**: new objects with \`ShouldScreen=false\` were inserted into the monitoring table but never got a delta track, making them invisible to future dataset rebuilds.

The root cause: the ingestion path mixed monitoring registration into the ingestion transaction, then handed off everything to \`DoScreeningWorker\`, which was designed for ongoing updates — not initial registration.

A concurrent race condition also existed: when an object with multiple continuous screening configurations was ingested, two \`RegisterObjectWorker\` jobs ran simultaneously for the same \`object_id\`. Both saw an empty monitored objects table and both created an \`Add\` delta track, resulting in duplicate entries.

## Solution

Extract object registration from the ingestion transaction into a dedicated \`RegisterObjectWorker\`. The worker owns the full registration lifecycle for objects added via ingestion:

1. **Registration** (client DB transaction): insert into \`_monitored_object\` and create an audit entry with caller identity (\`userId\`/\`apiKeyId\`). Idempotent — a duplicate job detects the existing entry and skips reinsertion.
2. **Delta track** (marble DB): record an \`Add\` operation independently of screening. Always attempted — \`ON CONFLICT DO NOTHING\` makes it idempotent, so retries and concurrent jobs for the same object are handled by the unique constraint on \`(org_id, object_type, object_id, object_internal_id)\` for \`add\`/\`update\` operations.
3. **Screening** (marble DB transaction, optional): query OpenSanctions, persist the result, enqueue match enrichment, and create a case if in-review. Always attempted even on retry, so a failed screening transaction does not leave the object permanently unscreened.

The unique constraint on the delta track table enforces the business invariant at the database level: two concurrent jobs racing to create the first \`Add\` delta track for the same object version will have one silently no-op via \`ON CONFLICT DO NOTHING\`. A migration deduplicates any existing duplicate rows before creating the index.

\`DoScreeningWorker\` becomes update-only, which makes its hardcoded \`DeltaTrackOperationUpdate\` always correct.

## Changes

- \`ingestion_usecase.go\`: remove \`InsertContinuousScreeningObject\` from the ingestion transaction; detect new \`(objectId, configId)\` pairs after ingestion and enqueue \`RegisterObjectWorker\` jobs instead.
- \`worker_register_object.go\`: new worker implementing the two-step registration flow above. Simplified from the original design — no verify enqueue needed since the delta track insert is idempotent.
- \`worker_verify_delta_track_existence.go\`: safety-net worker for the manual add endpoint path, repairs missing delta tracks from cross-DB atomicity failures (~5 min delayed).
- \`continuous_screening_repository.go\`: \`CreateContinuousScreeningDeltaTrack\` now uses \`ON CONFLICT DO NOTHING\`.
- \`migrations/20260427160000\`: deduplicates existing duplicate delta tracks, then adds the unique index on \`(org_id, object_type, object_id, object_internal_id)\` for \`add\`/\`update\` operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asynchronous background job processing for registering objects to continuous screening and verifying delta track status.
  * Enabled batch registration of multiple monitored objects for continuous screening.

* **Bug Fixes**
  * Made continuous screening registration idempotent; registering an already-monitored object no longer returns a conflict error.

* **Documentation**
  * Updated API documentation to reflect idempotent registration behavior and improved response descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->