### PR TITLE
feat: expose single-entity screening enrichment in internal API

### DIFF
--- a/api/handle_screening.go
+++ b/api/handle_screening.go
@@ -276,6 +276,22 @@ func handleEnrichScreeningMatch(uc usecases.Usecases) func(c *gin.Context) {
 	}
 }
 
+func handleGetScreeningEntity(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		entityId := c.Param("entityId")
+
+		screeningUsecase := usecasesWithCreds(ctx, uc).NewScreeningUsecase()
+
+		entity, err := screeningUsecase.GetEntity(ctx, entityId)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, json.RawMessage(entity))
+	}
+}
+
 const SCREENING_FREEFORM_SEARCH_LIMIT_MAX = 50
 
 func handleFreeformSearch(uc usecases.Usecases) func(c *gin.Context) {

--- a/api/routes.go
+++ b/api/routes.go
@@ -193,6 +193,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.PATCH("/screenings/matches/:id", tom, handleUpdateScreeningMatchStatus(uc))
 	router.POST("/screenings/matches/:id/enrich", tom, handleEnrichScreeningMatch(uc))
 	router.POST("/screenings/freeform-search", tom, handleFreeformSearch(uc))
+	router.GET("/screenings/entities/:entityId", tom, handleGetScreeningEntity(uc))
 
 	router.GET("/continuous-screenings/configs", tom, handleListContinuousScreeningConfigs(uc))
 	router.POST("/continuous-screenings/configs", tom,


### PR DESCRIPTION
## Summary
- Add `GET /screenings/entities/:entityId` to the internal API, mirroring the existing public-API endpoint at `pubapi/v1/screening.go:208`.
- The new handler delegates to the existing `ScreeningUsecase.GetEntity`, which calls OpenSanctions' `/entities/{id}` and returns the enriched payload.
- Lets the web frontend complete `POST /screenings/freeform-search` results (which return un-enriched match payloads) by fetching the full entity per ID.

No usecase, repository, model, or DTO changes — just a new handler and a new route under the standard `tom` auth middleware.

## Test plan
- [x] `go build ./...` and `go vet ./...` pass.
- [x] Run the API (`go run . --migrations --server`).
- [x] `POST /screenings/freeform-search` with a refine query — capture an `entity_id` from the returned payloads.
- [x] `GET /screenings/entities/<entityId>` returns a JSON object richer than the free-form payload (extra properties / datasets / referents).
- [x] Unknown `entityId` → 404.
- [x] Unauthenticated request → 401 from `tom`.
- [x] Compare response shape with the public `GET /screening/entities/:entityId` for parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added API endpoint to retrieve specific screening entity information by ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->