### PR TITLE
Pascal/fix percentile aggregator scale

### DIFF
--- a/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
+++ b/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
@@ -14,7 +14,7 @@ BEGIN
     FOR row_record IN
         SELECT id, formula_ast_expression::text AS ast_text
         FROM scenario_iteration_rules
-        WHERE formula_ast_expression::text ~ '"percentile":\{\s*"constant":[0-9]+'
+        WHERE formula_ast_expression::text ~ '"percentile":\{"constant":[0-9]+'
     LOOP
         -- Initialize our working text with the original JSON string
         modified_text := row_record.ast_text;

--- a/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
+++ b/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
@@ -1,0 +1,64 @@
+-- +goose Up
+DO $$
+DECLARE
+    row_record RECORD;
+    match_record RECORD;
+    modified_text TEXT;
+    old_snippet TEXT;
+    new_snippet TEXT;
+    val NUMERIC;
+BEGIN
+    -- 1. Find rows that match the pattern
+    -- Note: replace "id" with your actual primary key column name
+    FOR row_record IN
+        SELECT id, formula_ast_expression::text AS ast_text
+        FROM scenario_iteration_rules
+        WHERE formula_ast_expression::text ~ '"percentile":\{\s*"constant":[0-9]+'
+    LOOP
+        -- Initialize our working text with the original JSON string
+        modified_text := row_record.ast_text;
+
+        -- 2. Extract the actual pieces of JSON
+        -- We use regexp_matches with the 'g' (global) flag to find EVERY occurrence in the row.
+        -- It returns an array of our capture groups:
+        -- parts[1] = '"percentile":{"constant":'
+        -- parts[2] = the number (e.g., '85' or '99.9')
+        -- parts[3] = the closing brace '}' (accounting for potential spaces)
+        FOR match_record IN
+            SELECT regexp_matches(
+                row_record.ast_text,
+                '("percentile":\{"constant":)([0-9]+(?:\.[0-9]+)?)(\})',
+                'g'
+            ) AS parts
+        LOOP
+            -- Cast the extracted string number to numeric
+            val := match_record.parts[2]::numeric;
+
+            -- 3. Check the value
+            IF val > 1 THEN
+                -- Reconstruct the exact old string snippet so we can replace it safely
+                old_snippet := match_record.parts[1] || match_record.parts[2] || match_record.parts[3];
+
+                -- Create the new downscaled snippet
+                new_snippet := match_record.parts[1] || trim_scale(val / 100)::text || match_record.parts[3];
+
+                -- 4. Replace the old snippet with the new one in our working text.
+                -- (If the exact same snippet exists twice in the row, this safely updates both)
+                modified_text := REPLACE(modified_text, old_snippet, new_snippet);
+                raise notice '%', modified_text;
+                raise notice 'before: %, after: %', old_snippet, new_snippet;
+            END IF;
+        END LOOP;
+
+        -- 5. If the text was actually changed, update the database row
+        IF modified_text <> row_record.ast_text THEN
+           UPDATE scenario_iteration_rules
+            SET formula_ast_expression = modified_text::jsonb  -- Change to ::json if that's your column type
+            WHERE id = row_record.id;
+        END IF;
+
+
+    END LOOP;
+END $$;
+
+-- +goose Down

--- a/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
+++ b/repositories/migrations/20260427113900_fix_percentile_scale_ast.sql
@@ -1,4 +1,5 @@
 -- +goose Up
+-- +goose StatementBegin
 DO $$
 DECLARE
     row_record RECORD;
@@ -61,4 +62,5 @@ BEGIN
     END LOOP;
 END $$;
 
+-- +goose StatementEnd
 -- +goose Down

--- a/usecases/ast_eval/evaluate/evaluate_aggregator.go
+++ b/usecases/ast_eval/evaluate/evaluate_aggregator.go
@@ -137,9 +137,6 @@ func (a AggregatorEvaluator) Evaluate(ctx context.Context, arguments ast.Argumen
 			logger := utils.LoggerFromContext(ctx)
 			logger.WarnContext(ctx, fmt.Sprintf("percentile value %v is less than 0, setting to 0", arg))
 			arg = 0
-		} else if arg > 1 {
-			// Production runtime: auto-normalize legacy values stored on a 0-100 scale.
-			arg /= 100
 		}
 
 		options["percentile"] = arg


### PR DESCRIPTION
Already applied on our prod & staging, so it's mostly for old customers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed percentile value scaling in scenario formula expressions. Legacy percentile values greater than 1 are now automatically corrected to the proper 0-1 range. The evaluation logic has been strengthened to enforce consistent and accurate percentile value handling, significantly improving the reliability and accuracy of all percentile-based calculations and scenario evaluations across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->