### PR TITLE
try and silence some sentry errors

### DIFF
--- a/api/present_error.go
+++ b/api/present_error.go
@@ -69,7 +69,7 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 
 	case errors.Is(err, models.LLMRateLimitedError):
 		logger.WarnContext(ctx, fmt.Sprintf("LLM provider rate limited: %v", err))
-		c.JSON(http.StatusInternalServerError, dto.APIErrorResponse{
+		c.JSON(http.StatusServiceUnavailable, dto.APIErrorResponse{
 			Message: "The AI service is temporarily unavailable due to rate limits. Please try again in a moment.",
 		})
 

--- a/api/present_error.go
+++ b/api/present_error.go
@@ -67,6 +67,12 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 	case errors.Is(err, models.MissingLicenseEntitlementError):
 		c.JSON(http.StatusForbidden, errorResponse)
 
+	case errors.Is(err, models.LLMRateLimitedError):
+		logger.WarnContext(ctx, fmt.Sprintf("LLM provider rate limited: %v", err))
+		c.JSON(http.StatusInternalServerError, dto.APIErrorResponse{
+			Message: "The AI service is temporarily unavailable due to rate limits. Please try again in a moment.",
+		})
+
 	case errors.Is(err, context.DeadlineExceeded):
 		logger.WarnContext(ctx, fmt.Sprintf("Deadline exceeded: %v", err))
 		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
@@ -75,11 +81,13 @@ func presentError(ctx context.Context, c *gin.Context, err error) bool {
 		c.JSON(http.StatusRequestTimeout, dto.APIErrorResponse{Message: timeoutMst})
 
 	default:
-		logger.ErrorContext(ctx, fmt.Sprintf("Unexpected Error: %+v", err))
-		if hub := sentrygin.GetHubFromContext(c); hub != nil {
-			utils.CaptureSentryException(ctx, hub, err)
-		} else {
-			sentry.CaptureException(err)
+		if !utils.MaybeSuppressTransient(ctx, err) {
+			logger.ErrorContext(ctx, fmt.Sprintf("Unexpected Error: %+v", err))
+			if hub := sentrygin.GetHubFromContext(c); hub != nil {
+				utils.CaptureSentryException(ctx, hub, err)
+			} else {
+				sentry.CaptureException(err)
+			}
 		}
 		c.JSON(http.StatusInternalServerError, dto.APIErrorResponse{
 			Message: "An unexpected error occurred. Please try again later, or contact support if the problem persists.",

--- a/models/errors.go
+++ b/models/errors.go
@@ -29,6 +29,12 @@ var (
 
 	// MissingLicenseEntitlement indicates that the features required a license that was not acquired
 	MissingLicenseEntitlementError = errors.New("missing license entitlement")
+
+	// LLMRateLimitedError indicates an upstream LLM provider returned a
+	// rate-limit / resource-exhausted response. Surface to the client as a
+	// server error without Sentry capture (the condition is known and
+	// outside our control).
+	LLMRateLimitedError = errors.New("llm provider rate limited")
 )
 
 // Authentication related errors

--- a/pubapi/types/response.go
+++ b/pubapi/types/response.go
@@ -246,18 +246,20 @@ func (resp baseErrorResponse) Serve(c *gin.Context, statuses ...int) {
 	}
 
 	if resp.Error.status >= http.StatusInternalServerError {
-		utils.LoggerFromContext(ctx).ErrorContext(
-			ctx,
-			fmt.Sprintf("error (%s): %s", resp.Error.Code, msg),
-			"code", resp.Error.Code,
-			"status", resp.Error.status,
-		)
+		if !utils.MaybeSuppressTransient(ctx, resp.Error.err) {
+			utils.LoggerFromContext(ctx).ErrorContext(
+				ctx,
+				fmt.Sprintf("error (%s): %s", resp.Error.Code, msg),
+				"code", resp.Error.Code,
+				"status", resp.Error.status,
+			)
 
-		switch hub := sentrygin.GetHubFromContext(c); hub {
-		case nil:
-			sentry.CaptureException(resp.Error.err)
-		default:
-			utils.CaptureSentryException(ctx, hub, resp.Error.err)
+			switch hub := sentrygin.GetHubFromContext(c); hub {
+			case nil:
+				sentry.CaptureException(resp.Error.err)
+			default:
+				utils.CaptureSentryException(ctx, hub, resp.Error.err)
+			}
 		}
 	} else {
 		utils.LoggerFromContext(ctx).DebugContext(

--- a/usecases/ai_agent/ai_case_review.go
+++ b/usecases/ai_agent/ai_case_review.go
@@ -450,13 +450,12 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		}
 
 		// Create the request with Thread for the next steps which needs the response
-		requestDataModelSummary, err := llmberjack.NewUntypedRequest().
+		requestDataModelSummary, err := DoLLMRequest(ctx, client, llmberjack.NewUntypedRequest().
 			WithProvider(providerDataModelSummary).
 			WithModel(modelDataModelSummary).
 			WithThinking(false).
 			WithInstruction(systemInstruction).
-			WithText(llmberjack.RoleUser, promptDataModelSummary).
-			Do(ctx, client)
+			WithText(llmberjack.RoleUser, promptDataModelSummary))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate data model summary")
 		}
@@ -522,15 +521,14 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 						return nil, errors.Wrap(err, "could not prepare data model object field read options request")
 					}
 
-					requestDataModelObjectFieldReadOptions, err := llmberjack.NewRequest[map[string][]string]().
+					requestDataModelObjectFieldReadOptions, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[map[string][]string]().
 						OverrideResponseSchema(schema).
 						WithProvider(providerFieldReadOptions).
 						WithModel(modelDataModelObjectFieldReadOptions).
 						WithThinking(false).
 						WithInstruction(systemInstruction).
 						WithText(llmberjack.RoleAi, *caseReviewContext.DataModelSummary).
-						WithText(llmberjack.RoleUser, promptDataModelObjectFieldReadOptions).
-						Do(ctx, client)
+						WithText(llmberjack.RoleUser, promptDataModelObjectFieldReadOptions))
 					if err != nil {
 						return nil, errors.Wrap(err, "could not generate data model object field read options")
 					}
@@ -592,13 +590,12 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		if err != nil {
 			return nil, errors.Wrap(err, "could not prepare rules definitions review request")
 		}
-		requestRulesDefinitionsReview, err := llmberjack.NewUntypedRequest().
+		requestRulesDefinitionsReview, err := DoLLMRequest(ctx, client, llmberjack.NewUntypedRequest().
 			WithProvider(providerRulesDefinitions).
 			WithModel(modelRulesDefinitions).
 			WithThinking(false).
 			WithInstruction(systemInstruction).
-			WithText(llmberjack.RoleUser, promptRulesDefinitions).
-			Do(ctx, client)
+			WithText(llmberjack.RoleUser, promptRulesDefinitions))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate rules definitions review")
 		}
@@ -623,13 +620,12 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		if err != nil {
 			return nil, errors.Wrap(err, "could not prepare rule thresholds request")
 		}
-		requestRuleThresholds, err := llmberjack.NewUntypedRequest().
+		requestRuleThresholds, err := DoLLMRequest(ctx, client, llmberjack.NewUntypedRequest().
 			WithProvider(providerRuleThresholds).
 			WithModel(modelRuleThresholds).
 			WithThinking(false).
 			WithInstruction(systemInstruction).
-			WithText(llmberjack.RoleUser, promptRuleThresholds).
-			Do(ctx, client)
+			WithText(llmberjack.RoleUser, promptRuleThresholds))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate rule thresholds")
 		}
@@ -731,13 +727,12 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		logger.DebugContext(ctx, "case review prompt", "prompt", promptCaseReview)
 
 		schema := getProofSchema(caseData.dataModel)
-		requestCaseReview, err := llmberjack.NewRequest[caseReviewOutput]().
+		requestCaseReview, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[caseReviewOutput]().
 			OverrideResponseSchema(schema).
 			WithProvider(providerCaseReview).
 			WithModel(modelCaseReview).
 			WithInstruction(systemInstruction).
-			WithText(llmberjack.RoleUser, promptCaseReview).
-			Do(ctx, client)
+			WithText(llmberjack.RoleUser, promptCaseReview))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate case review")
 		}
@@ -800,12 +795,11 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		if err != nil {
 			return nil, errors.Wrap(err, "could not prepare sanity check request")
 		}
-		requestSanityCheck, err := llmberjack.NewRequest[sanityCheckOutput]().
+		requestSanityCheck, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[sanityCheckOutput]().
 			WithProvider(providerSanityCheck).
 			WithModel(modelSanityCheck).
 			WithInstruction(systemInstruction).
-			WithText(llmberjack.RoleUser, promptSanityCheck).
-			Do(ctx, client)
+			WithText(llmberjack.RoleUser, promptSanityCheck))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not generate sanity check")
 		}
