### PR TITLE
fix: import with custom list in rules

### DIFF
--- a/usecases/org_import_usecase.go
+++ b/usecases/org_import_usecase.go
@@ -1100,10 +1100,17 @@ func (uc *OrgImportUsecase) adaptAstNodeIds(ctx context.Context, ids map[string]
 		node.NamedChildren["customListId"] = ast.Node{Constant: ids[args]}
 	}
 
-	for _, child := range node.Children {
-		if err := uc.adaptAstNodeIds(ctx, ids, &child); err != nil {
+	for i := range node.Children {
+		if err := uc.adaptAstNodeIds(ctx, ids, &node.Children[i]); err != nil {
 			return err
 		}
+	}
+
+	for key, namedChild := range node.NamedChildren {
+		if err := uc.adaptAstNodeIds(ctx, ids, &namedChild); err != nil {
+			return err
+		}
+		node.NamedChildren[key] = namedChild
 	}
 
 	return nil


### PR DESCRIPTION
There are two bugs in adaptAstNodeIds that combine to cause "list not found":

Bug 1 (critical): NamedChildren are never recursed into.

The function only recurses into node.Children, but AST nodes use both Children (positional args) and NamedChildren (keyword args). A FUNC_CUSTOM_LIST_ACCESS node can appear as a named child of a parent node (e.g. inside an AND, IF, etc.). When it does, the recursion never visits it, so its customListId is never remapped — it stays as the old UUID from the export file, which doesn't exist in the new org → "list not found".

Bug 2 (subtle): the for _, child := range loop discards non-map mutations.

child is a copy of the struct. Passing &child lets the recursive call modify child, but changes to child.Children (slice header) are lost when the loop moves to the next iteration. Map mutations (child.NamedChildren[key] = ...) do propagate because maps are reference types — but that only masks Bug 1 at depth 1.



⚠️ We still have a bug when a scenario requires a preparation step (index creation). The first run fails because the index is considered not valid. However, the second run of the import succeeds because I believe the client table is already created with the index.

I attempted to add an index check with a retry (10 seconds) but it failed to find a valid index. I don't know how to fix that