### PR TITLE
correct filtering logic for delta file processing with lexis filters

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -291,7 +291,7 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 			}
 		}
 
-		if !w.matchesFilters(updateJob, record) {
+		if !matchesFilters(updateJob, record) {
 			iterLogger.DebugContext(iterCtx, "Skipping record because it does not meet filter")
 			continue
 		}
@@ -306,7 +306,7 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 		err = retry.Do(
 			func() error {
 				// Searches in this direction should use the Open Sanctions schema (no complex topics filters).
-				screeningResponse, err = w.screeningProvider.Search(iterCtx, models.ScreeningProviderOpenSanctions,  query)
+				screeningResponse, err = w.screeningProvider.Search(iterCtx, models.ScreeningProviderOpenSanctions, query)
 				return err
 			},
 			retry.Attempts(3),
@@ -537,7 +537,26 @@ func isTransientScreeningError(err error) bool {
 	return false
 }
 
-func (w *ApplyDeltaFileWorker) matchesFilters(updateJob models.EnrichedContinuousScreeningUpdateJob, record models.OpenSanctionsDeltaFileRecord) bool {
+// Topics come in groups, matching is a AND of groups with an OR inside groups.
+func topicsMatchForSection(sectionTopics map[string][]string, record models.OpenSanctionsDeltaFileRecord) bool {
+	for _, topicGroup := range sectionTopics {
+		topicFound := false
+
+		for _, topic := range record.Entity.Properties["topics"] {
+			if slices.Contains(topicGroup, topic) {
+				topicFound = true
+				break
+			}
+		}
+
+		if !topicFound {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesFilters(updateJob models.EnrichedContinuousScreeningUpdateJob, record models.OpenSanctionsDeltaFileRecord) bool {
 	filters := updateJob.Config.Filters.Resolve()
 
 	switch updateJob.Config.Provider {
@@ -556,16 +575,25 @@ func (w *ApplyDeltaFileWorker) matchesFilters(updateJob models.EnrichedContinuou
 
 	case models.ScreeningProviderLexisNexis:
 		// Loop over each configuration section
+		globalFilter := filters.Global
+		if globalFilter.Enabled {
+			if !topicsMatchForSection(globalFilter.Topics, record) {
+				return false
+			}
+		}
+
+		recordMatches := false
 		for rootTopic, section := range filters.WithRootTopics() {
-			// Short-circuit if the section is not enabled
-			if !section.Enabled && rootTopic != "global" {
+			// Short-circuit if the section is not enabled. Global filters ("is alive"...) are applied before the loop, separately because all records must match them regardless of their root topic.
+			if !section.Enabled || rootTopic == "global" {
 				continue
 			}
 
-			foundDataset := false
+			sectionMatches := true
 
 			// If we searches for specific datasets (programId for Lexis Nexis), break if not found
 			if len(section.Datasets) > 0 {
+				foundDataset := false
 				for _, recordDataset := range record.Entity.Properties["programId"] {
 					if slices.Contains(section.Datasets, recordDataset) {
 						foundDataset = true
@@ -574,33 +602,26 @@ func (w *ApplyDeltaFileWorker) matchesFilters(updateJob models.EnrichedContinuou
 				}
 
 				if !foundDataset {
-					return false
+					sectionMatches = false
 				}
 			}
 
 			// Check whether the record holds the root topic for the section
-			if rootTopic != "global" && rootTopic != "other" && !slices.Contains(record.Entity.Properties["topics"], rootTopic) {
-				return false
+			if rootTopic != "other" && !slices.Contains(record.Entity.Properties["topics"], rootTopic) {
+				sectionMatches = false
 			}
 
-			// For each group of filtered topic, break if there is no match in any of the groups
-			for _, topicGroup := range section.Topics {
-				topicFound := false
+			if !topicsMatchForSection(section.Topics, record) {
+				sectionMatches = false
+			}
 
-				for _, topic := range record.Entity.Properties["topics"] {
-					if slices.Contains(topicGroup, topic) {
-						topicFound = true
-						break
-					}
-				}
-
-				if !topicFound {
-					return false
-				}
+			if sectionMatches {
+				recordMatches = true
+				break
 			}
 		}
 
-		return true
+		return recordMatches
 	}
 
 	return false

--- a/usecases/continuous_screening/worker_apply_delta_file_test.go
+++ b/usecases/continuous_screening/worker_apply_delta_file_test.go
@@ -7,9 +7,69 @@ import (
 	"testing"
 	"testing/iotest"
 
+	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories/httpmodels"
 	"github.com/stretchr/testify/assert"
 )
+
+// matchesFilters (LexisNexis): a record matches when at least one enabled
+// section matches; it must not slip through when no section matches.
+func TestMatchesFilters_LexisNexis(t *testing.T) {
+	enabled := func(datasets []string, topics map[string][]string) *models.ScreeningConfigFilter {
+		return &models.ScreeningConfigFilter{Enabled: true, Datasets: datasets, Topics: topics}
+	}
+
+	// Mirrors cmd/filter.json: sanctions (with datasets) + peps + adverse_media
+	// enabled, other & global disabled.
+	filters := models.ScreeningConfigFilters{
+		Global:       &models.ScreeningConfigFilter{Enabled: false},
+		Other:        &models.ScreeningConfigFilter{Enabled: false},
+		Sanctions:    enabled([]string{"ofac", "eulist"}, nil),
+		Peps:         enabled(nil, nil),
+		AdverseMedia: enabled(nil, nil),
+	}
+
+	job := models.EnrichedContinuousScreeningUpdateJob{
+		Config: models.ContinuousScreeningConfig{
+			Provider: models.ScreeningProviderLexisNexis,
+			Filters:  filters,
+		},
+	}
+
+	recordWithTopics := func(topics ...string) models.OpenSanctionsDeltaFileRecord {
+		return models.OpenSanctionsDeltaFileRecord{
+			Entity: models.OpenSanctionsDeltaFileEntity{
+				Properties: map[string][]string{"topics": topics},
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		record   models.OpenSanctionsDeltaFileRecord
+		expected bool
+	}{
+		{
+			// Matches the enabled adverse_media section (no datasets required).
+			name:     "matches an enabled section",
+			record:   recordWithTopics("adverse_media"),
+			expected: true,
+		},
+		{
+			// "sanctions" topic, but no programId in the configured datasets.
+			// No section matches and global must not let it through.
+			name:     "matches no enabled section",
+			record:   recordWithTopics("sanctions"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, matchesFilters(job, tt.record))
+		})
+	}
+}
 
 // Test the json decoder offset behavior and resume from offset mechanism
 // Mock the S3/Blob storage with OneByteReader to simulate chunked data (stream)


### PR DESCRIPTION
If multiple filters were enabled, the filtering condition was enforcing a match on all of them instead of at least one of them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved continuous screening filter logic for better performance and code maintainability.

* **Tests**
  * Added comprehensive test coverage for screening filter validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->