### PR TITLE
feat: offload freeform search screening

### DIFF
--- a/repositories/freeform_search_repository.go
+++ b/repositories/freeform_search_repository.go
@@ -93,9 +93,13 @@ func (*MarbleDbRepository) SaveFreeformSearchResult(
 		return err
 	}
 
-	resultBytes, err := json.Marshal(result)
-	if err != nil {
-		return err
+	var resultBytes []byte
+	if result != nil {
+		var err error
+		resultBytes, err = json.Marshal(result)
+		if err != nil {
+			return err
+		}
 	}
 
 	sql := NewQueryBuilder().

--- a/repositories/offloaded_read_writer.go
+++ b/repositories/offloaded_read_writer.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"time"
 
@@ -23,6 +24,7 @@ type offloadableRepository interface {
 	GetOffloadedScreeningMatchKey(orgId uuid.UUID, screeningId, matchId string) string
 	GetOffloadedContinuousScreeningMatchKey(orgId, continuousScreeningId, matchId uuid.UUID) string
 	GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId uuid.UUID) string
+	GetOffloadedFreeformSearchResultKey(orgId, searchId uuid.UUID) string
 	GetWatermark(
 		ctx context.Context,
 		exec Executor,
@@ -508,6 +510,77 @@ func (uc OffloadedReadWriter) HydrateContinuousScreeningEntity(
 	}
 
 	screening.OpenSanctionEntityPayload = payload
+	return nil
+}
+
+// ReadOffloadedFreeformSearchResultPayload reads a saved freeform search's result array from blob
+// storage. Returns (nil, nil) when offloading is disabled or the object is missing.
+func (uc OffloadedReadWriter) ReadOffloadedFreeformSearchResultPayload(
+	ctx context.Context, orgId, searchId uuid.UUID,
+) ([]byte, error) {
+	if !uc.IsOffloadingEnabled() {
+		return nil, nil
+	}
+	return uc.readPayload(ctx, uc.Repository.GetOffloadedFreeformSearchResultKey(orgId, searchId))
+}
+
+// OffloadFreeformSearchResult marshals the result array to blob storage and returns the value to
+// store in the result column: nil once offloaded, or the result unchanged when offloading is
+// disabled.
+func (uc OffloadedReadWriter) OffloadFreeformSearchResult(
+	ctx context.Context, orgId, searchId uuid.UUID, result []json.RawMessage,
+) ([]json.RawMessage, error) {
+	if !uc.IsScreeningOffloadingEnabled() {
+		return result, nil
+	}
+
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not marshal freeform search result for offloading")
+	}
+
+	if err := uc.writePayload(ctx, uc.Repository.GetOffloadedFreeformSearchResultKey(orgId, searchId), payload); err != nil {
+		return nil, errors.Wrap(err, "failed to offload freeform search result")
+	}
+
+	return nil, nil
+}
+
+// HydrateFreeformSearchResult fills in, from blob storage, the result of a saved freeform search
+// when its DB column is empty (the offloaded-payload signal). No-op when offloading is disabled,
+// the search is not yet saved, or the column is already populated (legacy row). A missing blob is
+// logged and left empty rather than failing the read.
+func (uc OffloadedReadWriter) HydrateFreeformSearchResult(
+	ctx context.Context, search *models.FreeformSearch,
+) error {
+	if !uc.IsOffloadingEnabled() {
+		return nil
+	}
+
+	if !search.IsSaved || search.Result != nil {
+		return nil
+	}
+
+	payload, err := uc.ReadOffloadedFreeformSearchResultPayload(ctx, search.OrgId, search.Id)
+	if err != nil {
+		return errors.Wrap(err, "failed to read freeform search result payload")
+	}
+
+	if len(payload) == 0 {
+		utils.LoggerFromContext(ctx).WarnContext(ctx,
+			"freeform search result is missing from both the DB column and blob storage",
+			"org_id", search.OrgId,
+			"freeform_search_id", search.Id,
+		)
+		return nil
+	}
+
+	var result []json.RawMessage
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return errors.Wrap(err, "failed to unmarshal offloaded freeform search result")
+	}
+
+	search.Result = result
 	return nil
 }
 

--- a/repositories/offloading_repository.go
+++ b/repositories/offloading_repository.go
@@ -49,3 +49,10 @@ func (repo *MarbleDbRepository) GetOffloadedContinuousScreeningMatchKey(orgId, c
 func (repo *MarbleDbRepository) GetOffloadedContinuousScreeningEntityKey(orgId, continuousScreeningId uuid.UUID) string {
 	return fmt.Sprintf("continuous_screening/entity/%s/%s", orgId.String(), continuousScreeningId.String())
 }
+
+// GetOffloadedFreeformSearchResultKey returns the deterministic blob key under which a saved
+// freeform search's result array is offloaded. A populated result column means the row is legacy
+// (read it directly); an empty column means the payload lives at this key in blob storage.
+func (repo *MarbleDbRepository) GetOffloadedFreeformSearchResultKey(orgId, searchId uuid.UUID) string {
+	return fmt.Sprintf("freeform_search/result/%s/%s", orgId.String(), searchId.String())
+}

--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -718,7 +718,12 @@ func (uc ScreeningUsecase) SaveFreeformSearch(ctx context.Context, id uuid.UUID)
 		return m.Payload
 	})
 
-	if err := uc.repository.SaveFreeformSearchResult(ctx, exec, id, result); err != nil {
+	toStore, err := uc.offloadedReader.OffloadFreeformSearchResult(ctx, search.OrgId, id, result)
+	if err != nil {
+		return errors.Wrap(err, "could not offload freeform search result")
+	}
+
+	if err := uc.repository.SaveFreeformSearchResult(ctx, exec, id, toStore); err != nil {
 		return errors.Wrap(err, "could not save freeform search result")
 	}
 
@@ -732,6 +737,10 @@ func (uc ScreeningUsecase) GetFreeformSearch(ctx context.Context, id uuid.UUID) 
 	}
 
 	if err := uc.enforceSecurity.ReadFreeformSearch(search); err != nil {
+		return models.FreeformSearch{}, err
+	}
+
+	if err := uc.offloadedReader.HydrateFreeformSearchResult(ctx, &search); err != nil {
 		return models.FreeformSearch{}, err
 	}
 


### PR DESCRIPTION
Part 3 of the screening offloading process involves modifying the freeform search "save result" action. 
Instead of saving the screening result into a database, this modification saves it into a blob storage. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for offloading large freeform search result payloads to external storage, reducing database footprint and improving performance for complex searches.
  * Updated retrieval to automatically hydrate results from offloaded storage when available and needed.

* **Bug Fixes**
  * Prevented unnecessary JSON marshaling failures when a freeform search result is empty, while still persisting the save state correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->