### PR TITLE
Support motiva scope partitioning.

### DIFF
--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -62,6 +62,7 @@ type OpenSanctionsQuery struct {
 	Config             ScreeningConfig
 	OrgConfig          OrganizationOpenSanctionsConfig
 	Scope              string
+	Partition          bool
 	// cf: `exclude_entity_ids` in the OpenSanctions query
 	WhitelistedEntityIds []string
 	UseScopedIndex       bool

--- a/repositories/screening/provider_lexisnexis.go
+++ b/repositories/screening/provider_lexisnexis.go
@@ -115,6 +115,10 @@ func (p ScreeningLexisNexisProvider) BuildQueryString(ctx context.Context,
 	qs.Set("algorithm", p.Config.Algorithm())
 
 	if query != nil {
+		if query.Partition {
+			qs.Set("partition", "true")
+		}
+
 		if p.Config.MotivaFeatures(ctx).ScopedIndex && query.UseScopedIndex {
 			qs.Set("index_type", "scoped")
 		}

--- a/repositories/screening/provider_opensanctions.go
+++ b/repositories/screening/provider_opensanctions.go
@@ -102,6 +102,10 @@ func (p ScreeningOpenSanctionsProvider) BuildQueryString(ctx context.Context,
 	qs.Set("algorithm", p.Config.Algorithm())
 
 	if query != nil {
+		if query.Partition {
+			qs.Set("partition", "true")
+		}
+
 		if p.Config.MotivaFeatures(ctx).ScopedIndex && query.UseScopedIndex {
 			qs.Set("index_type", "scoped")
 		}

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -480,6 +480,7 @@ func (w *ApplyDeltaFileWorker) buildOpenSanctionQuery(
 		},
 		WhitelistedEntityIds: whitelistedEntityIds,
 		Scope:                orgCustomDatasetName(updateJob.OrgId),
+		Partition:            true,
 	}, nil
 }
 


### PR DESCRIPTION
Will require motiva v0.9.1 ~(_unreleased_)~ or at least https://github.com/apognu/motiva/commit/e3c1253fad59e0824d7ab5fc8060b01a31f63f69 but it forward compatible.

Adds `?partition=true` to the screening queries performed against organizations' indexes to scope the search to their index. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for partitioned sanctions screening queries.
  * When partitioning is enabled, requests sent to supported providers now include the appropriate `partition=true` query parameter, improving partition-aware screening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->