@@ -844,9 +838,8 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			logger.DebugContext(ctx, "Adding custom instruction", "instruction", instruction)
 			customFormatRequest = customFormatRequest.WithInstruction(instruction)
 		}
-		requestCustomFormat, err := customFormatRequest.
-			WithText(llmberjack.RoleUser, finalOutput).
-			Do(ctx, client)
+		requestCustomFormat, err := DoLLMRequest(ctx, client, customFormatRequest.
+			WithText(llmberjack.RoleUser, finalOutput))
 		if err != nil {
 			return nil, errors.Wrap(err, "could not execute custom format")
 		}

--- a/usecases/ai_agent/ai_enrichment.go
+++ b/usecases/ai_agent/ai_enrichment.go
@@ -177,7 +177,7 @@ func (uc *AiAgentUsecase) enrichData(
 	}
 	request = request.WithProviderOptions(options)
 
-	response, err := request.Do(ctx, adapter)
+	response, err := DoLLMRequest(ctx, adapter, request)
 	if err != nil {
 		return models.AiEnrichmentKYC{}, errors.Wrap(err, "failed to make request")
 	}

--- a/usecases/ai_agent/ai_enrichment.go
+++ b/usecases/ai_agent/ai_enrichment.go
@@ -11,7 +11,7 @@ import (
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
-	"github.com/pkg/errors"
+	"github.com/cockroachdb/errors"
 )
 
 const ENRICHMENT_DEFAULT_MODEL = "sonar-pro"

