### PR TITLE
bump version of postgres, es, motiva dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: postgres
-    image: postgis/postgis:17-3.6-alpine
+    image: postgis/postgis:18-3.6-alpine
     platform: linux/x86_64
     shm_size: 1g
     restart: always
@@ -15,13 +15,13 @@ services:
     volumes:
       - postgres-db:/data/postgres
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 2s
       timeout: 1s
       retries: 5
   elasticsearch:
     container_name: es
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.4.0
     ports:
       - "9200:9200"
     environment:
@@ -40,14 +40,15 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "curl -f http://localhost:9200/_cluster/health?wait_for_status=yellow || exit 1"
+        - "curl -f http://localhost:9200/_cluster/health?wait_for_status=yellow
+          || exit 1"
       interval: 5s
       timeout: 5s
       retries: 5
       start_period: 30s
   yente:
     container_name: yente
-    image: ghcr.io/opensanctions/yente:4.5.1
+    image: ghcr.io/opensanctions/yente:5.3.0
     depends_on:
       elasticsearch:
         condition: service_healthy
@@ -78,7 +79,7 @@ services:
     ports:
       - "6379:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 2s
       timeout: 1s
       retries: 5

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 	// pulls an image, creates a container based on it and runs it
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "postgis/postgis",
-		Tag:        "17-3.6-alpine",
+		Tag:        "18-3.6-alpine",
 		Platform:   "linux/amd64",
 		Env: []string{
 			fmt.Sprintf("POSTGRES_PASSWORD=%s", testPassword),

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -66,7 +66,7 @@ func setupPostgres(t *testing.T, ctx context.Context) *postgres.PostgresContaine
 
 	pg, err := postgres.Run(
 		ctx,
-		"postgis/postgis:17-3.6-alpine",
+		"postgis/postgis:18-3.6-alpine",
 		postgres.WithDatabase("marble_test"),
 		postgres.WithUsername("postgres"),
 		postgres.WithPassword("marble"),


### PR DESCRIPTION
Note for devs: you'll need to pg_dump / pg_restore your local db and reset your volume (or start from a fresh local db).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container images to newer versions: PostgreSQL with PostGIS (18.x), Elasticsearch (9.4.0), and Yente (5.3.0)
  * Enhanced health checks with improved failure detection for database, search, and cache services
  * Updated test infrastructure to use latest container versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->