### PR TITLE
Use the proper properties.programId filter.

### DIFF
--- a/repositories/screening/provider_lexisnexis.go
+++ b/repositories/screening/provider_lexisnexis.go
@@ -54,7 +54,7 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 				}
 
 				if filter.Datasets != nil {
-					q.Queries[id].Filters["programId"] = [][]string{filter.Datasets}
+					q.Queries[id].Filters["properties.programId"] = [][]string{filter.Datasets}
 				}
 
 				for _, globalTopic := range filters.Global.Topics {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the formatting of LexisNexis screening requests to properly structure dataset mappings sent to the screening match endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/checkmarble/marble-backend/pull/1765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->