### PR TITLE
fix: read decision with usecase rather than repo, in order to get scr…

### DIFF
--- a/usecases/decision_workflows/worker.go
+++ b/usecases/decision_workflows/worker.go
@@ -54,6 +54,10 @@ type ingestedDataReadRepository interface {
 	) ([]models.DataModelObject, error)
 }
 
+type decisionReader interface {
+	GetDecision(ctx context.Context, decisionId string) (models.DecisionWithRuleExecutions, error)
+}
+
 type DecisionWorkflowsWorker struct {
 	river.WorkerDefaults[models.DecisionWorkflowArgs]
 
@@ -64,6 +68,7 @@ type DecisionWorkflowsWorker struct {
 	ingestedDataReadRepository        ingestedDataReadRepository
 	decisionWorkflowsWorkerRepository decisionWorkflowsWorkerRepository
 	webhookEventsUsecase              webhookEventsUsecase
+	decisionReader                    decisionReader
 }
 
 func NewDecisionWorkflowsWorker(
@@ -74,6 +79,7 @@ func NewDecisionWorkflowsWorker(
 	ingestedDataReadRepository ingestedDataReadRepository,
 	decisionWorkflowsWorkerRepository decisionWorkflowsWorkerRepository,
 	webhookEventsUsecase webhookEventsUsecase,
+	decisionReader decisionReader,
 ) *DecisionWorkflowsWorker {
 	return &DecisionWorkflowsWorker{
 		executorFactory:                   executorFactory,
@@ -83,6 +89,7 @@ func NewDecisionWorkflowsWorker(
 		ingestedDataReadRepository:        ingestedDataReadRepository,
 		decisionWorkflowsWorkerRepository: decisionWorkflowsWorkerRepository,
 		webhookEventsUsecase:              webhookEventsUsecase,
+		decisionReader:                    decisionReader,
 	}
 }
 
@@ -94,7 +101,7 @@ func (w *DecisionWorkflowsWorker) Work(ctx context.Context, job *river.Job[model
 	exec := w.executorFactory.NewExecutor()
 
 	// Fetch/Build data for decision workflows
-	decision, err := w.decisionWorkflowsWorkerRepository.DecisionWithRuleExecutionsById(ctx, exec, job.Args.DecisionId)
+	decision, err := w.decisionReader.GetDecision(ctx, job.Args.DecisionId)
 	if err != nil {
 		return errors.Wrap(err, "error getting decision with rule executions")
 	}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -836,6 +836,7 @@ func (usecases *UsecasesWithCreds) NewUserSettingsUsecase() UserSettingsUsecase 
 }
 
 func (usecases *UsecasesWithCreds) NewDecisionWorkflowsWorker() *decision_workflows.DecisionWorkflowsWorker {
+	decisionUsecase := usecases.NewDecisionUsecase()
 	return decision_workflows.NewDecisionWorkflowsWorker(
 		usecases.NewExecutorFactory(),
 		usecases.NewTransactionFactory(),
@@ -844,6 +845,7 @@ func (usecases *UsecasesWithCreds) NewDecisionWorkflowsWorker() *decision_workfl
 		usecases.Repositories.IngestedDataReadRepository,
 		usecases.Repositories.MarbleDbRepository,
 		usecases.NewWebhookEventsUsecase(),
+		&decisionUsecase,
 	)
 }
 


### PR DESCRIPTION
This was broken since the switch to the worker.
The decision model contains screening rule executions, but they are not read by the repository, and only added on the usecase "get decision by id" method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to decision workflow processing architecture for enhanced code maintainability and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->