### PR TITLE
store continuous screening entry even if there were no matches

### DIFF
--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -708,7 +708,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningDatasetUpdate(
 
 	query := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_DATASET_UPDATES).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningDatasetUpdateColumn, ","))).
 		Columns(
 			"dataset_name",
 			"version",
@@ -736,7 +736,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningUpdateJob(
 
 	query := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_UPDATE_JOBS).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningUpdateJobColumn, ","))).
 		Columns(
 			"continuous_screening_dataset_update_id",
 			"continuous_screening_config_id",
@@ -1087,4 +1087,3 @@ func (repo *MarbleDbRepository) UpdateDeltaTracksDatasetFileId(
 
 	return ExecBuilder(ctx, exec, query)
 }
-

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -322,12 +322,6 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 		screening := screeningResponse.AdaptScreeningFromSearchResponse(query)
 		iterLogger.DebugContext(iterCtx, "Screening result", "matches", len(screening.Matches))
 
-		// No hit, skip the record
-		// Note: I'm not entirely sure that we SHOULD keep no written trace of the request that was made here, keeping this question open for now.
-		if screening.Status == models.ScreeningStatusNoHit {
-			continue
-		}
-
 		err = w.transactionFactory.Transaction(iterCtx, func(tx repositories.Transaction) error {
 			entityPayload, err := json.Marshal(record.Entity)
 			if err != nil {
@@ -346,6 +340,10 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 			)
 			if err != nil {
 				return err
+			}
+			// if there were no hits, that's it
+			if screening.Status == models.ScreeningStatusNoHit {
+				return nil
 			}
 
 			_, err = w.usecase.HandleCaseCreation(

--- a/usecases/continuous_screening/worker_scan_dataset_update.go
+++ b/usecases/continuous_screening/worker_scan_dataset_update.go
@@ -2,6 +2,7 @@ package continuous_screening
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -224,7 +225,7 @@ func (w *ScanDatasetUpdatesWorker) Work(
 
 type datasetWithVersionRange struct {
 	dataset     models.OpenSanctionsRawDataset
-	fromVersion string
+	fromVersion *string
 	toVersion   string
 }
 
@@ -250,14 +251,14 @@ func (w *ScanDatasetUpdatesWorker) getOutdatedDatasets(
 					"dataset", dataset.Name,
 					"version", dataset.Version,
 				)
-				_, err = w.repo.CreateContinuousScreeningDatasetUpdate(ctx, exec,
-					models.CreateContinuousScreeningDatasetUpdate{
-						DatasetName: dataset.Name,
-						Version:     dataset.Version,
-					})
-				if err != nil {
-					return nil, err
-				}
+				datasetsWithVersionRange = append(
+					datasetsWithVersionRange,
+					datasetWithVersionRange{
+						dataset:     dataset,
+						fromVersion: nil,
+						toVersion:   dataset.Version,
+					},
+				)
 				continue
 			}
 			return nil, err
@@ -288,7 +289,7 @@ func (w *ScanDatasetUpdatesWorker) getOutdatedDatasets(
 			datasetsWithVersionRange,
 			datasetWithVersionRange{
 				dataset:     dataset,
-				fromVersion: lastDatasetUpdate.Version,
+				fromVersion: &lastDatasetUpdate.Version,
 				toVersion:   dataset.Version,
 			},
 		)
@@ -334,7 +335,7 @@ func (w *ScanDatasetUpdatesWorker) processDatasetVersion(
 
 	filteredVersions := slices.DeleteFunc(versions, func(record deltaRecord) bool {
 		// Keep versions within (fromVersion, toVersion]
-		if record.version <= d.fromVersion {
+		if d.fromVersion != nil && record.version <= *d.fromVersion {
 			return true
 		}
 		if record.version > d.toVersion {
@@ -342,6 +343,16 @@ func (w *ScanDatasetUpdatesWorker) processDatasetVersion(
 		}
 		return false
 	})
+
+	// Cold start (no previously stored version): only process the most recent delta.
+	// Avoids replaying the full delta history on first run, which would be expensive and is
+	// not useful — we just want to register the dataset and start tracking updates going forward.
+	if d.fromVersion == nil && len(filteredVersions) > 1 {
+		slices.SortFunc(filteredVersions, func(a, b deltaRecord) int {
+			return cmp.Compare(a.version, b.version)
+		})
+		filteredVersions = filteredVersions[len(filteredVersions)-1:]
+	}
 
 	// Channel to collect results from concurrent downloads
 	// Use buffered channel to avoid goroutines blocking

--- a/usecases/continuous_screening/worker_scan_dataset_update_test.go
+++ b/usecases/continuous_screening/worker_scan_dataset_update_test.go
@@ -216,52 +216,104 @@ func TestScanDatasetUpdatesWorker(t *testing.T) {
 	suite.Run(t, new(ScanDatasetUpdatesWorkerTestSuite))
 }
 
-func (suite *ScanDatasetUpdatesWorkerTestSuite) TestWork_NewDataset_CreatesRecord_NoProcessing() {
-	// Setup
+func (suite *ScanDatasetUpdatesWorkerTestSuite) TestWork_NewDataset_OnlyProcessesLatestDelta() {
+	// On cold start (no previously stored version for the dataset), we should not
+	// replay the entire delta history — only the most recent delta is processed,
+	// so the dataset gets registered with that version going forward.
 	datasetName := "test-dataset"
-	version := "2024-01-01"
+	catalogVersion := "2024-01-04"
+	latestDeltaVersion := "2024-01-04"
+	deltaUrl := "https://example.com/delta"
 
-	// Mock catalog with one dataset
 	catalog := models.OpenSanctionsRawCatalog{
 		Current:  []string{datasetName},
 		Outdated: []string{},
 		Datasets: map[string]models.OpenSanctionsRawDataset{
 			datasetName: {
-				Name:    datasetName,
-				Version: version,
+				Name:     datasetName,
+				Version:  catalogVersion,
+				DeltaUrl: &deltaUrl,
 			},
 		},
 	}
 
-	// Job args
+	// Delta list contains several historical versions; only the most recent must be processed.
+	deltaList := `{
+		"versions": {
+			"2024-01-02": "https://example.com/delta/2024-01-02.ndjson",
+			"2024-01-03": "https://example.com/delta/2024-01-03.ndjson",
+			"2024-01-04": "https://example.com/delta/2024-01-04.ndjson"
+		}
+	}`
+
+	configId := pure_utils.NewId()
+	orgId := pure_utils.NewId()
+	configs := []models.ContinuousScreeningConfig{
+		{Id: configId, OrgId: orgId, Enabled: true},
+	}
+
+	blobKey := fmt.Sprintf("%s/%s/%s.ndjson", ProviderUpdatesFolderName, datasetName, latestDeltaVersion)
+	expectedDatasetUpdate := models.ContinuousScreeningDatasetUpdate{
+		Id:            pure_utils.NewId(),
+		DatasetName:   datasetName,
+		Version:       latestDeltaVersion,
+		DeltaFilePath: blobKey,
+		TotalItems:    1,
+	}
+	expectedUpdateJob := models.ContinuousScreeningUpdateJob{
+		Id:              pure_utils.NewId(),
+		DatasetUpdateId: expectedDatasetUpdate.Id,
+		ConfigId:        configId,
+		OrgId:           orgId,
+	}
+
 	job := &river.Job[models.ContinuousScreeningScanDatasetUpdatesArgs]{}
 
-	// Setup mocks
 	suite.screeningProvider.On("GetRawCatalog", suite.ctx, models.ScreeningProviderOpenSanctions).Return(catalog, nil)
-	suite.repository.On("ListContinuousScreeningConfigs", mock.Anything, mock.Anything).Return([]models.ContinuousScreeningConfig{
-		{Id: pure_utils.NewId(), OrgId: pure_utils.NewId(), Enabled: true},
-	}, nil)
-	// GetLastProcessedVersion returns NotFoundError for new dataset
+	suite.repository.On("ListContinuousScreeningConfigs", mock.Anything, mock.Anything).Return(configs, nil)
+	// GetLastProcessedVersion returns NotFoundError for new dataset (cold start).
 	suite.repository.On("GetLastProcessedVersion", suite.ctx, mock.Anything, datasetName).Return(
 		models.ContinuousScreeningDatasetUpdate{}, models.NotFoundError)
-	// CreateContinuousScreeningDatasetUpdate should be called for the new dataset
-	expectedInput := models.CreateContinuousScreeningDatasetUpdate{
-		DatasetName: datasetName,
-		Version:     version,
-	}
-	expectedUpdate := models.ContinuousScreeningDatasetUpdate{
-		Id:          pure_utils.NewId(),
-		DatasetName: datasetName,
-		Version:     version,
-	}
-	suite.repository.On("CreateContinuousScreeningDatasetUpdate", suite.ctx, mock.Anything,
-		expectedInput).Return(expectedUpdate, nil)
 
-	// Execute
+	defer gock.Off()
+	gock.New("https://example.com").
+		Get("/delta").
+		Reply(200).
+		BodyString(deltaList)
+	// Only the latest delta file must be downloaded. Older versions intentionally have no
+	// gock mock — if the worker tries to fetch them, the HTTP call will fail and the test fails.
+	gock.New("https://example.com").
+		Get("/delta/" + latestDeltaVersion + ".ndjson").
+		Reply(200).
+		BodyString("line1\n")
+
+	suite.blobRepo.On("OpenStream", mock.Anything, "test-bucket", blobKey, blobKey).Return(&mockBlobWriter{}, nil)
+
+	suite.featureAccessReader.On("GetOrganizationFeatureAccess", mock.Anything, orgId, mock.Anything).Return(
+		models.OrganizationFeatureAccess{ContinuousScreening: models.Allowed}, nil,
+	)
+
+	suite.repository.On("CreateContinuousScreeningDatasetUpdate", mock.Anything, mock.Anything,
+		models.CreateContinuousScreeningDatasetUpdate{
+			DatasetName:   datasetName,
+			Version:       latestDeltaVersion,
+			DeltaFilePath: blobKey,
+			TotalItems:    1,
+		}).Return(expectedDatasetUpdate, nil)
+
+	suite.repository.On("CreateContinuousScreeningUpdateJob", mock.Anything, mock.Anything,
+		models.CreateContinuousScreeningUpdateJob{
+			DatasetUpdateId: expectedDatasetUpdate.Id,
+			ConfigId:        configId,
+			OrgId:           orgId,
+		}).Return(expectedUpdateJob, nil)
+
+	suite.taskEnqueuer.On("EnqueueContinuousScreeningApplyDeltaFileTask",
+		mock.Anything, mock.Anything, orgId, expectedUpdateJob.Id).Return(nil)
+
 	worker := suite.makeWorker()
 	err := worker.Work(suite.ctx, job)
 
-	// Assert
 	suite.NoError(err)
 	suite.AssertExpectations()
 }


### PR DESCRIPTION
- store a `continuous_screenings` search record even if no matches found (useful for audit, debug)
- process the most recent delta file on continuous screening cold start (no impact on prod, convenient in local dev mode when running a cold start - used to be "nothing happens on the first run)
- fix a DB scan error related to a "returning *" pattern