### PR TITLE
batch size used by backend for csv ingestion internals is made config…

### DIFF
--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -32,11 +32,12 @@ import (
 )
 
 const (
-	csvIngestionBatchSize        = 1000
 	DefaultApiBatchIngestionSize = 100
 
 	CSV_INGESTION_ITERATION_TIMEOUT = 10 * time.Second
 )
+
+var csvIngestionBatchSize = utils.GetEnv("CSV_INGESTION_BATCH_SIZE", 1000)
 
 type continuousScreeningRepository interface {
 	ListContinuousScreeningConfigByObjectType(


### PR DESCRIPTION
We're running into issues with large numbers of columns. This is a dirty workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV ingestion batch size is now configurable via environment variable, enabling runtime optimization of data processing performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->