### PR TITLE
Implement soft delete for pivot records

### DIFF
--- a/mocks/data_model_repository.go
+++ b/mocks/data_model_repository.go
@@ -108,8 +108,9 @@ func (d *DataModelRepository) ListPivots(
 	organizationId uuid.UUID,
 	tableId *string,
 	useCache bool,
+	includeDeleted bool,
 ) ([]models.PivotMetadata, error) {
-	args := d.Called(ctx, exec, organizationId, tableId, useCache)
+	args := d.Called(ctx, exec, organizationId, tableId, useCache, includeDeleted)
 	if args.Error(1) != nil {
 		return nil, args.Error(1)
 	}
@@ -173,6 +174,16 @@ func (d *DataModelRepository) DeleteDataModelLink(ctx context.Context, exec repo
 }
 
 func (d *DataModelRepository) DeleteDataModelPivot(ctx context.Context, exec repositories.Executor, id string) error {
+	args := d.Called(ctx, exec, id)
+	return args.Error(0)
+}
+
+func (d *DataModelRepository) SoftDeletePivot(ctx context.Context, exec repositories.Executor, id string) error {
+	args := d.Called(ctx, exec, id)
+	return args.Error(0)
+}
+
+func (d *DataModelRepository) RestorePivot(ctx context.Context, exec repositories.Executor, id string) error {
 	args := d.Called(ctx, exec, id)
 	return args.Error(0)
 }

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -17,6 +17,10 @@ type PivotMetadata struct {
 	BaseTableId string
 	FieldId     *string
 	PathLinkIds []string
+
+	// Pivots are soft-deleted: decisions keep referencing their pivot_id after the
+	// pivot is removed, so the definition must remain readable for historical data.
+	DeletedAt *time.Time
 }
 
 type Pivot struct {
@@ -34,6 +38,8 @@ type Pivot struct {
 
 	PathLinks   []string
 	PathLinkIds []string
+
+	DeletedAt *time.Time
 }
 
 func (p PivotMetadata) Enrich(dataModel DataModel) Pivot {
@@ -44,6 +50,7 @@ func (p PivotMetadata) Enrich(dataModel DataModel) Pivot {
 
 		BaseTableId: p.BaseTableId,
 		PathLinkIds: p.PathLinkIds,
+		DeletedAt:   p.DeletedAt,
 	}
 
 	baseTable := dataModel.AllTablesAsMap()[p.BaseTableId]

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -686,6 +686,9 @@ func (repo *MarbleDbRepository) GetNextCase(ctx context.Context, exec Executor, 
 //     plus pivots defined directly on a field of that table (no belongs_to link, pivot uses field_id instead of a path)
 //  3. Find all decisions whose pivot ID is one of those pivots, and whose pivot value is the record under evaluation
 //
+// Soft-deleted pivots are intentionally included: historical decisions keep referencing
+// their pivot_id after the pivot is deleted, and must still surface related cases.
+//
 // Parameters: $1 = orgId, $2 = objectType (table name), $3 = objectId (pivot value).
 // Exposes a `decisions(case_id)` CTE for the caller to join against.
 const casesRelatedToObjectCTE = `

--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -64,8 +64,10 @@ type DataModelRepository interface {
 
 	CreatePivot(ctx context.Context, exec Executor, id string, pivot models.CreatePivotInput) error
 	ListPivots(ctx context.Context, exec Executor, organizationId uuid.UUID, tableId *string,
-		useCache bool) ([]models.PivotMetadata, error)
+		useCache bool, includeDeleted bool) ([]models.PivotMetadata, error)
 	GetPivot(ctx context.Context, exec Executor, pivotId string) (models.PivotMetadata, error)
+	SoftDeletePivot(ctx context.Context, exec Executor, id string) error
+	RestorePivot(ctx context.Context, exec Executor, id string) error
 
 	GetDataModelOptionsForTable(ctx context.Context, exec Executor, tableId string) (*models.DataModelOptions, error)
 	UpsertDataModelOptions(ctx context.Context, exec Executor,
@@ -526,6 +528,7 @@ func (repo MarbleDbRepository) GetLinks(ctx context.Context, exec Executor, orga
 			SELECT 1 FROM data_model_pivots p
 			WHERE p.organization_id = links.organization_id
 			AND links.id = ANY(p.path_link_ids)
+			AND p.deleted_at IS NULL
 		) AS is_belongs_to
 	FROM data_model_links AS links
     	JOIN data_model_tables AS parent_table ON (links.parent_table_id = parent_table.id)
@@ -701,16 +704,23 @@ func (repo MarbleDbRepository) CreatePivot(
 	return repo.DeleteDataModelCache(ctx, exec)
 }
 
+// ListPivots returns pivots that have not been soft-deleted, unless includeDeleted is
+// set. Including soft-deleted pivots is required when resolving pivots referenced by
+// historical decisions, which may point to a pivot that has since been deleted.
 func (repo MarbleDbRepository) ListPivots(
 	ctx context.Context,
 	exec Executor,
 	organizationId uuid.UUID,
 	tableId *string,
 	useCache bool,
+	includeDeleted bool,
 ) ([]models.PivotMetadata, error) {
 	cacheKey := organizationId.String()
 	if tableId != nil {
 		cacheKey = organizationId.String() + *tableId
+	}
+	if includeDeleted {
+		cacheKey += "|withDeleted"
 	}
 
 	if useCache && repo.withCache {
@@ -731,6 +741,9 @@ func (repo MarbleDbRepository) ListPivots(
 
 	if tableId != nil {
 		query = query.Where(squirrel.Eq{"base_table_id": *tableId})
+	}
+	if !includeDeleted {
+		query = query.Where(squirrel.Eq{"deleted_at": nil})
 	}
 
 	pivots, err := SqlToListOfModels(ctx, exec, query, dbmodels.AdaptPivotMetadata)
@@ -897,6 +910,10 @@ func (repo MarbleDbRepository) DeleteDataModelLink(ctx context.Context, exec Exe
 	return repo.DeleteDataModelCache(ctx, exec)
 }
 
+// DeleteDataModelPivot hard-deletes a pivot row. It must only be used when nothing can
+// reference the pivot anymore (e.g. the whole table is being deleted, or the pivot was
+// just created in the same transaction). User-facing deletion flows must use
+// SoftDeletePivot instead, because decisions keep referencing their pivot_id.
 func (repo MarbleDbRepository) DeleteDataModelPivot(ctx context.Context, exec Executor, id string) error {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return err
@@ -905,6 +922,40 @@ func (repo MarbleDbRepository) DeleteDataModelPivot(ctx context.Context, exec Ex
 	query := NewQueryBuilder().
 		Delete("data_model_pivots").
 		Where("id = ?", id)
+
+	if err := ExecBuilder(ctx, exec, query); err != nil {
+		return err
+	}
+
+	return repo.DeleteDataModelCache(ctx, exec)
+}
+
+func (repo MarbleDbRepository) SoftDeletePivot(ctx context.Context, exec Executor, id string) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_DATA_MODEL_PIVOTS).
+		Set("deleted_at", squirrel.Expr("now()")).
+		Where(squirrel.Eq{"id": id})
+
+	if err := ExecBuilder(ctx, exec, query); err != nil {
+		return err
+	}
+
+	return repo.DeleteDataModelCache(ctx, exec)
+}
+
+func (repo MarbleDbRepository) RestorePivot(ctx context.Context, exec Executor, id string) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_DATA_MODEL_PIVOTS).
+		Set("deleted_at", nil).
+		Where(squirrel.Eq{"id": id})
 
 	if err := ExecBuilder(ctx, exec, query); err != nil {
 		return err

--- a/repositories/dbmodels/db_data_model_pivot.go
+++ b/repositories/dbmodels/db_data_model_pivot.go
@@ -10,12 +10,13 @@ import (
 )
 
 type DbPivot struct {
-	Id             uuid.UUID   `db:"id"`
-	BaseTableId    string      `db:"base_table_id"`
-	CreatedAt      time.Time   `db:"created_at"`
-	FieldId        pgtype.Text `db:"field_id"`
-	OrganizationId uuid.UUID   `db:"organization_id"`
-	PathLinkIds    []string    `db:"path_link_ids"`
+	Id             uuid.UUID          `db:"id"`
+	BaseTableId    string             `db:"base_table_id"`
+	CreatedAt      time.Time          `db:"created_at"`
+	FieldId        pgtype.Text        `db:"field_id"`
+	OrganizationId uuid.UUID          `db:"organization_id"`
+	PathLinkIds    []string           `db:"path_link_ids"`
+	DeletedAt      pgtype.Timestamptz `db:"deleted_at"`
 }
 
 const TABLE_DATA_MODEL_PIVOTS = "data_model_pivots"
@@ -33,6 +34,9 @@ func AdaptPivotMetadata(dbPivot DbPivot) (models.PivotMetadata, error) {
 	}
 	if dbPivot.FieldId.Valid {
 		pivot.FieldId = &dbPivot.FieldId.String
+	}
+	if dbPivot.DeletedAt.Valid {
+		pivot.DeletedAt = &dbPivot.DeletedAt.Time
 	}
 
 	return pivot, nil

--- a/repositories/migrations/20260611100000_soft_delete_data_model_pivots.sql
+++ b/repositories/migrations/20260611100000_soft_delete_data_model_pivots.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+alter table data_model_pivots
+add column deleted_at timestamp with time zone;
+
+-- Replace the unique index with a partial one so that a new pivot can be created
+-- on a table after its previous pivot has been soft-deleted.
+drop index data_model_pivots_base_table_id_idx;
+
+create unique index data_model_pivots_base_table_id_idx
+on data_model_pivots (organization_id, base_table_id)
+where deleted_at is null;
+
+-- +goose Down
+delete from data_model_pivots
+where deleted_at is not null;
+
+drop index data_model_pivots_base_table_id_idx;
+
+create unique index data_model_pivots_base_table_id_idx
+on data_model_pivots (organization_id, base_table_id);
+
+alter table data_model_pivots
+drop column deleted_at;

--- a/usecases/ast_eval/evaluate/evaluate_entity_annotation_check.go
+++ b/usecases/ast_eval/evaluate/evaluate_entity_annotation_check.go
@@ -34,6 +34,7 @@ type EntityAnnotationCheckRepository interface {
 		organizationId uuid.UUID,
 		tableId *string,
 		useCache bool,
+		includeDeleted bool,
 	) ([]models.PivotMetadata, error)
 }
 
@@ -585,7 +586,7 @@ func (mlc EntityAnnotationCheck) buildDataModelWithNavigationOptions(
 	execDbClient repositories.Executor,
 ) (models.DataModel, error) {
 	// Fetch pivots
-	pivotsMeta, err := mlc.Repository.ListPivots(ctx, exec, mlc.OrgId, nil, true)
+	pivotsMeta, err := mlc.Repository.ListPivots(ctx, exec, mlc.OrgId, nil, true, false)
 	if err != nil {
 		return models.DataModel{}, errors.Wrap(err, "failed to list pivots")
 	}

--- a/usecases/ast_eval/evaluate/evaluate_entity_annotation_check_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_entity_annotation_check_test.go
@@ -51,8 +51,9 @@ func (m *mockMonitoringListCheckRepository) ListPivots(
 	organizationId uuid.UUID,
 	tableId *string,
 	useCache bool,
+	includeDeleted bool,
 ) ([]models.PivotMetadata, error) {
-	args := m.Called(ctx, exec, organizationId, tableId, useCache)
+	args := m.Called(ctx, exec, organizationId, tableId, useCache, includeDeleted)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/usecases/ast_eval/evaluate/evaluate_record_score.go
+++ b/usecases/ast_eval/evaluate/evaluate_record_score.go
@@ -31,6 +31,7 @@ type evaluateRecordRiskLevelRepository interface {
 		organizationId uuid.UUID,
 		tableId *string,
 		useCache bool,
+		includeDeleted bool,
 	) ([]models.PivotMetadata, error)
 	GetActiveScore(
 		ctx context.Context,
@@ -167,7 +168,7 @@ func (rs RecordRiskLevel) getPivotRuleset(ctx context.Context, exec repositories
 		return models.ScoringRuleset{}, "", "", models.NotFoundError
 	}
 
-	pivots, err := rs.repository.ListPivots(ctx, exec, rs.orgId, &table.ID, false)
+	pivots, err := rs.repository.ListPivots(ctx, exec, rs.orgId, &table.ID, false, false)
 	if err != nil {
 		return models.ScoringRuleset{}, "", "", err
 	}

--- a/usecases/data_model_destroy_usecase.go
+++ b/usecases/data_model_destroy_usecase.go
@@ -111,7 +111,7 @@ func (uc DataModelDestroyUsecase) DeleteTable(ctx context.Context, dryRun bool, 
 			// Should not occur since the table was fetched successfully before
 			return errors.New("table not found in data model")
 		}
-		pivotsToDelete, err := uc.dataModelRepository.ListPivots(ctx, tx, table.OrganizationID, &table.ID, false)
+		pivotsToDelete, err := uc.dataModelRepository.ListPivots(ctx, tx, table.OrganizationID, &table.ID, false, false)
 		if err != nil {
 			return err
 		}
@@ -261,6 +261,24 @@ func (uc DataModelDestroyUsecase) DeleteLink(ctx context.Context, dryRun bool, l
 			}
 		}
 
+		// Cascade soft-delete pivots whose path references this link. A "related" link
+		// is by definition referenced by no live pivot (link type is derived from pivot
+		// membership), so this is a no-op for them. It applies to "belongs_to" links:
+		// both the single-link pivot coupled to the link, and legacy multi-link path
+		// pivots in which the link appears at any position (such a pivot cannot survive
+		// the loss of one of its path links).
+		pivots, err := uc.dataModelRepository.ListPivots(ctx, tx, orgId, nil, false, false)
+		if err != nil {
+			return err
+		}
+		for _, pivot := range pivots {
+			if slices.Contains(pivot.PathLinkIds, linkId) {
+				if err := uc.dataModelRepository.SoftDeletePivot(ctx, tx, pivot.Id.String()); err != nil {
+					return err
+				}
+			}
+		}
+
 		if err := uc.dataModelRepository.DeleteDataModelLink(ctx, tx, linkId); err != nil {
 			return err
 		}
@@ -288,7 +306,9 @@ func (uc DataModelDestroyUsecase) DeletePivot(ctx context.Context, dryRun bool, 
 		return models.NewDataModelDeleteFieldReport(), nil
 	}
 
-	if err := uc.dataModelRepository.DeleteDataModelPivot(ctx, exec, pivotId); err != nil {
+	// Soft delete: decisions reference the pivot by id, so the definition must remain
+	// readable for historical data (pivot object enrichment, related cases, scoring).
+	if err := uc.dataModelRepository.SoftDeletePivot(ctx, exec, pivotId); err != nil {
 		return models.DataModelDeleteFieldReport{}, err
 	}
 
@@ -418,7 +438,7 @@ func (uc DataModelDestroyUsecase) canDeleteRef(
 	// the deletion will not break anything since the table will be deleted
 	// TODO: TBD What if the pivot has multi links?
 	if field != nil {
-		pivots, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false)
+		pivots, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false, false)
 		if err != nil {
 			return false, models.DataModelDeleteFieldReport{}, err
 		}
@@ -681,7 +701,7 @@ func (uc DataModelDestroyUsecase) canDeleteLink(
 	}
 
 	if linkType != models.LinkTypeBelongsTo {
-		pivots, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false)
+		pivots, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false, false)
 		if err != nil {
 			return false, models.DataModelDeleteFieldReport{}, err
 		}

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -84,7 +84,7 @@ func (usecase usecase) getDataModelWithExec(
 	}
 
 	if options.IncludeNavigationOptions {
-		pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationID, nil, useCache)
+		pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationID, nil, useCache, false)
 		if err != nil {
 			return models.DataModel{}, err
 		}
@@ -258,7 +258,7 @@ func (usecase *usecase) ensureTableHasPivot(
 	tableId string,
 	fieldIdsByName map[string]string,
 ) error {
-	pivots, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationId, utils.Ptr(tableId), false)
+	pivots, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationId, utils.Ptr(tableId), false, false)
 	if err != nil {
 		return err
 	}
@@ -717,17 +717,18 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 				}
 			}
 
-			// For BelongsTo links, cascade-delete associated pivot(s) found via PathLinkIds
+			// For BelongsTo links, cascade soft-delete associated pivot(s) found via
+			// PathLinkIds. Soft delete because decisions may reference the pivot.
 			if linkType == models.LinkTypeBelongsTo {
 				pivots, err := usecase.dataModelRepository.ListPivots(
-					ctx, tx, table.OrganizationID, nil, false)
+					ctx, tx, table.OrganizationID, nil, false, false)
 				if err != nil {
 					return err
 				}
 				for _, pivot := range pivots {
 					for _, pathLinkId := range pivot.PathLinkIds {
 						if pathLinkId == linkId {
-							if err := usecase.dataModelRepository.DeleteDataModelPivot(
+							if err := usecase.dataModelRepository.SoftDeletePivot(
 								ctx, tx, pivot.Id.String()); err != nil {
 								return err
 							}
@@ -783,19 +784,20 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 			}
 
 			pivots, err := usecase.dataModelRepository.ListPivots(
-				ctx, tx, table.OrganizationID, nil, false)
+				ctx, tx, table.OrganizationID, nil, false, false)
 			if err != nil {
 				return err
 			}
 
 			if linkUpdate.LinkType == models.LinkTypeRelated {
-				// Changing to "related": delete the path-based pivot that references this link.
-				// The child table is always tableID, and ensureTableHasPivot at the end of
-				// the transaction will recreate a default pivot if none remain.
+				// Changing to "related": soft-delete the path-based pivot that references
+				// this link (decisions may reference it). The child table is always tableID,
+				// and ensureTableHasPivot at the end of the transaction will recreate a
+				// default pivot if none remain.
 				for _, pivot := range pivots {
 					for _, pathLinkId := range pivot.PathLinkIds {
 						if pathLinkId == linkUpdate.ID {
-							if err := usecase.dataModelRepository.DeleteDataModelPivot(
+							if err := usecase.dataModelRepository.SoftDeletePivot(
 								ctx, tx, pivot.Id.String()); err != nil {
 								return err
 							}
@@ -816,11 +818,11 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 					}
 				}
 
-				// Delete the default pivot (field_id-based) on the child table, not path-based
-				// pivots that rely on another belongs_to link
+				// Soft-delete the default pivot (field_id-based) on the child table, not
+				// path-based pivots that rely on another belongs_to link
 				for _, pivot := range pivots {
 					if pivot.BaseTableId == existingLink.ChildTableId && pivot.FieldId != nil {
-						if err := usecase.dataModelRepository.DeleteDataModelPivot(
+						if err := usecase.dataModelRepository.SoftDeletePivot(
 							ctx, tx, pivot.Id.String()); err != nil {
 							return err
 						}
@@ -1426,16 +1428,17 @@ func (usecase *usecase) createDataModelLinkWithExec(ctx context.Context, exec re
 			}
 		}
 
-		// Delete the default pivot (field_id-based) to replace it with a path-based one.
-		// Do not delete path-based pivots that rely on another belongs_to link.
+		// Soft-delete the default pivot (field_id-based) to replace it with a path-based
+		// one (decisions may reference it). Do not delete path-based pivots that rely on
+		// another belongs_to link.
 		pivots, err := usecase.dataModelRepository.ListPivots(ctx, exec,
-			link.OrganizationID, utils.Ptr(link.ChildTableID), false)
+			link.OrganizationID, utils.Ptr(link.ChildTableID), false, false)
 		if err != nil {
 			return "", nil, err
 		}
 		for _, pivot := range pivots {
 			if pivot.FieldId != nil {
-				if err := usecase.dataModelRepository.DeleteDataModelPivot(ctx, exec, pivot.Id.String()); err != nil {
+				if err := usecase.dataModelRepository.SoftDeletePivot(ctx, exec, pivot.Id.String()); err != nil {
 					return "", nil, err
 				}
 			}
@@ -1532,6 +1535,33 @@ func (usecase *usecase) CreatePivotWithExec(ctx context.Context, exec repositori
 		return models.Pivot{}, err
 	}
 
+	// If a soft-deleted pivot with the same definition exists, restore it instead of
+	// creating a new row: historical decisions reference it by id, so reusing it keeps
+	// old and new decisions grouped under the same pivot (e.g. when a link is demoted
+	// to "related" then promoted back to "belongs_to").
+	existingPivots, err := usecase.dataModelRepository.ListPivots(
+		ctx, exec, input.OrganizationId, &input.BaseTableId, false, true)
+	if err != nil {
+		return models.Pivot{}, err
+	}
+	// Only restore if the table has no live pivot: otherwise let CreatePivot return its
+	// usual conflict error (one live pivot per table).
+	hasLivePivot := slices.ContainsFunc(existingPivots, func(p models.PivotMetadata) bool {
+		return p.DeletedAt == nil
+	})
+	if !hasLivePivot {
+		for _, existing := range existingPivots {
+			if !pivotDefinitionMatchesInput(existing, input) {
+				continue
+			}
+			if err := usecase.dataModelRepository.RestorePivot(ctx, exec, existing.Id.String()); err != nil {
+				return models.Pivot{}, err
+			}
+			pivotMeta, err := usecase.dataModelRepository.GetPivot(ctx, exec, existing.Id.String())
+			return pivotMeta.Enrich(dm), err
+		}
+	}
+
 	id := pure_utils.NewId().String()
 	err = usecase.dataModelRepository.CreatePivot(ctx, exec, id, input)
 	if err != nil {
@@ -1539,6 +1569,22 @@ func (usecase *usecase) CreatePivotWithExec(ctx context.Context, exec repositori
 	}
 	pivotMeta, err := usecase.dataModelRepository.GetPivot(ctx, exec, id)
 	return pivotMeta.Enrich(dm), err
+}
+
+// pivotDefinitionMatchesInput returns whether an existing pivot defines the same pivot
+// as the creation input: the same base table, and the same field (for field-based
+// pivots) or the same ordered path of links (for path-based pivots). A pivot is either
+// field-based (FieldId set, empty path) or path-based (FieldId nil, non-empty path).
+// Table ids are globally unique, so the organization is implied by the base table.
+func pivotDefinitionMatchesInput(pivot models.PivotMetadata, input models.CreatePivotInput) bool {
+	if pivot.BaseTableId != input.BaseTableId {
+		return false
+	}
+
+	sameField := (pivot.FieldId == nil && input.FieldId == nil) ||
+		(pivot.FieldId != nil && input.FieldId != nil && *pivot.FieldId == *input.FieldId)
+
+	return sameField && slices.Equal(pivot.PathLinkIds, input.PathLinkIds)
 }
 
 func (usecase *usecase) CreatePivot(ctx context.Context, input models.CreatePivotInput) (models.Pivot, error) {
@@ -1629,7 +1675,7 @@ func (usecase *usecase) ListPivots(ctx context.Context, organizationId uuid.UUID
 		return nil, err
 	}
 
-	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationId, tableID, false)
+	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, organizationId, tableID, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1683,7 +1729,7 @@ func (usecase *usecase) CreateNavigationOption(ctx context.Context, input models
 	dataModel = dataModel.AddUnicityConstraintStatusToDataModel(uniqueIndexes)
 	allTables := dataModel.AllTablesAsMap()
 
-	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false)
+	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false, false)
 	if err != nil {
 		return err
 	}

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
@@ -12,6 +13,7 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 )
@@ -276,7 +278,7 @@ func (suite *DatamodelUsecaseTestSuite) TestGetDataModel_nominal_no_unique() {
 	suite.executorFactory.On("NewExecutor").Return(suite.transaction, nil)
 	var nilStr *string
 	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction,
-		suite.organizationId, nilStr, mock.Anything).
+		suite.organizationId, nilStr, mock.Anything, false).
 		Return(nil, nil)
 	suite.clientDbIndexEditor.On("ListAllIndexes", suite.ctx, suite.organizationId, models.IndexTypeNavigation).
 		Return(nil, nil)
@@ -309,7 +311,7 @@ func (suite *DatamodelUsecaseTestSuite) TestGetDataModel_nominal_with_unique() {
 
 	var nilStr *string
 	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction,
-		suite.organizationId, nilStr, mock.Anything).
+		suite.organizationId, nilStr, mock.Anything, false).
 		Return(nil, nil)
 	suite.clientDbIndexEditor.On("ListAllIndexes", suite.ctx, suite.organizationId, models.IndexTypeNavigation).
 		Return(nil, nil)
@@ -409,7 +411,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelTable_nominal() {
 		Return(nil)
 	// ensureTableHasPivot: return non-empty pivots so no pivot creation needed
 	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction, suite.organizationId,
-		mock.AnythingOfType("*string"), false).
+		mock.AnythingOfType("*string"), false, false).
 		Return([]models.PivotMetadata{{Id: uuid.New()}}, nil)
 	suite.transactionFactory.On("TransactionInOrgSchema", suite.ctx, suite.organizationId, mock.Anything).
 		Return(nil)
@@ -510,7 +512,7 @@ func (suite *DatamodelUsecaseTestSuite) TestCreateDataModelTable_org_repository_
 		Return(nil)
 	// ensureTableHasPivot: return non-empty pivots so no pivot creation needed
 	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction, suite.organizationId,
-		mock.AnythingOfType("*string"), false).
+		mock.AnythingOfType("*string"), false, false).
 		Return([]models.PivotMetadata{{Id: uuid.New()}}, nil)
 	suite.transactionFactory.On("TransactionInOrgSchema", suite.ctx, suite.organizationId, mock.Anything).
 		Return(nil)
@@ -1475,6 +1477,155 @@ func (suite *DatamodelUsecaseTestSuite) TestUpdateDataModelField_with_invalid_pa
 		"expected error message about invalid property")
 
 	suite.AssertExpectations()
+}
+
+// CreatePivot
+func (suite *DatamodelUsecaseTestSuite) TestCreatePivot_restores_identical_soft_deleted_pivot() {
+	input := models.CreatePivotInput{
+		OrganizationId: suite.organizationId,
+		BaseTableId:    "accounts-table-id",
+		FieldId:        utils.Ptr("accounts-object-id-field-id"),
+	}
+	pivotId := uuid.MustParse("87654321-4321-8765-2109-876543210987")
+	deletedAt := time.Now()
+
+	usecase := suite.makeUsecase()
+	suite.enforceSecurity.On("WriteDataModel", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel",
+		suite.ctx, suite.transaction, suite.organizationId, false, mock.Anything).
+		Return(suite.dataModel, nil)
+	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction,
+		suite.organizationId, utils.Ptr("accounts-table-id"), false, true).
+		Return([]models.PivotMetadata{
+			{
+				Id:             pivotId,
+				OrganizationId: suite.organizationId,
+				BaseTableId:    "accounts-table-id",
+				FieldId:        utils.Ptr("accounts-object-id-field-id"),
+				DeletedAt:      &deletedAt,
+			},
+		}, nil)
+	suite.dataModelRepository.On("RestorePivot", suite.ctx, suite.transaction, pivotId.String()).
+		Return(nil)
+	suite.dataModelRepository.On("GetPivot", suite.ctx, suite.transaction, pivotId.String()).
+		Return(models.PivotMetadata{
+			Id:             pivotId,
+			OrganizationId: suite.organizationId,
+			BaseTableId:    "accounts-table-id",
+			FieldId:        utils.Ptr("accounts-object-id-field-id"),
+		}, nil)
+
+	pivot, err := usecase.CreatePivotWithExec(suite.ctx, suite.transaction, input)
+	suite.Require().NoError(err, "no error expected")
+	suite.Require().Equal(pivotId, pivot.Id, "the soft-deleted pivot should be restored with its original id")
+
+	// CreatePivot must not be called: the soft-deleted pivot is restored instead
+	suite.dataModelRepository.AssertNotCalled(suite.T(), "CreatePivot",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	suite.AssertExpectations()
+}
+
+func (suite *DatamodelUsecaseTestSuite) TestCreatePivot_does_not_restore_different_soft_deleted_pivot() {
+	input := models.CreatePivotInput{
+		OrganizationId: suite.organizationId,
+		BaseTableId:    "accounts-table-id",
+		FieldId:        utils.Ptr("accounts-object-id-field-id"),
+	}
+	deletedAt := time.Now()
+
+	usecase := suite.makeUsecase()
+	suite.enforceSecurity.On("WriteDataModel", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel",
+		suite.ctx, suite.transaction, suite.organizationId, false, mock.Anything).
+		Return(suite.dataModel, nil)
+	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction,
+		suite.organizationId, utils.Ptr("accounts-table-id"), false, true).
+		Return([]models.PivotMetadata{
+			{
+				Id:             uuid.MustParse("87654321-4321-8765-2109-876543210987"),
+				OrganizationId: suite.organizationId,
+				BaseTableId:    "accounts-table-id",
+				FieldId:        utils.Ptr("accounts-status-field-id"), // different definition
+				DeletedAt:      &deletedAt,
+			},
+		}, nil)
+	suite.dataModelRepository.On("CreatePivot", suite.ctx, suite.transaction,
+		mock.AnythingOfType("string"), input).
+		Return(nil)
+	suite.dataModelRepository.On("GetPivot", suite.ctx, suite.transaction, mock.AnythingOfType("string")).
+		Return(models.PivotMetadata{
+			OrganizationId: suite.organizationId,
+			BaseTableId:    "accounts-table-id",
+			FieldId:        utils.Ptr("accounts-object-id-field-id"),
+		}, nil)
+
+	_, err := usecase.CreatePivotWithExec(suite.ctx, suite.transaction, input)
+	suite.Require().NoError(err, "no error expected")
+
+	suite.dataModelRepository.AssertNotCalled(suite.T(), "RestorePivot",
+		mock.Anything, mock.Anything, mock.Anything)
+	suite.AssertExpectations()
+}
+
+func TestPivotDefinitionMatchesInput(t *testing.T) {
+	fieldA := utils.Ptr("field-a")
+	fieldB := utils.Ptr("field-b")
+
+	cases := []struct {
+		name     string
+		pivot    models.PivotMetadata
+		input    models.CreatePivotInput
+		expected bool
+	}{
+		{
+			name:     "same field",
+			pivot:    models.PivotMetadata{FieldId: fieldA},
+			input:    models.CreatePivotInput{FieldId: utils.Ptr("field-a")},
+			expected: true,
+		},
+		{
+			name:     "different field",
+			pivot:    models.PivotMetadata{FieldId: fieldA},
+			input:    models.CreatePivotInput{FieldId: fieldB},
+			expected: false,
+		},
+		{
+			name:     "field vs path",
+			pivot:    models.PivotMetadata{FieldId: fieldA},
+			input:    models.CreatePivotInput{PathLinkIds: []string{"link-1"}},
+			expected: false,
+		},
+		{
+			name:     "same path",
+			pivot:    models.PivotMetadata{PathLinkIds: []string{"link-1", "link-2"}},
+			input:    models.CreatePivotInput{PathLinkIds: []string{"link-1", "link-2"}},
+			expected: true,
+		},
+		{
+			name:     "different path",
+			pivot:    models.PivotMetadata{PathLinkIds: []string{"link-1"}},
+			input:    models.CreatePivotInput{PathLinkIds: []string{"link-2"}},
+			expected: false,
+		},
+		{
+			name:     "different path order",
+			pivot:    models.PivotMetadata{PathLinkIds: []string{"link-1", "link-2"}},
+			input:    models.CreatePivotInput{PathLinkIds: []string{"link-2", "link-1"}},
+			expected: false,
+		},
+		{
+			name:     "same field on different base table",
+			pivot:    models.PivotMetadata{BaseTableId: "table-a", FieldId: fieldA},
+			input:    models.CreatePivotInput{BaseTableId: "table-b", FieldId: utils.Ptr("field-a")},
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.expected, pivotDefinitionMatchesInput(c.pivot, c.input))
+		})
+	}
 }
 
 func TestDatamodelUsecase(t *testing.T) {

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -343,7 +343,7 @@ func (usecase *DecisionUsecase) CreateDecision(
 	}
 
 	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec,
-		input.OrganizationId, nil, true)
+		input.OrganizationId, nil, true, false)
 	if err != nil {
 		return false, models.DecisionWithRuleExecutions{}, err
 	}
@@ -524,7 +524,7 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 	}
 
 	pivotsMeta, err := usecase.dataModelRepository.ListPivots(ctx, exec,
-		input.OrganizationId, nil, true)
+		input.OrganizationId, nil, true, false)
 	if err != nil {
 		return nil, 0, nil, err
 	}

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -42,6 +42,7 @@ type ingestedDataReaderRepository interface {
 		organizationId uuid.UUID,
 		tableId *string,
 		useCache bool,
+		includeDeleted bool,
 	) ([]models.PivotMetadata, error)
 	GetEntityAnnotations(
 		ctx context.Context,
@@ -141,7 +142,9 @@ func (usecase IngestedDataReaderUsecase) ReadPivotObjectsFromValues(
 		return nil, err
 	}
 
-	pivotsMeta, err := usecase.repository.ListPivots(ctx, exec, orgId, nil, true)
+	// Include soft-deleted pivots: the input values come from decisions, which keep
+	// referencing their pivot_id after the pivot is deleted.
+	pivotsMeta, err := usecase.repository.ListPivots(ctx, exec, orgId, nil, true, true)
 	if err != nil {
 		return nil, err
 	}
@@ -175,6 +178,18 @@ func (usecase IngestedDataReaderUsecase) ReadPivotObjectsFromValues(
 			lastField := dataModel.AllFieldsAsMap()[lastLink.ParentFieldId]
 			fieldName = lastField.Name
 		}
+
+		// A pivot (typically soft-deleted) whose path references a link that no longer
+		// exists cannot be resolved to a table and field anymore. Degrade it to a plain
+		// value so decisions referencing it still render, without ingested data.
+		// see: enrichPivotObjectWithData
+		if t == models.PivotTypeObject && (pivot.PivotTable == "" || fieldName == "") {
+			logger.WarnContext(ctx,
+				"Pivot references a link that no longer exists, pivot objects will not be enriched",
+				"pivotId", pivot.Id)
+			t = models.PivotTypeField
+		}
+
 		mapOfPivotDetail[pivot.Id.String()] = pivotObjectDetail{
 			pivotTable: pivot.PivotTable,
 			pivotField: fieldName,
@@ -204,27 +219,31 @@ func (usecase IngestedDataReaderUsecase) ReadPivotObjectsFromValues(
 		}
 
 		pivotObject := models.PivotObject{
-			PivotValue:      value.PivotValue,
-			PivotId:         value.PivotId,
-			PivotType:       pivotDetail.pivotType,
-			PivotObjectName: pivotDetail.pivotTable,
-			PivotFieldName:  pivotDetail.pivotField,
-			PivotObjectData: models.ClientObjectDetail{
-				Data: map[string]any{
-					pivotDetail.pivotField: value.PivotValue,
-				},
-			},
+			PivotValue:        value.PivotValue,
+			PivotId:           value.PivotId,
+			PivotType:         pivotDetail.pivotType,
+			PivotObjectName:   pivotDetail.pivotTable,
+			PivotFieldName:    pivotDetail.pivotField,
+			PivotObjectData:   models.ClientObjectDetail{Data: map[string]any{}},
 			NumberOfDecisions: value.NbOfDecisions,
+		}
+		if pivotDetail.pivotField != "" {
+			pivotObject.PivotObjectData.Data[pivotDetail.pivotField] = value.PivotValue
 		}
 		if pivotDetail.pivotField == "object_id" {
 			pivotObject.PivotObjectId = value.PivotValue
 		}
 
-		pivotObject, err = usecase.enrichPivotObjectWithData(ctx, pivotObject, orgId, dataModel)
+		// Best effort: a pivot object that cannot be enriched (e.g. its pivot definition
+		// references data model elements that no longer exist) is still returned with the
+		// bare pivot value, and must not fail the whole batch.
+		enrichedPivotObject, err := usecase.enrichPivotObjectWithData(ctx, pivotObject, orgId, dataModel)
 		if err != nil {
-			return nil, errors.Wrapf(err,
-				"failed to read data for pivot object {id: %s, value: %s} in ReadPivotObjectsFromValues",
-				pivotObject.PivotId, pivotObject.PivotValue)
+			logger.WarnContext(ctx,
+				"failed to read data for pivot object in ReadPivotObjectsFromValues, returning it without enrichment",
+				"pivotId", pivotObject.PivotId, "pivotValue", pivotObject.PivotValue, "error", err.Error())
+		} else {
+			pivotObject = enrichedPivotObject
 		}
 		pivotObjectsMap[pivotObjectsMapKey(pivotDetail.pivotTable, pivotDetail.pivotField, value.PivotValue)] = pivotObject
 	}

--- a/usecases/org_export_usecase.go
+++ b/usecases/org_export_usecase.go
@@ -97,7 +97,7 @@ func (uc *OrgExportUsecase) Export(ctx context.Context, orgId uuid.UUID) (dto.Or
 	}
 
 	// Fetch pivots
-	pivotMetadatas, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false)
+	pivotMetadatas, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false, false)
 	if err != nil {
 		return dto.OrgImport{}, errors.Wrap(err, "failed to fetch pivots")
 	}

--- a/usecases/org_import_usecase.go
+++ b/usecases/org_import_usecase.go
@@ -461,7 +461,7 @@ func (uc *OrgImportUsecase) createDataModel(ctx context.Context, tx repositories
 	// CreateDataModelTable may have auto-created a default pivot (object_id field-based or
 	// belongs_to path-based). If the import spec defines a different pivot for the same
 	// table, replace the auto-created one; if it matches, keep it.
-	existingPivots, err := uc.dataModelRepository.ListPivots(ctx, tx, orgId, nil, false)
+	existingPivots, err := uc.dataModelRepository.ListPivots(ctx, tx, orgId, nil, false, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to list existing pivots")
 	}
@@ -490,6 +490,8 @@ func (uc *OrgImportUsecase) createDataModel(ctx context.Context, tx repositories
 			}
 			// Auto-created pivot differs from the spec; delete it before creating the
 			// imported one to avoid the unique-constraint conflict on (org, base_table).
+			// Hard delete is safe here: import only runs on a new or empty organization,
+			// so no object can reference the pivot.
 			if err := uc.dataModelRepository.DeleteDataModelPivot(ctx, tx, existing.Id.String()); err != nil {
 				return errors.Wrapf(err, "failed to delete auto-created pivot for table %s", baseTableId)
 			}

--- a/usecases/worker_jobs/async_decision_job.go
+++ b/usecases/worker_jobs/async_decision_job.go
@@ -258,7 +258,7 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 			scenario.TriggerObjectType, models.NotFoundError)
 	}
 
-	pivotsMeta, err := w.dataModelRepository.ListPivots(ctx, tx, scenario.OrganizationId, nil, true)
+	pivotsMeta, err := w.dataModelRepository.ListPivots(ctx, tx, scenario.OrganizationId, nil, true, false)
 	if err != nil {
 		return false, nil, nil, err
 	}


### PR DESCRIPTION
## Problem

The new data model link management lets users change a link's type (`belongs_to ⇄ related`). Demoting a `belongs_to` link must remove its pivot, but pivots are hard-deleted today, and `decisions.pivot_id` references them with a NO ACTION FK, so deleting any pivot that has produced decisions fails with an FK violation. Hard-deleting also breaks every consumer that resolves a decision's pivot by id (pivot object enrichment on cases, related-cases lookup, scoring).

## Solution: soft delete

Pivots get a `deleted_at` column. Decisions keep referencing their pivot after deletion, so everything reading pivots from historical decisions keeps working. Among the options considered (block deletion forever, soft-delete links too, snapshot pivot metadata), soft delete is the smallest change that preserves all historical data paths.

- Schema: `deleted_at` on `data_model_pivots`; the unique index on (organization_id, base_table_id) becomes partial (`WHERE deleted_at IS NULL`) so a table can get a new pivot after its old one is deleted.
- Link type stays coherent: is_belongs_to is derived from live pivots only, so a demoted link correctly reads as related.
- All user-facing deletion flows (pivot endpoint, link demotion, belongs_to cascade on link deletion, default-pivot replacement) now soft-delete. Hard delete remains only where nothing can reference the pivot (table deletion, org import into an empty org).
- Resurrection: re-creating a pivot with the same definition (e.g. demote then re-promote a link) restores the soft-deleted row instead of inserting a new one, so old and new decisions stay grouped under the same `pivot_id`.
- Live-only vs. historical reads: ListPivots gains an includeDeleted parameter; only the paths resolving pivots referenced by historical decisions include deleted ones (pivot object enrichment, resurrection lookup). The related-cases CTE intentionally includes them.

## Known limitation (deferred by design): links

A soft-deleted pivot's path_link_ids can end up pointing to a hard-deleted link (demote the link, then delete it — nothing references it anymore, so deletion is allowed). The pivot definition then can't be resolved to a table/field, and old decisions lose their entity enrichment.

The problem is deferred, but guarded: `ReadPivotObjectsFromValues` now (1) detects pivots whose path links no longer resolve and downgrades them to plain-value pivots — skipping ingested-data enrichment instead of querying with an empty table name — and (2) keeps a per-object enrichment failure local: the object is returned without entity data instead of failing the whole batch (previously one broken pivot blanked the entire case view).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Soft-delete and restore for pivots to preserve historical references.
  * Option to include/exclude deleted pivots when listing pivots.
  * Automatic restoration of matching soft-deleted pivots instead of creating duplicates.

* **Improvements**
  * Pivot lifecycle now favors soft-deletion to retain identity and history.
  * Decision/export/import flows and navigation options respect soft-deleted pivot state.
  * Pivot enrichment made best-effort (logs warnings and returns partial data when enrichment fails).

* **Chores**
  * Database migration adds a deleted_at column and adjusts uniqueness to ignore soft-deleted rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->