### PR TITLE
Fixed panic when error was left nil on ServeErrorResponse in the public screening API.

### DIFF
--- a/pubapi/types/response.go
+++ b/pubapi/types/response.go
@@ -235,6 +235,10 @@ func (resp baseResponse[T]) Serve(c *gin.Context, statuses ...int) {
 }
 
 func (resp baseErrorResponse) Serve(c *gin.Context, statuses ...int) {
+	if resp.Error.err == nil {
+		resp.Error.err = ErrInternalServerError
+	}
+
 	ctx := c.Request.Context()
 	msg := resp.Error.err.Error()
 

--- a/pubapi/v1/screening.go
+++ b/pubapi/v1/screening.go
@@ -106,6 +106,7 @@ func HandleRefineScreening(uc usecases.Usecases, write bool) gin.HandlerFunc {
 		if !params.Validate() {
 			types.
 				NewErrorResponse().
+				WithError(types.ErrInvalidPayload).
 				WithErrorMessage("refine query is missing some required fields").
 				Serve(c, http.StatusBadRequest)
 			return
@@ -175,6 +176,7 @@ func HandleScreeningFreeformSearch(uc usecases.Usecases) gin.HandlerFunc {
 		if !params.Validate() {
 			types.
 				NewErrorResponse().
+				WithError(types.ErrInvalidPayload).
 				WithErrorMessage("refine query is missing some required fields").
 				Serve(c, http.StatusBadRequest)
 			return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling consistency across API responses by implementing proper initialization checks to ensure all error values are correctly initialized before processing and downstream use.
  * Enhanced error reporting for screening operations, now providing more explicit and detailed error information when parameter validation fails to help clients better understand validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->