### PR TITLE
redirect to signed url instead of streaming data with gin for screeni…

### DIFF
--- a/api/handle_continuous_screening.go
+++ b/api/handle_continuous_screening.go
@@ -71,8 +71,7 @@ func handleCreateContinuousScreeningConfig(uc usecases.Usecases) func(c *gin.Con
 			return
 		}
 
-		createContinuousScreeningConfigInput :=
-			dto.AdaptCreateContinuousScreeningConfigDtoToModel(input)
+		createContinuousScreeningConfigInput := dto.AdaptCreateContinuousScreeningConfigDtoToModel(input)
 		createContinuousScreeningConfigInput.OrgId = organizationId
 
 		uc := usecasesWithCreds(ctx, uc).NewContinuousScreeningUsecase()
@@ -380,12 +379,11 @@ func handleGetContinuousScreeningDelta(uc usecases.Usecases) func(c *gin.Context
 			return
 		}
 		usecase := uc.NewContinuousScreeningManifestUsecase()
-		deltaBlob, err := usecase.GetContinuousScreeningDeltaBlob(ctx, orgId, deltaId)
+		url, err := usecase.GetContinuousScreeningDeltaUrl(ctx, orgId, deltaId)
 		if presentError(ctx, c, err) {
 			return
 		}
-		defer deltaBlob.ReadCloser.Close()
-		c.DataFromReader(http.StatusOK, -1, "application/x-ndjson", deltaBlob.ReadCloser, nil)
+		c.Redirect(http.StatusFound, url)
 	}
 }
 
@@ -400,11 +398,10 @@ func handleGetContinuousScreeningFull(uc usecases.Usecases) func(c *gin.Context)
 		}
 
 		usecase := uc.NewContinuousScreeningManifestUsecase()
-		fullBlob, err := usecase.GetContinuousScreeningFullBlob(ctx, orgId)
+		url, err := usecase.GetContinuousScreeningFullUrl(ctx, orgId)
 		if presentError(ctx, c, err) {
 			return
 		}
-		defer fullBlob.ReadCloser.Close()
-		c.DataFromReader(http.StatusOK, -1, "application/x-ndjson", fullBlob.ReadCloser, nil)
+		c.Redirect(http.StatusFound, url)
 	}
 }

--- a/usecases/continuous_screening/usecase_manifest.go
+++ b/usecases/continuous_screening/usecase_manifest.go
@@ -103,56 +103,50 @@ func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaList(
 	}, nil
 }
 
-func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaBlob(
+func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaUrl(
 	ctx context.Context,
 	orgId uuid.UUID,
 	deltaId uuid.UUID,
-) (models.Blob, error) {
+) (string, error) {
 	exec := u.executorFactory.NewExecutor()
 
 	delta, err := u.repository.GetContinuousScreeningDatasetFileById(ctx, exec, deltaId)
 	if err != nil {
-		return models.Blob{},
-			errors.Wrap(err, "failed to get continuous screening delta")
+		return "", errors.Wrap(err, "failed to get continuous screening delta")
 	}
 
 	if delta.OrgId != orgId {
-		return models.Blob{},
-			errors.New("delta does not belong to the organization")
+		return "", errors.New("delta does not belong to the organization")
 	}
 
-	blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
+	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
 	if err != nil {
-		return models.Blob{},
-			errors.Wrap(err, "failed to get delta file blob")
+		return "", errors.Wrap(err, "failed to generate signed url for delta file")
 	}
 
-	return blob, nil
+	return url, nil
 }
 
-func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningFullBlob(
+func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningFullUrl(
 	ctx context.Context,
 	orgId uuid.UUID,
-) (models.Blob, error) {
+) (string, error) {
 	exec := u.executorFactory.NewExecutor()
 
 	fullFile, err := u.repository.GetContinuousScreeningLatestDatasetFileByOrgId(ctx, exec, orgId,
 		models.ContinuousScreeningDatasetFileTypeFull)
 	if err != nil {
-		return models.Blob{},
-			errors.Wrap(err, "failed to get latest full dataset file")
+		return "", errors.Wrap(err, "failed to get latest full dataset file")
 	}
 
 	if fullFile == nil {
-		return models.Blob{},
-			errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
+		return "", errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
 	}
 
-	blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
+	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
 	if err != nil {
-		return models.Blob{},
-			errors.Wrap(err, "failed to get full dataset file blob")
+		return "", errors.Wrap(err, "failed to generate signed url for full dataset file")
 	}
 
-	return blob, nil
+	return url, nil
 }


### PR DESCRIPTION
Redirect rather than stream blob data through the backend, because it avoids a whole word of potential problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Continuous screening dataset endpoints now return signed URL redirects for delta and full datasets instead of direct streaming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-backend/pull/1748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->