### PR TITLE
fix: test failing when /tmp and the repository are not in the same fs

### DIFF
--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -175,8 +175,8 @@ func TestMain(m *testing.M) {
 	testUsecases = usecases.NewUsecases(repos,
 		usecases.WithAppName("marble-test"),
 		usecases.WithLicense(models.NewFullLicense()),
-		usecases.WithIngestionBucketUrl("file://./tempFiles?create_dir=true"),
-		usecases.WithCaseManagerBucketUrl("file://./tempFiles?create_dir=true"),
+		usecases.WithIngestionBucketUrl("file://./tempFiles?create_dir=true&no_tmp_dir=true"),
+		usecases.WithCaseManagerBucketUrl("file://./tempFiles?create_dir=true&no_tmp_dir=true"),
 		usecases.WithFirebaseAdmin(auth.TokenProviderFirebase, firebaseAdminClient),
 	)
 


### PR DESCRIPTION
This fixes the error "invalid cross-device link" upon rename:

```
❯ go test ./integration_test/ -run TestBatchIngestionAndExecution
2026/06/17 09:47:00 DB connection pool created.
[...]
--- FAIL: TestBatchIngestionAndExecution (2.16s)
    batch_ingestion_and_execution_test.go:80: 
        	Error Trace:	/home/marco/src/marble/marble-backend/integration_test/batch_ingestion_and_execution_test.go:80
        	           				/home/marco/src/marble/marble-backend/integration_test/batch_ingestion_and_execution_test.go:60
        	Error:      	failed to validate and upload ingestion csv
        	Test:       	TestBatchIngestionAndExecution
        	Messages:   	blob (key "019ed48c-4d9d-7e38-8a9d-ba03180b293e/transactions/1781682427.csv") (code=Unknown):
        	           	   gocloud.dev/blob.(*Writer).Close
        	           	       /home/marco/go/pkg/mod/gocloud.dev@v0.43.0/blob/blob.go:468
        	           	 - rename /tmp/1781682427.csv.18b9ceba5c33052e.tmp /home/marco/src/marble/marble-backend/integration_test/tempFiles/019ed48c-4d9d-7e38-8a9d-ba03180b293e/transactions/1781682427.csv: invalid cross-device link
FAIL
FAIL	github.com/checkmarble/marble-backend/integration_test	6.933s
FAIL
```

This is a minimal fix, a batter approach could be to only work in tmp so the rest can be read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test configuration for storage directory handling in test use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->