### PR TITLE
fix: create Firebase user when seeding admin users

### DIFF
--- a/usecases/seed_usecase.go
+++ b/usecases/seed_usecase.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/repositories/idp"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/organization"
 	"github.com/checkmarble/marble-backend/utils"
@@ -22,6 +23,7 @@ type SeedUseCase struct {
 	organizationCreator    organization.OrganizationCreator
 	organizationRepository repositories.OrganizationRepository
 	customListRepository   repositories.CustomListRepository
+	firebaseAdmin          idp.Adminer
 }
 
 func (usecase *SeedUseCase) SeedMarbleAdmins(ctx context.Context, firstMarbleAdminEmail string) error {
@@ -38,6 +40,27 @@ func (usecase *SeedUseCase) SeedMarbleAdmins(ctx context.Context, firstMarbleAdm
 		return err
 	}
 	logger.InfoContext(ctx, fmt.Sprintf("Created marble admin user with email %s (or already exists)", firstMarbleAdminEmail))
+
+	// Mirror the API user-creation path and create the user in Firebase too. This is
+	// idempotent (the Firebase client skips creation when the user already exists), so it
+	// is safe to run on every startup and heals users that exist in DB but not in Firebase.
+	if err := usecase.createFirebaseUser(ctx, firstMarbleAdminEmail); err != nil {
+		return err
+	}
+	return nil
+}
+
+// createFirebaseUser creates the user in Firebase if a Firebase admin client is configured.
+// It is a no-op when Firebase is not configured, and idempotent otherwise.
+func (usecase *SeedUseCase) createFirebaseUser(ctx context.Context, email string) error {
+	if usecase.firebaseAdmin == nil {
+		return nil
+	}
+	// Seeded users have no first/last name, so use the email as the Firebase display name
+	// (the Firebase client rejects an empty display name).
+	if err := usecase.firebaseAdmin.CreateUser(ctx, email, email); err != nil {
+		return errors.Wrap(err, "could not create Firebase user")
+	}
 	return nil
 }
 
@@ -98,6 +121,10 @@ func (usecase *SeedUseCase) CreateOrgAndUser(ctx context.Context, input models.I
 			ctx,
 			fmt.Sprintf("Created admin user for organization %s with email %s (or already exists)", targetOrg.Id, input.AdminEmail),
 		)
+
+		if err := usecase.createFirebaseUser(ctx, input.AdminEmail); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -378,6 +378,7 @@ func (usecases *Usecases) NewSeedUseCase() SeedUseCase {
 		organizationCreator:    usecases.NewOrganizationCreator(),
 		organizationRepository: usecases.Repositories.MarbleDbRepository,
 		customListRepository:   usecases.Repositories.CustomListRepository,
+		firebaseAdmin:          usecases.firebaseAdmin,
 	}
 }
 


### PR DESCRIPTION
## Problem

The seeding usecase — `SeedMarbleAdmins` (global marble admin) and `CreateOrgAndUser` (org admin) in `usecases/seed_usecase.go` — created users **only in the database**, never in Firebase. The normal API user-creation path (`UserUseCase.AddUser`) creates the user in Firebase via `firebaseAdmin.CreateUser(...)` after the DB insert. The `SeedUseCase` struct simply lacked the `firebaseAdmin` dependency, so seeded admin users could not sign in.

## Fix

- Added `firebaseAdmin idp.Adminer` to the `SeedUseCase` struct and wired it in `NewSeedUseCase()`.
- Added a `createFirebaseUser` helper, called from both seeding methods after the DB insert, mirroring the API path.

## Idempotency

Seeding runs on every startup, so the change is idempotent and self-healing:

- **DB insert** — a duplicate returns a unique-violation error, already ignored by existing code.
- **Firebase insert** — `AdminClient.CreateUser` catches `auth.IsEmailAlreadyExists`, logs, and returns `nil`. The password-reset email is only sent on actual creation, so restarts don't spam emails.
- **Self-healing** — `createFirebaseUser` is called regardless of whether the DB insert was a unique violation, so users that already exist in the DB but are missing in Firebase (from before this fix) get created on the next startup.

## Notes

- The Firebase Go SDK rejects an empty `DisplayName`; seeded users have no first/last name, so the email is used as the display name.
- When Firebase is not configured (`firebaseAdmin == nil`), the helper is a no-op — matching how `AddUser` guards the same call.

## Testing

`go build ./usecases/...` and `go vet ./usecases/` pass. No existing seed test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firebase users are now created for marble admins and organization admins during the seeding process.
  * Firebase user creation errors are properly reported and handled during seeding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->