### PR TITLE
feat: save decision screening match payload into blobl storage

### DIFF
--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
+	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 	"gocloud.dev/blob"
@@ -329,6 +330,47 @@ func (uc OffloadedReadWriter) OffloadScreeningMatches(
 	}
 
 	return offloaded, nil
+}
+
+// HydrateScreeningMatches fills in, from blob storage, the payload of every match whose DB column
+// is empty (the offloaded-payload signal) across the given screenings. It is the read-side
+// counterpart of OffloadScreeningMatches, for callers that read screenings outside ScreeningUsecase
+// (e.g. the AI case review). No-op when offloading is disabled. A match whose payload is missing
+// from both the column and blob storage is logged and left empty rather than failing the read.
+func (uc OffloadedReadWriter) HydrateScreeningMatches(
+	ctx context.Context, screenings []models.ScreeningWithMatches,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+
+	for _, screening := range screenings {
+		for i := range screening.Matches {
+			if len(screening.Matches[i].Payload) > 0 {
+				continue
+			}
+
+			payload, err := uc.ReadOffloadedScreeningMatchPayload(ctx, screening.OrgId,
+				screening.Matches[i].ScreeningId, screening.Matches[i].Id)
+			if err != nil {
+				return err
+			}
+
+			if len(payload) == 0 {
+				utils.LoggerFromContext(ctx).WarnContext(ctx,
+					"screening match payload is missing from blob storage",
+					"org_id", screening.OrgId,
+					"screening_id", screening.Matches[i].ScreeningId,
+					"match_id", screening.Matches[i].Id,
+				)
+				continue
+			}
+
+			screening.Matches[i].Payload = payload
+		}
+	}
+
+	return nil
 }
 
 // OffloadContinuousScreeningMatchPayload writes a continuous screening match payload to blob

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -8,6 +8,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
@@ -18,12 +19,19 @@ type offloadableRepository interface {
 	GetOffloadedDecisionRuleKey(orgId uuid.UUID, decisionId, ruleId, outcome string, createdAt time.Time) string
 	GetOffloadedDecisionEvaluationKey(orgId uuid.UUID, decision models.Decision) string
 	GetScoreComputationEvaluationKey(ruleset models.ScoringRuleset, score models.ScoringScore) string
+	GetOffloadedScreeningMatchKey(orgId uuid.UUID, screeningId, matchId string) string
+	GetOffloadedContinuousScreeningMatchKey(orgId, continuousScreeningId, matchId uuid.UUID) string
+	GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId uuid.UUID) string
 	GetWatermark(
 		ctx context.Context,
 		exec Executor,
 		orgId *uuid.UUID,
 		watermarkType models.WatermarkType,
 	) (*models.Watermark, error)
