### PR TITLE
feat: offload continuous screening match and entity payload

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -403,6 +403,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithContinuousScreeningBucketUrl(serverConfig.continuousScreeningBucketUrl),
 		usecases.WithMarbleApiInternalUrl(apiConfig.MarbleApiInternalUrl),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
+		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -382,6 +382,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		usecases.WithContinuousScreeningBucketUrl(workerConfig.continuousScreeningBucketUrl),
 		usecases.WithCsCreateFullDatasetInterval(workerConfig.CreateFullDatasetInterval),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
+		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
 	)
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, uc)
 

--- a/mocks/continuous_screening_repository.go
+++ b/mocks/continuous_screening_repository.go
@@ -425,6 +425,24 @@ func (m *ContinuousScreeningRepository) UpdateContinuousScreeningMatchEnrichedPa
 	return args.Error(0)
 }
 
+func (m *ContinuousScreeningRepository) SetContinuousScreeningEntityEnriched(
+	ctx context.Context,
+	exec repositories.Executor,
+	id uuid.UUID,
+) error {
+	args := m.Called(ctx, exec, id)
+	return args.Error(0)
+}
+
+func (m *ContinuousScreeningRepository) SetContinuousScreeningMatchEnriched(
+	ctx context.Context,
+	exec repositories.Executor,
+	id uuid.UUID,
+) error {
+	args := m.Called(ctx, exec, id)
+	return args.Error(0)
+}
+
 type ContinuousScreeningClientDbRepository struct {
 	mock.Mock
 }

--- a/models/continuous_screening.go
+++ b/models/continuous_screening.go
@@ -95,6 +95,9 @@ type UpdateContinuousScreeningInput struct {
 }
 
 type CreateContinuousScreening struct {
+	// Id is optionally pre-assigned by the caller
+	// Repository will generated a new UUID if not provided during insertion
+	Id                        uuid.UUID
 	Screening                 ScreeningWithMatches
 	Config                    ContinuousScreeningConfig
 	ObjectType                *string
@@ -117,6 +120,18 @@ type ContinuousScreeningMatch struct {
 
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+// GetScoreFromPayload extracts the match score from the (possibly offloaded) payload. The score
+// is not a dedicated column, so it can only be read once the payload has been hydrated.
+func (m ContinuousScreeningMatch) GetScoreFromPayload() float64 {
+	var parsed struct {
+		Score float64 `json:"score"`
+	}
+	if err := json.Unmarshal(m.Payload, &parsed); err != nil {
+		return 0
+	}
+	return parsed.Score
 }
 
 type ContinuousScreeningWithMatches struct {

--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -137,7 +137,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningConfig(ctx context.Cont
 
 	sql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_CONFIGS).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningConfigColumnList, ","))).
 		Columns(
 			"id",
 			"org_id",
@@ -186,7 +186,7 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningConfig(
 
 	sql := NewQueryBuilder().
 		Update(dbmodels.TABLE_CONTINUOUS_SCREENING_CONFIGS).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningConfigColumnList, ","))).
 		Set("updated_at", squirrel.Expr("NOW()")).
 		Where(squirrel.Eq{"id": id})
 
@@ -253,11 +253,16 @@ func (repo *MarbleDbRepository) InsertContinuousScreening(
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 
-	id := pure_utils.NewId()
+	// The caller may pre-assign the id (so it can offload the entity payload to blob storage,
+	// keyed by this id, before insert). Generate one when it isn't set.
+	id := input.Id
+	if id == uuid.Nil {
+		id = pure_utils.NewId()
+	}
 
 	sql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENINGS).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningColumn, ","))).
 		Columns(
 			"id",
 			"org_id",
@@ -304,11 +309,18 @@ func (repo *MarbleDbRepository) InsertContinuousScreening(
 
 	matchSql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_MATCHES).
-		Suffix("RETURNING *").
-		Columns("continuous_screening_id", "opensanction_entity_id", "payload")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningMatchesColumn, ","))).
+		Columns("id", "continuous_screening_id", "opensanction_entity_id", "payload")
 
 	for _, match := range input.Screening.Matches {
-		matchSql = matchSql.Values(id, match.EntityId, match.Payload)
+		// Matches offloaded by the caller carry a pre-assigned id (their blob key); otherwise
+		// generate one here.
+		matchId := match.Id
+		if matchId == "" {
+			matchId = pure_utils.NewId().String()
+		}
+
+		matchSql = matchSql.Values(matchId, id, match.EntityId, match.Payload)
 	}
 
 	matches, err := SqlToListOfModels(ctx, exec, matchSql, dbmodels.AdaptContinuousScreeningMatch)
@@ -335,11 +347,18 @@ func (repo *MarbleDbRepository) InsertContinuousScreeningMatches(
 
 	matchSql := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_MATCHES).
-		Suffix("RETURNING *").
-		Columns("continuous_screening_id", "opensanction_entity_id", "payload")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningMatchesColumn, ","))).
+		Columns("id", "continuous_screening_id", "opensanction_entity_id", "payload")
 
 	for _, match := range matches {
-		matchSql = matchSql.Values(screeningId, match.OpenSanctionEntityId, match.Payload)
+		// Matches offloaded by the caller carry a pre-assigned id (their blob key); otherwise
+		// generate one here.
+		matchId := match.Id
+		if matchId == uuid.Nil {
+			matchId = pure_utils.NewId()
+		}
+
+		matchSql = matchSql.Values(matchId, screeningId, match.OpenSanctionEntityId, match.Payload)
 	}
 
 	return SqlToListOfModels(ctx, exec, matchSql, dbmodels.AdaptContinuousScreeningMatch)
