### PR TITLE
wip: allow multiple pivot (exclusive) for a table

### DIFF
--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -2,9 +2,10 @@ package models
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
-	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 )
@@ -119,20 +120,28 @@ func FieldFromPath(dm DataModel, pathLinkIds []string) Field {
 	return dm.AllFieldsAsMap()[lastLink.ParentFieldId]
 }
 
-// Find the pivot definition, if there is one for this table
-func FindPivot(pivotsMeta []PivotMetadata, table string, dm DataModel) *Pivot {
-	pivots := pure_utils.Map(pivotsMeta, func(p PivotMetadata) Pivot {
-		return p.Enrich(dm)
-	})
-	var pivot *Pivot
-	for _, p := range pivots {
-		if p.BaseTable == table {
-			pivot = &p
-			break
+// FindPivotsForTable returns every pivot definition whose base table is the given
+// table. A table may have several pivots (polymorphic belongs_to: at most one
+// applies per row); the per-row resolution of which one applies happens at
+// evaluation time. The result is sorted deterministically (by creation time then
+// id) so that "first non-null path wins" resolution is stable.
+func FindPivotsForTable(pivotsMeta []PivotMetadata, table string, dm DataModel) []Pivot {
+	pivots := make([]Pivot, 0, len(pivotsMeta))
+	for _, p := range pivotsMeta {
+		enriched := p.Enrich(dm)
+		if enriched.BaseTable == table {
+			pivots = append(pivots, enriched)
 		}
 	}
 
-	return pivot
+	slices.SortFunc(pivots, func(a, b Pivot) int {
+		if c := a.CreatedAt.Compare(b.CreatedAt); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Id.String(), b.Id.String())
+	})
+
+	return pivots
 }
 
 type CreatePivotInput struct {

--- a/models/data_model_pivot.go
+++ b/models/data_model_pivot.go
@@ -124,7 +124,8 @@ func FieldFromPath(dm DataModel, pathLinkIds []string) Field {
 // table. A table may have several pivots (polymorphic belongs_to: at most one
 // applies per row); the per-row resolution of which one applies happens at
 // evaluation time. The result is sorted deterministically (by creation time then
-// id) so that "first non-null path wins" resolution is stable.
+// id) so the candidate set is stable; evaluation then selects among the candidates
+// that resolve to a non-null value.
 func FindPivotsForTable(pivotsMeta []PivotMetadata, table string, dm DataModel) []Pivot {
 	pivots := make([]Pivot, 0, len(pivotsMeta))
 	for _, p := range pivotsMeta {

--- a/models/decision_phantom.go
+++ b/models/decision_phantom.go
@@ -11,7 +11,6 @@ type CreatePhantomDecisionInput struct {
 	OrganizationId     uuid.UUID
 	Scenario           Scenario
 	ClientObject       ClientObject
-	Pivot              *Pivot
 	TriggerObjectTable string
 }
 

--- a/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
+++ b/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
@@ -5,22 +5,17 @@
 
 drop index data_model_pivots_base_table_id_idx;
 
--- Lookup index for ListPivots (filters by organization_id [+ base_table_id]).
-create index data_model_pivots_base_table_id_idx
-on data_model_pivots (organization_id, base_table_id)
-where deleted_at is null;
-
 -- Prevent exact-duplicate live pivots while allowing distinct ones on the same
 -- table. NULLS NOT DISTINCT (PG15+) makes two path pivots with the same
 -- path_link_ids (field_id NULL) collide, while pivots with different paths or
--- fields coexist.
+-- fields coexist. Its (organization_id, base_table_id) prefix also serves the
+-- ListPivots lookups, so no separate lookup index is needed.
 create unique index data_model_pivots_signature_idx
 on data_model_pivots (organization_id, base_table_id, field_id, path_link_ids) nulls not distinct
 where deleted_at is null;
 
 -- +goose Down
 drop index data_model_pivots_signature_idx;
-drop index data_model_pivots_base_table_id_idx;
 
 -- Restore the single-pivot-per-table constraint (fails if a table has >1 live pivot).
 delete from data_model_pivots

--- a/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
+++ b/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+-- Allow a table to have several (belongs_to) pivots pointing at different parent
+-- tables (polymorphic / discriminated belongs_to: at most one applies per row).
+-- The old index enforced a single live pivot per (organization_id, base_table_id).
+
+drop index data_model_pivots_base_table_id_idx;
+
+-- Lookup index for ListPivots (filters by organization_id [+ base_table_id]).
+create index data_model_pivots_base_table_id_idx
+on data_model_pivots (organization_id, base_table_id)
+where deleted_at is null;
+
+-- Prevent exact-duplicate live pivots while allowing distinct ones on the same
+-- table. NULLS NOT DISTINCT (PG15+) makes two path pivots with the same
+-- path_link_ids (field_id NULL) collide, while pivots with different paths or
+-- fields coexist.
+create unique index data_model_pivots_signature_idx
+on data_model_pivots (organization_id, base_table_id, field_id, path_link_ids) nulls not distinct
+where deleted_at is null;
+
+-- +goose Down
+drop index data_model_pivots_signature_idx;
+drop index data_model_pivots_base_table_id_idx;
+
+-- Restore the single-pivot-per-table constraint (fails if a table has >1 live pivot).
+delete from data_model_pivots
+where deleted_at is not null;
+
+create unique index data_model_pivots_base_table_id_idx
+on data_model_pivots (organization_id, base_table_id)
+where deleted_at is null;

--- a/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
+++ b/repositories/migrations/20260616100000_allow_multiple_pivots_per_table.sql
@@ -17,9 +17,21 @@ where deleted_at is null;
 -- +goose Down
 drop index data_model_pivots_signature_idx;
 
--- Restore the single-pivot-per-table constraint (fails if a table has >1 live pivot).
-delete from data_model_pivots
-where deleted_at is not null;
+-- The restored index allows only one live pivot per (organization_id, base_table_id),
+-- but the forward migration may have created several. Soft-delete all but the oldest
+-- live pivot per table so the unique index can be recreated. Soft-delete (rather than
+-- hard delete) preserves decisions that reference these pivots by id.
+update data_model_pivots p
+set deleted_at = now()
+where p.deleted_at is null
+  and exists (
+    select 1
+    from data_model_pivots q
+    where q.organization_id = p.organization_id
+      and q.base_table_id = p.base_table_id
+      and q.deleted_at is null
+      and (q.created_at, q.id) < (p.created_at, p.id)
+  );
 
 create unique index data_model_pivots_base_table_id_idx
 on data_model_pivots (organization_id, base_table_id)

--- a/usecases/data_model_destroy_usecase.go
+++ b/usecases/data_model_destroy_usecase.go
@@ -391,7 +391,9 @@ func (uc DataModelDestroyUsecase) canDeleteRef(
 		case nil:
 			// The case link.FieldTableId == table.ID will not create a conflict because when deleting a table, we will allow
 			// cascade deletion of all links.
-			// TODO: TBD what if the link is part of a pivot with multi links?
+			// A path pivot (possibly one of several on its base table) references its links
+			// via path_link_ids; deleting a table that any such link points at is flagged
+			// here as a link conflict
 			if link.ParentTableId == table.ID {
 				canDelete = false
 				report.Conflicts.Links.Insert(link.Id)
@@ -433,10 +435,11 @@ func (uc DataModelDestroyUsecase) canDeleteRef(
 		}
 	}
 
-	// This only covers table referencing themselves, pivots to other tables are covered by the check on links.
+	// This only covers field-based pivots referencing the field directly. Path pivots
+	// (including multi-link ones, and tables that have several pivots) reference their
+	// links via path_link_ids and are already covered by the link conflict checks above.
 	// When deleting a table (field == nil), we don't need to check if a pivot was referencing itself because
 	// the deletion will not break anything since the table will be deleted
-	// TODO: TBD What if the pivot has multi links?
 	if field != nil {
 		pivots, err := uc.dataModelRepository.ListPivots(ctx, exec, orgId, nil, false, false)
 		if err != nil {

--- a/usecases/data_model_semantic_validation.go
+++ b/usecases/data_model_semantic_validation.go
@@ -121,29 +121,28 @@ func transactionTableSemanticTypeValidation(tableName string, datamodel models.D
 	}
 	table := datamodel.Tables[tableName]
 
-	linkBelongsToName := ""
+	// A transaction table may have several BelongsTo links (polymorphic belongs_to: at
+	// most one parent applies per row), but it must have at least one, and every one of
+	// them must point at a Party table.
+	belongsToCount := 0
 	for _, link := range table.LinksToSingle {
-		if link.LinkType == models.LinkTypeBelongsTo {
-			if linkBelongsToName != "" {
-				return errors.Wrap(models.BadParameterError,
-					"transaction table must have only one BelongsTo link to a Party table")
-			}
-			linkBelongsToName = link.Name
+		if link.LinkType != models.LinkTypeBelongsTo {
+			continue
+		}
+		belongsToCount++
+
+		linkedTable, ok := datamodel.Tables[link.ParentTableName]
+		if !ok {
+			return errors.Wrap(models.BadParameterError,
+				"linked table not found in data model")
+		}
+		if !linkedTable.SemanticType.IsParty() {
+			return errors.Wrap(models.BadParameterError,
+				"every BelongsTo link of a transaction table must point at a Party table")
 		}
 	}
 
-	if linkBelongsToName == "" {
-		return errors.Wrap(models.BadParameterError,
-			"transaction table must have a BelongsTo link to a Party table")
-	}
-
-	link := table.LinksToSingle[linkBelongsToName]
-	linkedTable, ok := datamodel.Tables[link.ParentTableName]
-	if !ok {
-		return errors.Wrap(models.BadParameterError,
-			"linked table not found in data model")
-	}
-	if !linkedTable.SemanticType.IsParty() {
+	if belongsToCount == 0 {
 		return errors.Wrap(models.BadParameterError,
 			"transaction table must have a BelongsTo link to a Party table")
 	}

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -1533,21 +1533,21 @@ func (usecase *usecase) CreatePivotWithExec(ctx context.Context, exec repositori
 	if err != nil {
 		return models.Pivot{}, err
 	}
-	// Only restore if the table has no live pivot: otherwise let CreatePivot return its
-	// usual conflict error (one live pivot per table).
-	hasLivePivot := slices.ContainsFunc(existingPivots, func(p models.PivotMetadata) bool {
-		return p.DeletedAt == nil
+	// A table may have several pivots, so match by definition rather than "any live pivot":
+	// restore a soft-deleted pivot with this exact definition, unless a live pivot already
+	// has it — in which case CreatePivot returns the usual conflict via the signature index.
+	liveMatchExists := slices.ContainsFunc(existingPivots, func(p models.PivotMetadata) bool {
+		return p.DeletedAt == nil && pivotDefinitionMatchesInput(p, input)
 	})
-	if !hasLivePivot {
+	if !liveMatchExists {
 		for _, existing := range existingPivots {
-			if !pivotDefinitionMatchesInput(existing, input) {
-				continue
+			if existing.DeletedAt != nil && pivotDefinitionMatchesInput(existing, input) {
+				if err := usecase.dataModelRepository.RestorePivot(ctx, exec, existing.Id.String()); err != nil {
+					return models.Pivot{}, err
+				}
+				pivotMeta, err := usecase.dataModelRepository.GetPivot(ctx, exec, existing.Id.String())
+				return pivotMeta.Enrich(dm), err
 			}
-			if err := usecase.dataModelRepository.RestorePivot(ctx, exec, existing.Id.String()); err != nil {
-				return models.Pivot{}, err
-			}
-			pivotMeta, err := usecase.dataModelRepository.GetPivot(ctx, exec, existing.Id.String())
-			return pivotMeta.Enrich(dm), err
 		}
 	}
 

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -250,7 +250,9 @@ func retrieveParentFieldIdForLink(parentTableId string, TablesById map[string]mo
 	return parentFieldId.ID, nil
 }
 
-// Table can have only one pivot because of the unique index on `organization_id + base_table_id`
+// ensureTableHasPivot creates the default field pivot (on object_id) only when the table
+// has no pivot at all. Once any belongs_to pivot exists, the default is mutually exclusive
+// and is not (re)created.
 func (usecase *usecase) ensureTableHasPivot(
 	ctx context.Context,
 	exec repositories.Executor,
@@ -808,15 +810,8 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 			}
 
 			if linkUpdate.LinkType == models.LinkTypeBelongsTo {
-				// Changing to "belongs_to": validate no other belongs_to link on child table
-				for _, l := range links {
-					if l.Id != linkUpdate.ID && l.ChildTableId == tableID &&
-						l.LinkType == models.LinkTypeBelongsTo {
-						return errors.Wrap(models.BadParameterError,
-							fmt.Sprintf("child table %s already has a belongs_to link",
-								existingLink.ChildTableName))
-					}
-				}
+				// A child table may have several belongs_to links (polymorphic belongs_to:
+				// at most one applies per row), each with its own path-based pivot.
 
 				// Soft-delete the default pivot (field_id-based) on the child table, not
 				// path-based pivots that rely on another belongs_to link
@@ -1419,15 +1414,9 @@ func (usecase *usecase) createDataModelLinkWithExec(ctx context.Context, exec re
 			"child field cannot be object_id")
 	}
 
-	// Can only have one BelongsTo link on the child Table
+	// A child table may have several BelongsTo links (polymorphic belongs_to: at most one
+	// applies per row), each with its own path-based pivot.
 	if link.LinkType == models.LinkTypeBelongsTo {
-		for _, l := range allTables[link.ChildTableID].LinksToSingle {
-			if l.LinkType == models.LinkTypeBelongsTo {
-				return "", nil, errors.Wrap(models.BadParameterError,
-					fmt.Sprintf("child table %s already has a belongs_to link", allTables[link.ChildTableID].Name))
-			}
-		}
-
 		// Soft-delete the default pivot (field_id-based) to replace it with a path-based
 		// one (decisions may reference it). Do not delete path-based pivots that rely on
 		// another belongs_to link.

--- a/usecases/data_model_usecase_test.go
+++ b/usecases/data_model_usecase_test.go
@@ -1525,6 +1525,61 @@ func (suite *DatamodelUsecaseTestSuite) TestCreatePivot_restores_identical_soft_
 	suite.AssertExpectations()
 }
 
+// With multiple pivots per table, a matching soft-deleted pivot must be restored even
+// when another (different) live pivot already exists on the same table — otherwise a new
+// row would be created and historical decisions referencing the old id would be orphaned.
+func (suite *DatamodelUsecaseTestSuite) TestCreatePivot_restores_matching_soft_deleted_pivot_when_another_live_pivot_exists() {
+	input := models.CreatePivotInput{
+		OrganizationId: suite.organizationId,
+		BaseTableId:    "accounts-table-id",
+		FieldId:        utils.Ptr("accounts-object-id-field-id"),
+	}
+	matchingPivotId := uuid.MustParse("87654321-4321-8765-2109-876543210987")
+	deletedAt := time.Now()
+
+	usecase := suite.makeUsecase()
+	suite.enforceSecurity.On("WriteDataModel", suite.organizationId).Return(nil)
+	suite.dataModelRepository.On("GetDataModel",
+		suite.ctx, suite.transaction, suite.organizationId, false, mock.Anything).
+		Return(suite.dataModel, nil)
+	suite.dataModelRepository.On("ListPivots", suite.ctx, suite.transaction,
+		suite.organizationId, utils.Ptr("accounts-table-id"), false, true).
+		Return([]models.PivotMetadata{
+			{
+				// A different, live pivot on the same table (must not block the restore).
+				Id:             uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+				OrganizationId: suite.organizationId,
+				BaseTableId:    "accounts-table-id",
+				FieldId:        utils.Ptr("accounts-status-field-id"),
+			},
+			{
+				// The soft-deleted pivot matching the input: it should be restored.
+				Id:             matchingPivotId,
+				OrganizationId: suite.organizationId,
+				BaseTableId:    "accounts-table-id",
+				FieldId:        utils.Ptr("accounts-object-id-field-id"),
+				DeletedAt:      &deletedAt,
+			},
+		}, nil)
+	suite.dataModelRepository.On("RestorePivot", suite.ctx, suite.transaction, matchingPivotId.String()).
+		Return(nil)
+	suite.dataModelRepository.On("GetPivot", suite.ctx, suite.transaction, matchingPivotId.String()).
+		Return(models.PivotMetadata{
+			Id:             matchingPivotId,
+			OrganizationId: suite.organizationId,
+			BaseTableId:    "accounts-table-id",
+			FieldId:        utils.Ptr("accounts-object-id-field-id"),
+		}, nil)
+
+	pivot, err := usecase.CreatePivotWithExec(suite.ctx, suite.transaction, input)
+	suite.Require().NoError(err, "no error expected")
+	suite.Require().Equal(matchingPivotId, pivot.Id, "the matching soft-deleted pivot should be restored")
+
+	suite.dataModelRepository.AssertNotCalled(suite.T(), "CreatePivot",
+		mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	suite.AssertExpectations()
+}
+
 func (suite *DatamodelUsecaseTestSuite) TestCreatePivot_does_not_restore_different_soft_deleted_pivot() {
 	input := models.CreatePivotInput{
 		OrganizationId: suite.organizationId,

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -358,13 +358,13 @@ func (usecase *DecisionUsecase) CreateDecision(
 	if err != nil {
 		return false, models.DecisionWithRuleExecutions{}, err
 	}
-	pivot := models.FindPivot(pivotsMeta, input.TriggerObjectTable, dataModel)
+	pivots := models.FindPivotsForTable(pivotsMeta, input.TriggerObjectTable, dataModel)
 
 	evaluationParameters := evaluate_scenario.ScenarioEvaluationParameters{
 		Scenario:        scenario,
 		ClientObject:    payload,
 		DataModel:       dataModel,
-		Pivot:           pivot,
+		Pivots:          pivots,
 		ConcurrentRules: params.ConcurrentRules,
 	}
 
@@ -546,7 +546,7 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 	if err != nil {
 		return nil, 0, nil, err
 	}
-	pivot := models.FindPivot(pivotsMeta, input.TriggerObjectTable, dataModel)
+	pivots := models.FindPivotsForTable(pivotsMeta, input.TriggerObjectTable, dataModel)
 
 	org, err := usecase.orgRepository.GetOrganizationById(ctx, exec, input.OrganizationId)
 	if err != nil {
@@ -588,7 +588,7 @@ func (usecase *DecisionUsecase) CreateAllDecisions(
 			Scenario:        scenario,
 			ClientObject:    payload,
 			DataModel:       dataModel,
-			Pivot:           pivot,
+			Pivots:          pivots,
 			ConcurrentRules: params.ConcurrentRules,
 		}
 
@@ -779,7 +779,6 @@ func (usecase *DecisionUsecase) executeTestRun(
 		OrganizationId:     organizationId,
 		Scenario:           scenario,
 		ClientObject:       evaluationParameters.ClientObject,
-		Pivot:              evaluationParameters.Pivot,
 		TriggerObjectTable: triggerObjectTable,
 	}
 	if scenarioExecution != nil {

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -44,9 +44,11 @@ type ScenarioEvaluationParameters struct {
 	TargetIterationId *string
 	ClientObject      models.ClientObject
 	DataModel         models.DataModel
-	Pivot             *models.Pivot
-	CachedScreenings  map[string]models.ScreeningWithMatches
-	ConcurrentRules   int
+	// Pivots is the set of candidate pivots for the trigger table.
+	// The applicable one is resolved per row at evaluation time ("first non-null path wins").
+	Pivots           []models.Pivot
+	CachedScreenings map[string]models.ScreeningWithMatches
+	ConcurrentRules  int
 }
 
 type EvalScreeningUsecase interface {
@@ -191,14 +193,22 @@ func (e ScenarioEvaluator) processScenarioIteration(
 		triggerExpressionDuration = time.Since(beforeTriggerExpression)
 	}
 
+	// Resolve which pivot applies to this row: try each candidate in order and keep
+	// the first one whose path resolves to a non-null value ("first non-null path
+	// wins").
 	var pivotValue *string
-	var errPv error
-	if params.Pivot != nil {
-		pivotValue, errPv = getPivotValue(ctx, *params.Pivot, dataAccessor)
+	var selectedPivot *models.Pivot
+	for i := range params.Pivots {
+		value, errPv := getPivotValue(ctx, params.Pivots[i], dataAccessor)
 		if errPv != nil {
 			return false, models.ScenarioExecution{}, errors.Wrap(
 				errPv,
 				"error getting pivot value in EvalScenario")
+		}
+		if value != nil {
+			pivotValue = value
+			selectedPivot = &params.Pivots[i]
+			break
 		}
 	}
 
@@ -336,8 +346,8 @@ func (e ScenarioEvaluator) processScenarioIteration(
 		Outcome:             outcome,
 		OrganizationId:      params.Scenario.OrganizationId,
 	}
-	if params.Pivot != nil {
-		se.PivotId = &params.Pivot.Id
+	if selectedPivot != nil {
+		se.PivotId = &selectedPivot.Id
 		se.PivotValue = pivotValue
 	}
 

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"runtime/debug"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -193,11 +194,15 @@ func (e ScenarioEvaluator) processScenarioIteration(
 		triggerExpressionDuration = time.Since(beforeTriggerExpression)
 	}
 
-	// Resolve which pivot applies to this row: try each candidate in order and keep
-	// the first one whose path resolves to a non-null value ("first non-null path
-	// wins").
-	var pivotValue *string
-	var selectedPivot *models.Pivot
+	// Resolve which pivot applies to this row. Under polymorphic belongs_to at most one
+	// candidate pivot should resolve to a non-null value for a given row. We evaluate all
+	// candidates so we can detect the (unexpected) case where several are populated, and
+	// in that case pick one deterministically by pivot field name (alphanumeric order).
+	type eligiblePivot struct {
+		pivot *models.Pivot
+		value string
+	}
+	var eligible []eligiblePivot
 	for i := range params.Pivots {
 		value, errPv := getPivotValue(ctx, params.Pivots[i], dataAccessor)
 		if errPv != nil {
@@ -206,10 +211,32 @@ func (e ScenarioEvaluator) processScenarioIteration(
 				"error getting pivot value in EvalScenario")
 		}
 		if value != nil {
-			pivotValue = value
-			selectedPivot = &params.Pivots[i]
-			break
+			eligible = append(eligible, eligiblePivot{pivot: &params.Pivots[i], value: *value})
 		}
+	}
+
+	var pivotValue *string
+	var selectedPivot *models.Pivot
+	if len(eligible) > 0 {
+		// Deterministic selection: alphanumeric order on the pivot field name.
+		slices.SortFunc(eligible, func(a, b eligiblePivot) int {
+			return strings.Compare(a.pivot.Field, b.pivot.Field)
+		})
+
+		if len(eligible) > 1 {
+			utils.LoggerFromContext(ctx).InfoContext(ctx,
+				"multiple eligible pivot values present in payload; selecting deterministically by pivot field name",
+				"scenario_id", params.Scenario.Id,
+				"trigger_object_type", params.Scenario.TriggerObjectType,
+				"eligible_pivot_fields", pure_utils.Map(eligible, func(e eligiblePivot) string { return e.pivot.Field }),
+				"selected_pivot_field", eligible[0].pivot.Field,
+				"selected_pivot_id", eligible[0].pivot.Id,
+				"object_id", params.ClientObject.Data["object_id"],
+			)
+		}
+
+		selectedPivot = eligible[0].pivot
+		pivotValue = &eligible[0].value
 	}
 
 	snoozes := make([]models.RuleSnooze, 0)

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -197,10 +197,24 @@ func (e ScenarioEvaluator) processScenarioIteration(
 	// Resolve which pivot applies to this row. Under polymorphic belongs_to at most one
 	// candidate pivot should resolve to a non-null value for a given row. We evaluate all
 	// candidates so we can detect the (unexpected) case where several are populated, and
-	// in that case pick one deterministically by pivot field name (alphanumeric order).
+	// in that case pick one deterministically by the pivot's start field (see below).
+	links := dataAccessor.DataModel.AllLinksAsMap()
+	// pivotStartField is the field the pivot value is read from on the trigger object: the
+	// belongs_to FK column for a path pivot, or the pivot field itself for a field pivot.
+	// We sort on this (the payload-side start of the pivot) rather than on pivot.Field,
+	// because path pivots typically all end at the parent's "object_id" field and so would
+	// not be distinguishable by their end field.
+	pivotStartField := func(p models.Pivot) string {
+		if len(p.PathLinkIds) == 0 {
+			return p.Field
+		}
+		return links[p.PathLinkIds[0]].ChildFieldName
+	}
+
 	type eligiblePivot struct {
-		pivot *models.Pivot
-		value string
+		pivot      *models.Pivot
+		value      string
+		startField string
 	}
 	var eligible []eligiblePivot
 	for i := range params.Pivots {
@@ -211,25 +225,33 @@ func (e ScenarioEvaluator) processScenarioIteration(
 				"error getting pivot value in EvalScenario")
 		}
 		if value != nil {
-			eligible = append(eligible, eligiblePivot{pivot: &params.Pivots[i], value: *value})
+			eligible = append(eligible, eligiblePivot{
+				pivot:      &params.Pivots[i],
+				value:      *value,
+				startField: pivotStartField(params.Pivots[i]),
+			})
 		}
 	}
 
 	var pivotValue *string
 	var selectedPivot *models.Pivot
 	if len(eligible) > 0 {
-		// Deterministic selection: alphanumeric order on the pivot field name.
-		slices.SortFunc(eligible, func(a, b eligiblePivot) int {
-			return strings.Compare(a.pivot.Field, b.pivot.Field)
+		// Deterministic selection: alphanumeric order on the start field, with the pivot id
+		// as a tiebreaker in case two pivots start from the same field.
+		slices.SortStableFunc(eligible, func(a, b eligiblePivot) int {
+			if c := strings.Compare(a.startField, b.startField); c != 0 {
+				return c
+			}
+			return strings.Compare(a.pivot.Id.String(), b.pivot.Id.String())
 		})
 
 		if len(eligible) > 1 {
 			utils.LoggerFromContext(ctx).InfoContext(ctx,
-				"multiple eligible pivot values present in payload; selecting deterministically by pivot field name",
+				"multiple eligible pivot values present in payload; selecting deterministically by pivot start field",
 				"scenario_id", params.Scenario.Id,
 				"trigger_object_type", params.Scenario.TriggerObjectType,
-				"eligible_pivot_fields", pure_utils.Map(eligible, func(e eligiblePivot) string { return e.pivot.Field }),
-				"selected_pivot_field", eligible[0].pivot.Field,
+				"eligible_pivot_start_fields", pure_utils.Map(eligible, func(e eligiblePivot) string { return e.startField }),
+				"selected_pivot_start_field", eligible[0].startField,
 				"selected_pivot_id", eligible[0].pivot.Id,
 				"object_id", params.ClientObject.Data["object_id"],
 			)

--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -45,8 +45,8 @@ type ScenarioEvaluationParameters struct {
 	TargetIterationId *string
 	ClientObject      models.ClientObject
 	DataModel         models.DataModel
-	// Pivots is the set of candidate pivots for the trigger table.
-	// The applicable one is resolved per row at evaluation time ("first non-null path wins").
+	// Pivots is the set of candidate pivots for the trigger table (polymorphic belongs_to:
+	// at most one applies per row). The applicable one is resolved per row at evaluation time.
 	Pivots           []models.Pivot
 	CachedScreenings map[string]models.ScreeningWithMatches
 	ConcurrentRules  int

--- a/usecases/org_import_usecase.go
+++ b/usecases/org_import_usecase.go
@@ -457,19 +457,30 @@ func (uc *OrgImportUsecase) createDataModel(ctx context.Context, tx repositories
 	}
 
 	// Step F: Reconcile pivots with the import spec.
-	// Each table has at most one pivot (unique index on organization_id + base_table_id).
-	// CreateDataModelTable may have auto-created a default pivot (object_id field-based or
-	// belongs_to path-based). If the import spec defines a different pivot for the same
-	// table, replace the auto-created one; if it matches, keep it.
+	// A table may have several pivots (polymorphic belongs_to: at most one applies per row).
+	// CreateDataModelTable / link creation may have auto-created pivots (a default object_id
+	// field pivot, or a belongs_to path pivot per link). For every table the spec mentions,
+	// the auto-created set is reconciled to exactly the spec set: matching pivots are kept
+	// (recording the ID mapping), spec pivots not present are created, and auto-created
+	// pivots absent from the spec are deleted (e.g. the default object_id pivot when the
+	// spec defines belongs_to pivots instead). Tables the spec does not mention keep their
+	// auto-created default. Hard delete is safe: import only runs on a new/empty org.
 	existingPivots, err := uc.dataModelRepository.ListPivots(ctx, tx, orgId, nil, false, false)
 	if err != nil {
 		return errors.Wrap(err, "failed to list existing pivots")
 	}
-	existingPivotByBaseTable := make(map[string]models.PivotMetadata, len(existingPivots))
+	existingPivotsByTable := make(map[string][]models.PivotMetadata, len(existingPivots))
 	for _, p := range existingPivots {
-		existingPivotByBaseTable[p.BaseTableId] = p
+		existingPivotsByTable[p.BaseTableId] = append(existingPivotsByTable[p.BaseTableId], p)
 	}
 
+	// Resolve the spec pivots into create inputs grouped by (resolved) base table id.
+	type resolvedPivot struct {
+		input  models.CreatePivotInput
+		sig    string
+		origId string
+	}
+	specPivotsByTable := make(map[string][]resolvedPivot, len(dataModel.Pivots))
 	for _, pivot := range dataModel.Pivots {
 		var fieldId *string
 		if pivot.FieldId != nil {
@@ -479,35 +490,49 @@ func (uc *OrgImportUsecase) createDataModel(ctx context.Context, tx repositories
 			return ids[id]
 		})
 		baseTableId := ids[pivot.BaseTableId]
+		specPivotsByTable[baseTableId] = append(specPivotsByTable[baseTableId], resolvedPivot{
+			input: models.CreatePivotInput{
+				OrganizationId: orgId,
+				BaseTableId:    baseTableId,
+				FieldId:        fieldId,
+				PathLinkIds:    pathLinkIds,
+			},
+			sig:    pivotSignature(baseTableId, fieldId, pathLinkIds),
+			origId: pivot.Id.String(),
+		})
+	}
 
-		newSig := pivotSignature(baseTableId, fieldId, pathLinkIds)
-		if existing, ok := existingPivotByBaseTable[baseTableId]; ok {
-			if pivotSignature(existing.BaseTableId, existing.FieldId, existing.PathLinkIds) == newSig {
-				// Auto-created pivot already matches the spec; keep it but record
-				// the ID mapping so downstream references resolve correctly.
-				ids[pivot.Id.String()] = existing.Id.String()
-				continue
-			}
-			// Auto-created pivot differs from the spec; delete it before creating the
-			// imported one to avoid the unique-constraint conflict on (org, base_table).
-			// Hard delete is safe here: import only runs on a new or empty organization,
-			// so no object can reference the pivot.
-			if err := uc.dataModelRepository.DeleteDataModelPivot(ctx, tx, existing.Id.String()); err != nil {
-				return errors.Wrapf(err, "failed to delete auto-created pivot for table %s", baseTableId)
+	for baseTableId, specPivots := range specPivotsByTable {
+		specSigs := make(map[string]struct{}, len(specPivots))
+		for _, sp := range specPivots {
+			specSigs[sp.sig] = struct{}{}
+		}
+
+		existingBySig := make(map[string]models.PivotMetadata, len(existingPivotsByTable[baseTableId]))
+		for _, ex := range existingPivotsByTable[baseTableId] {
+			sig := pivotSignature(ex.BaseTableId, ex.FieldId, ex.PathLinkIds)
+			existingBySig[sig] = ex
+			// Delete auto-created pivots that the spec does not define for this table.
+			if _, ok := specSigs[sig]; !ok {
+				if err := uc.dataModelRepository.DeleteDataModelPivot(ctx, tx, ex.Id.String()); err != nil {
+					return errors.Wrapf(err, "failed to delete auto-created pivot for table %s", baseTableId)
+				}
 			}
 		}
 
-		pivotId := pure_utils.NewId()
-		ids[pivot.Id.String()] = pivotId.String()
+		for _, sp := range specPivots {
+			if existing, ok := existingBySig[sp.sig]; ok {
+				// Auto-created pivot already matches the spec; keep it but record the
+				// ID mapping so downstream references resolve correctly.
+				ids[sp.origId] = existing.Id.String()
+				continue
+			}
 
-		err := uc.dataModelRepository.CreatePivot(ctx, tx, pivotId.String(), models.CreatePivotInput{
-			OrganizationId: orgId,
-			BaseTableId:    baseTableId,
-			FieldId:        fieldId,
-			PathLinkIds:    pathLinkIds,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to create pivot for table %s", baseTableId)
+			pivotId := pure_utils.NewId()
+			ids[sp.origId] = pivotId.String()
+			if err := uc.dataModelRepository.CreatePivot(ctx, tx, pivotId.String(), sp.input); err != nil {
+				return errors.Wrapf(err, "failed to create pivot for table %s", baseTableId)
+			}
 		}
 	}
 

--- a/usecases/worker_jobs/async_decision_job.go
+++ b/usecases/worker_jobs/async_decision_job.go
@@ -262,7 +262,7 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 	if err != nil {
 		return false, nil, nil, err
 	}
-	pivot := models.FindPivot(pivotsMeta, scenario.TriggerObjectType, dataModel)
+	pivots := models.FindPivotsForTable(pivotsMeta, scenario.TriggerObjectType, dataModel)
 
 	// list objects to score
 	db, err := w.executorFactory.NewClientDbExecutor(ctx, scenario.OrganizationId)
@@ -303,7 +303,7 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 		TargetIterationId: &args.ScenarioIterationId,
 		ClientObject:      object,
 		DataModel:         dataModel,
-		Pivot:             pivot,
+		Pivots:            pivots,
 	}
 
 	// Note: Statistics on test runs when using batch scenarios may still be slightly off, because the batch execution does a partial
@@ -325,7 +325,6 @@ func (w *AsyncDecisionWorker) createSingleDecisionForObjectId(
 			OrganizationId: scenario.OrganizationId,
 			Scenario:       scenario,
 			ClientObject:   object,
-			Pivot:          pivot,
 		}
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 		defer cancel()


### PR DESCRIPTION
- Allow a table to have multiple (link based) pivot values (AKA "belong to" links) configured. E.g. a transaction belongs to either a user or a company.
- Only one is computed at decision execution time. Info log + deterministic choice if there are more than 1 relevant values present in the payload
   - we can't just reject it, because the data model may have been modified to have multiple pivots after data was ingested, and we may create decisions on them via batch jobs
- otherwise, there should not be weird side effects at the backend level. The other invariantes related to this are about "a decision only has one pivot value".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple pivots with distinct configurations can now coexist per table
  * Transaction tables support multiple relationship configurations

* **Improvements**
  * Enhanced pivot selection logic to deterministically handle multiple candidates
  * Optimized validation for transaction table relationships

* **Database Changes**
  * Modified uniqueness constraints for pivot records to reflect new structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->