### PR TITLE
fix: drop aggregator label from LLM rule description input

### DIFF
--- a/models/ast/ast_node.go
+++ b/models/ast/ast_node.go
@@ -159,6 +159,13 @@ func (node *Node) formatNamedChildrenParams(depth int) []string {
 	sort.Strings(keys)
 
 	for _, key := range keys {
+		// The aggregator label is a free-text user-supplied name; including it in
+		// the LLM-bound rendering biases the description toward the user's wording
+		// rather than what the aggregator actually computes.
+		if node.Function == FUNC_AGGREGATOR && key == "label" {
+			continue
+		}
+
 		child := node.NamedChildren[key]
 		childStr := child.toHumanReadableWithDepth(depth + 1)
 

--- a/models/ast/ast_node_human_readable_test.go
+++ b/models/ast/ast_node_human_readable_test.go
@@ -249,6 +249,25 @@ func TestToHumanReadable_ListsAndFilters(t *testing.T) {
 			},
 			expected: "Aggregator(aggregator: COUNT, fieldName: object_id, filters: [Filter(fieldName: payment_type, operator: =, tableName: transaction, value: card)], tableName: transaction)",
 		},
+		{
+			// The user-supplied label must not appear in the LLM-bound rendering;
+			// it is free text that biases the generated description.
+			name: "Aggregator with label is stripped",
+			node: Node{
+				Function: FUNC_AGGREGATOR,
+				NamedChildren: map[string]Node{
+					"aggregator": NewNodeConstant("COUNT"),
+					"fieldName":  NewNodeConstant("object_id"),
+					"tableName":  NewNodeConstant("transaction"),
+					"label":      NewNodeConstant("Number of risky txns"),
+					"filters": {
+						Function: FUNC_LIST,
+						Children: []Node{filterNode},
+					},
+				},
+			},
+			expected: "Aggregator(aggregator: COUNT, fieldName: object_id, filters: [Filter(fieldName: payment_type, operator: =, tableName: transaction, value: card)], tableName: transaction)",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- The user-supplied label on an aggregator is free text shown only in the editor. It was being serialized into the AST text fed to the LLM for rule description generation, which biased the model into parroting the label instead of describing what the aggregator actually computes (real labels in the prompt examples included things like `Number txn 90D` and `I dont know`).
- Skip `label` in `formatNamedChildrenParams` when the parent function is `FUNC_AGGREGATOR`. Scoped to aggregator only so a future function with a legitimate `label` named child is unaffected.
- Drop the `labeled aggregates` mention from the prompt guidance and strip `label: ...` from the four `Aggregator(...)` strings in Examples 3 and 4 so the example inputs match what the renderer now produces.

The aggregator's `label` stays in the AST and is still stored/displayed in the UI — only the LLM-bound rendering changes.

⚠️ The Human representation method is exclusively used to describe LLM rules. This change is the simplest to implement. If we want more flexibility, we can pass an `output option` structure to customize the output, like how we want filter in functions and keys. However, don't think it is worth it now

## Test plan

- [x] Added a test case in `models/ast/ast_node_human_readable_test.go` asserting that an aggregator with a `label` named child renders identically to one without
- [x] `go test ./models/ast/...`
- [x] `go test ./...`
- [x] Manual: hit the AI rule description endpoint on a rule with a deliberately misleading aggregate label and confirm the LLM no longer parrots it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Aggregator nodes no longer include user-supplied label fields in human-readable output, removing unexpected free-text from rendered displays.

* **Tests**
  * Added test coverage that verifies labels are omitted from aggregator node rendering and prevents regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->