@@ -445,7 +464,7 @@ func (repo *MarbleDbRepository) ListContinuousScreeningsForOrg(
 func selectContinuousScreeningWithMatches() squirrel.SelectBuilder {
 	return NewQueryBuilder().
 		Select(columnsNames("cs", dbmodels.SelectContinuousScreeningColumn)...).
-		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s) ORDER BY array_position(array['confirmed_hit', 'pending', 'no_hit', 'skipped'], csm.status), csm.payload->>'score' DESC) FILTER (WHERE csm.id IS NOT NULL) AS matches",
+		Column(fmt.Sprintf("ARRAY_AGG(ROW(%s)) FILTER (WHERE csm.id IS NOT NULL) AS matches",
 			strings.Join(columnsNames("csm", dbmodels.SelectContinuousScreeningMatchesColumn), ","))).
 		From(dbmodels.TABLE_CONTINUOUS_SCREENINGS + " AS cs").
 		LeftJoin(dbmodels.TABLE_CONTINUOUS_SCREENING_MATCHES +
@@ -555,7 +574,7 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningMatchStatus(
 		Set("status", newStatus.String()).
 		Set("reviewed_by", reviewedBy).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING *")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningMatchesColumn, ",")))
 
 	return SqlToModel(ctx, exec, query, dbmodels.AdaptContinuousScreeningMatch)
 }
@@ -581,7 +600,7 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningMatchStatusByBatch(
 		Set("status", newStatus.String()).
 		Set("reviewed_by", reviewedBy).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING *")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningMatchesColumn, ",")))
 
 	return SqlToListOfModels(ctx, exec, query, dbmodels.AdaptContinuousScreeningMatch)
 }
@@ -601,7 +620,7 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningStatus(
 		Where(squirrel.Eq{"id": id}).
 		Set("status", newStatus.String()).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING *")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningColumn, ",")))
 
 	return SqlToModel(ctx, exec, query, dbmodels.AdaptContinuousScreening)
 }
@@ -621,7 +640,7 @@ func (repo *MarbleDbRepository) UpdateContinuousScreening(
 		Update(dbmodels.TABLE_CONTINUOUS_SCREENINGS).
 		Where(squirrel.Eq{"id": id}).
 		Set("updated_at", squirrel.Expr("NOW()")).
-		Suffix("RETURNING *")
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningColumn, ",")))
 
 	if input.Status != nil {
 		sql = sql.Set("status", input.Status.String())
@@ -667,6 +686,26 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningEntityEnrichedPayload(
 	return ExecBuilder(ctx, exec, query)
 }
 
+// SetContinuousScreeningEntityEnriched marks the entity as enriched without touching the payload
+// column.
+func (repo *MarbleDbRepository) SetContinuousScreeningEntityEnriched(
+	ctx context.Context,
+	exec Executor,
+	id uuid.UUID,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_CONTINUOUS_SCREENINGS).
+		Where(squirrel.Eq{"id": id}).
+		Set("opensanction_entity_enriched", true).
+		Set("updated_at", squirrel.Expr("NOW()"))
+
+	return ExecBuilder(ctx, exec, query)
+}
+
 func (repo *MarbleDbRepository) UpdateContinuousScreeningMatchEnrichedPayload(
 	ctx context.Context,
 	exec Executor,
@@ -681,6 +720,26 @@ func (repo *MarbleDbRepository) UpdateContinuousScreeningMatchEnrichedPayload(
 		Update(dbmodels.TABLE_CONTINUOUS_SCREENING_MATCHES).
 		Where(squirrel.Eq{"id": id}).
 		Set("payload", enrichedPayload).
+		Set("enriched", true).
+		Set("updated_at", squirrel.Expr("NOW()"))
+
+	return ExecBuilder(ctx, exec, query)
+}
+
+// SetContinuousScreeningMatchEnriched marks a match as enriched without touching the payload
+// column.
+func (repo *MarbleDbRepository) SetContinuousScreeningMatchEnriched(
+	ctx context.Context,
+	exec Executor,
+	id uuid.UUID,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_CONTINUOUS_SCREENING_MATCHES).
+		Where(squirrel.Eq{"id": id}).
 		Set("enriched", true).
 		Set("updated_at", squirrel.Expr("NOW()"))
 
@@ -1061,7 +1120,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningDatasetFile(
 
 	query := NewQueryBuilder().
 		Insert(dbmodels.TABLE_CONTINUOUS_SCREENING_DATASET_FILES).
-		Suffix("RETURNING *").
+		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.SelectContinuousScreeningDatasetFileColumn, ","))).
 		Columns(
 			"org_id",
 			"file_type",

--- a/repositories/migrations/20260612100000_relax_continuous_screening_entity_payload_check.sql
+++ b/repositories/migrations/20260612100000_relax_continuous_screening_entity_payload_check.sql
@@ -1,0 +1,39 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- The OpenSanctions entity payload of a (dataset-triggered) continuous screening can now be
+-- offloaded to blob storage, in which case the `opensanction_entity_payload` column is left NULL.
+-- Relax the check constraint so it no longer requires the payload to be present: an entity id is
+-- enough to identify the dataset-triggered branch.
+ALTER TABLE continuous_screenings DROP CONSTRAINT continuous_screenings_object_or_opensanction_check;
+
+ALTER TABLE continuous_screenings ADD CONSTRAINT continuous_screenings_object_or_opensanction_check
+CHECK (
+    (object_type IS NOT NULL AND object_id IS NOT NULL AND object_internal_id IS NOT NULL)
+    OR
+    (opensanction_entity_id IS NOT NULL)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE continuous_screenings DROP CONSTRAINT continuous_screenings_object_or_opensanction_check;
+
+-- Rows whose entity payload was offloaded (and thus stored as NULL) while the constraint was
+-- relaxed would violate the stricter constraint below. Backfill them with an empty JSON object so
+-- the constraint can be recreated.
+UPDATE continuous_screenings
+SET opensanction_entity_payload = '{}'::jsonb
+WHERE opensanction_entity_id IS NOT NULL
+    AND opensanction_entity_payload IS NULL;
+
+ALTER TABLE continuous_screenings ADD CONSTRAINT continuous_screenings_object_or_opensanction_check
+CHECK (
+    (object_type IS NOT NULL AND object_id IS NOT NULL AND object_internal_id IS NOT NULL)
+    OR
+    (opensanction_entity_id IS NOT NULL AND opensanction_entity_payload IS NOT NULL)
+);
+
+-- +goose StatementEnd

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -419,7 +419,7 @@ func (uc OffloadedReadWriter) OffloadContinuousScreeningEntityPayload(
 func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningEntityPayload(
 	ctx context.Context, orgId, continuousScreeningId uuid.UUID,
 ) ([]byte, error) {
-	if !uc.IsScreeningOffloadingEnabled() {
+	if !uc.IsOffloadingEnabled() {
 		return nil, nil
 	}
 	return uc.readPayload(ctx,

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -35,10 +35,15 @@ func (uc OffloadedReadWriter) IsOffloadingEnabled() bool {
 	return uc.OffloadingBucketUrl != ""
 }
 
+func (uc OffloadedReadWriter) IsScreeningOffloadingEnabled() bool {
+	return uc.IsOffloadingEnabled() && uc.ScreeningOffloadingEnabled
+}
+
 type OffloadedReadWriter struct {
-	Repository          offloadableRepository
-	BlobRepository      BlobRepository
-	OffloadingBucketUrl string
+	Repository                 offloadableRepository
+	BlobRepository             BlobRepository
+	OffloadingBucketUrl        string
+	ScreeningOffloadingEnabled bool
 }
 
 func (uc OffloadedReadWriter) OffloadRuleExecutions(
@@ -282,7 +287,7 @@ func (uc OffloadedReadWriter) readPayload(ctx context.Context, key string) ([]by
 func (uc OffloadedReadWriter) OffloadScreeningMatchPayload(
 	ctx context.Context, orgId uuid.UUID, screeningId, matchId string, payload []byte,
 ) error {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return nil
 	}
 	return uc.writePayload(ctx, uc.Repository.GetOffloadedScreeningMatchKey(orgId, screeningId, matchId), payload)
@@ -309,7 +314,7 @@ func (uc OffloadedReadWriter) ReadOffloadedScreeningMatchPayload(
 func (uc OffloadedReadWriter) OffloadScreeningMatches(
 	ctx context.Context, screening models.ScreeningWithMatches,
 ) ([]models.ScreeningMatch, error) {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return screening.Matches, nil
 	}
 
@@ -378,7 +383,7 @@ func (uc OffloadedReadWriter) HydrateScreeningMatches(
 func (uc OffloadedReadWriter) OffloadContinuousScreeningMatchPayload(
 	ctx context.Context, orgId, continuousScreeningId, matchId uuid.UUID, payload []byte,
 ) error {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return nil
 	}
 	return uc.writePayload(ctx,
@@ -402,7 +407,7 @@ func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningMatchPayload(
 func (uc OffloadedReadWriter) OffloadContinuousScreeningEntityPayload(
 	ctx context.Context, orgId, continuousScreeningId uuid.UUID, payload []byte,
 ) error {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return nil
 	}
 	return uc.writePayload(ctx,
@@ -414,7 +419,7 @@ func (uc OffloadedReadWriter) OffloadContinuousScreeningEntityPayload(
 func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningEntityPayload(
 	ctx context.Context, orgId, continuousScreeningId uuid.UUID,
 ) ([]byte, error) {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return nil, nil
 	}
 	return uc.readPayload(ctx,
@@ -428,7 +433,7 @@ func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningEntityPayload(
 func (uc OffloadedReadWriter) OffloadContinuousScreeningEntity(
 	ctx context.Context, orgId, continuousScreeningId uuid.UUID, payload []byte,
 ) ([]byte, error) {
-	if !uc.IsOffloadingEnabled() || len(payload) == 0 {
+	if !uc.IsScreeningOffloadingEnabled() || len(payload) == 0 {
 		return payload, nil
 	}
 
@@ -446,7 +451,7 @@ func (uc OffloadedReadWriter) OffloadContinuousScreeningEntity(
 func (uc OffloadedReadWriter) OffloadContinuousScreeningMatches(
 	ctx context.Context, orgId, continuousScreeningId uuid.UUID, matches []models.ScreeningMatch,
 ) ([]models.ScreeningMatch, error) {
-	if !uc.IsOffloadingEnabled() {
+	if !uc.IsScreeningOffloadingEnabled() {
 		return matches, nil
 	}
 

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -420,3 +420,124 @@ func (uc OffloadedReadWriter) ReadOffloadedContinuousScreeningEntityPayload(
 	return uc.readPayload(ctx,
 		uc.Repository.GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId))
 }
+
+// OffloadContinuousScreeningEntity offloads the OpenSanctions entity payload of a continuous
+// screening to blob storage (keyed by the screening id) and returns the value to store in the
+// `opensanction_entity_payload` column: nil once offloaded, or the payload unchanged when
+// offloading is disabled (or there is no payload).
+func (uc OffloadedReadWriter) OffloadContinuousScreeningEntity(
+	ctx context.Context, orgId, continuousScreeningId uuid.UUID, payload []byte,
+) ([]byte, error) {
+	if !uc.IsOffloadingEnabled() || len(payload) == 0 {
+		return payload, nil
+	}
+
+	if err := uc.OffloadContinuousScreeningEntityPayload(ctx, orgId, continuousScreeningId, payload); err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// OffloadContinuousScreeningMatches offloads match payloads to blob storage and returns a copy of
+// the matches with a pre-assigned id (matching its blob key) and a blanked payload, ready to be
+// inserted with empty payload columns. When offloading is disabled the matches are returned
+// unchanged.
+func (uc OffloadedReadWriter) OffloadContinuousScreeningMatches(
+	ctx context.Context, orgId, continuousScreeningId uuid.UUID, matches []models.ScreeningMatch,
+) ([]models.ScreeningMatch, error) {
+	if !uc.IsOffloadingEnabled() {
+		return matches, nil
+	}
+
+	offloaded := make([]models.ScreeningMatch, len(matches))
+	for i := range matches {
+		match := matches[i]
+		if match.Id == "" {
+			match.Id = pure_utils.NewId().String()
+		}
+
+		matchId, err := uuid.Parse(match.Id)
+		if err != nil {
+			return nil, errors.Wrap(err, "invalid screening match id")
+		}
+
+		if err := uc.OffloadContinuousScreeningMatchPayload(ctx, orgId, continuousScreeningId,
+			matchId, match.Payload); err != nil {
+			return nil, err
+		}
+
+		match.Payload = nil
+		offloaded[i] = match
+	}
+
+	return offloaded, nil
+}
+
+// HydrateContinuousScreeningEntity fills in, from blob storage, the entity payload of a
+// dataset-triggered continuous screening when it was offloaded (empty DB column). No-op when
+// offloading is disabled or the screening has no entity id. A missing blob is logged and left
+// empty rather than failing the read.
+func (uc OffloadedReadWriter) HydrateContinuousScreeningEntity(
+	ctx context.Context, screening *models.ContinuousScreeningWithMatches,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+
+	if screening.OpenSanctionEntityId == nil || len(screening.OpenSanctionEntityPayload) > 0 {
+		return nil
+	}
+
+	payload, err := uc.ReadOffloadedContinuousScreeningEntityPayload(ctx, screening.OrgId, screening.Id)
+	if err != nil {
+		return err
+	}
+	if len(payload) == 0 {
+		utils.LoggerFromContext(ctx).WarnContext(ctx,
+			"continuous screening entity payload is missing from both the DB column and blob storage",
+			"org_id", screening.OrgId,
+			"continuous_screening_id", screening.Id,
+		)
+		return nil
+	}
+
+	screening.OpenSanctionEntityPayload = payload
+	return nil
+}
+
+// HydrateContinuousScreeningMatch fills in, from blob storage, the match payloads that
+// were offloaded (empty DB column) for the given screening. No-op when offloading is disabled.
+// A missing blob is logged and left empty rather than failing the read.
+func (uc OffloadedReadWriter) HydrateContinuousScreeningMatch(
+	ctx context.Context, screening *models.ContinuousScreeningWithMatches,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+
+	for j := range screening.Matches {
+		if len(screening.Matches[j].Payload) > 0 {
+			continue
+		}
+
+		payload, err := uc.ReadOffloadedContinuousScreeningMatchPayload(ctx, screening.OrgId,
+			screening.Id, screening.Matches[j].Id)
+		if err != nil {
+			return err
+		}
+		if len(payload) == 0 {
+			utils.LoggerFromContext(ctx).WarnContext(ctx,
+				"continuous screening match payload is missing from both the DB column and blob storage",
+				"org_id", screening.OrgId,
+				"continuous_screening_id", screening.Id,
+				"match_id", screening.Matches[j].Id,
+			)
+			continue
+		}
+
+		screening.Matches[j].Payload = payload
+	}
+
+	return nil
+}

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -433,7 +433,7 @@ func (uc OffloadedReadWriter) OffloadContinuousScreeningEntity(
 	}
 
 	if err := uc.OffloadContinuousScreeningEntityPayload(ctx, orgId, continuousScreeningId, payload); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to offload continuous screening entity payload")
 	}
 
 	return nil, nil
@@ -464,7 +464,7 @@ func (uc OffloadedReadWriter) OffloadContinuousScreeningMatches(
 
 		if err := uc.OffloadContinuousScreeningMatchPayload(ctx, orgId, continuousScreeningId,
 			matchId, match.Payload); err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "failed to offload continuous screening match payload")
 		}
 
 		match.Payload = nil
@@ -491,7 +491,7 @@ func (uc OffloadedReadWriter) HydrateContinuousScreeningEntity(
 
 	payload, err := uc.ReadOffloadedContinuousScreeningEntityPayload(ctx, screening.OrgId, screening.Id)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to read continuous screening entity payload")
 	}
 	if len(payload) == 0 {
 		utils.LoggerFromContext(ctx).WarnContext(ctx,
@@ -524,7 +524,7 @@ func (uc OffloadedReadWriter) HydrateContinuousScreeningMatch(
 		payload, err := uc.ReadOffloadedContinuousScreeningMatchPayload(ctx, screening.OrgId,
 			screening.Id, screening.Matches[j].Id)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to read continuous screening match payload")
 		}
 		if len(payload) == 0 {
 			utils.LoggerFromContext(ctx).WarnContext(ctx,

--- a/repositories/offloaded_read_writer_test.go
+++ b/repositories/offloaded_read_writer_test.go
@@ -16,9 +16,10 @@ func newFileOffloadedReadWriter(t *testing.T) OffloadedReadWriter {
 	t.Helper()
 
 	return OffloadedReadWriter{
-		Repository:          NewMarbleDbRepository(false, 0.3),
-		BlobRepository:      NewBlobRepository(infra.GcpConfig{}),
-		OffloadingBucketUrl: "file://" + t.TempDir(),
+		Repository:                 NewMarbleDbRepository(false, 0.3),
+		BlobRepository:             NewBlobRepository(infra.GcpConfig{}),
+		OffloadingBucketUrl:        "file://" + t.TempDir(),
+		ScreeningOffloadingEnabled: true,
 	}
 }
 

--- a/repositories/offloaded_read_writer_test.go
+++ b/repositories/offloaded_read_writer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/infra"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,9 @@ func newFileOffloadedReadWriter(t *testing.T) OffloadedReadWriter {
 	}
 }
 
+// /////////////////////////////
+// Offload screening payload //
+// /////////////////////////////
 func TestOffloadScreeningMatchPayloadRoundTrip(t *testing.T) {
 	ctx := context.Background()
 	rw := newFileOffloadedReadWriter(t)
@@ -173,4 +177,112 @@ func TestOffloadingDisabledIsNoOp(t *testing.T) {
 	got, err := rw.ReadOffloadedScreeningMatchPayload(ctx, uuid.New(), "sc", "m")
 	require.NoError(t, err)
 	assert.Nil(t, got)
+}
+
+// ///////////////////////////////////////
+// Offload continuous screening payload //
+// ///////////////////////////////////////
+
+func TestOffloadContinuousScreeningEntity(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	orgId := uuid.New()
+	csId := uuid.New()
+	entityPayload := []byte(`{"id":"entity-1","caption":"ACME"}`)
+
+	// Offloaded: returns nil (to store an empty column) and writes the payload to blob storage.
+	stored, err := rw.OffloadContinuousScreeningEntity(ctx, orgId, csId, entityPayload)
+	require.NoError(t, err)
+	assert.Empty(t, stored)
+
+	got, err := rw.ReadOffloadedContinuousScreeningEntityPayload(ctx, orgId, csId)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(entityPayload), string(got))
+
+	// Disabled: returns the payload unchanged so it is written to the DB column.
+	rw.OffloadingBucketUrl = ""
+	stored, err = rw.OffloadContinuousScreeningEntity(ctx, orgId, csId, entityPayload)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(entityPayload), string(stored))
+}
+
+func TestOffloadContinuousScreeningMatches(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	orgId := uuid.New()
+	csId := uuid.New()
+	matches := []models.ScreeningMatch{
+		{EntityId: "match-1", Payload: []byte(`{"score":0.9}`)},
+		{EntityId: "match-2", Payload: []byte(`{"score":0.4}`)},
+	}
+
+	offloaded, err := rw.OffloadContinuousScreeningMatches(ctx, orgId, csId, matches)
+	require.NoError(t, err)
+	require.Len(t, offloaded, 2)
+
+	for i, m := range offloaded {
+		// Each offloaded match has a pre-assigned id and an empty payload.
+		assert.NotEmpty(t, m.Id)
+		assert.Empty(t, m.Payload)
+
+		matchId, err := uuid.Parse(m.Id)
+		require.NoError(t, err)
+
+		got, err := rw.ReadOffloadedContinuousScreeningMatchPayload(ctx, orgId, csId, matchId)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(matches[i].Payload), string(got))
+	}
+}
+
+func TestOffloadContinuousScreeningMatchesDisabledIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+	rw.OffloadingBucketUrl = ""
+
+	matches := []models.ScreeningMatch{{EntityId: "match-1", Payload: []byte(`{"score":0.9}`)}}
+
+	offloaded, err := rw.OffloadContinuousScreeningMatches(ctx, uuid.New(), uuid.New(), matches)
+	require.NoError(t, err)
+
+	// Unchanged: payloads stay so the repository writes them to the DB column as before.
+	assert.Equal(t, matches, offloaded)
+	assert.NotEmpty(t, offloaded[0].Payload)
+}
+
+func TestHydrateContinuousScreeningMatches(t *testing.T) {
+	ctx := context.Background()
+	rw := newFileOffloadedReadWriter(t)
+
+	orgId := uuid.New()
+	csId := uuid.New()
+	offloadedMatchId := uuid.New()
+	legacyMatchId := uuid.New()
+
+	entityPayload := []byte(`{"id":"entity-1"}`)
+	matchPayload := []byte(`{"score":0.7}`)
+	require.NoError(t, rw.OffloadContinuousScreeningEntityPayload(ctx, orgId, csId, entityPayload))
+	require.NoError(t, rw.OffloadContinuousScreeningMatchPayload(ctx, orgId, csId, offloadedMatchId, matchPayload))
+
+	screenings := []models.ContinuousScreeningWithMatches{
+		{
+			ContinuousScreening: models.ContinuousScreening{
+				Id:                   csId,
+				OrgId:                orgId,
+				OpenSanctionEntityId: utils.Ptr("entity-1"),
+			},
+			Matches: []models.ContinuousScreeningMatch{
+				{Id: offloadedMatchId, ContinuousScreeningId: csId, Payload: nil},
+				{Id: legacyMatchId, ContinuousScreeningId: csId, Payload: []byte(`{"score":0.2}`)},
+			},
+		},
+	}
+
+	require.NoError(t, rw.HydrateContinuousScreeningEntity(ctx, &screenings[0]))
+	require.NoError(t, rw.HydrateContinuousScreeningMatch(ctx, &screenings[0]))
+
+	assert.JSONEq(t, string(entityPayload), string(screenings[0].OpenSanctionEntityPayload))
+	assert.JSONEq(t, string(matchPayload), string(screenings[0].Matches[0].Payload))
+	assert.JSONEq(t, `{"score":0.2}`, string(screenings[0].Matches[1].Payload))
 }

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -156,6 +156,7 @@ type CaseUseCase struct {
 	featureAccessReader     feature_access.FeatureAccessReader
 	publicApiAdapterUsecase PublicApiAdapterUsecase
 	scoringScoreUsecase     scoring.ScoringScoresUsecase
+	offloadedReader         repositories.OffloadedReadWriter
 }
 
 func (usecase *CaseUseCase) ListCases(
@@ -1430,6 +1431,15 @@ func (usecase *CaseUseCase) getCaseWithDetails(ctx context.Context, exec reposit
 		continuousScreeningsWithMatches, err := usecase.repository.ListContinuousScreeningsWithMatchesByCaseId(ctx, exec, caseId)
 		if err != nil {
 			return models.Case{}, err
+		}
+
+		for i := range continuousScreeningsWithMatches {
+			if err := usecase.offloadedReader.HydrateContinuousScreeningEntity(ctx, &continuousScreeningsWithMatches[i]); err != nil {
+				return models.Case{}, err
+			}
+			if err := usecase.offloadedReader.HydrateContinuousScreeningMatch(ctx, &continuousScreeningsWithMatches[i]); err != nil {
+				return models.Case{}, err
+			}
 		}
 
 		c.ContinuousScreenings = continuousScreeningsWithMatches

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -1435,10 +1435,10 @@ func (usecase *CaseUseCase) getCaseWithDetails(ctx context.Context, exec reposit
 
 		for i := range continuousScreeningsWithMatches {
 			if err := usecase.offloadedReader.HydrateContinuousScreeningEntity(ctx, &continuousScreeningsWithMatches[i]); err != nil {
-				return models.Case{}, err
+				return models.Case{}, errors.Wrap(err, "failed to hydrate continuous screening entity")
 			}
 			if err := usecase.offloadedReader.HydrateContinuousScreeningMatch(ctx, &continuousScreeningsWithMatches[i]); err != nil {
-				return models.Case{}, err
+				return models.Case{}, errors.Wrap(err, "failed to hydrate continuous screening match")
 			}
 		}
 

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -171,7 +171,7 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 		createInput.Screening.Matches, err = uc.offloadedReader.OffloadContinuousScreeningMatches(
 			ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
 		if err != nil {
-			return models.ContinuousScreeningWithMatches{}, err
+			return models.ContinuousScreeningWithMatches{}, errors.Wrap(err, "failed to offload continuous screening matches")
 		}
 	}
 

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -149,31 +149,38 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 	}
 
 	var screeningWithMatches models.ScreeningWithMatches
+	var createInput models.CreateContinuousScreening
 	if !input.SkipScreen {
 		screeningWithMatches, err = uc.DoScreening(ctx, exec, ingestedObject, mapping, config, input.ObjectType, objectId)
 		if err != nil {
 			logger.WarnContext(ctx, "Continuous Screening - error searching on open sanctions", "error", err.Error())
 			return models.ContinuousScreeningWithMatches{}, err
 		}
+
+		createInput = models.CreateContinuousScreening{
+			Id:               pure_utils.NewId(),
+			Screening:        screeningWithMatches,
+			Config:           config,
+			ObjectType:       &input.ObjectType,
+			ObjectId:         &objectId,
+			ObjectInternalId: &ingestedObjectInternalId,
+			TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
+		}
+
+		// Try to offload the match payloads to blob storage
+		createInput.Screening.Matches, err = uc.offloadedReader.OffloadContinuousScreeningMatches(
+			ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
+		if err != nil {
+			return models.ContinuousScreeningWithMatches{}, err
+		}
 	}
 
-	return executor_factory.TransactionReturnValue(
+	continuousScreening, err := executor_factory.TransactionReturnValue(
 		ctx,
 		uc.transactionFactory,
 		func(tx repositories.Transaction) (models.ContinuousScreeningWithMatches, error) {
 			if !input.SkipScreen {
-				continuousScreeningWithMatches, err := uc.repository.InsertContinuousScreening(
-					ctx,
-					tx,
-					models.CreateContinuousScreening{
-						Screening:        screeningWithMatches,
-						Config:           config,
-						ObjectType:       &input.ObjectType,
-						ObjectId:         &objectId,
-						ObjectInternalId: &ingestedObjectInternalId,
-						TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
-					},
-				)
+				continuousScreeningWithMatches, err := uc.repository.InsertContinuousScreening(ctx, tx, createInput)
 				if err != nil {
 					return models.ContinuousScreeningWithMatches{}, err
 				}
@@ -217,6 +224,17 @@ func (uc *ContinuousScreeningUsecase) CreateContinuousScreeningObject(
 			return models.ContinuousScreeningWithMatches{}, nil
 		},
 	)
+	if err != nil {
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
+	// The inserted matches come back with empty payload columns when offloaded; hydrate them from
+	// blob storage (and sort) so the create response carries the full match data.
+	if err := uc.hydrateContinuousScreening(ctx, &continuousScreening); err != nil {
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
+	return continuousScreening, nil
 }
 
 type payloadObjectID struct {
@@ -326,6 +344,11 @@ func (uc *ContinuousScreeningUsecase) ListContinuousScreeningsForOrg(
 			return nil, err
 		}
 	}
+
+	if err := uc.hydrateContinuousScreenings(ctx, monitorings); err != nil {
+		return nil, err
+	}
+
 	return monitorings, nil
 }
 

--- a/usecases/continuous_screening/screening.go
+++ b/usecases/continuous_screening/screening.go
@@ -508,19 +508,26 @@ func (uc *ContinuousScreeningUsecase) LoadMoreContinuousScreeningMatches(
 			return err
 		}
 
-		matchesToInsert := pure_utils.Map(offloadedMatches, func(m models.ScreeningMatch) models.ContinuousScreeningMatch {
-			// m.Id was pre-assigned by the offloader (it is the blob key); empty when offloading is
-			// disabled, in which case InsertContinuousScreeningMatches generates one.
+		// m.Id was pre-assigned by the offloader (it is the blob key); empty when offloading is
+		// disabled, in which case InsertContinuousScreeningMatches generates one.
+		matchesToInsert, err := pure_utils.MapErr(offloadedMatches, func(m models.ScreeningMatch) (models.ContinuousScreeningMatch, error) {
 			var matchId uuid.UUID
 			if m.Id != "" {
-				matchId = uuid.MustParse(m.Id)
+				var parseErr error
+				matchId, parseErr = uuid.Parse(m.Id)
+				if parseErr != nil {
+					return models.ContinuousScreeningMatch{}, errors.Wrap(parseErr, "invalid screening match id")
+				}
 			}
 			return models.ContinuousScreeningMatch{
 				Id:                   matchId,
 				OpenSanctionEntityId: m.EntityId,
 				Payload:              m.Payload,
-			}
+			}, nil
 		})
+		if err != nil {
+			return err
+		}
 
 		// Insert new matches
 		insertedMatches, err := uc.repository.InsertContinuousScreeningMatches(

--- a/usecases/continuous_screening/screening.go
+++ b/usecases/continuous_screening/screening.go
@@ -200,7 +200,7 @@ func (uc *ContinuousScreeningUsecase) UpdateContinuousScreeningMatchStatus(
 			Matches:             []models.ContinuousScreeningMatch{updatedMatch},
 		}
 		if err := uc.offloadedReader.HydrateContinuousScreeningMatch(ctx, &matchHolder); err != nil {
-			return err
+			return errors.Wrap(err, "failed to hydrate continuous screening match")
 		}
 		updatedMatch = matchHolder.Matches[0]
 
@@ -505,7 +505,7 @@ func (uc *ContinuousScreeningUsecase) LoadMoreContinuousScreeningMatches(
 			newMatches,
 		)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to offload continuous screening matches")
 		}
 
 		// m.Id was pre-assigned by the offloader (it is the blob key); empty when offloading is

--- a/usecases/continuous_screening/screening.go
+++ b/usecases/continuous_screening/screening.go
@@ -190,6 +190,20 @@ func (uc *ContinuousScreeningUsecase) UpdateContinuousScreeningMatchStatus(
 				continuousScreeningMatch.ContinuousScreeningId)
 		}
 
+		// The refreshed screening and the updated match are read from the DB, so their payloads
+		// are empty when offloaded; hydrate them so the webhook carries the full match/entity data.
+		if err := uc.hydrateContinuousScreening(ctx, &refreshedScreening); err != nil {
+			return err
+		}
+		matchHolder := models.ContinuousScreeningWithMatches{
+			ContinuousScreening: refreshedScreening.ContinuousScreening,
+			Matches:             []models.ContinuousScreeningMatch{updatedMatch},
+		}
+		if err := uc.offloadedReader.HydrateContinuousScreeningMatch(ctx, &matchHolder); err != nil {
+			return err
+		}
+		updatedMatch = matchHolder.Matches[0]
+
 		if err := uc.webhookEventsUsecase.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
 			Id:             pure_utils.NewId().String(),
 			OrganizationId: refreshedScreening.OrgId,
@@ -372,6 +386,10 @@ func (uc *ContinuousScreeningUsecase) DismissContinuousScreening(ctx context.Con
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 
+	if err := uc.hydrateContinuousScreening(ctx, &continuousScreening); err != nil {
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
 	return continuousScreening, nil
 }
 
@@ -479,17 +497,37 @@ func (uc *ContinuousScreeningUsecase) LoadMoreContinuousScreeningMatches(
 			)
 		}
 
+		// Offload the new match payloads to blob storage
+		offloadedMatches, err := uc.offloadedReader.OffloadContinuousScreeningMatches(
+			ctx,
+			continuousScreening.OrgId,
+			continuousScreeningId,
+			newMatches,
+		)
+		if err != nil {
+			return err
+		}
+
+		matchesToInsert := pure_utils.Map(offloadedMatches, func(m models.ScreeningMatch) models.ContinuousScreeningMatch {
+			// m.Id was pre-assigned by the offloader (it is the blob key); empty when offloading is
+			// disabled, in which case InsertContinuousScreeningMatches generates one.
+			var matchId uuid.UUID
+			if m.Id != "" {
+				matchId = uuid.MustParse(m.Id)
+			}
+			return models.ContinuousScreeningMatch{
+				Id:                   matchId,
+				OpenSanctionEntityId: m.EntityId,
+				Payload:              m.Payload,
+			}
+		})
+
 		// Insert new matches
 		insertedMatches, err := uc.repository.InsertContinuousScreeningMatches(
 			ctx,
 			tx,
 			continuousScreeningId,
-			pure_utils.Map(newMatches, func(m models.ScreeningMatch) models.ContinuousScreeningMatch {
-				return models.ContinuousScreeningMatch{
-					OpenSanctionEntityId: m.EntityId,
-					Payload:              m.Payload,
-				}
-			}),
+			matchesToInsert,
 		)
 		if err != nil {
 			return err
@@ -526,6 +564,10 @@ func (uc *ContinuousScreeningUsecase) LoadMoreContinuousScreeningMatches(
 		return nil
 	})
 	if err != nil {
+		return models.ContinuousScreeningWithMatches{}, err
+	}
+
+	if err := uc.hydrateContinuousScreening(ctx, &continuousScreening); err != nil {
 		return models.ContinuousScreeningWithMatches{}, err
 	}
 

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -12,6 +12,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/payload_parser"
 	"github.com/checkmarble/marble-backend/usecases/security"
+	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 )
 
@@ -387,10 +388,10 @@ func (uc *ContinuousScreeningUsecase) hydrateContinuousScreenings(
 ) error {
 	for i := range screenings {
 		if err := uc.offloadedReader.HydrateContinuousScreeningEntity(ctx, &screenings[i]); err != nil {
-			return err
+			return errors.Wrap(err, "failed to hydrate continuous screening entity")
 		}
 		if err := uc.offloadedReader.HydrateContinuousScreeningMatch(ctx, &screenings[i]); err != nil {
-			return err
+			return errors.Wrap(err, "failed to hydrate continuous screening match")
 		}
 
 		slices.SortStableFunc(screenings[i].Matches, func(a, b models.ContinuousScreeningMatch) int {

--- a/usecases/continuous_screening/usecase.go
+++ b/usecases/continuous_screening/usecase.go
@@ -1,8 +1,10 @@
 package continuous_screening
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
+	"slices"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
@@ -329,6 +331,7 @@ type ContinuousScreeningUsecase struct {
 	featureAccessReader          featureAccessReader
 	objectRiskTagWriter          objectRiskTagWriter
 	webhookEventsUsecase         webhookEventsUsecase
+	offloadedReader              repositories.OffloadedReadWriter
 }
 
 func NewContinuousScreeningUsecase(
@@ -350,6 +353,7 @@ func NewContinuousScreeningUsecase(
 	featureAccessReader featureAccessReader,
 	objectRiskTagWriter objectRiskTagWriter,
 	webhookEventsUsecase webhookEventsUsecase,
+	offloadedReader repositories.OffloadedReadWriter,
 ) *ContinuousScreeningUsecase {
 	return &ContinuousScreeningUsecase{
 		executorFactory:              executorFactory,
@@ -370,5 +374,64 @@ func NewContinuousScreeningUsecase(
 		featureAccessReader:          featureAccessReader,
 		objectRiskTagWriter:          objectRiskTagWriter,
 		webhookEventsUsecase:         webhookEventsUsecase,
+		offloadedReader:              offloadedReader,
+	}
+}
+
+// hydrateContinuousScreenings loads offloaded entity and match payloads from blob storage (no-op
+// when offloading is disabled) and then sorts each screening's matches by status, then descending
+// score. The score lives in the (possibly offloaded) payload, so the sort runs in memory here
+// rather than in SQL. The slice is mutated in place.
+func (uc *ContinuousScreeningUsecase) hydrateContinuousScreenings(
+	ctx context.Context, screenings []models.ContinuousScreeningWithMatches,
+) error {
+	for i := range screenings {
+		if err := uc.offloadedReader.HydrateContinuousScreeningEntity(ctx, &screenings[i]); err != nil {
+			return err
+		}
+		if err := uc.offloadedReader.HydrateContinuousScreeningMatch(ctx, &screenings[i]); err != nil {
+			return err
+		}
+
+		slices.SortStableFunc(screenings[i].Matches, func(a, b models.ContinuousScreeningMatch) int {
+			if n := cmp.Compare(continuousScreeningMatchStatusRank(a.Status),
+				continuousScreeningMatchStatusRank(b.Status)); n != 0 {
+				return n
+			}
+			return cmp.Compare(b.GetScoreFromPayload(), a.GetScoreFromPayload())
+		})
+	}
+
+	return nil
+}
+
+// hydrateContinuousScreening hydrates and sorts a single continuous screening in place. Unlike
+// passing a value to hydrateContinuousScreenings, this reflects the hydrated entity payload back
+// onto the caller's screening (a scalar field, not a shared slice).
+func (uc *ContinuousScreeningUsecase) hydrateContinuousScreening(
+	ctx context.Context, screening *models.ContinuousScreeningWithMatches,
+) error {
+	wrapped := []models.ContinuousScreeningWithMatches{*screening}
+	if err := uc.hydrateContinuousScreenings(ctx, wrapped); err != nil {
+		return err
+	}
+	*screening = wrapped[0]
+	return nil
+}
+
+// continuousScreeningMatchStatusRank mirrors the status ordering previously expressed in SQL
+// (array['confirmed_hit', 'pending', 'no_hit', 'skipped']).
+func continuousScreeningMatchStatusRank(s models.ScreeningMatchStatus) int {
+	switch s {
+	case models.ScreeningMatchStatusConfirmedHit:
+		return 0
+	case models.ScreeningMatchStatusPending:
+		return 1
+	case models.ScreeningMatchStatusNoHit:
+		return 2
+	case models.ScreeningMatchStatusSkipped:
+		return 3
+	default:
+		return 4
 	}
 }

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -372,16 +372,10 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 			TriggerType:               models.ContinuousScreeningTriggerTypeDatasetUpdated,
 		}
 
-		// Offload the entity and match payloads to blob storage (no-op when offloading is
-		// disabled) before persisting, so the rows are written with empty payload columns.
+		// Offload only the entity payload to blob storage (no-op when offloading is disabled).
+		// Match payloads are customer data and are kept in the DB column in this direction.
 		createInput.OpenSanctionEntityPayload, err = w.offloadedReader.OffloadContinuousScreeningEntity(
 			iterCtx, updateJob.Config.OrgId, createInput.Id, createInput.OpenSanctionEntityPayload)
-		if err != nil {
-			return err
-		}
-
-		createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
-			iterCtx, updateJob.Config.OrgId, createInput.Id, createInput.Screening.Matches)
 		if err != nil {
 			return err
 		}

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -377,7 +377,7 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 		createInput.OpenSanctionEntityPayload, err = w.offloadedReader.OffloadContinuousScreeningEntity(
 			iterCtx, updateJob.Config.OrgId, createInput.Id, createInput.OpenSanctionEntityPayload)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "failed to offload continuous screening entity payload")
 		}
 
 		err = w.transactionFactory.Transaction(iterCtx, func(tx repositories.Transaction) error {

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/repositories/httpmodels"
 	"github.com/checkmarble/marble-backend/repositories/screening"
@@ -131,6 +132,7 @@ type ApplyDeltaFileWorker struct {
 	blobRepository     repositories.BlobRepository
 	screeningProvider  applyDeltaFileWorkerScreeningProvider
 	usecase            applyDeltaFileWorkerUsecase
+	offloadedReader    repositories.OffloadedReadWriter
 	bucketUrl          string
 }
 
@@ -144,6 +146,7 @@ func NewApplyDeltaFileWorker(
 	screeningProvider applyDeltaFileWorkerScreeningProvider,
 	bucketUrl string,
 	usecase applyDeltaFileWorkerUsecase,
+	offloadedReader repositories.OffloadedReadWriter,
 ) *ApplyDeltaFileWorker {
 	return &ApplyDeltaFileWorker{
 		executorFactory:    executorFactory,
@@ -155,6 +158,7 @@ func NewApplyDeltaFileWorker(
 		screeningProvider:  screeningProvider,
 		bucketUrl:          bucketUrl,
 		usecase:            usecase,
+		offloadedReader:    offloadedReader,
 	}
 }
 
@@ -354,22 +358,36 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 		screening := screeningResponse.AdaptScreeningFromSearchResponse(query)
 		iterLogger.DebugContext(iterCtx, "Screening result", "matches", len(screening.Matches))
 
+		entityPayload, err := json.Marshal(record.Entity)
+		if err != nil {
+			return err
+		}
+
+		createInput := models.CreateContinuousScreening{
+			Id:                        pure_utils.NewId(),
+			Screening:                 screening,
+			Config:                    updateJob.Config,
+			OpenSanctionEntityId:      &record.Entity.Id,
+			OpenSanctionEntityPayload: entityPayload,
+			TriggerType:               models.ContinuousScreeningTriggerTypeDatasetUpdated,
+		}
+
+		// Offload the entity and match payloads to blob storage (no-op when offloading is
+		// disabled) before persisting, so the rows are written with empty payload columns.
+		createInput.OpenSanctionEntityPayload, err = w.offloadedReader.OffloadContinuousScreeningEntity(
+			iterCtx, updateJob.Config.OrgId, createInput.Id, createInput.OpenSanctionEntityPayload)
+		if err != nil {
+			return err
+		}
+
+		createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
+			iterCtx, updateJob.Config.OrgId, createInput.Id, createInput.Screening.Matches)
+		if err != nil {
+			return err
+		}
+
 		err = w.transactionFactory.Transaction(iterCtx, func(tx repositories.Transaction) error {
-			entityPayload, err := json.Marshal(record.Entity)
-			if err != nil {
-				return err
-			}
-			continuousScreeningWithMatches, err := w.repository.InsertContinuousScreening(
-				iterCtx,
-				tx,
-				models.CreateContinuousScreening{
-					Screening:                 screening,
-					Config:                    updateJob.Config,
-					OpenSanctionEntityId:      &record.Entity.Id,
-					OpenSanctionEntityPayload: entityPayload,
-					TriggerType:               models.ContinuousScreeningTriggerTypeDatasetUpdated,
-				},
-			)
+			continuousScreeningWithMatches, err := w.repository.InsertContinuousScreening(iterCtx, tx, createInput)
 			if err != nil {
 				return err
 			}

--- a/usecases/continuous_screening/worker_do_screening.go
+++ b/usecases/continuous_screening/worker_do_screening.go
@@ -319,7 +319,7 @@ func (w *DoScreeningWorker) Work(ctx context.Context, job *river.Job[models.Cont
 	createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
 		ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to offload continuous screening matches")
 	}
 
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {

--- a/usecases/continuous_screening/worker_do_screening.go
+++ b/usecases/continuous_screening/worker_do_screening.go
@@ -105,6 +105,7 @@ type DoScreeningWorker struct {
 	clientDbRepo       doScreeningWorkerClientDbRepository
 	ingestedDataReader doScreeningWorkerIngestedDataReader
 	usecase            doScreeningWorkerCSUsecase
+	offloadedReader    repositories.OffloadedReadWriter
 }
 
 func NewDoScreeningWorker(
@@ -115,6 +116,7 @@ func NewDoScreeningWorker(
 	clientDbRepo doScreeningWorkerClientDbRepository,
 	ingestedDataReader doScreeningWorkerIngestedDataReader,
 	uc doScreeningWorkerCSUsecase,
+	offloadedReader repositories.OffloadedReadWriter,
 ) *DoScreeningWorker {
 	return &DoScreeningWorker{
 		executorFactory:    executorFactory,
@@ -124,6 +126,7 @@ func NewDoScreeningWorker(
 		clientDbRepo:       clientDbRepo,
 		ingestedDataReader: ingestedDataReader,
 		usecase:            uc,
+		offloadedReader:    offloadedReader,
 	}
 }
 
@@ -301,20 +304,27 @@ func (w *DoScreeningWorker) Work(ctx context.Context, job *river.Job[models.Cont
 		}
 	}
 
+	createInput := models.CreateContinuousScreening{
+		Id:               pure_utils.NewId(),
+		Screening:        screeningWithMatches,
+		Config:           config,
+		ObjectType:       &job.Args.ObjectType,
+		ObjectId:         &monitoredObject.ObjectId,
+		ObjectInternalId: &newObjectInternalId,
+		TriggerType:      job.Args.TriggerType,
+	}
+
+	// Offload the match payloads to blob storage (no-op when offloading is disabled) before
+	// persisting, so the rows are written with empty payload columns.
+	createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
+		ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
+	if err != nil {
+		return err
+	}
+
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
 		// Insert the continuous screening result
-		continuousScreeningWithMatches, err := w.repo.InsertContinuousScreening(
-			ctx,
-			tx,
-			models.CreateContinuousScreening{
-				Screening:        screeningWithMatches,
-				Config:           config,
-				ObjectType:       &job.Args.ObjectType,
-				ObjectId:         &monitoredObject.ObjectId,
-				ObjectInternalId: &newObjectInternalId,
-				TriggerType:      job.Args.TriggerType,
-			},
-		)
+		continuousScreeningWithMatches, err := w.repo.InsertContinuousScreening(ctx, tx, createInput)
 		if err != nil {
 			return err
 		}

--- a/usecases/continuous_screening/worker_do_screening_test.go
+++ b/usecases/continuous_screening/worker_do_screening_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
@@ -65,6 +66,7 @@ func (suite *DoScreeningWorkerTestSuite) makeWorker() *DoScreeningWorker {
 		suite.clientDbRepository,
 		suite.ingestedDataReader,
 		suite.usecase,
+		repositories.OffloadedReadWriter{},
 	)
 }
 

--- a/usecases/continuous_screening/worker_match_enrichment.go
+++ b/usecases/continuous_screening/worker_match_enrichment.go
@@ -46,6 +46,8 @@ type matchEnrichmentWorkerRepository interface {
 		id uuid.UUID,
 		enrichedPayload []byte,
 	) error
+	SetContinuousScreeningEntityEnriched(ctx context.Context, exec repositories.Executor, id uuid.UUID) error
+	SetContinuousScreeningMatchEnriched(ctx context.Context, exec repositories.Executor, id uuid.UUID) error
 }
 
 type ContinuousScreeningMatchEnrichmentWorker struct {
@@ -54,17 +56,20 @@ type ContinuousScreeningMatchEnrichmentWorker struct {
 	executorFactory     executor_factory.ExecutorFactory
 	openSanctionsConfig matchEnrichmentWorkerOpenSanctionsProvider
 	repository          matchEnrichmentWorkerRepository
+	offloadedReader     repositories.OffloadedReadWriter
 }
 
 func NewContinuousScreeningMatchEnrichmentWorker(
 	executorFactory executor_factory.ExecutorFactory,
 	openSanctionsProvider matchEnrichmentWorkerOpenSanctionsProvider,
 	repository matchEnrichmentWorkerRepository,
+	offloadedReader repositories.OffloadedReadWriter,
 ) *ContinuousScreeningMatchEnrichmentWorker {
 	return &ContinuousScreeningMatchEnrichmentWorker{
 		executorFactory:     executorFactory,
 		openSanctionsConfig: openSanctionsProvider,
 		repository:          repository,
+		offloadedReader:     offloadedReader,
 	}
 }
 
@@ -127,7 +132,7 @@ func (w *ContinuousScreeningMatchEnrichmentWorker) Work(
 				continue
 			}
 
-			if err := w.enrichMatch(ctx, provider, match); err != nil {
+			if err := w.enrichMatch(ctx, provider, continuousScreeningWithMatches.OrgId, match); err != nil {
 				errs = errors.Join(errs, err)
 			}
 		}
@@ -161,30 +166,50 @@ func (w *ContinuousScreeningMatchEnrichmentWorker) enrichEntity(
 		EntityId: *screening.OpenSanctionEntityId,
 	}
 
+	// An empty payload column on a bucket-enabled deployment means the entity payload was
+	// offloaded to blob storage; read it back so we can merge the enrichment into it.
+	offloaded := w.offloadedReader.IsOffloadingEnabled() && len(screening.OpenSanctionEntityPayload) == 0
+
+	originalPayload := screening.OpenSanctionEntityPayload
+	if offloaded {
+		var err error
+		originalPayload, err = w.offloadedReader.ReadOffloadedContinuousScreeningEntityPayload(
+			ctx, screening.OrgId, screening.Id)
+		if err != nil {
+			return errors.Wrap(err, "could not read offloaded continuous screening entity payload")
+		}
+	}
+
 	newPayload, err := w.openSanctionsConfig.EnrichMatch(ctx, providerName, fakeMatch)
 	if err != nil {
 		return err
 	}
 
-	mergedPayload, err := mergePayloads(screening.OpenSanctionEntityPayload, newPayload)
+	mergedPayload, err := mergePayloads(originalPayload, newPayload)
 	if err != nil {
 		return errors.Wrap(err,
 			"could not merge payloads for continuous screening entity enrichment")
 	}
 
 	exec := w.executorFactory.NewExecutor()
-	if err := w.repository.UpdateContinuousScreeningEntityEnrichedPayload(
-		ctx, exec, screening.Id, mergedPayload,
-	); err != nil {
-		return err
+
+	// Offloaded entities keep their payload in blob storage: overwrite the same key and only flip
+	// the enriched flag in the DB. Legacy entities keep their payload in the DB column.
+	if offloaded {
+		if err := w.offloadedReader.OffloadContinuousScreeningEntityPayload(
+			ctx, screening.OrgId, screening.Id, mergedPayload); err != nil {
+			return errors.Wrap(err, "could not write enriched continuous screening entity payload")
+		}
+		return w.repository.SetContinuousScreeningEntityEnriched(ctx, exec, screening.Id)
 	}
 
-	return nil
+	return w.repository.UpdateContinuousScreeningEntityEnrichedPayload(ctx, exec, screening.Id, mergedPayload)
 }
 
 func (w *ContinuousScreeningMatchEnrichmentWorker) enrichMatch(
 	ctx context.Context,
 	providerName models.ScreeningProvider,
+	orgId uuid.UUID,
 	match models.ContinuousScreeningMatch,
 ) error {
 	if match.Enriched {
@@ -200,25 +225,44 @@ func (w *ContinuousScreeningMatchEnrichmentWorker) enrichMatch(
 		EntityId: match.OpenSanctionEntityId,
 	}
 
+	// An empty payload column on a bucket-enabled deployment means the match payload was
+	// offloaded to blob storage; read it back so we can merge the enrichment into it.
+	offloaded := w.offloadedReader.IsOffloadingEnabled() && len(match.Payload) == 0
+
+	originalPayload := match.Payload
+	if offloaded {
+		var err error
+		originalPayload, err = w.offloadedReader.ReadOffloadedContinuousScreeningMatchPayload(
+			ctx, orgId, match.ContinuousScreeningId, match.Id)
+		if err != nil {
+			return errors.Wrap(err, "could not read offloaded continuous screening match payload")
+		}
+	}
+
 	newPayload, err := w.openSanctionsConfig.EnrichMatch(ctx, providerName, fakeMatch)
 	if err != nil {
 		return err
 	}
 
-	mergedPayload, err := mergePayloads(match.Payload, newPayload)
+	mergedPayload, err := mergePayloads(originalPayload, newPayload)
 	if err != nil {
 		return errors.Wrap(err,
 			"could not merge payloads for continuous screening match enrichment")
 	}
 
 	exec := w.executorFactory.NewExecutor()
-	if err := w.repository.UpdateContinuousScreeningMatchEnrichedPayload(
-		ctx, exec, match.Id, mergedPayload,
-	); err != nil {
-		return err
+
+	// Offloaded matches keep their payload in blob storage: overwrite the same key and only flip
+	// the enriched flag in the DB. Legacy matches keep their payload in the DB column.
+	if offloaded {
+		if err := w.offloadedReader.OffloadContinuousScreeningMatchPayload(
+			ctx, orgId, match.ContinuousScreeningId, match.Id, mergedPayload); err != nil {
+			return errors.Wrap(err, "could not write enriched continuous screening match payload")
+		}
+		return w.repository.SetContinuousScreeningMatchEnriched(ctx, exec, match.Id)
 	}
 
-	return nil
+	return w.repository.UpdateContinuousScreeningMatchEnrichedPayload(ctx, exec, match.Id, mergedPayload)
 }
 
 func mergePayloads(originalRaw, newRaw []byte) ([]byte, error) {

--- a/usecases/continuous_screening/worker_match_enrichment_test.go
+++ b/usecases/continuous_screening/worker_match_enrichment_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/google/uuid"
 	"github.com/riverqueue/river"
@@ -40,6 +41,7 @@ func (suite *MatchEnrichmentWorkerTestSuite) makeWorker() *ContinuousScreeningMa
 		suite.executorFactory,
 		suite.openSanctionsProvider,
 		suite.repository,
+		repositories.OffloadedReadWriter{},
 	)
 }
 

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -113,6 +113,7 @@ type RegisterObjectWorker struct {
 	clientDbRepo       registerObjectWorkerClientDbRepository
 	ingestedDataReader registerObjectWorkerIngestedDataReader
 	usecase            registerObjectWorkerCSUsecase
+	offloadedReader    repositories.OffloadedReadWriter
 }
 
 func NewRegisterObjectWorker(
@@ -123,6 +124,7 @@ func NewRegisterObjectWorker(
 	clientDbRepo registerObjectWorkerClientDbRepository,
 	ingestedDataReader registerObjectWorkerIngestedDataReader,
 	uc registerObjectWorkerCSUsecase,
+	offloadedReader repositories.OffloadedReadWriter,
 ) *RegisterObjectWorker {
 	return &RegisterObjectWorker{
 		executorFactory:    executorFactory,
@@ -132,6 +134,7 @@ func NewRegisterObjectWorker(
 		clientDbRepo:       clientDbRepo,
 		ingestedDataReader: ingestedDataReader,
 		usecase:            uc,
+		offloadedReader:    offloadedReader,
 	}
 }
 
@@ -277,15 +280,26 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 		return err
 	}
 
+	createInput := models.CreateContinuousScreening{
+		Id:               pure_utils.NewId(),
+		Screening:        screeningWithMatches,
+		Config:           config,
+		ObjectType:       &job.Args.ObjectType,
+		ObjectId:         &job.Args.ObjectId,
+		ObjectInternalId: &newObjectInternalId,
+		TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
+	}
+
+	// Offload the match payloads to blob storage (no-op when offloading is disabled) before
+	// persisting, so the rows are written with empty payload columns.
+	createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
+		ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
+	if err != nil {
+		return err
+	}
+
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		continuousScreeningWithMatches, err := w.repo.InsertContinuousScreening(ctx, tx, models.CreateContinuousScreening{
-			Screening:        screeningWithMatches,
-			Config:           config,
-			ObjectType:       &job.Args.ObjectType,
-			ObjectId:         &job.Args.ObjectId,
-			ObjectInternalId: &newObjectInternalId,
-			TriggerType:      models.ContinuousScreeningTriggerTypeObjectAdded,
-		})
+		continuousScreeningWithMatches, err := w.repo.InsertContinuousScreening(ctx, tx, createInput)
 		if err != nil {
 			return err
 		}

--- a/usecases/continuous_screening/worker_register_object.go
+++ b/usecases/continuous_screening/worker_register_object.go
@@ -295,7 +295,7 @@ func (w *RegisterObjectWorker) Work(ctx context.Context, job *river.Job[models.C
 	createInput.Screening.Matches, err = w.offloadedReader.OffloadContinuousScreeningMatches(
 		ctx, config.OrgId, createInput.Id, createInput.Screening.Matches)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to offload continuous screening matches")
 	}
 
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -201,7 +201,7 @@ func (uc ScreeningUsecase) hydrateAndSortMatches(ctx context.Context, orgId uuid
 	if err := uc.offloadedReader.HydrateScreeningMatches(ctx, []models.ScreeningWithMatches{
 		{Screening: models.Screening{OrgId: orgId}, Matches: matches},
 	}); err != nil {
-		return err
+		return errors.Wrap(err, "failed to hydrate screening matches")
 	}
 
 	slices.SortStableFunc(matches, func(a, b models.ScreeningMatch) int {

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -53,6 +53,7 @@ type Usecases struct {
 	webhookSystemMigrated        bool   // True when migrated to new internal webhook system
 	allowInsecureWebhookURLs     bool   // Allow HTTP webhook URLs (dev only)
 	webhookIPWhitelist           string // Comma-separated CIDR ranges to whitelist for webhooks
+	screeningOffloadingEnabled   bool
 
 	coordsEnricher *rgeo.Rgeo
 	ipEnricher     *maxminddb.Reader
@@ -222,6 +223,12 @@ func WithIpEnrichmentDatabase(db *maxminddb.Reader) Option {
 	}
 }
 
+func WithScreeningOffloadingEnabled(enabled bool) Option {
+	return func(o *options) {
+		o.screeningOffloadingEnabled = enabled
+	}
+}
+
 type options struct {
 	appName                      string
 	apiVersion                   string
@@ -245,6 +252,7 @@ type options struct {
 	csCreateFullDatasetInterval  time.Duration
 	webhookSystemMigrated        bool
 	allowInsecureWebhookURLs     bool
+	screeningOffloadingEnabled   bool
 	webhookIPWhitelist           string
 	ipEnricher                   *maxminddb.Reader
 }
@@ -284,6 +292,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		webhookSystemMigrated:        o.webhookSystemMigrated,
 		allowInsecureWebhookURLs:     o.allowInsecureWebhookURLs,
 		webhookIPWhitelist:           o.webhookIPWhitelist,
+		screeningOffloadingEnabled:   o.screeningOffloadingEnabled,
 
 		coordsEnricher: coordsEnricher,
 		ipEnricher:     o.ipEnricher,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -195,9 +195,10 @@ func (usecases *UsecasesWithCreds) NewAsyncDecisionExecutionUsecase() AsyncDecis
 
 func (usecases *UsecasesWithCreds) NewOffloadedReader() repositories.OffloadedReadWriter {
 	return repositories.OffloadedReadWriter{
-		Repository:          usecases.Repositories.MarbleDbRepository,
-		BlobRepository:      usecases.Repositories.BlobRepository,
-		OffloadingBucketUrl: usecases.offloadingBucketUrl,
+		Repository:                 usecases.Repositories.MarbleDbRepository,
+		BlobRepository:             usecases.Repositories.BlobRepository,
+		OffloadingBucketUrl:        usecases.offloadingBucketUrl,
+		ScreeningOffloadingEnabled: usecases.screeningOffloadingEnabled,
 	}
 }
 
@@ -470,6 +471,7 @@ func (usecases *UsecasesWithCreds) NewCaseUseCase() *CaseUseCase {
 		featureAccessReader:     usecases.NewFeatureAccessReader(),
 		publicApiAdapterUsecase: usecases.NewPublicApiAdapterUsecase(),
 		scoringScoreUsecase:     usecases.NewScoringScoresUsecase(),
+		offloadedReader:         usecases.NewOffloadedReader(),
 	}
 }
 

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -894,6 +894,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningUsecase() *continuous_s
 		usecases.NewFeatureAccessReader(),
 		usecases.NewEntityAnnotationUsecase(),
 		usecases.NewWebhookEventsUsecase(),
+		usecases.NewOffloadedReader(),
 	)
 }
 
@@ -906,6 +907,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningDoScreeningWorker() *co
 		&usecases.Repositories.ClientDbRepository,
 		usecases.Repositories.IngestedDataReadRepository,
 		usecases.NewContinuousScreeningUsecase(),
+		usecases.NewOffloadedReader(),
 	)
 }
 
@@ -918,6 +920,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningRegisterObjectWorker() 
 		&usecases.Repositories.ClientDbRepository,
 		usecases.Repositories.IngestedDataReadRepository,
 		usecases.NewContinuousScreeningUsecase(),
+		usecases.NewOffloadedReader(),
 	)
 }
 
@@ -941,6 +944,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningApplyDeltaFileWorker() 
 		usecases.Repositories.OpenSanctionsRepository,
 		usecases.continuousScreeningBucketUrl,
 		usecases.NewContinuousScreeningUsecase(),
+		usecases.NewOffloadedReader(),
 	)
 }
 
@@ -963,6 +967,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningMatchEnrichmentWorker()
 		usecases.NewExecutorFactory(),
 		usecases.Repositories.OpenSanctionsRepository,
 		usecases.Repositories.MarbleDbRepository,
+		usecases.NewOffloadedReader(),
 	)
 }
 


### PR DESCRIPTION
Part 2 of the Offload screening match payload into blob storage feature. This PR focuses on the continuous screening by offload match, but also on the provider entity (depending on the screening direction). 

## Solution
Extend the offloading pattern introduced in #1793 to continuous screening — both entity payloads and match payloads are offloaded to blob storage, while remaining backward compatible with existing rows that still have their payload in the DB column.

## How it works
- Write: match and entity payloads are offloaded to blob storage before insert; the DB columns are left NULL. The screening and match IDs are pre-assigned before the DB transaction so the blob key is known up front.
- Read: payloads are hydrated from blob after read — an empty column means offloaded, a populated column means legacy row (use it directly).
- Enrichment: reads the original payload from blob, merges the enriched data back to blob, and only flips the enriched flag in DB (legacy rows keep using the column).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a configurable screening offloading toggle (default enabled).
  * Continuous screening now hydrates offloaded entity and match payloads when returning results, with scores read from match payloads when available.
* **Bug Fixes**
  * Relaxed the database constraint to allow continuous screening rows where the entity payload can be omitted while still requiring the entity ID.
  * Enrichment completion now works correctly for offloaded payloads using enrichment flags.
* **Tests**
  * Expanded coverage for offloading/hydration and enrichment scenarios, including disabled no-op behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->