+}
+
+func (uc OffloadedReadWriter) IsOffloadingEnabled() bool {
+	return uc.OffloadingBucketUrl != ""
 }
 
 type OffloadedReadWriter struct {
@@ -38,7 +46,7 @@ func (uc OffloadedReadWriter) OffloadRuleExecutions(
 	decision models.Decision,
 	evaluation []byte,
 ) error {
-	if uc.OffloadingBucketUrl == "" {
+	if !uc.IsOffloadingEnabled() {
 		return nil
 	}
 
@@ -76,7 +84,7 @@ func (uc OffloadedReadWriter) MutateWithOffloadedDecisionRules(
 	orgId uuid.UUID,
 	decision models.DecisionWithRuleExecutions,
 ) error {
-	if uc.OffloadingBucketUrl == "" {
+	if !uc.IsOffloadingEnabled() {
 		return nil
 	}
 
@@ -162,7 +170,7 @@ func (uc OffloadedReadWriter) OffloadScoreComputation(
 	score models.ScoringScore,
 	evaluation []byte,
 ) error {
-	if uc.OffloadingBucketUrl == "" {
+	if !uc.IsOffloadingEnabled() {
 		return nil
 	}
 
@@ -201,7 +209,7 @@ func (uc OffloadedReadWriter) GetOffloadedScoreComputation(
 	ruleset models.ScoringRuleset,
 	score models.ScoringScore,
 ) ([]*ast.NodeEvaluationDto, error) {
-	if uc.OffloadingBucketUrl == "" {
+	if !uc.IsOffloadingEnabled() {
 		return nil, nil
 	}
 
@@ -236,4 +244,137 @@ func (uc OffloadedReadWriter) GetOffloadedScoreComputation(
 	}
 
 	return nil, nil
+}
+
+// writePayload writes a raw payload to the given blob key, overwriting any existing object.
+func (uc OffloadedReadWriter) writePayload(ctx context.Context, key string, payload []byte) error {
+	wr, err := uc.BlobRepository.OpenStream(ctx, uc.OffloadingBucketUrl, key, key)
+	if err != nil {
+		return err
+	}
+	defer wr.Close()
+
+	if _, err := wr.Write(payload); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// readPayload reads a raw payload from the given blob key. It returns (nil, nil) when the object
+// does not exist, so callers can fall back to the DB column without treating a miss as an error.
+func (uc OffloadedReadWriter) readPayload(ctx context.Context, key string) ([]byte, error) {
+	blob, err := uc.BlobRepository.GetBlob(ctx, uc.OffloadingBucketUrl, key)
+	if err != nil {
+		if errors.Is(err, models.NotFoundError) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer blob.ReadCloser.Close()
+
+	return io.ReadAll(blob.ReadCloser)
+}
+
+// OffloadScreeningMatchPayload writes a screening match payload to blob storage at its
+// deterministic key. No-op when offloading is disabled.
+func (uc OffloadedReadWriter) OffloadScreeningMatchPayload(
+	ctx context.Context, orgId uuid.UUID, screeningId, matchId string, payload []byte,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+	return uc.writePayload(ctx, uc.Repository.GetOffloadedScreeningMatchKey(orgId, screeningId, matchId), payload)
+}
+
+// ReadOffloadedScreeningMatchPayload reads a screening match payload from blob storage. Returns
+// (nil, nil) when offloading is disabled or the object is missing.
+func (uc OffloadedReadWriter) ReadOffloadedScreeningMatchPayload(
+	ctx context.Context, orgId uuid.UUID, screeningId, matchId string,
+) ([]byte, error) {
+	if !uc.IsOffloadingEnabled() {
+		return nil, nil
+	}
+	return uc.readPayload(ctx, uc.Repository.GetOffloadedScreeningMatchKey(orgId, screeningId, matchId))
+}
+
+// OffloadScreeningMatches writes every match payload of a screening to blob storage and returns a
+// copy of the matches with their payload blanked, ready to be inserted with an empty `payload`
+// column. Match IDs are assigned here (and back-filled onto the input matches) so the blob keys
+// line up with the rows the repository will create, while the caller keeps the original matches
+// with their payloads intact for the API response.
+//
+// When offloading is disabled it is a no-op: the input matches are returned unchanged.
+func (uc OffloadedReadWriter) OffloadScreeningMatches(
+	ctx context.Context, screening models.ScreeningWithMatches,
+) ([]models.ScreeningMatch, error) {
+	if !uc.IsOffloadingEnabled() {
+		return screening.Matches, nil
+	}
+
+	offloaded := make([]models.ScreeningMatch, len(screening.Matches))
+
+	for i := range screening.Matches {
+		if screening.Matches[i].Id == "" {
+			screening.Matches[i].Id = pure_utils.NewId().String()
+		}
+
+		if err := uc.OffloadScreeningMatchPayload(ctx, screening.OrgId, screening.Id,
+			screening.Matches[i].Id, screening.Matches[i].Payload); err != nil {
+			return nil, err
+		}
+
+		offloaded[i] = screening.Matches[i]
+		offloaded[i].Payload = nil
+	}
+
+	return offloaded, nil
+}
+
+// OffloadContinuousScreeningMatchPayload writes a continuous screening match payload to blob
+// storage. No-op when offloading is disabled.
+func (uc OffloadedReadWriter) OffloadContinuousScreeningMatchPayload(
+	ctx context.Context, orgId, continuousScreeningId, matchId uuid.UUID, payload []byte,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+	return uc.writePayload(ctx,
+		uc.Repository.GetOffloadedContinuousScreeningMatchKey(orgId, continuousScreeningId, matchId), payload)
+}
+
+// ReadOffloadedContinuousScreeningMatchPayload reads a continuous screening match payload from
+// blob storage. Returns (nil, nil) when offloading is disabled or the object is missing.
+func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningMatchPayload(
+	ctx context.Context, orgId, continuousScreeningId, matchId uuid.UUID,
+) ([]byte, error) {
+	if !uc.IsOffloadingEnabled() {
+		return nil, nil
+	}
+	return uc.readPayload(ctx,
+		uc.Repository.GetOffloadedContinuousScreeningMatchKey(orgId, continuousScreeningId, matchId))
+}
+
+// OffloadContinuousScreeningEntityPayload writes the OpenSanctions entity payload attached to a
+// continuous screening to blob storage. No-op when offloading is disabled.
+func (uc OffloadedReadWriter) OffloadContinuousScreeningEntityPayload(
+	ctx context.Context, orgId, continuousScreeningId uuid.UUID, payload []byte,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+	return uc.writePayload(ctx,
+		uc.Repository.GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId), payload)
+}
+
+// ReadOffloadedContinuousScreeningEntityPayload reads the continuous screening entity payload
+// from blob storage. Returns (nil, nil) when offloading is disabled or the object is missing.
+func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningEntityPayload(
+	ctx context.Context, orgId, continuousScreeningId uuid.UUID,
+) ([]byte, error) {
+	if !uc.IsOffloadingEnabled() {
+		return nil, nil
+	}
+	return uc.readPayload(ctx,
+		uc.Repository.GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId))
 }

--- a/repositories/offloaded_read_writer_screening_test.go
+++ b/repositories/offloaded_read_writer_screening_test.go
@@ -1,0 +1,126 @@
+package repositories
+
+import (
+	"context"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/infra"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newFileOffloadedReadWriter(t *testing.T) OffloadedReadWriter {
+	t.Helper()
+
+	return OffloadedReadWriter{
+		Repository:          NewMarbleDbRepository(false, 0.3),
+		BlobRepository:      NewBlobRepository(infra.GcpConfig{}),
+		OffloadingBucketUrl: "file://" + t.TempDir(),
+	}
+}
+
+func TestOffloadScreeningMatchPayloadRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	orgId := uuid.New()
+	screeningId := uuid.NewString()
+	matchId := uuid.NewString()
+	payload := []byte(`{"score":0.9,"id":"entity-1"}`)
+
+	require.NoError(t, rw.OffloadScreeningMatchPayload(ctx, orgId, screeningId, matchId, payload))
+
+	got, err := rw.ReadOffloadedScreeningMatchPayload(ctx, orgId, screeningId, matchId)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(payload), string(got))
+
+	// Overwriting the same key (the enrichment case) replaces the payload.
+	enriched := []byte(`{"score":0.9,"id":"entity-1","extra":"enriched"}`)
+	require.NoError(t, rw.OffloadScreeningMatchPayload(ctx, orgId, screeningId, matchId, enriched))
+
+	got, err = rw.ReadOffloadedScreeningMatchPayload(ctx, orgId, screeningId, matchId)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(enriched), string(got))
+}
+
+func TestReadOffloadedScreeningMatchPayloadMissingKey(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	// A missing object is not an error: the caller falls back to the DB column.
+	got, err := rw.ReadOffloadedScreeningMatchPayload(ctx, uuid.New(), uuid.NewString(), uuid.NewString())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestOffloadScreeningMatches(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	screening := models.ScreeningWithMatches{
+		Screening: models.Screening{Id: uuid.NewString(), OrgId: uuid.New()},
+		Matches: []models.ScreeningMatch{
+			{EntityId: "entity-1", Payload: []byte(`{"score":0.9}`)},
+			{EntityId: "entity-2", Payload: []byte(`{"score":0.4}`)},
+		},
+	}
+
+	forInsert, err := rw.OffloadScreeningMatches(ctx, screening)
+	require.NoError(t, err)
+	require.Len(t, forInsert, 2)
+
+	for i := range forInsert {
+		// The matches handed to InsertScreening have an id and an empty payload (the read-time
+		// signal that the payload was offloaded).
+		assert.NotEmpty(t, forInsert[i].Id)
+		assert.Empty(t, forInsert[i].Payload)
+
+		// The same id is back-filled onto the caller's matches, which keep their payload for the
+		// API response.
+		assert.Equal(t, forInsert[i].Id, screening.Matches[i].Id)
+		assert.NotEmpty(t, screening.Matches[i].Payload)
+
+		// The payload was actually written to blob storage under the match's key.
+		got, err := rw.ReadOffloadedScreeningMatchPayload(ctx, screening.OrgId, screening.Id, forInsert[i].Id)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(screening.Matches[i].Payload), string(got))
+	}
+}
+
+func TestOffloadScreeningMatchesDisabledReturnsMatchesUnchanged(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+	rw.OffloadingBucketUrl = ""
+
+	screening := models.ScreeningWithMatches{
+		Screening: models.Screening{Id: uuid.NewString(), OrgId: uuid.New()},
+		Matches: []models.ScreeningMatch{
+			{EntityId: "entity-1", Payload: []byte(`{"score":0.9}`)},
+		},
+	}
+
+	forInsert, err := rw.OffloadScreeningMatches(ctx, screening)
+	require.NoError(t, err)
+
+	// When offloading is disabled the matches are returned unchanged, payload included, so the
+	// repository writes them to the DB column as before.
+	assert.Equal(t, screening.Matches, forInsert)
+	assert.NotEmpty(t, forInsert[0].Payload)
+}
+
+func TestOffloadingDisabledIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+	rw.OffloadingBucketUrl = ""
+
+	assert.False(t, rw.IsOffloadingEnabled())
+
+	// Writing is a no-op and reading returns nil so callers keep using the DB column.
+	require.NoError(t, rw.OffloadScreeningMatchPayload(ctx, uuid.New(), "sc", "m", []byte(`{"score":1}`)))
+
+	got, err := rw.ReadOffloadedScreeningMatchPayload(ctx, uuid.New(), "sc", "m")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/repositories/offloaded_read_writer_screening_test.go
+++ b/repositories/offloaded_read_writer_screening_test.go
@@ -89,6 +89,56 @@ func TestOffloadScreeningMatches(t *testing.T) {
 	}
 }
 
+func TestHydrateScreeningMatches(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	orgId := uuid.New()
+	screeningId := uuid.NewString()
+	offloadedMatchId := uuid.NewString()
+	legacyMatchId := uuid.NewString()
+	missingMatchId := uuid.NewString()
+
+	// An offloaded match: payload lives in blob storage, column is empty.
+	payload := []byte(`{"score":0.7,"id":"entity-1"}`)
+	require.NoError(t, rw.OffloadScreeningMatchPayload(ctx, orgId, screeningId, offloadedMatchId, payload))
+
+	screenings := []models.ScreeningWithMatches{
+		{
+			Screening: models.Screening{Id: screeningId, OrgId: orgId},
+			Matches: []models.ScreeningMatch{
+				{Id: offloadedMatchId, ScreeningId: screeningId, Payload: nil},
+				// A legacy match still has its payload in the column: left untouched, no blob read.
+				{Id: legacyMatchId, ScreeningId: screeningId, Payload: []byte(`{"score":0.2}`)},
+				// A match with no blob and no column payload: stays empty
+				{Id: missingMatchId, ScreeningId: screeningId, Payload: nil},
+			},
+		},
+	}
+
+	require.NoError(t, rw.HydrateScreeningMatches(ctx, screenings))
+
+	assert.JSONEq(t, string(payload), string(screenings[0].Matches[0].Payload))
+	assert.JSONEq(t, `{"score":0.2}`, string(screenings[0].Matches[1].Payload))
+	assert.Empty(t, screenings[0].Matches[2].Payload)
+}
+
+func TestHydrateScreeningMatchesDisabledIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+	rw.OffloadingBucketUrl = ""
+
+	screenings := []models.ScreeningWithMatches{
+		{
+			Screening: models.Screening{Id: uuid.NewString(), OrgId: uuid.New()},
+			Matches:   []models.ScreeningMatch{{Id: uuid.NewString(), Payload: nil}},
+		},
+	}
+
+	require.NoError(t, rw.HydrateScreeningMatches(ctx, screenings))
+	assert.Empty(t, screenings[0].Matches[0].Payload)
+}
+
 func TestOffloadScreeningMatchesDisabledReturnsMatchesUnchanged(t *testing.T) {
 	ctx := context.Background()
 	rw := newFileOffloadedReadWriter(t)

--- a/repositories/offloading_repository.go
+++ b/repositories/offloading_repository.go
@@ -28,3 +28,24 @@ func (repo *MarbleDbRepository) GetScoreComputationEvaluationKey(ruleset models.
 	return fmt.Sprintf("offloading/score_computations/%s/%s/%d/%d/%s", ruleset.OrgId.String(), ruleset.RecordType,
 		score.CreatedAt.Year(), score.CreatedAt.Month(), score.Id.String())
 }
+
+// GetOffloadedScreeningMatchKey returns the deterministic blob key under which a screening
+// match payload is offloaded. The key is fully derivable from data we already have, so we do
+// not store it in the database: a populated payload column means the row is legacy (read it
+// directly), an empty column means the payload lives at this key in blob storage.
+func (repo *MarbleDbRepository) GetOffloadedScreeningMatchKey(orgId uuid.UUID, screeningId, matchId string) string {
+	return fmt.Sprintf("screening/match/%s/%s/%s", orgId.String(), screeningId, matchId)
+}
+
+// GetOffloadedContinuousScreeningMatchKey returns the deterministic blob key for a continuous
+// screening match payload.
+func (repo *MarbleDbRepository) GetOffloadedContinuousScreeningMatchKey(orgId, continuousScreeningId, matchId uuid.UUID) string {
+	return fmt.Sprintf("continuous_screening/match/%s/%s/%s", orgId.String(),
+		continuousScreeningId.String(), matchId.String())
+}
+
+// GetOffloadedContinuousScreeningEntityKey returns the deterministic blob key for the
+// OpenSanctions entity payload attached to a (dataset-triggered) continuous screening.
+func (repo *MarbleDbRepository) GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId uuid.UUID) string {
+	return fmt.Sprintf("continuous_screening/entity/%s/%s", orgId.String(), continuousScreeningId.String())
+}

--- a/repositories/screening_repository.go
+++ b/repositories/screening_repository.go
@@ -97,11 +97,15 @@ func selectScreenings() squirrel.SelectBuilder {
 		InnerJoin(dbmodels.TABLE_SCREENING_CONFIGS + " AS scc ON sc.screening_config_id=scc.id")
 }
 
+// The screening matches are returned unordered. The score used for sorting lives inside the
+// payload, which may be offloaded to blob storage (NULL `payload` column), so it can't be read
+// in SQL reliably. The whole ordering (status, then descending score) is therefore done in one
+// place, in memory after hydration - see ScreeningUsecase.hydrateAndSortMatches.
 func selectScreeningsWithMatches() squirrel.SelectBuilder {
 	return NewQueryBuilder().
 		Select(columnsNames("sc", dbmodels.SelectScreeningColumn)...).
 		Columns("scc.id AS config_id", "stable_id", "scc.name", "scc.datasets", "scc.filters").
-		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s) ORDER BY array_position(array['confirmed_hit', 'pending', 'no_hit', 'skipped'], scm.status), scm.payload->>'score' DESC) FILTER (WHERE scm.id IS NOT NULL) AS matches",
+		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s)) FILTER (WHERE scm.id IS NOT NULL) AS matches",
 			strings.Join(columnsNames("scm", dbmodels.SelectScreeningMatchesColumn), ","))).
 		From(dbmodels.TABLE_SCREENINGS + " AS sc").
 		InnerJoin(dbmodels.TABLE_SCREENING_CONFIGS + " AS scc ON sc.screening_config_id=scc.id").
