### PR TITLE
chore: add missing dataset category when filtering matches

### DIFF
--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -605,6 +605,7 @@ func matchesFilters(updateJob models.EnrichedContinuousScreeningUpdateJob, recor
 		ds := append(filters.Sanctions.Datasets, filters.Peps.Datasets...)
 		ds = append(ds, filters.AdverseMedia.Datasets...)
 		ds = append(ds, filters.Other.Datasets...)
+		ds = append(ds, filters.Custom.Datasets...)
 
 		return AtLeastOneDatasetsAreMonitored(record.Entity.Datasets, ds)
 


### PR DESCRIPTION
Just in case we using `custom` dataset category in our continuous screening configuration for filtering dataset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended monitoring capabilities to include custom datasets in continuous screening workflows, complementing existing dataset categories for comprehensive coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->