### PR TITLE
feat: add free form table to store search history

### DIFF
--- a/models/freeform_search.go
+++ b/models/freeform_search.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type FreeformSearch struct {
+	Id          uuid.UUID
+	OrgId       uuid.UUID
+	UserId      *uuid.UUID
+	ApiKeyId    *uuid.UUID
+	Provider    string
+	CreatedAt   time.Time
+	SearchInput json.RawMessage
+	Result      json.RawMessage
+}

--- a/models/screening_providers.go
+++ b/models/screening_providers.go
@@ -1,0 +1,4 @@
+package models
+
+// TODO: TBD confirm provider name
+const ScreeningProviderOpenSanctions = "opensanctions"

--- a/repositories/dbmodels/db_freeform_search.go
+++ b/repositories/dbmodels/db_freeform_search.go
@@ -1,0 +1,38 @@
+package dbmodels
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/google/uuid"
+)
+
+const TABLE_FREEFORM_SEARCHES = "screening_freeform_searches"
+
+var SelectFreeformSearchColumn = utils.ColumnList[DBFreeformSearch]()
+
+type DBFreeformSearch struct {
+	Id          uuid.UUID       `db:"id"`
+	OrgId       uuid.UUID       `db:"org_id"`
+	UserId      *uuid.UUID      `db:"user_id"`
+	ApiKeyId    *uuid.UUID      `db:"api_key_id"`
+	Provider    string          `db:"provider"`
+	CreatedAt   time.Time       `db:"created_at"`
+	SearchInput json.RawMessage `db:"search_input"`
+	Result      json.RawMessage `db:"result"`
+}
+
+func AdaptFreeformSearch(db DBFreeformSearch) (models.FreeformSearch, error) {
+	return models.FreeformSearch{
+		Id:          db.Id,
+		OrgId:       db.OrgId,
+		UserId:      db.UserId,
+		ApiKeyId:    db.ApiKeyId,
+		Provider:    db.Provider,
+		CreatedAt:   db.CreatedAt,
+		SearchInput: db.SearchInput,
+		Result:      db.Result,
+	}, nil
+}

--- a/repositories/freeform_search_repository.go
+++ b/repositories/freeform_search_repository.go
@@ -1,0 +1,39 @@
+package repositories
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/repositories/dbmodels"
+)
+
+func (*MarbleDbRepository) InsertFreeformSearch(
+	ctx context.Context,
+	exec Executor,
+	h models.FreeformSearch,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	sql := NewQueryBuilder().
+		Insert(dbmodels.TABLE_FREEFORM_SEARCHES).
+		Columns(
+			"id",
+			"org_id",
+			"user_id",
+			"api_key_id",
+			"provider",
+			"search_input",
+		).
+		Values(
+			h.Id,
+			h.OrgId,
+			h.UserId,
+			h.ApiKeyId,
+			h.Provider,
+			h.SearchInput,
+		)
+
+	return ExecBuilder(ctx, exec, sql)
+}

--- a/repositories/migrations/20260504163901_add_freeform_search.sql
+++ b/repositories/migrations/20260504163901_add_freeform_search.sql
@@ -1,0 +1,24 @@
+-- +goose Up
+-- +goose StatementBegin
+create table screening_freeform_searches (
+    id uuid primary key,
+    org_id uuid not null,
+    user_id uuid null,
+    api_key_id uuid null,
+    provider text not null,
+    created_at timestamp with time zone not null default now(),
+    search_input jsonb not null,
+    result jsonb,
+
+    constraint fk_screening_freeform_searches_org foreign key (org_id) references organizations (id) on delete cascade,
+    constraint fk_screening_freeform_searches_user foreign key (user_id) references users (id) on delete set null,
+    constraint fk_screening_freeform_searches_api_key foreign key (api_key_id) references api_keys (id) on delete set null
+);
+
+create index idx_screening_freeform_searches_org_created_at on screening_freeform_searches (org_id, created_at DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+drop table screening_freeform_searches;
+-- +goose StatementEnd

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -95,6 +95,9 @@ type ScreeningRepository interface {
 		orgId uuid.UUID, counterpartyId, entityId *string) ([]models.ScreeningWhitelist, error)
 	UpdateScreeningMatchPayload(ctx context.Context, exec repositories.Executor,
 		match models.ScreeningMatch, newPayload []byte) (models.ScreeningMatch, error)
+
+	InsertFreeformSearch(ctx context.Context, exec repositories.Executor,
+		h models.FreeformSearch) error
 }
 
 type ScreeningUsecaseExternalRepository interface {
@@ -373,6 +376,8 @@ func (uc ScreeningUsecase) FreeformSearch(ctx context.Context,
 	scc models.ScreeningConfig,
 	refine models.ScreeningRefineRequest,
 ) (models.ScreeningWithMatches, error) {
+	exec := uc.executorFactory.NewExecutor()
+
 	features, err := uc.featureAccessReader.GetOrganizationFeatureAccess(ctx, orgId, nil)
 	if err != nil {
 		return models.ScreeningWithMatches{}, err
@@ -404,8 +409,56 @@ func (uc ScreeningUsecase) FreeformSearch(ctx context.Context,
 	if err != nil {
 		return models.ScreeningWithMatches{}, err
 	}
+	err = uc.persistFreeformSearch(ctx, exec, orgId, refine)
+	if err != nil {
+		return models.ScreeningWithMatches{}, err
+	}
 
 	return screening, nil
+}
+
+func (uc ScreeningUsecase) persistFreeformSearch(
+	ctx context.Context,
+	exec repositories.Executor,
+	orgId uuid.UUID,
+	refine models.ScreeningRefineRequest,
+) error {
+	searchInput, err := json.Marshal(refine)
+	if err != nil {
+		return err
+	}
+
+	var (
+		userId   *uuid.UUID
+		apiKeyId *uuid.UUID
+	)
+	if creds, ok := utils.CredentialsFromCtx(ctx); ok {
+		if id := string(creds.ActorIdentity.UserId); id != "" {
+			if parsed, err := uuid.Parse(id); err == nil {
+				userId = &parsed
+			}
+		}
+		if creds.ActorIdentity.ApiKeyId != "" {
+			if parsed, err := uuid.Parse(creds.ActorIdentity.ApiKeyId); err == nil {
+				apiKeyId = &parsed
+			}
+		}
+	}
+
+	row := models.FreeformSearch{
+		Id:          pure_utils.NewId(),
+		OrgId:       orgId,
+		UserId:      userId,
+		ApiKeyId:    apiKeyId,
+		Provider:    models.ScreeningProviderOpenSanctions,
+		SearchInput: searchInput,
+	}
+
+	if err := uc.repository.InsertFreeformSearch(ctx, exec, row); err != nil {
+		return errors.Wrap(err, "could not persist freeform search")
+	}
+
+	return nil
 }
 
 func (uc ScreeningUsecase) UpdateMatchStatus(


### PR DESCRIPTION
Create a free form table to store each free form search made by a user, whether from the frontend or API. This table will be used to display the search history and also for the metric collector to count the number of searches made by providers.
Persist every freeform search usage

Currently, only Opensanctions is available for free form searches. By default, we store the results with this provider. 
In the future, we can change the provider and store the appropriate one in the table. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added freeform search functionality for screening operations
* Added OpenSanctions provider support
* Search requests are now recorded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->