### PR TITLE
Copy provider when updating a continuous screening config.

### DIFF
--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -65,7 +65,6 @@ type OpenSanctionsQuery struct {
 	// cf: `exclude_entity_ids` in the OpenSanctions query
 	WhitelistedEntityIds []string
 	UseScopedIndex       bool
-	Filters              ScreeningConfigFilters
 }
 
 type OpenSanctionsCheckQuery struct {

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -281,8 +281,8 @@ func prepareOpenSanctionsQuery(
 		},
 		Config: models.ScreeningConfig{
 			Datasets: config.Datasets,
+			Filters:  config.Filters,
 		},
-		Filters: config.Filters,
 		Queries: []models.OpenSanctionsCheckQuery{
 			{
 				Type:    dataModelEntityType,

--- a/usecases/continuous_screening/org_config.go
+++ b/usecases/continuous_screening/org_config.go
@@ -396,6 +396,7 @@ func createUpdatedConfig(config models.ContinuousScreeningConfig,
 	return models.CreateContinuousScreeningConfig{
 		OrgId:          config.OrgId,
 		StableId:       config.StableId,
+		Provider:       config.Provider,
 		Name:           pure_utils.PtrValueOrDefault(updateInput.Name, config.Name),
 		Description:    pure_utils.PtrValueOrDefault(updateInput.Description, config.Description),
 		Algorithm:      pure_utils.PtrValueOrDefault(updateInput.Algorithm, config.Algorithm),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Continuous screening updates now preserve provider settings so existing provider info remains intact after edits.
  * Screening queries now apply configured filters correctly (filters are nested with the screening configuration), improving accuracy of screening results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->