### PR TITLE
remove unused (renormalized) columns on screening tables

### DIFF
--- a/pubapi/tests/fixtures/screening_configs.yml
+++ b/pubapi/tests/fixtures/screening_configs.yml
@@ -4,3 +4,4 @@
   forced_outcome: approve
   stable_id: 10000000-0000-0000-0000-000000000000
   config_version: v2
+  datasets: RAW=array['one', 'two']

--- a/pubapi/tests/fixtures/screenings.yml
+++ b/pubapi/tests/fixtures/screenings.yml
@@ -5,7 +5,6 @@
   status: in_review
   search_input:
     lorem: ipsum
-  search_datasets: RAW=array['one', 'two']
   match_threshold: 0.9
   match_limit: 20
 
@@ -16,6 +15,5 @@
   status: in_review
   search_input:
     lorem: ipsum
-  search_datasets: RAW=array['one', 'two']
   match_threshold: 0.9
   match_limit: 20

--- a/repositories/migrations/20260527225700_drop_unused_screening_columns.sql
+++ b/repositories/migrations/20260527225700_drop_unused_screening_columns.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+alter table screenings
+drop column whitelisted_entities,
+drop column search_datasets;
+
+-- +goose Down
+alter table screenings
+add column whitelisted_entities text[],
+add column search_datasets text[];


### PR DESCRIPTION
The main steps of the migration were done in previous releases.
Here, we drop columns that are no longer used in the application code.