### PR TITLE
add an additional (in theory redudant) filter on the case events expo…

### DIFF
--- a/repositories/analytics_export_repository.go
+++ b/repositories/analytics_export_repository.go
@@ -419,6 +419,7 @@ func AnalyticsCopyCaseEvents(ctx context.Context, exec AnalyticsExecutor, req An
 			Where("ce.org_id = ?", req.OrgId).
 			Where("ce.event_type = 'outcome_updated'").
 			Where("c.status = 'closed'").
+			Where("d.org_id = ?", req.OrgId).
 			Where("d.trigger_object_type = ?", req.TriggerObject).
 			Where("ce.created_at < ?", req.EndTime).
 			OrderBy("ce.created_at, ce.id").


### PR DESCRIPTION
…rt query to properly nudge the pg optimizer

Without it: on tables that don't have any decisions, the query planner proposes a query that full index scans the decisions_case_id_idx_2 index, doing heap lookups for every decision, which is super slow with cold buffers.
With it: the main query uses the idx_analytics_export index which includes the trigger object, and only joins decisions_case_id_idx_2 later as a index only scan.

I feel like this should work, but please note it's hard to properly reproduce because it's super buffer-dependant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where case events could be exported outside their intended organization scope. Exported case events are now properly constrained to the requested organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->