### PR TITLE
Snooze job on enrichment 404 fail

### DIFF
--- a/usecases/continuous_screening/worker_match_enrichment.go
+++ b/usecases/continuous_screening/worker_match_enrichment.go
@@ -133,6 +133,11 @@ func (w *ContinuousScreeningMatchEnrichmentWorker) Work(
 		}
 	}
 
+	if errors.Is(errs, models.NotFoundError) {
+		logger.DebugContext(ctx, "404 returned while trying to enrich a delta file row, this may happen if indexation has not yet run. Snoozing one hour...")
+		return river.JobSnooze(1 * time.Hour)
+	}
+
 	return errs
 }
 


### PR DESCRIPTION
We enqueue a job to enrich a row from a delta file when processing it for continuous screening.
If this happens before indexation, we get a 404 and noisy retries of the enrichment job.
Instead, this PR snoozes the job for an hour.