@@ -165,6 +169,26 @@ func (*MarbleDbRepository) UpdateScreeningMatchPayload(ctx context.Context, exec
 	return SqlToModel(ctx, exec, sql, dbmodels.AdaptScreeningMatch)
 }
 
+// SetScreeningMatchEnriched marks a match as enriched without touching the payload column. It is
+// used for offloaded matches, whose enriched payload is written back to blob storage instead of
+// the DB column.
+func (*MarbleDbRepository) SetScreeningMatchEnriched(ctx context.Context, exec Executor,
+	matchId string,
+) (models.ScreeningMatch, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return models.ScreeningMatch{}, err
+	}
+
+	sql := NewQueryBuilder().
+		Update(dbmodels.TABLE_SCREENING_MATCHES).
+		Set("enriched", true).
+		Set("updated_at", "NOW()").
+		Where(squirrel.Eq{"id": matchId}).
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectScreeningMatchesColumn, ",")))
+
+	return SqlToModel(ctx, exec, sql, dbmodels.AdaptScreeningMatch)
+}
+
 func (*MarbleDbRepository) ListScreeningMatches(
 	ctx context.Context,
 	exec Executor,
@@ -220,6 +244,11 @@ func (*MarbleDbRepository) UpdateScreeningMatchStatus(
 	return SqlToModel(ctx, exec, sql, dbmodels.AdaptScreeningMatch)
 }
 
+// InsertScreening persists a screening and its matches. Match payloads that should be offloaded
+// to blob storage are expected to be offloaded and blanked by the caller (see
+// OffloadedReadWriter.OffloadScreeningMatches) before this is called - this method only writes
+// whatever payload it is given. Matches with a pre-assigned Id keep it (so it matches their blob
+// key); otherwise an Id is generated here.
 func (*MarbleDbRepository) InsertScreening(
 	ctx context.Context,
 	exec Executor,
@@ -284,8 +313,12 @@ func (*MarbleDbRepository) InsertScreening(
 		Columns("id", "screening_id", "opensanction_entity_id", "query_ids", "payload")
 
 	for _, match := range screening.Matches {
-		matchSql = matchSql.Values(pure_utils.NewId(), screening.Id, match.EntityId, match.QueryIds,
-			match.Payload)
+		matchId := match.Id
+		if matchId == "" {
+			matchId = pure_utils.NewId().String()
+		}
+
+		matchSql = matchSql.Values(matchId, screening.Id, match.EntityId, match.QueryIds, match.Payload)
 	}
 
 	return ExecBuilder(ctx, exec, matchSql)

--- a/usecases/ai_agent/ai_agent_usecase.go
+++ b/usecases/ai_agent/ai_agent_usecase.go
@@ -185,6 +185,7 @@ type AiAgentUsecase struct {
 	billingUsecase                     AiAgentUsecaseBillingUsecase
 	caseReviewFileRepository           caseReviewWorkerRepository
 	blobRepository                     repositories.BlobRepository
+	offloadedReader                    repositories.OffloadedReadWriter
 	caseReviewTaskEnqueuer             caseReviewTaskEnqueuer
 	screeningHitSuggestionTaskEnqueuer screeningHitSuggestionTaskEnqueuer
 	screeningUsecase                   AiAgentScreeningUsecase
@@ -213,6 +214,7 @@ func NewAiAgentUsecase(
 	billingUsecase AiAgentUsecaseBillingUsecase,
 	caseReviewFileRepository caseReviewWorkerRepository,
 	blobRepository repositories.BlobRepository,
+	offloadedReader repositories.OffloadedReadWriter,
 	caseReviewTaskEnqueuer caseReviewTaskEnqueuer,
 	transactionFactory executor_factory.TransactionFactory,
 	featureAccessReader featureAccessReader,
@@ -237,6 +239,7 @@ func NewAiAgentUsecase(
 		billingUsecase:                     billingUsecase,
 		caseReviewFileRepository:           caseReviewFileRepository,
 		blobRepository:                     blobRepository,
+		offloadedReader:                    offloadedReader,
 		caseReviewTaskEnqueuer:             caseReviewTaskEnqueuer,
 		transactionFactory:                 transactionFactory,
 		screeningHitSuggestionTaskEnqueuer: screeningHitSuggestionTaskEnqueuer,

--- a/usecases/ai_agent/ai_case_review.go
+++ b/usecases/ai_agent/ai_case_review.go
@@ -997,6 +997,12 @@ func (uc *AiAgentUsecase) getCaseDataWithPermissions(ctx context.Context, caseId
 			return caseData{}, casePivotDataByPivot{}, errors.Wrapf(err,
 				"could not retrieve screenings for decision %s", decision.DecisionId)
 		}
+		// Match payloads may be offloaded to blob storage (empty `payload` column); load them back
+		// so the AI review sees the full match data instead of empty payloads.
+		if err := uc.offloadedReader.HydrateScreeningMatches(ctx, screenings); err != nil {
+			return caseData{}, casePivotDataByPivot{}, errors.Wrapf(err,
+				"could not hydrate offloaded screening match payloads for decision %s", decision.DecisionId)
+		}
 		for _, s := range screenings {
 			screeningIds = append(screeningIds, s.Id)
 		}

--- a/usecases/decision_phantom/decision_phantom.go
+++ b/usecases/decision_phantom/decision_phantom.go
@@ -84,8 +84,7 @@ func (usecase *PhantomDecisionUsecase) CreatePhantomDecision(
 		return false, models.PhantomDecision{}, err
 	}
 
-	triggerPassed, testRunScenarioExecution, err :=
-		usecase.scenarioEvaluator.EvalTestRunScenario(ctx, evaluationParameters)
+	triggerPassed, testRunScenarioExecution, err := usecase.scenarioEvaluator.EvalTestRunScenario(ctx, evaluationParameters)
 	if err != nil {
 		return false, models.PhantomDecision{},
 			fmt.Errorf("error evaluating scenario: %w", err)
@@ -121,7 +120,8 @@ func (usecase *PhantomDecisionUsecase) CreatePhantomDecision(
 
 			for _, sce := range phantomDecision.ScreeningExecutions {
 				// We don't need to store the matches in the case of a phantom decision
-				// because we are only interested in statistics on the screening status
+				// because we are only interested in statistics on the screening status.
+				// Nothing to offload
 				sce.Matches = nil
 				err := usecase.externalRepository.InsertScreening(ctx, tx, sce)
 				if err != nil {

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -396,6 +396,13 @@ func (usecase *DecisionUsecase) CreateDecision(
 		}
 
 		for _, sce := range decision.ScreeningExecutions {
+			matchesToInsert, offloadErr := usecase.offloadedReader.OffloadScreeningMatches(ctx, sce)
+			if offloadErr != nil {
+				return models.DecisionWithRuleExecutions{},
+					errors.Wrapf(offloadErr, "could not offload screening match payloads in CreateDecision")
+			}
+			sce.Matches = matchesToInsert
+
 			err := usecase.screeningRepository.InsertScreening(ctx, tx, sce)
 			if err != nil {
 				return models.DecisionWithRuleExecutions{},
@@ -646,6 +653,12 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 				Observe(time.Since(decisionStart).Seconds())
 
 			for _, sce := range item.decision.ScreeningExecutions {
+				matchesToInsert, offloadErr := usecase.offloadedReader.OffloadScreeningMatches(ctx, sce)
+				if offloadErr != nil {
+					return errors.Wrapf(offloadErr, "could not offload screening match payloads in CreateAllDecisions")
+				}
+				sce.Matches = matchesToInsert
+
 				err := usecase.screeningRepository.InsertScreening(ctx, tx, sce)
 				if err != nil {
 					return errors.Wrapf(err, "error storing screening execution in CreateAllDecisions")

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -193,26 +193,14 @@ func (uc ScreeningUsecase) GetScreening(ctx context.Context, id string) (models.
 
 // hydrateAndSortMatches loads offloaded match payloads from blob storage (for matches whose DB
 // payload column is empty) and sorts the matches by status, then by descending score. The score
-// lives inside the payload, so the sort must happen after hydration rather than in SQL. Matches
-// whose payload cannot be loaded (missing from both the column and blob storage) are logged and
-// pushed to the end of their status group rather than failing the whole read.
+// lives inside the payload, so the sort must happen after hydration rather than in SQL.
 func (uc ScreeningUsecase) hydrateAndSortMatches(ctx context.Context, orgId uuid.UUID,
 	matches []models.ScreeningMatch,
 ) error {
-	if uc.offloadedReader.IsOffloadingEnabled() {
-		for i := range matches {
-			if len(matches[i].Payload) > 0 {
-				continue
-			}
-
-			payload, err := uc.offloadedReader.ReadOffloadedScreeningMatchPayload(ctx, orgId,
-				matches[i].ScreeningId, matches[i].Id)
-			if err != nil {
-				return errors.Wrap(err, "could not read offloaded screening match payload")
-			}
-
-			matches[i].Payload = payload
-		}
+	if err := uc.offloadedReader.HydrateScreeningMatches(ctx, []models.ScreeningWithMatches{
+		{Screening: models.Screening{OrgId: orgId}, Matches: matches},
+	}); err != nil {
+		return err
 	}
 
 	slices.SortStableFunc(matches, func(a, b models.ScreeningMatch) int {

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -1,12 +1,14 @@
 package usecases
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"maps"
 	"mime/multipart"
+	"slices"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
@@ -98,6 +100,8 @@ type ScreeningRepository interface {
 		orgId uuid.UUID, counterpartyId, entityId *string) ([]models.ScreeningWhitelist, error)
 	UpdateScreeningMatchPayload(ctx context.Context, exec repositories.Executor,
 		match models.ScreeningMatch, newPayload []byte) (models.ScreeningMatch, error)
+	SetScreeningMatchEnriched(ctx context.Context, exec repositories.Executor,
+		matchId string) (models.ScreeningMatch, error)
 
 	InsertFreeformSearch(ctx context.Context, exec repositories.Executor,
 		h models.FreeformSearch) error
@@ -140,6 +144,7 @@ type ScreeningUsecase struct {
 	openSanctionsProvider ScreeningProvider
 	blobBucketUrl         string
 	blobRepository        repositories.BlobRepository
+	offloadedReader       repositories.OffloadedReadWriter
 
 	executorFactory    executor_factory.ExecutorFactory
 	transactionFactory executor_factory.TransactionFactory
@@ -179,7 +184,63 @@ func (uc ScreeningUsecase) GetScreening(ctx context.Context, id string) (models.
 		}
 	}
 
+	if err := uc.hydrateAndSortMatches(ctx, sc.OrgId, sc.Matches); err != nil {
+		return models.ScreeningWithMatches{}, err
+	}
+
 	return sc, nil
+}
+
+// hydrateAndSortMatches loads offloaded match payloads from blob storage (for matches whose DB
+// payload column is empty) and sorts the matches by status, then by descending score. The score
+// lives inside the payload, so the sort must happen after hydration rather than in SQL. Matches
+// whose payload cannot be loaded (missing from both the column and blob storage) are logged and
+// pushed to the end of their status group rather than failing the whole read.
+func (uc ScreeningUsecase) hydrateAndSortMatches(ctx context.Context, orgId uuid.UUID,
+	matches []models.ScreeningMatch,
+) error {
+	if uc.offloadedReader.IsOffloadingEnabled() {
+		for i := range matches {
+			if len(matches[i].Payload) > 0 {
+				continue
+			}
+
+			payload, err := uc.offloadedReader.ReadOffloadedScreeningMatchPayload(ctx, orgId,
+				matches[i].ScreeningId, matches[i].Id)
+			if err != nil {
+				return errors.Wrap(err, "could not read offloaded screening match payload")
+			}
+
+			matches[i].Payload = payload
+		}
+	}
+
+	slices.SortStableFunc(matches, func(a, b models.ScreeningMatch) int {
+		// Status drives the primary grouping.
+		if n := cmp.Compare(screeningMatchStatusRank(a.Status), screeningMatchStatusRank(b.Status)); n != 0 {
+			return n
+		}
+		return cmp.Compare(b.GetScoreFromPayload(), a.GetScoreFromPayload())
+	})
+
+	return nil
+}
+
+// screeningMatchStatusRank mirrors the status ordering previously expressed in SQL
+// (array['confirmed_hit', 'pending', 'no_hit', 'skipped']).
+func screeningMatchStatusRank(s models.ScreeningMatchStatus) int {
+	switch s {
+	case models.ScreeningMatchStatusConfirmedHit:
+		return 0
+	case models.ScreeningMatchStatusPending:
+		return 1
+	case models.ScreeningMatchStatusNoHit:
+		return 2
+	case models.ScreeningMatchStatusSkipped:
+		return 3
+	default:
+		return 4
+	}
 }
 
 func (uc ScreeningUsecase) GetAvailableFilters(ctx context.Context, feature models.ScreeningFeature) (dto.ScreeningAvailableFilters, error) {
@@ -301,6 +362,12 @@ func (uc ScreeningUsecase) ListScreenings(ctx context.Context, decisionId string
 		}
 	}
 
+	for sidx := range scs {
+		if err := uc.hydrateAndSortMatches(ctx, scs[sidx].OrgId, scs[sidx].Matches); err != nil {
+			return nil, err
+		}
+	}
+
 	return scs, nil
 }
 
@@ -383,7 +450,14 @@ func (uc ScreeningUsecase) Refine(ctx context.Context, refine models.ScreeningRe
 			return models.ScreeningWithMatches{}, err
 		}
 
-		if err = uc.repository.InsertScreening(ctx, tx, screening); err != nil {
+		screeningToInsert := screening
+		screeningToInsert.Matches, err = uc.offloadedReader.OffloadScreeningMatches(ctx, screening)
+		if err != nil {
+			return models.ScreeningWithMatches{}, errors.Wrap(err,
+				"could not offload screening match payloads")
+		}
+
+		if err = uc.repository.InsertScreening(ctx, tx, screeningToInsert); err != nil {
 			return models.ScreeningWithMatches{}, err
 		}
 
@@ -777,17 +851,51 @@ func (uc ScreeningUsecase) EnrichMatchWithoutAuthorization(ctx context.Context, 
 			"this screening match was already enriched")
 	}
 
+	// An empty payload column on a bucket-enabled deployment means the original payload was
+	// offloaded to blob storage; read it back so we can merge the enrichment into it.
+	offloaded := uc.offloadedReader.IsOffloadingEnabled() && len(match.Payload) == 0
+
+	originalPayload := match.Payload
+	if offloaded {
+		originalPayload, err = uc.offloadedReader.ReadOffloadedScreeningMatchPayload(ctx,
+			screening.OrgId, match.ScreeningId, match.Id)
+		if err != nil {
+			return models.ScreeningMatch{}, errors.Wrap(err,
+				"could not read offloaded screening match payload for enrichment")
+		}
+	}
+
 	newPayload, err := uc.openSanctionsProvider.EnrichMatch(ctx, screening.Provider, match)
 	if err != nil {
 		return models.ScreeningMatch{}, err
 	}
 
-	mergedPayload, err := mergePayloads(match.Payload, newPayload)
+	mergedPayload, err := mergePayloads(originalPayload, newPayload)
 	if err != nil {
 		return models.ScreeningMatch{}, errors.Wrap(err,
 			"could not merge payloads for match enrichment")
 	}
 
+	// Offloaded matches keep their payload in blob storage: overwrite the same key and only
+	// flip the enriched flag in the DB. Legacy matches keep their payload in the DB column.
+	if offloaded {
+		if err := uc.offloadedReader.OffloadScreeningMatchPayload(ctx, screening.OrgId,
+			match.ScreeningId, match.Id, mergedPayload); err != nil {
+			return models.ScreeningMatch{}, errors.Wrap(err,
+				"could not write enriched screening match payload")
+		}
+
+		newMatch, err := uc.repository.SetScreeningMatchEnriched(ctx,
+			uc.executorFactory.NewExecutor(), match.Id)
+		if err != nil {
+			return models.ScreeningMatch{}, err
+		}
+
+		newMatch.Payload = mergedPayload
+		return newMatch, nil
+	}
+
+	// Legacy match, update the payload and set enriched to true
 	newMatch, err := uc.repository.UpdateScreeningMatchPayload(ctx,
 		uc.executorFactory.NewExecutor(), match, mergedPayload)
 	if err != nil {

--- a/usecases/screening_usecase_test.go
+++ b/usecases/screening_usecase_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/utils"
 	ops "github.com/go-faker/faker/v4/pkg/options"
+	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -65,8 +66,7 @@ func TestListScreeningOnDecision(t *testing.T) {
 		SELECT
 			sc.id, sc.decision_id, sc.org_id, sc.screening_config_id, sc.status, sc.provider, sc.search_input, sc.initial_query, sc.counterparty_id, sc.match_threshold, sc.match_limit, sc.is_manual, sc.requested_by, sc.is_partial, sc.is_archived, sc.initial_has_matches, sc.error_codes, sc.number_of_matches, sc.created_at, sc.updated_at,
 			scc.id AS config_id, stable_id, scc.name, scc.datasets, scc.filters,
-			ARRAY_AGG(ROW(scm.id,scm.screening_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.payload,scm.enriched,scm.reviewed_by,scm.created_at,scm.updated_at)
-				ORDER BY array_position(.+, scm.status), scm.payload->>'score' DESC) FILTER (WHERE scm.id IS NOT NULL)
+			ARRAY_AGG(ROW(scm.id,scm.screening_id,scm.opensanction_entity_id,scm.status,scm.query_ids,scm.payload,scm.enriched,scm.reviewed_by,scm.created_at,scm.updated_at)) FILTER (WHERE scm.id IS NOT NULL)
 				AS matches
 		FROM screenings AS sc
 		INNER JOIN screening_configs AS scc ON sc.screening_config_id=scc.id
@@ -186,4 +186,42 @@ func TestUpdateMatchStatus(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NoError(t, exec.Mock.ExpectationsWereMet())
+}
+
+// TestHydrateAndSortMatches checks the in-memory match ordering (status, then descending score)
+// that replaced the SQL `ORDER BY payload->>'score'` once payloads can be offloaded. Offloading
+// is disabled here, so payloads are read straight from the in-memory matches. Two matches per
+// status, in scrambled input order, so both the status grouping and the within-status score
+// ordering are exercised.
+func TestHydrateAndSortMatches(t *testing.T) {
+	uc, _ := buildScreeningUsecaseMock()
+
+	matches := []models.ScreeningMatch{
+		{Id: "no_hit_low", Status: models.ScreeningMatchStatusNoHit, Payload: []byte(`{"score":0.10}`)},
+		{Id: "confirmed_high", Status: models.ScreeningMatchStatusConfirmedHit, Payload: []byte(`{"score":0.90}`)},
+		{Id: "skipped_high", Status: models.ScreeningMatchStatusSkipped, Payload: []byte(`{"score":0.70}`)},
+		{Id: "pending_low", Status: models.ScreeningMatchStatusPending, Payload: []byte(`{"score":0.20}`)},
+		{Id: "no_hit_high", Status: models.ScreeningMatchStatusNoHit, Payload: []byte(`{"score":0.95}`)},
+		{Id: "confirmed_low", Status: models.ScreeningMatchStatusConfirmedHit, Payload: []byte(`{"score":0.30}`)},
+		{Id: "skipped_low", Status: models.ScreeningMatchStatusSkipped, Payload: []byte(`{"score":0.40}`)},
+		{Id: "pending_high", Status: models.ScreeningMatchStatusPending, Payload: []byte(`{"score":0.80}`)},
+		// A confirmed_hit match whose payload could not be loaded: it stays in its status group
+		// but sorts to the end of that group (after the confirmed_hit matches with a score).
+		{Id: "confirmed_missing", Status: models.ScreeningMatchStatusConfirmedHit, Payload: nil},
+	}
+
+	err := uc.hydrateAndSortMatches(context.TODO(), uuid.New(), matches)
+	assert.NoError(t, err)
+
+	got := make([]string, len(matches))
+	for i, m := range matches {
+		got[i] = m.Id
+	}
+
+	assert.Equal(t, []string{
+		"confirmed_high", "confirmed_low", "confirmed_missing",
+		"pending_high", "pending_low",
+		"no_hit_high", "no_hit_low",
+		"skipped_high", "skipped_low",
+	}, got)
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -246,6 +246,7 @@ func (usecases *UsecasesWithCreds) NewScreeningUsecase() ScreeningUsecase {
 		repository:                usecases.Repositories.MarbleDbRepository,
 		blobRepository:            usecases.Repositories.BlobRepository,
 		blobBucketUrl:             usecases.caseManagerBucketUrl,
+		offloadedReader:           usecases.NewOffloadedReader(),
 		executorFactory:           usecases.NewExecutorFactory(),
 		transactionFactory:        usecases.NewTransactionFactory(),
 	}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -794,6 +794,7 @@ func (usecases *UsecasesWithCreds) NewAiAgentUsecase() ai_agent.AiAgentUsecase {
 		usecases.NewBillingUsecase(),
 		usecases.Repositories.MarbleDbRepository,
 		usecases.Repositories.BlobRepository,
+		usecases.NewOffloadedReader(),
 		usecases.Repositories.TaskQueueRepository,
 		usecases.NewTransactionFactory(),
 		usecases.NewFeatureAccessReader(),

--- a/usecases/worker_jobs/async_decision_job.go
+++ b/usecases/worker_jobs/async_decision_job.go
@@ -390,6 +390,13 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 	}
 
 	for _, sce := range decision.ScreeningExecutions {
+		matchesToInsert, offloadErr := w.offloadedReader.OffloadScreeningMatches(ctx, sce)
+		if offloadErr != nil {
+			return false, nil, nil, errors.Wrapf(offloadErr,
+				"could not offload screening match payloads in createSingleDecisionForObjectId")
+		}
+		sce.Matches = matchesToInsert
+
 		err := w.screeningRepository.InsertScreening(ctx, tx, sce)
 		if err != nil {
 			return false, nil, nil, errors.Wrapf(err,


### PR DESCRIPTION
## Problem

With the new screening provider, a match's entity payload can be very large. Storing it in the `screening_matches.payload` column bloats the table and slows queries.

## Solution

Offload match payloads to blob storage (the existing offloading bucket) instead of the DB column, while staying backward compatible with older matches whose payload is still in the column.

Scope: this PR covers decision screening only. Continuous screening will follow in a separate PR (the blob key builders + offloader methods for it are already in place, unused).

## How it works

- Write: the usecase offloads each match payload to a deterministic key (`screening/match/{org}/{screening}/{match}`) before insert and stores an empty payload column.
- Read: payloads are hydrated from blob on read. The read signal is the column itself: 
    - populated ⇒ legacy row (use it)
    - empty ⇒ offloaded (fetch from blob)  
- Enrichment: merges into the same blob key and only flips the enriched flag in DB (legacy rows keep using the column).

## Notable choices

- No key column: the blob key is deterministic, and an empty payload column is the offloaded marker.
- Sort moved to runtime: the score lives in the payload (now possibly offloaded), so the old SQL `ORDER BY payload->>'score'` is gone; matches are sorted in memory by status, then descending score.
- Toggle via OFFLOADING_BUCKET_URL -> empty ⇒ legacy DB-column behavior, unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled payload offloading for screening matches and continuous screening match/entity payloads to external blob storage.
  * Added APIs to read offloaded payloads and hydrate match payloads when the database payload is empty.
  * Improved screening match ordering by status priority and descending score after hydration.

* **Tests**
  * Expanded coverage for offload round-trips, missing payload reads (nil without error), hydration behavior, and no-op behavior when offloading is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->