### PR TITLE
do 'reverse' search for continuous screening on LegalEntity rows

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -36,6 +36,7 @@ var AllowedSchemaTypes = []string{
 	"Organization",
 	"Vessel",
 	"Airplane",
+	"LegalEntity",
 }
 
 type applyDeltaFileWorkerRepository interface {


### PR DESCRIPTION
https://linear.app/marble-eu/issue/MAR-1897/legalentity-rows-in-os-delta-files-are-ignored-in-continuous-screening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legal Entity records are now properly processed during continuous screening instead of being skipped.
  * Continuous screening coverage and result accuracy improved for Legal Entity data, reducing missed records and ensuring more complete monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-backend/pull/1755?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->