### PR TITLE
fix: import&export don't manage screening provider field

### DIFF
--- a/dto/org_export.go
+++ b/dto/org_export.go
@@ -7,12 +7,21 @@ import (
 )
 
 func AdaptImportOrgDto(org models.Organization) ImportOrg {
+	var screeningProviders map[string]models.ScreeningProvider
+	if len(org.OpenSanctionsConfig.Providers) > 0 {
+		screeningProviders = make(map[string]models.ScreeningProvider, len(org.OpenSanctionsConfig.Providers))
+		for feature, provider := range org.OpenSanctionsConfig.Providers {
+			screeningProviders[string(feature)] = provider
+		}
+	}
+
 	return ImportOrg{
 		Name: org.Name,
 		UpdateOrganizationBodyDto: UpdateOrganizationBodyDto{
 			DefaultScenarioTimezone: org.DefaultScenarioTimezone,
 			SanctionsThreshold:      utils.Ptr(org.OpenSanctionsConfig.MatchThreshold),
 			SanctionsLimit:          utils.Ptr(org.OpenSanctionsConfig.MatchLimit),
+			ScreeningProviders:      screeningProviders,
 		},
 	}
 }

--- a/dto/screening_config_dto.go
+++ b/dto/screening_config_dto.go
@@ -16,6 +16,7 @@ type ScreeningConfig struct {
 	Name                     *string                              `json:"name"`
 	Description              *string                              `json:"description"`
 	RuleGroup                *string                              `json:"rule_group,omitempty"`
+	Provider                 models.ScreeningProvider             `json:"provider,omitempty"`
 	Datasets                 []string                             `json:"datasets,omitempty"`
 	Filters                  models.ScreeningConfigFilters        `json:"filters"`
 	Threshold                *int                                 `json:"threshold,omitempty" binding:"omitempty,min=0,max=100"`
@@ -34,6 +35,7 @@ func AdaptScreeningConfig(model models.ScreeningConfig) (ScreeningConfig, error)
 		Name:          &model.Name,
 		Description:   &model.Description,
 		RuleGroup:     model.RuleGroup,
+		Provider:      model.Provider,
 		Datasets:      model.Datasets,
 		Filters:       model.Filters,
 		Threshold:     model.Threshold,

--- a/repositories/screening_config_repository.go
+++ b/repositories/screening_config_repository.go
@@ -153,6 +153,11 @@ func (repo *MarbleDbRepository) CreateScreeningConfig(ctx context.Context, exec 
 		filters = *cfg.Filters
 	}
 
+	provider := models.DefaultScreeningProvider
+	if cfg.Provider != nil && *cfg.Provider != "" {
+		provider = *cfg.Provider
+	}
+
 	sql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_SCREENING_CONFIGS).
 		Columns(
@@ -178,7 +183,7 @@ func (repo *MarbleDbRepository) CreateScreeningConfig(ctx context.Context, exec 
 			cfg.Name,
 			utils.Or(cfg.Description, ""),
 			utils.Or(cfg.RuleGroup, ""),
-			cfg.Provider,
+			provider,
 			cfg.Datasets,
 			filters,
 			cfg.Threshold,

--- a/usecases/org_import_usecase.go
+++ b/usecases/org_import_usecase.go
@@ -305,6 +305,7 @@ func (uc *OrgImportUsecase) createOrganization(ctx context.Context, tx repositor
 		ScreeningConfig: models.OrganizationOpenSanctionsConfigUpdateInput{
 			MatchThreshold: spec.Org.SanctionsThreshold,
 			MatchLimit:     spec.Org.SanctionsLimit,
+			Providers:      spec.Org.ScreeningProviders,
 		},
 	})
 	if err != nil {
@@ -948,6 +949,7 @@ func (uc *OrgImportUsecase) createScenarios(ctx context.Context, tx repositories
 				Name:                     sc.Name,
 				Description:              sc.Description,
 				RuleGroup:                sc.RuleGroup,
+				Provider:                 utils.Ptr(sc.Provider),
 				Datasets:                 sc.Datasets,
 				Threshold:                sc.Threshold,
 				TriggerRule:              triggerRule,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization import now propagates screening provider settings into imported organizations.
  * Screening configuration now exposes and preserves provider selection with imports and edits.
  * Creation of screening configs applies a sensible default provider when none is specified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->