### PR TITLE
fix: return the user scoring entitlement in feature access endpoint

### DIFF
--- a/dto/organization_feature_access_dto.go
+++ b/dto/organization_feature_access_dto.go
@@ -19,6 +19,7 @@ type APIOrganizationFeatureAccess struct {
 	CaseAiAssist        string `json:"case_ai_assist"`
 	ContinuousScreening string `json:"continuous_screening"`
 	AiRuleBuilding      string `json:"ai_rule_building"`
+	UserScoring         string `json:"user_scoring"`
 
 	// user-scoped
 	// Currently only used to control display of the AI assist button in the UI - DO NOT use for anything else as it will be removed
@@ -40,6 +41,7 @@ func AdaptOrganizationFeatureAccessDto(f models.OrganizationFeatureAccess) APIOr
 		ContinuousScreening: f.ContinuousScreening.String(),
 		AiRuleBuilding:      f.AiRuleBuilding.String(),
 		AiAssist:            f.AiAssist.String(),
+		UserScoring:         f.UserScoring.String(),
 	}
 }
 


### PR DESCRIPTION
The backend server didn't transmit the user scoring feature access data to the frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization feature access now includes user scoring information in API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->