--- a/usecases/ai_agent/ai_rule_assist.go
+++ b/usecases/ai_agent/ai_rule_assist.go
@@ -99,12 +99,11 @@ func (uc *AiAgentUsecase) GenerateRule(
 		return dto.GenerateRuleResponse{}, err
 	}
 
-	resp, err := llmberjack.NewRequest[string]().
+	resp, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[string]().
 		WithProvider(provider).
 		WithModel(model).
 		WithText(llmberjack.RoleUser, ruleGenerationPrompt).
-		WithThinking(true).
-		Do(ctx, client)
+		WithThinking(true))
 	if err != nil {
 		return dto.GenerateRuleResponse{}, fmt.Errorf(
 			"failed to generate rule from LLM: %w", err)
@@ -131,12 +130,11 @@ func (uc *AiAgentUsecase) GenerateRule(
 		return dto.GenerateRuleResponse{}, err
 	}
 
-	resp, err = llmberjack.NewRequest[string]().
+	resp, err = DoLLMRequest(ctx, client, llmberjack.NewRequest[string]().
 		WithProvider(provider).
 		WithModel(model).
 		WithSchemaDescription("NodeDto", "The AST node of the rule").
-		WithText(llmberjack.RoleUser, ruleGenerationPrompt).
-		Do(ctx, client)
+		WithText(llmberjack.RoleUser, ruleGenerationPrompt))
 	if err != nil {
 		return dto.GenerateRuleResponse{}, fmt.Errorf(
 			"failed to generate rule from LLM: %w", err)
@@ -285,12 +283,11 @@ func (uc *AiAgentUsecase) AiASTDescription(
 		return models.AiRuleDescription{}, err
 	}
 
-	aiStudioRequest, err := llmberjack.NewRequest[aiRuleDescriptionOutput]().
+	aiStudioRequest, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[aiRuleDescriptionOutput]().
 		WithProvider(provider).
 		WithModel(model).
 		WithText(llmberjack.RoleUser, ruleDescription).
-		WithThinking(false).
-		Do(ctx, client)
+		WithThinking(false))
 	if err != nil {
 		return models.AiRuleDescription{}, err
 	}

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -203,12 +203,11 @@ func (uc *AiAgentUsecase) analyseScreeningMatch(
 		"match_id", match.Id, "model", model)
 
 	// Call LLM
-	response, err := llmberjack.NewRequest[screeningHitLlmOutput]().
+	response, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[screeningHitLlmOutput]().
 		WithInstruction(systemInstruction).
 		WithModel(model).
 		WithText(llmberjack.RoleUser, userMessage).
-		WithThinking(false).
-		Do(ctx, client)
+		WithThinking(false))
 	if err != nil {
 		return nil, errors.Wrap(err, "LLM call failed")
 	}

