### PR TITLE
Add special treatment for custom datasets.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -174,7 +174,9 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		openSanctionsConfig.WithScope(scope)
 	}
 	if host := utils.GetEnv("SCREENING_LEXISNEXIS_API_HOST", ""); host != "" {
-		openSanctionsConfig.WithLexisNexisHost(host, utils.GetEnv("SCREENING_LEXISNEXIS_TOKEN", ""))
+		openSanctionsConfig.
+			WithLexisNexisHost(host, utils.GetEnv("SCREENING_LEXISNEXIS_TOKEN", "")).
+			WithLexisNexisScope(utils.GetEnv("SCREENING_LEXISNEXIS_SCOPE", ""))
 	}
 
 	if algo := utils.GetEnv("SCREENING_ALGORITHM", ""); algo != "" {

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -106,8 +106,13 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		utils.GetEnv("SCREENING_OPENSANCTIONS_AUTH_METHOD", ""),
 		utils.GetEnv("SCREENING_OPENSANCTIONS_API_KEY", ""),
 	)
+	if scope := utils.GetEnv("SCREENING_OPENSANCTIONS_SCOPE", ""); scope != "" {
+		openSanctionsConfig.WithScope(scope)
+	}
 	if host := utils.GetEnv("SCREENING_LEXISNEXIS_API_HOST", ""); host != "" {
-		openSanctionsConfig.WithLexisNexisHost(host, utils.GetEnv("SCREENING_LEXISNEXIS_TOKEN", ""))
+		openSanctionsConfig.
+			WithLexisNexisHost(host, utils.GetEnv("SCREENING_LEXISNEXIS_TOKEN", "")).
+			WithLexisNexisScope(utils.GetEnv("SCREENING_LEXISNEXIS_SCOPE", ""))
 	}
 	if apiUrl := utils.GetEnv("NAME_RECOGNITION_API_URL", ""); apiUrl != "" {
 		openSanctionsConfig.WithNameRecognition(apiUrl,

--- a/dto/screening_dto.go
+++ b/dto/screening_dto.go
@@ -26,7 +26,7 @@ type ScreeningAvailableFiltersSections struct {
 	Peps         ScreeningAvailableFiltersSection `json:"peps,omitzero"`
 	AdverseMedia ScreeningAvailableFiltersSection `json:"adverse_media,omitzero"`
 	Other        ScreeningAvailableFiltersSection `json:"other,omitzero"`
-	Custom       ScreeningAvailableFiltersSection `json:"custom"`
+	Custom       ScreeningAvailableFiltersSection `json:"custom,omitzero"`
 }
 
 type ScreeningAvailableFiltersSection struct {

--- a/dto/screening_dto.go
+++ b/dto/screening_dto.go
@@ -26,6 +26,7 @@ type ScreeningAvailableFiltersSections struct {
 	Peps         ScreeningAvailableFiltersSection `json:"peps,omitzero"`
 	AdverseMedia ScreeningAvailableFiltersSection `json:"adverse_media,omitzero"`
 	Other        ScreeningAvailableFiltersSection `json:"other,omitzero"`
+	Custom       ScreeningAvailableFiltersSection `json:"custom"`
 }
 
 type ScreeningAvailableFiltersSection struct {

--- a/infra/screening.go
+++ b/infra/screening.go
@@ -113,6 +113,14 @@ func (os *Screening) WithLexisNexisHost(host, token string) *Screening {
 	return os
 }
 
+func (os *Screening) WithLexisNexisScope(scope string) *Screening {
+	if scope != "" {
+		os.providers["lexisnexis"].scope = scope
+	}
+
+	return os
+}
+
 func (os *Screening) WithNameRecognition(apiUrl, apiKey string) *Screening {
 	os.nameRecognition = &NameRecognitionProvider{
 		ApiUrl: apiUrl,

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -16,6 +16,7 @@ const OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY = 1 * time.Hour
 // Note: I didn't declare all fields, only those needed for our logic, don't hesitate to add more if needed
 type OpenSanctionsRawDataset struct {
 	Name     string
+	Title    string
 	Version  string
 	Load     bool
 	Tags     []string

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -107,6 +107,7 @@ type ScreeningConfigFilters struct {
 	Peps         *ScreeningConfigFilter `json:"peps,omitempty"`
 	AdverseMedia *ScreeningConfigFilter `json:"adverse_media,omitempty"`
 	Other        *ScreeningConfigFilter `json:"other,omitempty"`
+	Custom       *ScreeningConfigFilter `json:"custom,omitempty"`
 }
 
 type ResolvedScreeningConfigFilters struct {
@@ -115,6 +116,7 @@ type ResolvedScreeningConfigFilters struct {
 	Peps         ScreeningConfigFilter
 	AdverseMedia ScreeningConfigFilter
 	Other        ScreeningConfigFilter
+	Custom       ScreeningConfigFilter
 }
 
 func (scf *ScreeningConfigFilters) IsEmpty() bool {
@@ -122,14 +124,15 @@ func (scf *ScreeningConfigFilters) IsEmpty() bool {
 		return true
 	}
 
-	return scf.Global == nil && scf.Sanctions == nil && scf.Peps == nil && scf.AdverseMedia == nil && scf.Other == nil
+	return scf.Global == nil && scf.Sanctions == nil && scf.Peps == nil && scf.AdverseMedia == nil && scf.Other == nil && scf.Custom == nil
 }
 
 func (scf ResolvedScreeningConfigFilters) NoFilters() bool {
 	return !scf.Sanctions.IsEnabled() &&
 		!scf.Peps.IsEnabled() &&
 		!scf.AdverseMedia.IsEnabled() &&
-		!scf.Other.IsEnabled()
+		!scf.Other.IsEnabled() &&
+		!scf.Custom.IsEnabled()
 }
 
 func (scf ResolvedScreeningConfigFilters) WithRootTopics() map[string]ScreeningConfigFilter {
@@ -139,6 +142,7 @@ func (scf ResolvedScreeningConfigFilters) WithRootTopics() map[string]ScreeningC
 		"pep":           scf.Peps,
 		"adverse_media": scf.AdverseMedia,
 		"other":         scf.Other,
+		"custom":        scf.Custom,
 	}
 }
 
@@ -178,6 +182,7 @@ func (scf ResolvedScreeningConfigFilters) ToLegacyDatasets() []string {
 	datasets = append(datasets, scf.Peps.Datasets...)
 	datasets = append(datasets, scf.AdverseMedia.Datasets...)
 	datasets = append(datasets, scf.Other.Datasets...)
+	datasets = append(datasets, scf.Custom.Datasets...)
 
 	return datasets
 }
@@ -190,6 +195,7 @@ func (scf *ScreeningConfigFilters) Resolve() ResolvedScreeningConfigFilters {
 			Peps:         ScreeningConfigFilter{},
 			AdverseMedia: ScreeningConfigFilter{},
 			Other:        ScreeningConfigFilter{},
+			Custom:       ScreeningConfigFilter{},
 		}
 	}
 
@@ -223,6 +229,12 @@ func (scf *ScreeningConfigFilters) Resolve() ResolvedScreeningConfigFilters {
 				return ScreeningConfigFilter{}
 			}
 			return *scf.Other
+		}(),
+		Custom: func() ScreeningConfigFilter {
+			if scf.Custom == nil {
+				return ScreeningConfigFilter{}
+			}
+			return *scf.Custom
 		}(),
 	}
 }

--- a/repositories/httpmodels/http_opensanctions_dataset.go
+++ b/repositories/httpmodels/http_opensanctions_dataset.go
@@ -56,6 +56,7 @@ func AdaptOpenSanctionCatalogResponse(datasets HTTPOpenSanctionCatalogResponse) 
 	for _, dataset := range datasets.Datasets {
 		rawCatalog.Datasets[dataset.Name] = models.OpenSanctionsRawDataset{
 			Name:     dataset.Name,
+			Title:    dataset.Title,
 			Version:  dataset.Version,
 			Load:     dataset.Load,
 			Tags:     dataset.Tags,

--- a/repositories/screening/provider_lexisnexis.go
+++ b/repositories/screening/provider_lexisnexis.go
@@ -31,7 +31,9 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 	}
 
 	if p.Config.MotivaFeatures(ctx).BodyParams {
-		q.Params = &motivaRequestParams{}
+		q.Params = &motivaRequestParams{
+			IncludeDatasets: []string{"lexisnexis"},
+		}
 
 		if len(query.WhitelistedEntityIds) > 0 {
 			q.Params.ExcludeEntityIds = query.WhitelistedEntityIds
@@ -42,12 +44,13 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 		filters := query.Config.Filters.Resolve()
 
 		for topic, filter := range filters.WithRootTopics() {
-			if topic != "global" && (filters.NoFilters() || filter.IsEnabled()) {
+			if topic != "global" && topic != "custom" && (filters.NoFilters() || filter.IsEnabled()) {
 				id := pure_utils.NewId().String()
 
 				q.Queries[id] = openSanctionsRequestQuery{
 					Schema:     subquery.Type,
 					Properties: subquery.Filters,
+					Params:     &motivaRequestParams{IncludeDatasets: []string{"lexisnexis"}},
 					Filters: map[string][][]string{
 						"topics": {{topic}},
 					},
@@ -66,6 +69,16 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 						q.Queries[id].Filters["topics"] = append(q.Queries[id].Filters["topics"], topic)
 					}
 				}
+			}
+		}
+
+		if len(filters.Custom.Datasets) > 0 {
+			id := pure_utils.NewId().String()
+
+			q.Queries[id] = openSanctionsRequestQuery{
+				Schema:     subquery.Type,
+				Properties: subquery.Filters,
+				Params:     &motivaRequestParams{IncludeDatasets: filters.Custom.Datasets},
 			}
 		}
 	}
@@ -150,8 +163,9 @@ func (p ScreeningLexisNexisProvider) BuildQueryString(ctx context.Context,
 }
 
 type lexisNexisAvailableFilters struct {
-	Datasets []string `json:"properties.programId"` //nolint:tagliatelle
-	Topics   []string `json:"properties.topics"`    //nolint:tagliatelle
+	Datasets       []string `json:"properties.programId"` //nolint:tagliatelle
+	Topics         []string `json:"properties.topics"`    //nolint:tagliatelle
+	CustomDatasets []string `json:"datasets"`             //nolint:tagliatelle
 }
 
 func (p ScreeningLexisNexisProvider) FindAvailableFilters(ctx context.Context, feature models.ScreeningFeature) (dto.ScreeningAvailableFilters, error) {
@@ -163,10 +177,14 @@ func (p ScreeningLexisNexisProvider) FindAvailableFilters(ctx context.Context, f
 	url := fmt.Sprintf("%s/catalog/fields", p.Config.Host(models.ScreeningProviderLexisNexis))
 
 	payload := map[string]any{
-		"fields": []string{"properties.programId", "properties.topics"},
+		"fields": []string{"properties.programId", "properties.topics", "datasets"},
 		"query": map[string]any{
-			"term": map[string]any{
-				"datasets": "lexisnexis",
+			"bool": map[string]any{
+				"minimum_should_match": 1,
+				"should": []any{
+					map[string]any{"term": map[string]any{"datasets": "lexisnexis"}},
+					map[string]any{"prefix": map[string]any{"datasets": "marble_custom_"}},
+				},
 			},
 		},
 	}
@@ -243,6 +261,26 @@ func (p ScreeningLexisNexisProvider) FindAvailableFilters(ctx context.Context, f
 		filters.Sections.AdverseMedia = dto.ScreeningAvailableFiltersSection{
 			Self:   "adverse_media",
 			Topics: p.buildTopicFilterFor(feature, values.Topics, "adverse_media"),
+		}
+	}
+
+	if len(values.CustomDatasets) > 0 {
+		for _, ds := range values.CustomDatasets {
+			if ds == "lexisnexis" {
+				continue
+			}
+
+			if filters.Sections.Custom.Self == "" {
+				filters.Sections.Custom = dto.ScreeningAvailableFiltersSection{
+					Self: "other",
+				}
+			}
+
+			filters.Sections.Custom.Datasets = append(filters.Sections.Custom.Datasets, dto.ScreeningAvailableFiltersItem{
+				Section: "custom",
+				Name:    ds,
+				Title:   ds,
+			})
 		}
 	}
 

--- a/repositories/screening/provider_lexisnexis.go
+++ b/repositories/screening/provider_lexisnexis.go
@@ -20,7 +20,8 @@ import (
 )
 
 type ScreeningLexisNexisProvider struct {
-	Config infra.Screening
+	Config     infra.Screening
+	Repository OpenSanctionsRepository
 }
 
 func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
@@ -72,13 +73,32 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 			}
 		}
 
-		if len(filters.Custom.Datasets) > 0 {
-			id := pure_utils.NewId().String()
+		if len(filters.Custom.Datasets) > 0 || filters.NoFilters() {
+			datasets := filters.Custom.Datasets
 
-			q.Queries[id] = openSanctionsRequestQuery{
-				Schema:     subquery.Type,
-				Properties: subquery.Filters,
-				Params:     &motivaRequestParams{IncludeDatasets: filters.Custom.Datasets},
+			if filters.NoFilters() {
+				catalog, err := p.Repository.GetRawCatalog(ctx, models.ScreeningProviderLexisNexis)
+				if err != nil {
+					return nil, nil, err
+				}
+
+				datasets = make([]string, 0)
+
+				for _, ds := range catalog.Datasets {
+					if strings.HasPrefix(ds.Name, "marble_custom_") {
+						datasets = append(datasets, ds.Name)
+					}
+				}
+			}
+
+			if len(datasets) > 0 {
+				id := pure_utils.NewId().String()
+
+				q.Queries[id] = openSanctionsRequestQuery{
+					Schema:     subquery.Type,
+					Properties: subquery.Filters,
+					Params:     &motivaRequestParams{IncludeDatasets: datasets},
+				}
 			}
 		}
 	}
@@ -169,6 +189,11 @@ type lexisNexisAvailableFilters struct {
 }
 
 func (p ScreeningLexisNexisProvider) FindAvailableFilters(ctx context.Context, feature models.ScreeningFeature) (dto.ScreeningAvailableFilters, error) {
+	rawCatalog, err := p.Repository.GetRawCatalog(ctx, models.ScreeningProviderLexisNexis)
+	if err != nil {
+		return dto.ScreeningAvailableFilters{}, err
+	}
+
 	catalog, err := p.GetLexisNexisCatalog(ctx)
 	if err != nil {
 		return dto.ScreeningAvailableFilters{}, err
@@ -272,14 +297,22 @@ func (p ScreeningLexisNexisProvider) FindAvailableFilters(ctx context.Context, f
 
 			if filters.Sections.Custom.Self == "" {
 				filters.Sections.Custom = dto.ScreeningAvailableFiltersSection{
-					Self: "other",
+					Self: "custom",
+				}
+			}
+
+			title := ds
+
+			for _, catalogDataset := range rawCatalog.Datasets {
+				if catalogDataset.Name == ds {
+					title = catalogDataset.Title
 				}
 			}
 
 			filters.Sections.Custom.Datasets = append(filters.Sections.Custom.Datasets, dto.ScreeningAvailableFiltersItem{
 				Section: "custom",
 				Name:    ds,
-				Title:   ds,
+				Title:   title,
 			})
 		}
 	}

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -76,6 +76,7 @@ type openSanctionsRequestQuery struct {
 	Schema     string                     `json:"schema"`
 	Properties models.OpenSanctionsFilter `json:"properties"`
 	Filters    map[string][][]string      `json:"filters"`
+	Params     *motivaRequestParams       `json:"params"`
 }
 
 func (repo OpenSanctionsRepository) IsSelfHosted(ctx context.Context) bool {

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -327,7 +327,7 @@ func (repo OpenSanctionsRepository) GetAlgorithms(ctx context.Context) (models.O
 func (repo OpenSanctionsRepository) GetProvider(provider models.ScreeningProvider) ScreeningProvider {
 	switch provider {
 	case models.ScreeningProviderLexisNexis:
-		return ScreeningLexisNexisProvider(repo)
+		return ScreeningLexisNexisProvider{Config: repo.Config, Repository: repo}
 	default:
 		return ScreeningOpenSanctionsProvider(repo)
 	}

--- a/usecases/screening_config_usecase.go
+++ b/usecases/screening_config_usecase.go
@@ -179,6 +179,7 @@ func (uc ScreeningUsecase) AdaptConfigForProvider(providerName models.ScreeningP
 		scc.Datasets = make([]string, 0)
 		scc.Datasets = append(scc.Datasets, filters.Sanctions.Datasets...)
 		scc.Datasets = append(scc.Datasets, filters.Other.Datasets...)
+		scc.Datasets = append(scc.Datasets, filters.Custom.Datasets...)
 	}
 
 	return scc

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"mime/multipart"
 	"slices"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
@@ -251,9 +252,14 @@ func (uc ScreeningUsecase) GetAvailableFilters(ctx context.Context, feature mode
 		pepDatasets := []dto.ScreeningAvailableFiltersItem{}
 		mediaDatasets := []dto.ScreeningAvailableFiltersItem{}
 		otherDatasets := []dto.ScreeningAvailableFiltersItem{}
+		customDatasets := []dto.ScreeningAvailableFiltersItem{}
 
 		for _, s := range catalog.Sections {
 			for _, d := range s.Datasets {
+				if d.Name == "lexisnexis" {
+					continue
+				}
+
 				switch d.Tag {
 				case "sanctions":
 					sanctionsDatasets = append(sanctionsDatasets, dto.ScreeningAvailableFiltersItem{Section: s.Name, Name: d.Name, Title: d.Title})
@@ -262,7 +268,12 @@ func (uc ScreeningUsecase) GetAvailableFilters(ctx context.Context, feature mode
 				case "adverse-media":
 					mediaDatasets = append(mediaDatasets, dto.ScreeningAvailableFiltersItem{Section: s.Name, Name: d.Name, Title: d.Title})
 				default:
-					otherDatasets = append(otherDatasets, dto.ScreeningAvailableFiltersItem{Section: s.Name, Name: d.Name, Title: d.Title})
+					switch strings.HasPrefix(d.Name, "marble_custom_") {
+					case true:
+						customDatasets = append(customDatasets, dto.ScreeningAvailableFiltersItem{Section: "Custom", Name: d.Name, Title: d.Title})
+					case false:
+						otherDatasets = append(otherDatasets, dto.ScreeningAvailableFiltersItem{Section: s.Name, Name: d.Name, Title: d.Title})
+					}
 				}
 			}
 		}
@@ -281,6 +292,9 @@ func (uc ScreeningUsecase) GetAvailableFilters(ctx context.Context, feature mode
 				},
 				Other: dto.ScreeningAvailableFiltersSection{
 					Datasets: otherDatasets,
+				},
+				Custom: dto.ScreeningAvailableFiltersSection{
+					Datasets: customDatasets,
 				},
 			},
 		}


### PR DESCRIPTION
Custom datasets are required to have the `marble_custom_` prefix, and will appear under their own sections when configuring screening.

When using Lexis Nexis, use of custom datasets will add (yet another) query, in the form of Open Sanctions (no topics, no programId, but actual datasets) containing the search terms for all selected custom datasets.

It **will** require an upgrade to motiva that can support query-level params.

---

Related (and required) PRs:

 * checkmarble/marble-frontend#1605
 * apognu/motiva#93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for user-configurable custom datasets in screening.
  * Dedicated "Custom" section added to available screening filters.
  * Provider search now includes custom datasets as selectable query targets.

* **Enhancements**
  * Configurable scope options for LexisNexis and OpenSanctions integrations via environment settings.
  * Dataset title metadata surfaced in OpenSanctions catalog listings.
  * Improved filter evaluation and query handling to surface and organize custom datasets alongside existing categories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->