### PR TITLE
fix: nil dereference when using redis client

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -125,7 +125,7 @@ type ApplyDeltaFileWorker struct {
 
 	executorFactory    executor_factory.ExecutorFactory
 	transactionFactory executor_factory.TransactionFactory
-	redisClient        repositories.RedisClient
+	redisClient        *repositories.RedisClient
 	repository         applyDeltaFileWorkerRepository
 	taskQueueRepo      applyDeltaFileWorkerTaskQueueRepository
 	blobRepository     repositories.BlobRepository
@@ -137,7 +137,7 @@ type ApplyDeltaFileWorker struct {
 func NewApplyDeltaFileWorker(
 	executorFactory executor_factory.ExecutorFactory,
 	transactionFactory executor_factory.TransactionFactory,
-	redisClient repositories.RedisClient,
+	redisClient *repositories.RedisClient,
 	repository applyDeltaFileWorkerRepository,
 	taskQueueRepo applyDeltaFileWorkerTaskQueueRepository,
 	blobRepository repositories.BlobRepository,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -934,7 +934,7 @@ func (usecases *UsecasesWithCreds) NewContinuousScreeningApplyDeltaFileWorker() 
 	return continuous_screening.NewApplyDeltaFileWorker(
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
-		*usecases.Repositories.RedisClient,
+		usecases.Repositories.RedisClient,
 		usecases.Repositories.MarbleDbRepository,
 		usecases.Repositories.TaskQueueRepository,
 		usecases.Repositories.BlobRepository,


### PR DESCRIPTION
Fix: 

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x105603a54]

goroutine 1 [running]:
github.com/checkmarble/marble-backend/usecases.(*UsecasesWithCreds).NewContinuousScreeningApplyDeltaFileWorker(0x1f8394092508)
	/Users/leo/Workspace/Marble/marble/api/usecases/usecases_with_creds.go:937 +0x194
github.com/checkmarble/marble-backend/cmd.RunTaskQueue({0x1075b5e8e, 0x3}, {0x0, 0x0}, {0x0, 0x0})
	/Users/leo/Workspace/Marble/marble/api/cmd/worker.go:412 +0x44ac
main.main()
	/Users/leo/Workspace/Marble/marble/api/main.go:87 +0x58c
Process Exit with Code: 2
```

We dereferences the pointer without checking its value. If Redis is not configured, we encounter this error.