### PR TITLE
fix: continuous screening dataset filter on new opensanction config

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -119,6 +119,7 @@ type applyDeltaFileWorkerUsecase interface {
 		continuousScreeningWithMatches models.ContinuousScreeningWithMatches,
 	) (models.Case, error)
 	CheckFeatureAccess(ctx context.Context, orgId uuid.UUID) error
+	AdaptLegacyDatasets(ctx context.Context, config models.ContinuousScreeningConfig) (models.ContinuousScreeningConfig, error)
 }
 
 type ApplyDeltaFileWorker struct {
@@ -293,14 +294,10 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 			continue
 		}
 
-		if updateJob.Provider != "lexisnexis" {
-			// The new record should be in a dataset that is monitored
-			if !AtLeastOneDatasetsAreMonitored(record.Entity.Datasets, updateJob.Config.Datasets) {
-				iterLogger.DebugContext(iterCtx, "Skipping record because none of its datasets are monitored", "datasets", record.Entity.Datasets)
-				continue
-			}
+		updateJob.Config, err = w.usecase.AdaptLegacyDatasets(ctx, updateJob.Config)
+		if err != nil {
+			return err
 		}
-
 		if !matchesFilters(updateJob, record) {
 			iterLogger.DebugContext(iterCtx, "Skipping record because it does not meet filter")
 			continue
@@ -607,13 +604,7 @@ func matchesFilters(updateJob models.EnrichedContinuousScreeningUpdateJob, recor
 		ds = append(ds, filters.AdverseMedia.Datasets...)
 		ds = append(ds, filters.Other.Datasets...)
 
-		for _, recordDataset := range record.Entity.Datasets {
-			if slices.Contains(ds, recordDataset) {
-				return true
-			}
-		}
-
-		return false
+		return AtLeastOneDatasetsAreMonitored(record.Entity.Datasets, ds)
 
 	case models.ScreeningProviderLexisNexis:
 		// Loop over each configuration section

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -215,6 +215,12 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 		return nil
 	}
 
+	// Adapt legacy datasets to the new format for the the filtering which will be used in matchesFilters method
+	updateJob.Config, err = w.usecase.AdaptLegacyDatasets(ctx, updateJob.Config)
+	if err != nil {
+		return err
+	}
+
 	initialOffset, initialItemsProcessed, err := w.getLastIterationOffset(
 		ctx,
 		exec,
@@ -294,10 +300,6 @@ func (w *ApplyDeltaFileWorker) Work(ctx context.Context, job *river.Job[models.C
 			continue
 		}
 
-		updateJob.Config, err = w.usecase.AdaptLegacyDatasets(ctx, updateJob.Config)
-		if err != nil {
-			return err
-		}
 		if !matchesFilters(updateJob, record) {
 			iterLogger.DebugContext(iterCtx, "Skipping record because it does not meet filter")
 			continue


### PR DESCRIPTION
I tested the continuous screening `dataset_update` flow and encountered a bug when using an old opensanctions configuration. Specifically, the `dataset` column becomes empty, and the dataset list is moved to the `filters` column.

However, copying the dataset list from the `filters` column to the `datasets` column resolves the issue, ensuring that the old continuous screening configuration remains unaffected by the bug.

To fix this, utilize the existing `AdaptLegacyDatasets` method to adapt the old configuration to the new one. This method utilizes the `filters` property to achieve this adaptation. Subsequently, rely on the `matchesFilters` method to filter based on the presence of a dataset. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy dataset configuration handling in continuous screening operations
  * Enhanced record filtering accuracy and consistency across monitoring providers
  * Refined OpenSanctions provider dataset monitoring checks for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->