--- a/usecases/ai_agent/async_case_review.go
+++ b/usecases/ai_agent/async_case_review.go
@@ -3,7 +3,6 @@ package ai_agent
 import (
 	"context"
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/dto/agent_dto"
@@ -161,7 +160,7 @@ func (w *CaseReviewWorker) Work(ctx context.Context, job *river.Job[models.CaseR
 			return nil
 		}
 		// Check if this is a rate limit error from the LLM provider
-		if isRateLimitError(err) {
+		if errors.Is(err, models.LLMRateLimitedError) {
 			logger.WarnContext(ctx, "LLM provider rate limited, rescheduling job", "error", err.Error())
 			return river.JobSnooze(30 * time.Second)
 		}
@@ -288,12 +287,3 @@ func (w *CaseReviewWorker) getPreviousCaseReviewContext(
 	return caseReviewContext, nil
 }
 
-// isRateLimitError checks if the error is a 429 rate limit error from the LLM provider
-func isRateLimitError(err error) bool {
-	errStr := err.Error()
-	return strings.Contains(errStr, "Error 429") ||
-		strings.Contains(errStr, "Error 504") ||
-		strings.Contains(errStr, "Resource exhausted") ||
-		strings.Contains(errStr, "RESOURCE_EXHAUSTED") ||
-		strings.Contains(errStr, "DEADLINE_EXCEEDED")
-}

--- a/usecases/ai_agent/llm_errors.go
+++ b/usecases/ai_agent/llm_errors.go
@@ -24,13 +24,16 @@ func IsLLMRateLimitError(err error) bool {
 		strings.Contains(errStr, "DEADLINE_EXCEEDED")
 }
 
-// WrapIfLLMRateLimit returns err wrapped with models.LLMRateLimitedError when
-// IsLLMRateLimitError matches, otherwise returns err unchanged.
+// WrapIfLLMRateLimit tags err with the models.LLMRateLimitedError marker when
+// IsLLMRateLimitError matches, otherwise returns err unchanged. The original
+// error chain (wraps, stack frames, provider-specific types) is preserved so
+// that errors.Is(result, models.LLMRateLimitedError) reports true while
+// upstream details remain available for debugging.
 func WrapIfLLMRateLimit(err error) error {
 	if err == nil || !IsLLMRateLimitError(err) {
 		return err
 	}
-	return errors.Wrap(models.LLMRateLimitedError, err.Error())
+	return errors.Mark(err, models.LLMRateLimitedError)
 }
 
 // DoLLMRequest is the single sanctioned entrypoint for executing an

--- a/usecases/ai_agent/llm_errors.go
+++ b/usecases/ai_agent/llm_errors.go
@@ -1,0 +1,48 @@
+package ai_agent
+
+import (
+	"context"
+	"strings"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/llmberjack"
+	"github.com/cockroachdb/errors"
+)
+
+// IsLLMRateLimitError reports whether err corresponds to an upstream LLM
+// provider rate-limit / resource-exhausted response. Matching is done on the
+// error string because the provider SDKs do not expose a stable typed shape.
+func IsLLMRateLimitError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "Error 429") ||
+		strings.Contains(errStr, "Error 504") ||
+		strings.Contains(errStr, "Resource exhausted") ||
+		strings.Contains(errStr, "RESOURCE_EXHAUSTED") ||
+		strings.Contains(errStr, "DEADLINE_EXCEEDED")
+}
+
+// WrapIfLLMRateLimit returns err wrapped with models.LLMRateLimitedError when
+// IsLLMRateLimitError matches, otherwise returns err unchanged.
+func WrapIfLLMRateLimit(err error) error {
+	if err == nil || !IsLLMRateLimitError(err) {
+		return err
+	}
+	return errors.Wrap(models.LLMRateLimitedError, err.Error())
+}
+
+// DoLLMRequest is the single sanctioned entrypoint for executing an
+// llmberjack request. It tags upstream rate-limit / resource-exhausted
+// responses with models.LLMRateLimitedError so callers and presentError
+// can react with typed checks instead of string matching. New LLM calls
+// must go through this helper rather than calling req.Do directly.
+func DoLLMRequest[T any](
+	ctx context.Context,
+	client *llmberjack.Llmberjack,
+	req llmberjack.Request[T],
+) (*llmberjack.Response[T], error) {
+	resp, err := req.Do(ctx, client)
+	return resp, WrapIfLLMRateLimit(err)
+}

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -92,7 +92,10 @@ func (usecase IngestedDataReaderUsecase) GetIngestedObject(
 		dataModel = &d
 	}
 
-	table := dataModel.Tables[objectType]
+	table, ok := dataModel.Tables[objectType]
+	if !ok {
+		return nil, errors.Wrapf(models.NotFoundError, "Table '%s' not found in GetIngestedObject", objectType)
+	}
 
 	db, err := usecase.executorFactory.NewClientDbExecutor(ctx, organizationId)
 	if err != nil {

--- a/utils/network_errors.go
+++ b/utils/network_errors.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"syscall"
+)
+
+// IsTransientNetworkError reports whether err is a transient network-level
+// failure we don't want to capture in Sentry: socket timeouts and
+// remote-closed connections (broken pipe / connection reset). The returned
+// kind is a stable label suitable for metric/log fields.
+func IsTransientNetworkError(err error) (kind string, ok bool) {
+	if err == nil {
+		return "", false
+	}
+	switch {
+	case errors.Is(err, syscall.EPIPE):
+		return "broken_pipe", true
+	case errors.Is(err, syscall.ECONNRESET):
+		return "conn_reset", true
+	case errors.Is(err, io.ErrUnexpectedEOF):
+		return "unexpected_eof", true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout", true
+	}
+	return "", false
+}
+
+// MaybeSuppressTransient handles transient network errors uniformly: if err
+// matches, it is logged at warn level and counted via Prometheus, and the
+// function returns true so callers can skip Sentry capture.
+func MaybeSuppressTransient(ctx context.Context, err error) bool {
+	kind, ok := IsTransientNetworkError(err)
+	if !ok {
+		return false
+	}
+	LoggerFromContext(ctx).WarnContext(ctx, "transient network error",
+		"kind", kind,
+		"error", err.Error(),
+	)
+	MetricTransientNetworkErrors.WithLabelValues(kind).Inc()
+	return true
+}

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -55,6 +55,11 @@ var (
 		Name: "marble_job_duration",
 		Help: "Duration of asynchronous worker jobs",
 	}, []string{"queue", "job_name"})
