### PR TITLE
specific error message (for UI) in case of null value in trigger cond…

### DIFF
--- a/pubapi/v1/dto/screening.go
+++ b/pubapi/v1/dto/screening.go
@@ -11,7 +11,7 @@ import (
 type Screening struct {
 	Id           string                           `json:"id"`
 	Status       string                           `json:"status"`
-	Provider     models.ScreeningProvider         `json:"provider"`
+	Provider     models.ScreeningProvider         `json:"-"`
 	Query        json.RawMessage                  `json:"query"`
 	InitialQuery []models.OpenSanctionsCheckQuery `json:"initial_query"`
 	Partial      bool                             `json:"partial"`

--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -23,7 +23,6 @@ const (
 	ErrScreeningCounterpartyIdNotString = "counterparty_id_not_string"
 	ErrScreeningAllFieldsNullOrEmpty    = "all_fields_null_or_empty"
 	ErrScreeningFieldsNotString         = "fields_not_string"
-	ErrScreeningPreprocessingFailed     = "preprocessing_failed"
 )
 
 func (e ScenarioEvaluator) evaluateScreening(
@@ -161,7 +160,7 @@ func (e ScenarioEvaluator) evaluateScreening(
 				}
 
 				if queries, err = e.preprocess(ctx, scId, queriesBeforeProcessing, iteration, scc); err != nil {
-					addScreeningResult(idx, outcomeError(scc, ErrScreeningPreprocessingFailed, nil))
+					addScreeningError(scc, errors.Wrap(err, "could not perform screening"))
 					return
 				}
 			}

--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -16,7 +16,9 @@ import (
 	"github.com/mohae/deepcopy"
 )
 
+// NB: these are used in DTOs used by the frontend (but not exposed to the end user through the public API).
 const (
+	ErrScreeningTriggerRuleNull         = "trigger_rule_null"
 	ErrScreeningTriggerRuleNotBoolean   = "trigger_rule_not_boolean"
 	ErrScreeningCounterpartyIdNotString = "counterparty_id_not_string"
 	ErrScreeningAllFieldsNullOrEmpty    = "all_fields_null_or_empty"
@@ -94,8 +96,12 @@ func (e ScenarioEvaluator) evaluateScreening(
 					return
 				}
 
+				if triggerEvaluation.ReturnValue == nil {
+					addScreeningResult(idx, outcomeError(scc,
+						ErrScreeningTriggerRuleNull, nil))
+					return
+				}
 				passed, ok := triggerEvaluation.ReturnValue.(bool)
-
 				if !ok {
 					addScreeningResult(idx, outcomeError(scc,
 						ErrScreeningTriggerRuleNotBoolean, nil))

--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -127,6 +127,7 @@ func (e ScenarioEvaluator) evaluateScreening(
 					},
 				}
 
+				numEmptyFields := 0
 				for fieldName, fieldAst := range scc.Query {
 					inputAst, err := e.evaluateAstExpression.EvaluateAstExpression(ctx, nil,
 						fieldAst, iteration.OrganizationId,
@@ -137,8 +138,8 @@ func (e ScenarioEvaluator) evaluateScreening(
 					}
 
 					if inputAst.ReturnValue == nil {
-						addScreeningResult(idx, outcomeError(scc, ErrScreeningAllFieldsNullOrEmpty, nil))
-						return
+						numEmptyFields++
+						continue
 					}
 
 					input, ok := inputAst.ReturnValue.(string)
@@ -147,15 +148,20 @@ func (e ScenarioEvaluator) evaluateScreening(
 						return
 					}
 					if input == "" {
-						addScreeningResult(idx, outcomeError(scc, ErrScreeningAllFieldsNullOrEmpty, nil))
-						return
+						numEmptyFields++
+						continue
 					}
 
 					queriesBeforeProcessing[0].Filters[fieldName] = []string{input}
 				}
 
-				if queries, err = e.preprocess(ctx, scId, queriesBeforeProcessing, iteration, scc); err != nil {
+				if numEmptyFields == len(scc.Query) {
 					addScreeningResult(idx, outcomeError(scc, ErrScreeningAllFieldsNullOrEmpty, nil))
+					return
+				}
+
+				if queries, err = e.preprocess(ctx, scId, queriesBeforeProcessing, iteration, scc); err != nil {
+					addScreeningResult(idx, outcomeError(scc, ErrScreeningPreprocessingFailed, nil))
 					return
 				}
 			}

--- a/usecases/evaluate_scenario/preprocessing.go
+++ b/usecases/evaluate_scenario/preprocessing.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"time"
 	"unicode"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -147,8 +146,12 @@ func IgnoreList(ctx context.Context, e ScenarioEvaluator, screeningId string,
 	return out, nil
 }
 
-func NameEntityRecognition(ctx context.Context, e ScenarioEvaluator, screeningId string,
-	queries []models.OpenSanctionsCheckQuery, iteration models.ScenarioIteration,
+func NameEntityRecognition(
+	ctx context.Context,
+	e ScenarioEvaluator,
+	screeningId string,
+	queries []models.OpenSanctionsCheckQuery,
+	iteration models.ScenarioIteration,
 	scc models.ScreeningConfig,
 ) ([]models.OpenSanctionsCheckQuery, error) {
 	if !scc.Preprocessing.UseNer {
@@ -162,19 +165,13 @@ func NameEntityRecognition(ctx context.Context, e ScenarioEvaluator, screeningId
 	performed := false
 
 	for _, query := range queries {
-		nerCtx, cancel := context.WithTimeout(ctx,
-			utils.GetEnvDuration("NER_TIMEOUT", 2*time.Second))
-		defer cancel()
-
-		matches, err := e.nameRecognizer.PerformNameRecognition(nerCtx, query.GetName())
+		matches, err := e.nameRecognizer.PerformNameRecognition(ctx, query.GetName())
 		if err != nil {
-			utils.LoggerFromContext(ctx).Warn("screening preprocessing: name entity recognition returned an error, using initial query", "error", err.Error())
-			return queries, nil
+			return queries, errors.Wrap(err, "name entity recognition failed")
 		}
 
 		if len(matches) == 0 {
 			utils.LoggerFromContext(ctx).Debug("screening preprocessing: name entity recognition returns no match, using initial query")
-			out = append(out, query)
 			continue
 		}
 
@@ -228,5 +225,4 @@ func NameEntityRecognition(ctx context.Context, e ScenarioEvaluator, screeningId
 	}
 
 	return queries, nil
-	// return append(queries, out...), nil
 }


### PR DESCRIPTION
- error out the decision if a screening preprocessing fails (rather than silent failing the screening)
  - remove the custom timeout for NER that was only relevant in the old context
- new error status (for UI display) on screening if trigger condition fails due to null value
- only make the screening fail if all input fields are null or empty string, not just any one of them

See also related changes on translation keys in https://github.com/checkmarble/marble-frontend/pull/1582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API Changes**
  * Provider field removed from screening API responses

* **Bug Fixes**
  * Improved error detection during screening trigger rule evaluation
  * Enhanced error handling for screening query field processing
  * Strengthened error propagation for name entity recognition failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-backend/pull/1759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->