### PR TITLE
avoid error on payload re-parsing for decision workflows about decisi…

### DIFF
--- a/usecases/payload_parser/payload.go
+++ b/usecases/payload_parser/payload.go
@@ -24,6 +24,7 @@ type fieldParser map[models.DataType]func(result gjson.Result) (any, error)
 type Parser struct {
 	parsers               fieldParser
 	allowPatch            bool
+	allFieldsNullable     bool
 	disallowUnknownFields bool
 	columnEscape          bool
 	enricher              PayloadEnrichementUsecase
@@ -80,14 +81,14 @@ func (p *Parser) ParsePayload(ctx context.Context, table models.Table, json []by
 					Field:          field,
 					ErrorIfMissing: errIsNotNullable.Error(),
 				})
-			} else if !field.Nullable {
+			} else if !field.Nullable && !p.allFieldsNullable {
 				addError(allErrors, objectId, name, errIsNotNullable)
 			}
 			continue
 		}
 
 		if value.Type == gjson.Null {
-			if !field.Nullable {
+			if !field.Nullable && !p.allFieldsNullable {
 				addError(allErrors, objectId, name, errIsNotNullable)
 			}
 			out[name] = nil
@@ -179,6 +180,7 @@ func (p *Parser) ParsePayload(ctx context.Context, table models.Table, json []by
 
 type parserOpts struct {
 	allowPatch            bool
+	allFieldsNullable     bool
 	disallowUnknownFields bool
 	columnEscape          bool
 	enricher              PayloadEnrichementUsecase
@@ -195,6 +197,17 @@ func WithAllowPatch() ParserOpt {
 func WithAllowedPatch(allowed bool) ParserOpt {
 	return func(o *parserOpts) {
 		o.allowPatch = allowed
+	}
+}
+
+// WithAllFieldsNullable disables the "not nullable" validation for all fields, both when a
+// field is missing and when it is present with a null value. Used when re-parsing a payload
+// that was already validated and persisted (e.g. when re-typing a decision's client object
+// for async workflow execution), where the data model may have tightened required/nullable
+// constraints since the object was ingested.
+func WithAllFieldsNullable() ParserOpt {
+	return func(o *parserOpts) {
+		o.allFieldsNullable = true
 	}
 }
 
@@ -291,6 +304,7 @@ func NewParser(opts ...ParserOpt) *Parser {
 	return &Parser{
 		parsers:               parsers,
 		allowPatch:            options.allowPatch,
+		allFieldsNullable:     options.allFieldsNullable,
 		disallowUnknownFields: options.disallowUnknownFields,
 		columnEscape:          options.columnEscape,
 		enricher:              options.enricher,
@@ -303,7 +317,7 @@ func TypedClientObject(ctx context.Context, dataModel models.DataModel, o models
 		return models.ClientObject{}, err
 	}
 
-	parser := NewParser(WithAllowedPatch(true))
+	parser := NewParser(WithAllFieldsNullable())
 
 	clientObject, err := parser.ParsePayload(ctx, dataModel.Tables[o.TableName], payloadJson)
 	if err != nil {

--- a/usecases/payload_parser/payload_test.go
+++ b/usecases/payload_parser/payload_test.go
@@ -331,4 +331,20 @@ func TestTypedClientObject_BackwardCompatibility(t *testing.T) {
 	assert.Equal(t, "transactions", result.TableName)
 	assert.Equal(t, "123", result.Data["object_id"])
 	assert.Equal(t, 99.99, result.Data["amount"])
+
+	// Old payload with the new required field explicitly set to null (was nullable at ingestion time)
+	oldPayloadWithNull := models.ClientObject{
+		TableName: "transactions",
+		Data: map[string]any{
+			"object_id":          "124",
+			"updated_at":         "2026-03-13T10:00:00Z",
+			"amount":             99.99,
+			"new_required_field": nil,
+		},
+	}
+
+	resultWithNull, err := TypedClientObject(context.Background(), dataModel, oldPayloadWithNull)
+	assert.NoError(t, err, "TypedClientObject should handle old payloads with null on now-required fields")
+	assert.Equal(t, "124", resultWithNull.Data["object_id"])
+	assert.Nil(t, resultWithNull.Data["new_required_field"])
 }


### PR DESCRIPTION
We added re-parsing of decision payloads to execute workflows, so they don't fail if fields that need to be parsed from json (in practice, timestamps) are used in the workflow (esp. Case name template).

However, this now fails if a decision is taken on an old object (mostly in batch mode) if some of the data model has been made required since.

See [those errors](https://marble-eu.sentry.io/issues/117695279/?project=4509310347640912&query=is%3Aunresolved&referrer=issue-stream)
```
could not type client object from decision payload: {"10397":{"is_deleted":"is not nullable"}}
```