### PR TITLE
fix: redis get Scalar didn't check exec value before using it

### DIFF
--- a/repositories/redis_executor.go
+++ b/repositories/redis_executor.go
@@ -200,6 +200,10 @@ func RedisLoadMap[T comparable](ctx context.Context, exec *RedisExecutor, key st
 }
 
 func RedisGetScalar[T any](ctx context.Context, exec *RedisExecutor, key string) (T, error) {
+	if exec == nil {
+		return *new(T), models.NotFoundError
+	}
+
 	cmd := exec.client.client.Get(ctx, key)
 
 	var model T


### PR DESCRIPTION
RedisGetScalar method didn't check if the exec parameter is not nil before using it, which could result in an error at runtime if the Redis client is not properly configured.