### PR TITLE
fix: recover AI case review with screening suggestions, make screening best-effort

### DIFF
--- a/dto/agent_dto/screening_suggestion.go
+++ b/dto/agent_dto/screening_suggestion.go
@@ -1,13 +1,13 @@
 package agent_dto
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
-	"io"
+	"slices"
 	"time"
 
+	"github.com/buger/jsonparser"
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/cockroachdb/errors"
 )
 
 // ⚠️⚠️⚠️
@@ -18,6 +18,8 @@ import (
 const (
 	VersionScreeningHitSuggestionV1 = "v1"
 )
+
+var ValidScreeningHitSuggestionVersions = []string{VersionScreeningHitSuggestionV1}
 
 type AiScreeningHitSuggestionDto interface {
 	aiScreeningHitSuggestionDto()
@@ -36,28 +38,36 @@ func (s *ScreeningHitSuggestions) UnmarshalJSON(data []byte) error {
 		*s = nil
 		return nil
 	}
-	var raws []json.RawMessage
-	if err := json.Unmarshal(data, &raws); err != nil {
-		return err
-	}
-	result := make(ScreeningHitSuggestions, 0, len(raws))
-	for _, raw := range raws {
-		var probe struct {
-			Version string `json:"version"`
+	var result ScreeningHitSuggestions
+	var parseErr error
+	_, err := jsonparser.ArrayEach(data, func(raw []byte, _ jsonparser.ValueType, _ int, err error) {
+		if err != nil || parseErr != nil {
+			parseErr = err
+			return
 		}
-		if err := json.Unmarshal(raw, &probe); err != nil {
-			return err
-		}
-		version := probe.Version
-		if version == "" {
-			// Tolerate pre-versioning data: the only format ever written is v1.
-			version = VersionScreeningHitSuggestionV1
-		}
-		dto, err := UnmarshalScreeningHitSuggestionDto(version, bytes.NewReader(raw))
+		version, err := jsonparser.GetString(raw, "version")
 		if err != nil {
-			return err
+			parseErr = err
+			return
+		}
+
+		if !slices.Contains(ValidScreeningHitSuggestionVersions, version) {
+			parseErr = errors.New("invalid version in screening hit suggestion")
+			return
+		}
+
+		dto, err := UnmarshalScreeningHitSuggestionDto(version, raw)
+		if err != nil {
+			parseErr = err
+			return
 		}
 		result = append(result, dto)
+	})
+	if err != nil {
+		return err
+	}
+	if parseErr != nil {
+		return parseErr
 	}
 	*s = result
 	return nil
@@ -95,11 +105,11 @@ func NewScreeningHitSuggestionBlob(dto AiScreeningHitSuggestionDto) (ScreeningHi
 	}, nil
 }
 
-func UnmarshalScreeningHitSuggestionDto(version string, payload io.Reader) (AiScreeningHitSuggestionDto, error) {
+func UnmarshalScreeningHitSuggestionDto(version string, payload []byte) (AiScreeningHitSuggestionDto, error) {
 	switch version {
 	case VersionScreeningHitSuggestionV1:
 		var dto ScreeningHitSuggestionV1
-		err := json.NewDecoder(payload).Decode(&dto)
+		err := json.Unmarshal(payload, &dto)
 		return dto, err
 	}
 	return nil, errors.New("unsupported version")

--- a/dto/agent_dto/screening_suggestion.go
+++ b/dto/agent_dto/screening_suggestion.go
@@ -1,6 +1,7 @@
 package agent_dto
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"io"
@@ -21,6 +22,45 @@ const (
 type AiScreeningHitSuggestionDto interface {
 	aiScreeningHitSuggestionDto()
 	GetVersion() string
+}
+
+// ScreeningHitSuggestions is a version-aware list of suggestions.
+// It marshals natively (each concrete element embeds its "version"), and unmarshals by
+// dispatching per element on that "version" field — so decoding never depends on a single
+// struct version, and a plain json.Unmarshal into a struct holding this type just works
+// (the standard decoder cannot, on its own, unmarshal a JSON object into the interface).
+type ScreeningHitSuggestions []AiScreeningHitSuggestionDto
+
+func (s *ScreeningHitSuggestions) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*s = nil
+		return nil
+	}
+	var raws []json.RawMessage
+	if err := json.Unmarshal(data, &raws); err != nil {
+		return err
+	}
+	result := make(ScreeningHitSuggestions, 0, len(raws))
+	for _, raw := range raws {
+		var probe struct {
+			Version string `json:"version"`
+		}
+		if err := json.Unmarshal(raw, &probe); err != nil {
+			return err
+		}
+		version := probe.Version
+		if version == "" {
+			// Tolerate pre-versioning data: the only format ever written is v1.
+			version = VersionScreeningHitSuggestionV1
+		}
+		dto, err := UnmarshalScreeningHitSuggestionDto(version, bytes.NewReader(raw))
+		if err != nil {
+			return err
+		}
+		result = append(result, dto)
+	}
+	*s = result
+	return nil
 }
 
 // ScreeningHitSuggestionBlob is the versioned envelope stored in blob storage.

--- a/dto/agent_dto/screening_suggestion_test.go
+++ b/dto/agent_dto/screening_suggestion_test.go
@@ -1,0 +1,83 @@
+package agent_dto
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScreeningHitSuggestions_RoundTrip(t *testing.T) {
+	original := ScreeningHitSuggestions{
+		ScreeningHitSuggestionV1{
+			MatchId:    "019eca91-4bf5-738e-b8a0-1d89dbf8e219",
+			EntityId:   "Q1317",
+			Confidence: models.ScreeningHitConfidenceProbableFalsePositive,
+			Reason:     "names do not match",
+			Version:    VersionScreeningHitSuggestionV1,
+			CreatedAt:  time.Date(2026, 6, 15, 11, 35, 6, 0, time.UTC),
+		},
+		ScreeningHitSuggestionV1{
+			MatchId:    "019eca91-4c1e-70c7-896c-4a6c562a760a",
+			EntityId:   "Q2821441",
+			Confidence: models.ScreeningHitConfidenceInconclusive,
+			Reason:     "not enough information",
+			Version:    VersionScreeningHitSuggestionV1,
+			CreatedAt:  time.Date(2026, 6, 15, 11, 35, 7, 0, time.UTC),
+		},
+	}
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded ScreeningHitSuggestions
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Equal(t, original, decoded)
+}
+
+// Decoding the flat, per-element format that is actually persisted inside CaseReviewContext
+// (each object carries its own "version") must dispatch to the right concrete type.
+func TestScreeningHitSuggestions_UnmarshalPersistedFormat(t *testing.T) {
+	const payload = `[
+		{
+			"match_id": "019eca91-4bf5-738e-b8a0-1d89dbf8e219",
+			"entity_id": "Q1317",
+			"confidence": "probable_false_positive",
+			"reason": "names do not match",
+			"version": "v1",
+			"created_at": "2026-06-15T11:35:06.711318Z"
+		}
+	]`
+
+	var decoded ScreeningHitSuggestions
+	require.NoError(t, json.Unmarshal([]byte(payload), &decoded))
+
+	require.Len(t, decoded, 1)
+	v1, ok := decoded[0].(ScreeningHitSuggestionV1)
+	require.True(t, ok, "element should decode to ScreeningHitSuggestionV1")
+	assert.Equal(t, "Q1317", v1.EntityId)
+	assert.Equal(t, models.ScreeningHitConfidenceProbableFalsePositive, v1.Confidence)
+	assert.Equal(t, VersionScreeningHitSuggestionV1, decoded[0].GetVersion())
+}
+
+func TestScreeningHitSuggestions_UnmarshalNullAndEmpty(t *testing.T) {
+	var fromNull ScreeningHitSuggestions
+	require.NoError(t, json.Unmarshal([]byte("null"), &fromNull))
+	assert.Nil(t, fromNull)
+
+	var fromEmpty ScreeningHitSuggestions
+	require.NoError(t, json.Unmarshal([]byte("[]"), &fromEmpty))
+	assert.Empty(t, fromEmpty)
+}
+
+func TestScreeningHitSuggestions_UnmarshalUnknownVersion(t *testing.T) {
+	const payload = `[{"version": "v999"}]`
+
+	var decoded ScreeningHitSuggestions
+	err := json.Unmarshal([]byte(payload), &decoded)
+	assert.Error(t, err)
+}

--- a/usecases/ai_agent/ai_case_review.go
+++ b/usecases/ai_agent/ai_case_review.go
@@ -339,14 +339,14 @@ func (uc *AiAgentUsecase) getOrganizationInstructionsForPrompt(ctx context.Conte
 // Update this struct during the process and expose this struct to the caller to save the results in case we need to resume it
 // Does not include the custom format output because it's the last step and we don't need to save it.
 type CaseReviewContext struct {
-	DataModelSummary       *string                                 `json:"data_model_summary"`
-	FieldsToReadPerTable   map[string][]string                     `json:"fields_to_read_per_table"`
-	RulesDefinitionsReview *string                                 `json:"rules_definitions_review"`
-	RuleThresholds         *string                                 `json:"rule_thresholds"`
-	PivotEnrichments       []models.AiEnrichmentKYC                `json:"pivot_enrichments"`
-	ScreeningSuggestions   []agent_dto.AiScreeningHitSuggestionDto `json:"screening_suggestions"`
-	CaseReview             *caseReviewOutput                       `json:"case_review"`
-	SanityCheck            *sanityCheckOutput                      `json:"sanity_check"`
+	DataModelSummary       *string                           `json:"data_model_summary"`
+	FieldsToReadPerTable   map[string][]string               `json:"fields_to_read_per_table"`
+	RulesDefinitionsReview *string                           `json:"rules_definitions_review"`
+	RuleThresholds         *string                           `json:"rule_thresholds"`
+	PivotEnrichments       []models.AiEnrichmentKYC          `json:"pivot_enrichments"`
+	ScreeningSuggestions   agent_dto.ScreeningHitSuggestions `json:"screening_suggestions"`
+	CaseReview             *caseReviewOutput                 `json:"case_review"`
+	SanityCheck            *sanityCheckOutput                `json:"sanity_check"`
 }
 
 // CreateCaseReviewSync performs a comprehensive AI-powered review of a case by analyzing
@@ -533,8 +533,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 						return nil, errors.Wrap(err, "could not generate data model object field read options")
 					}
 
-					dataModelObjectFieldReadOptions, err :=
-						requestDataModelObjectFieldReadOptions.Get(0)
+					dataModelObjectFieldReadOptions, err := requestDataModelObjectFieldReadOptions.Get(0)
 					if err != nil {
 						return nil, errors.Wrap(err, "could not get data model object field read options")
 					}
@@ -580,8 +579,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			"decisions": caseData.decisions,
 		}
 		if aiSetting.CaseReviewSetting.OrgDescription != nil {
-			ruleDefinitionsData["activity_description"] =
-				*aiSetting.CaseReviewSetting.OrgDescription
+			ruleDefinitionsData["activity_description"] = *aiSetting.CaseReviewSetting.OrgDescription
 		}
 		providerRulesDefinitions, modelRulesDefinitions, promptRulesDefinitions, err := uc.preparePromptWithModel(
 			PROMPT_RULE_DEFINITIONS_PATH,
@@ -657,17 +655,26 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 	if len(caseReviewContext.ScreeningSuggestions) == 0 && len(caseData.screeningIds) > 0 {
 		var allSuggestions []agent_dto.AiScreeningHitSuggestionDto
 		for _, screeningId := range caseData.screeningIds {
-			// If analysis already exists for the screening, the method will do nothing
+			// Best-effort: screening suggestions enrich the review but must not block it.
+			// If analysis fails for some/all matches, log and continue — failed matches simply
+			// get no suggestion (the per-match step is idempotent and skips matches with no blob).
+			// If analysis already exists for the screening, the method will do nothing.
 			if err := uc.AnalyseScreeningHits(ctx, screeningId); err != nil {
-				logger.ErrorContext(ctx, "Failed to generate screening suggestions",
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				logger.WarnContext(ctx, "Some screening matches could not be analysed, continuing with partial suggestions",
 					"screening_id", screeningId, "error", err)
-				return nil, errors.Wrapf(err, "failed to generate screening suggestions for screening id %s", screeningId)
+				// Do not return: fall through to gather whatever succeeded.
 			}
 			suggestions, err := uc.GetScreeningSuggestions(ctx, screeningId)
 			if err != nil {
-				logger.ErrorContext(ctx, "Failed to load screening suggestions",
+				if ctx.Err() != nil {
+					return nil, ctx.Err()
+				}
+				logger.WarnContext(ctx, "Could not load screening suggestions, skipping screening",
 					"screening_id", screeningId, "error", err)
-				return nil, errors.Wrapf(err, "failed to load screening suggestions for screening id %s", screeningId)
+				continue
 			}
 			allSuggestions = append(allSuggestions, suggestions...)
 		}
@@ -713,8 +720,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			caseReviewData["screening_suggestions"] = caseReviewContext.ScreeningSuggestions
 		}
 		if aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction != nil {
-			caseReviewData["additional_case_review_instruction"] =
-				*aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
+			caseReviewData["additional_case_review_instruction"] = *aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
 		}
 		providerCaseReview, modelCaseReview, promptCaseReview, err := uc.preparePromptWithModel(
 			PROMPT_CASE_REVIEW_PATH,
@@ -723,8 +729,6 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 		if err != nil {
 			return nil, errors.Wrap(err, "could not prepare case review request")
 		}
-
-		logger.DebugContext(ctx, "case review prompt", "prompt", promptCaseReview)
 
 		schema := getProofSchema(caseData.dataModel)
 		requestCaseReview, err := DoLLMRequest(ctx, client, llmberjack.NewRequest[caseReviewOutput]().
@@ -785,8 +789,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			sanityCheckData["screening_suggestions"] = caseReviewContext.ScreeningSuggestions
 		}
 		if aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction != nil {
-			sanityCheckData["additional_case_review_instruction"] =
-				*aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
+			sanityCheckData["additional_case_review_instruction"] = *aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
 		}
 		providerSanityCheck, modelSanityCheck, promptSanityCheck, err := uc.preparePromptWithModel(
 			PROMPT_SANITY_CHECK_PATH,
@@ -1047,11 +1050,9 @@ func (uc *AiAgentUsecase) getCaseDataWithPermissions(ctx context.Context, caseId
 		pivotObjectKey := agent_dto.PivotObjectKeyForMap(pivotObject)
 
 		// This map is a map of [tableName]IngestedDataResult for this pivot object
-		relatedDataPerClient.ingestedData[pivotObjectKey] =
-			make(agent_dto.CasePivotIngestedData, len(dataModel.Tables))
+		relatedDataPerClient.ingestedData[pivotObjectKey] = make(agent_dto.CasePivotIngestedData, len(dataModel.Tables))
 
-		relatedDataPerClient.relatedCases[pivotObjectKey] =
-			make([]agent_dto.CaseWithDecisions, 0, 10)
+		relatedDataPerClient.relatedCases[pivotObjectKey] = make([]agent_dto.CaseWithDecisions, 0, 10)
 
 		previousCases, err := uc.repository.GetCasesWithPivotValue(ctx, exec,
 			c.OrganizationId, pivotObject.PivotValue)
@@ -1101,8 +1102,7 @@ func (uc *AiAgentUsecase) getCaseDataWithPermissions(ctx context.Context, caseId
 				return caseData{}, casePivotDataByPivot{}, errors.Wrapf(err,
 					"could not adapt case with decisions for previous case %s", previousCase.Id)
 			}
-			relatedDataPerClient.relatedCases[pivotObjectKey] =
-				append(relatedDataPerClient.relatedCases[pivotObjectKey], rc)
+			relatedDataPerClient.relatedCases[pivotObjectKey] = append(relatedDataPerClient.relatedCases[pivotObjectKey], rc)
 		}
 
 		// then, retrieve the ingested data for this pivot object (of any navigation options exist)

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -1,7 +1,6 @@
 package ai_agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -397,8 +396,7 @@ func (uc *AiAgentUsecase) loadSuggestionFromBlob(
 		return nil, errors.Wrap(err, "could not decode suggestion blob")
 	}
 
-	return agent_dto.UnmarshalScreeningHitSuggestionDto(
-		envelope.Version, bytes.NewReader(envelope.Content))
+	return agent_dto.UnmarshalScreeningHitSuggestionDto(envelope.Version, envelope.Content)
 }
 
 func (uc *AiAgentUsecase) writeSuggestionToBlob(

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -55,6 +55,10 @@ func (uc *AiAgentUsecase) AnalyseScreeningHits(ctx context.Context, screeningId 
 		return err
 	}
 
+	if err := uc.offloadedReader.HydrateScreeningMatches(ctx, []models.ScreeningWithMatches{screening}); err != nil {
+		return errors.Wrap(err, "could not hydrate offloaded screening match payloads")
+	}
+
 	// Check feature access
 	enabled, err := uc.hasScreeningHitSuggestionEnabled(ctx, screening.OrgId)
 	if err != nil {

--- a/usecases/ai_agent/async_case_review.go
+++ b/usecases/ai_agent/async_case_review.go
@@ -162,6 +162,8 @@ func (w *CaseReviewWorker) Work(ctx context.Context, job *river.Job[models.CaseR
 		// Check if this is a rate limit error from the LLM provider
 		if errors.Is(err, models.LLMRateLimitedError) {
 			logger.WarnContext(ctx, "LLM provider rate limited, rescheduling job", "error", err.Error())
+			// Ignore the error, if the save fails, we will retry the entire job
+			_ = w.saveCaseReviewContext(ctx, aiCaseReview, &caseReviewContext)
 			return river.JobSnooze(30 * time.Second)
 		}
 		return w.handleCreateCaseReviewSyncError(
@@ -221,6 +223,23 @@ func (w *CaseReviewWorker) Work(ctx context.Context, job *river.Job[models.CaseR
 	return nil
 }
 
+func (w *CaseReviewWorker) saveCaseReviewContext(ctx context.Context, aiCaseReview models.AiCaseReview, caseReviewContext *CaseReviewContext) error {
+	// Store the case review context into a blob
+	stream, errStream := w.blobRepository.OpenStream(ctx, w.bucketUrl,
+		aiCaseReview.FileTempReference, aiCaseReview.FileTempReference)
+	if errStream != nil {
+		return errors.Wrap(errStream, "Error while opening temporary file stream")
+	}
+	defer stream.Close()
+
+	errEncode := json.NewEncoder(stream).Encode(caseReviewContext)
+	if errEncode != nil {
+		return errors.Wrap(errEncode, "Error while encoding case review context to temporary file")
+	}
+
+	return nil
+}
+
 // handleCreateCaseReviewSyncError is a helper function to handle errors during the case review process
 // It stores the case review context into a blob and updates the case review file status to failed
 // It returns the original error
@@ -233,20 +252,11 @@ func (w *CaseReviewWorker) handleCreateCaseReviewSyncError(
 	// Use a detached context so cleanup operations succeed even if the original context is cancelled/expired.
 	cleanupCtx := context.WithoutCancel(ctx)
 
-	// Store the case review context into a blob
-	stream, errStream := w.blobRepository.OpenStream(cleanupCtx, w.bucketUrl,
-		aiCaseReview.FileTempReference, aiCaseReview.FileTempReference)
-	if errStream != nil {
-		return errors.Join(err, errors.Wrap(errStream,
-			"Error while opening temporary file stream"))
-	}
-	defer stream.Close()
-
-	errEncode := json.NewEncoder(stream).Encode(caseReviewContext)
-	if errEncode != nil {
+	errSave := w.saveCaseReviewContext(cleanupCtx, aiCaseReview, caseReviewContext)
+	if errSave != nil {
 		return errors.Join(
 			err,
-			errors.Wrap(errEncode, "Error while encoding case review context to temporary file"),
+			errors.Wrap(errSave, "Error while encoding case review context to temporary file"),
 		)
 	}
 
@@ -286,4 +296,3 @@ func (w *CaseReviewWorker) getPreviousCaseReviewContext(
 
 	return caseReviewContext, nil
 }
-

--- a/usecases/ai_agent/async_case_review_test.go
+++ b/usecases/ai_agent/async_case_review_test.go
@@ -219,6 +219,49 @@ func (suite *CaseReviewWorkerTestSuite) TestGetPreviousCaseReviewContext_ValidFi
 	suite.AssertExpectations()
 }
 
+// TestGetPreviousCaseReviewContext_WithScreeningSuggestions is a regression test: CaseReviewContext.ScreeningSuggestions
+// is a slice of an interface, which marshals fine but historically failed to unmarshal, permanently breaking case review
+// recovery once suggestions had been saved ("cannot unmarshal object into ... AiScreeningHitSuggestionDto").
+func (suite *CaseReviewWorkerTestSuite) TestGetPreviousCaseReviewContext_WithScreeningSuggestions() {
+	worker := suite.makeWorker()
+	ctx := context.Background()
+
+	_, _, _, aiCaseReview := createTestCaseReviewData()
+
+	expectedContext := CaseReviewContext{
+		DataModelSummary: utils.Ptr("test summary"),
+		ScreeningSuggestions: agent_dto.ScreeningHitSuggestions{
+			agent_dto.ScreeningHitSuggestionV1{
+				MatchId:    "019eca91-4bf5-738e-b8a0-1d89dbf8e219",
+				EntityId:   "Q1317",
+				Confidence: models.ScreeningHitConfidenceProbableFalsePositive,
+				Reason:     "names do not match",
+				Version:    agent_dto.VersionScreeningHitSuggestionV1,
+				CreatedAt:  time.Date(2026, 6, 15, 11, 35, 6, 0, time.UTC),
+			},
+		},
+	}
+
+	contextJSON, err := json.Marshal(expectedContext)
+	suite.NoError(err)
+
+	mockReader := newMockReadCloser(string(contextJSON))
+	blob := models.Blob{
+		FileName:   aiCaseReview.FileTempReference,
+		ReadCloser: mockReader,
+	}
+	suite.blobRepo.On("GetBlob", ctx, "test-bucket-url", aiCaseReview.FileTempReference, mock.Anything).
+		Return(blob, nil)
+
+	result, err := worker.getPreviousCaseReviewContext(ctx, aiCaseReview)
+
+	suite.NoError(err, "getPreviousCaseReviewContext should decode screening suggestions")
+	suite.Equal(expectedContext, result, "Round-tripped context should match the original")
+	suite.True(mockReader.closed, "ReadCloser should be closed")
+
+	suite.AssertExpectations()
+}
+
 // TestGetPreviousCaseReviewContext_InvalidJSON tests that getPreviousCaseReviewContext returns an error for invalid JSON
 func (suite *CaseReviewWorkerTestSuite) TestGetPreviousCaseReviewContext_InvalidJSON() {
 	worker := suite.makeWorker()


### PR DESCRIPTION
## Context

The AI case review (`CreateCaseReviewSync`) runs several steps; one classifies each screening match (`probable_false_positive` / `investigate` / `inconclusive`). Two related problems existed:

1. **Recovery was permanently broken once suggestions were saved.** `CaseReviewContext.ScreeningSuggestions` was typed as `[]agent_dto.AiScreeningHitSuggestionDto`, and `AiScreeningHitSuggestionDto` is an **interface**. Marshaling works (it writes the concrete `ScreeningHitSuggestionV1` fields), but `encoding/json` **cannot unmarshal a JSON object back into a non-empty interface**. So `getPreviousCaseReviewContext` crashed on every retry where suggestions had already been written:

   ```
   Error while getting previous case review context
   json: cannot unmarshal object into Go struct field CaseReviewContext.screening_suggestions of type agent_dto.AiScreeningHitSuggestionDto
   ```

2. **A single match failure aborted the whole review.** In `CreateCaseReviewSync`, an error from `AnalyseScreeningHits` did `return nil, err`, failing the entire case review.

## Changes

- **Version-aware list type** (`dto/agent_dto/screening_suggestion.go`): added `ScreeningHitSuggestions []AiScreeningHitSuggestionDto` with a custom `UnmarshalJSON` that decodes each element via `json.RawMessage`, reads its embedded `"version"`, and dispatches through the existing `UnmarshalScreeningHitSuggestionDto`. Marshaling is unchanged. `null`/`[]` decode to nil/empty; missing version tolerantly defaults to `v1`.
- **`CaseReviewContext.ScreeningSuggestions`** now uses `agent_dto.ScreeningHitSuggestions`. `getPreviousCaseReviewContext` needs no edit — `json.Decode` auto-invokes the new `UnmarshalJSON`, so recovery works again and existing saved blobs (which carry `"version":"v1"`) become loadable.
- **Best-effort screening in the review** (`usecases/ai_agent/ai_case_review.go`): a per-screening failure now logs a warning and continues instead of aborting; partially-successful matches are still gathered, and failed matches simply get no suggestion. The standalone screening-suggestion job (`async_screening_suggestion.go`) is untouched and keeps retrying transient failures.
- **Save previous LLM results in case of rate limiting**: If we encounter an error due to LLM rate limiting, we didn’t save the results of the previous step for the next retry.
- **Missing match hydrating when requesting AI outcome on match**: The match is not hydrated when we request the AI outcome on a match.

## Tests

- `dto/agent_dto/screening_suggestion_test.go` (new): round-trip, persisted flat-format decode, null/empty, and unknown-version error.
- `usecases/ai_agent/async_case_review_test.go`: regression test feeding a `CaseReviewContext` with populated suggestions through `getPreviousCaseReviewContext` — the exact path that was crashing.

`go build ./...`, `go vet`, and `go test ./dto/agent_dto/... ./usecases/ai_agent/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of screening suggestions handling; errors now result in partial results instead of complete failure during case review.

* **Tests**
  * Added comprehensive test coverage for screening suggestions serialization, deserialization, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->