+
+	MetricTransientNetworkErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "marble_transient_network_errors_total",
+		Help: "Count of transient network-level errors (db socket timeouts, broken pipe, conn reset) suppressed from Sentry",
+	}, []string{"kind"})
 )
 
 func MeasureLatencyErr[R any](metric *prometheus.HistogramVec, labels prometheus.Labels, f func() (R, error)) (R, error) {

--- a/utils/sentry.go
+++ b/utils/sentry.go
@@ -11,14 +11,17 @@ import (
 
 func LogAndReportSentryError(ctx context.Context, err error) {
 	logger := LoggerFromContext(ctx)
-	logger.ErrorContext(ctx, fmt.Sprintf("%+v", err))
 
 	// Ignore errors that are due to context deadlines or canceled context, as presumably their root case has been handled
 	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		logger.DebugContext(ctx, fmt.Sprintf("Deadline exceeded or context canceled: %v", err))
 		return
 	}
+	if MaybeSuppressTransient(ctx, err) {
+		return
+	}
 
+	logger.ErrorContext(ctx, fmt.Sprintf("%+v", err))
 	if hub := sentry.GetHubFromContext(ctx); hub != nil {
 		CaptureSentryException(ctx, hub, err)
 	} else {


### PR DESCRIPTION
Trying to make our Sentry error inbox usable again. Transient errors should be tracked better than we currently do (ideally), but not by tracking individual instances of errors on Sentry.

<details>
<summary> screenshot</summary>
<img width="1726" height="1297" alt="Capture d’écran 2026-05-11 à 13 15 22" src="https://github.com/user-attachments/assets/e3f48d11-4235-4373-849e-9e9e801e8a71" />

</details>

### In order to do this
- broad-ish catching of network errors, in the usual error handler functions
   - start adding some prometheus metrics for this family of errors
- centralize "rate limit" and similar errors from LLM providers

#### Side change
Cleanly handle empty object_id (or wrong table for an org) passed for the ingested data reader endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graceful handling and user-facing messaging for upstream LLM rate-limit conditions.
  * Suppression of transient network errors to reduce noisy alerts.

* **Chores**
  * Standardized LLM request execution across workflows (refactor).
  * Improved logging/monitoring and added metric to track suppressed transient network errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-backend/pull/1737)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->