### PR TITLE
fix: invalid navigation options when fields have same name

### DIFF
--- a/models/data_model.go
+++ b/models/data_model.go
@@ -551,7 +551,7 @@ func (d DataModel) AddNavigationOptionsToDataModel(indexes []ConcreteIndex, pivo
 			if pivot.BaseTable != index.TableName {
 				continue
 			}
-			if pivot.Field != field.Name {
+			if pivot.FieldId != field.ID {
 				continue
 			}
 


### PR DESCRIPTION
### Problem

Importing an org export was failing with:

```
NotFoundError: filter field <id> not found in table <table>
```

Investigating the export revealed a malformed navigation option where `source_field_id == filter_field_id`, and the filter field belonged to the **source** table rather than the target table — which is structurally invalid and caused the import to fail.

### Root cause

In `AddNavigationOptionsToDataModel` (`models/data_model.go`), the pivot branch matched using field **names** (`pivot.Field != field.Name`). For a **path pivot**, `pivot.Field` resolves to the parent field at the end of the path (in a remote table), while `field` is the indexed field in the base table. Because field names like `legal_person_id` (in our example) are reused across tables, these two different fields could produce a false name match, triggering spurious navigation option generation.

Concretely: `account` had a path pivot (`account.legal_person_id → legal_person`), and a navigation index on `account.legal_person_id`. The pivot's resolved field name (`legal_person.legal_person_id`) matched the index field name (`account.legal_person_id`) → an invalid navigation option was generated from `account` back to `legal_person` with `source_field == filter_field`, both pointing to the same `account` field.

### Fix

Replace the name comparison with an **ID comparison** (`pivot.FieldId != field.ID`). Field IDs are globally unique, so this correctly distinguishes fields that share the same name in different tables. The fix only suppresses navigation options produced by path pivots with name collisions — link-based and field-pivot-based options are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation option generation for pivot definitions by enhancing the underlying field matching mechanism to ensure more reliable and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->