### PR TITLE
Fix scheduled execution giving typed values for GPS/IP to the decision.

### DIFF
--- a/usecases/worker_jobs/async_decision_job.go
+++ b/usecases/worker_jobs/async_decision_job.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"math"
 	"math/rand/v2"
+	"net/netip"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -20,6 +22,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
+	"github.com/twpayne/go-geos"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -180,8 +183,7 @@ func (w *AsyncDecisionWorker) handleDecision(
 		return nil, nil, nil
 	}
 
-	decisionCreated, webhookEventIds, testRunCallback, err :=
-		w.createSingleDecisionForObjectId(ctx, args, tx)
+	decisionCreated, webhookEventIds, testRunCallback, err := w.createSingleDecisionForObjectId(ctx, args, tx)
 	if err != nil {
 		statusErr := w.repository.UpdateDecisionToCreateStatus(
 			ctx,
@@ -275,6 +277,25 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 		return false, nil, nil, nil
 	}
 
+	// Scheduled executions are special, they are retrieved from the database whereas
+	// all the process was made for JSON input. We need to untype all special
+	// types (geolocations, IP address, metadata fields).
+	for idx := range objectMap {
+		for k, v := range objectMap[idx].Data {
+			if strings.Contains(k, ".metadata") {
+				delete(objectMap[idx].Data, k)
+				continue
+			}
+
+			switch typed := v.(type) {
+			case *geos.Geom:
+				objectMap[idx].Data[k] = fmt.Sprintf("%f,%f", typed.Y(), typed.X())
+			case netip.Prefix:
+				objectMap[idx].Data[k] = typed.String()
+			}
+		}
+	}
+
 	object := models.ClientObject{TableName: table.Name, Data: objectMap[0].Data}
 
 	evaluationParameters := evaluate_scenario.ScenarioEvaluationParameters{
@@ -316,8 +337,7 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 		}
 	}
 
-	triggerPassed, scenarioExecution, err :=
-		w.scenarioEvaluator.EvalScenario(ctx, evaluationParameters)
+	triggerPassed, scenarioExecution, err := w.scenarioEvaluator.EvalScenario(ctx, evaluationParameters)
 	if err != nil {
 		return false, nil, nil, errors.Wrapf(err, "error evaluating scenario in AsyncDecisionWorker %s", scenario.Id)
 	}


### PR DESCRIPTION
The decision subsystem assumes it received a JSON-encoded map for the trigger object where special fields come in in their serialized forms (strings for GPS and IP fields).

When performing an async decision, the trigger object comes from the database, with those fields actually being Go types (*geos.Geom and netip.Prefix). This breaks a lot of assumptions when those are subsequently serialized in a JSONB column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced data normalization during decision evaluation to properly handle specialized data types, ensuring consistent and accurate processing of geographic coordinates and network address information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->