### PR TITLE
Optionally use container IP instead of localhost for test containers.

### DIFF
--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -93,6 +93,10 @@ func TestMain(m *testing.M) {
 
 	hostAndPort := resource.GetHostPort("5432/tcp") // docker container will bind to another port than 5432 if already taken
 
+	if os.Getenv("_INTERNAL_TEST_USE_CONTAINER_IP") == "1" {
+		hostAndPort = fmt.Sprintf("%s:5432", resource.Container.NetworkSettings.IPAddress)
+	}
+
 	connectionString := fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=disable", testUser, testPassword, hostAndPort, testDbName)
 	testDbPool, err := pgxpool.New(context.Background(), connectionString)
 	if err != nil {

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -88,6 +88,14 @@ func setupPostgres(t *testing.T, ctx context.Context) *postgres.PostgresContaine
 	}
 
 	dsn := pg.MustConnectionString(ctx)
+	if os.Getenv("_INTERNAL_TEST_USE_CONTAINER_IP") == "1" {
+		ip, err := pg.ContainerIP(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		dsn = pg.MustConnectionString(ctx, fmt.Sprintf("host=%s", ip), "port=5432")
+	}
+
 	pgConfig := infra.PgConfig{ConnectionString: dsn}
 	migrator := repositories.NewMigrater(pgConfig)
 


### PR DESCRIPTION
For those of us (me) who do not expose their containers' exposed port to their host, the current setup for tests makes it impossible to run them locally without changes.

This introduces an optional change of configuration where, when `_INTERNAL_TEST_USE_CONTAINER_IP` is set, uses the container's IP address instead of `localhost`.

This should not impact regular runs of the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced PostgreSQL test connectivity to support Docker container-based testing environments through environment variable configuration, enabling flexible test database connection routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->