### PR TITLE
feat: restrict screening provider changes to Marble admins on managed deployments

### DIFF
--- a/mocks/enforce_security.go
+++ b/mocks/enforce_security.go
@@ -175,6 +175,11 @@ func (e *EnforceSecurity) EditOrganization(org models.Organization) error {
 	return args.Error(0)
 }
 
+func (e *EnforceSecurity) EditOrganizationScreeningProvider(org models.Organization, isManagedMarble bool) error {
+	args := e.Called(org, isManagedMarble)
+	return args.Error(0)
+}
+
 func (e *EnforceSecurity) DeleteOrganization() error {
 	args := e.Called()
 	return args.Error(0)

--- a/usecases/organization_usecase.go
+++ b/usecases/organization_usecase.go
@@ -40,6 +40,7 @@ type OrganizationUseCase struct {
 	executorFactory              executor_factory.ExecutorFactory
 	featureAccessReader          OrganizationUsecaseFeatureAccessReader
 	screeningConfigRepository    organizationUsecaseScreeningChecksRepository
+	isManagedMarble              bool
 }
 
 func NewOrganizationUseCase(
@@ -53,6 +54,7 @@ func NewOrganizationUseCase(
 	executorFactory executor_factory.ExecutorFactory,
 	featureAccessReader OrganizationUsecaseFeatureAccessReader,
 	screeningConfigRepository organizationUsecaseScreeningChecksRepository,
+	isManagedMarble bool,
 ) OrganizationUseCase {
 	return OrganizationUseCase{
 		enforceSecurity:              enforceSecurity,
@@ -65,6 +67,7 @@ func NewOrganizationUseCase(
 		executorFactory:              executorFactory,
 		featureAccessReader:          featureAccessReader,
 		screeningConfigRepository:    screeningConfigRepository,
+		isManagedMarble:              isManagedMarble,
 	}
 }
 
@@ -144,6 +147,10 @@ func (usecase *OrganizationUseCase) UpdateOrganization(
 
 		for feature, provider := range organization.ScreeningConfig.Providers {
 			if org.GetScreeningProviderFor(models.ScreeningFeature(feature)) != provider {
+				if err := usecase.enforceSecurity.EditOrganizationScreeningProvider(org, usecase.isManagedMarble); err != nil {
+					return models.Organization{}, err
+				}
+
 				switch feature {
 				case string(models.ScreeningFeatureTransactionMonitoring):
 					configExists, err := usecase.screeningConfigRepository.HasScreeningConfigs(ctx, tx, org.Id)

--- a/usecases/security/enforce_security_organization.go
+++ b/usecases/security/enforce_security_organization.go
@@ -1,9 +1,8 @@
 package security
 
 import (
-	"errors"
-
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 )
 
@@ -12,6 +11,7 @@ type EnforceSecurityOrganization interface {
 	ListOrganization() error
 	CreateOrganization() error
 	EditOrganization(org models.Organization) error
+	EditOrganizationScreeningProvider(org models.Organization, isManagedMarble bool) error
 	DeleteOrganization() error
 	ReadDataModel() error
 	WriteDataModel(organizationId uuid.UUID) error
@@ -40,6 +40,23 @@ func (e *EnforceSecurityOrganizationImpl) EditOrganization(org models.Organizati
 		e.Permission(models.ORGANIZATIONS_UPDATE),
 		e.ReadOrganization(org.Id),
 	)
+}
+
+// EditOrganizationScreeningProvider enforces the correct permissions for editing the screening provider,
+// depending on whether the deployment is managed by Marble or self-hosted.
+// For managed deployments, only Marble admins can change the screening provider.
+// For self-hosted deployments, the credentials are used to determine the authority.
+func (e *EnforceSecurityOrganizationImpl) EditOrganizationScreeningProvider(org models.Organization, isManagedMarble bool) error {
+	if isManagedMarble {
+		if e.Credentials.Role != models.MARBLE_ADMIN {
+			return errors.Wrap(
+				models.ForbiddenError,
+				"only marble admins can change the screening provider on managed deployments",
+			)
+		}
+		return nil
+	}
+	return e.EditOrganization(org)
 }
 
 func (e *EnforceSecurityOrganizationImpl) DeleteOrganization() error {

--- a/usecases/security/enforce_security_organization_test.go
+++ b/usecases/security/enforce_security_organization_test.go
@@ -1,0 +1,52 @@
+package security
+
+import (
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditScreeningProvider(t *testing.T) {
+	orgId := utils.TextToUUID("org")
+
+	tts := []struct {
+		name            string
+		role            models.Role
+		isManagedMarble bool
+		allowed         bool
+	}{
+		{"managed: marble admin can change provider", models.MARBLE_ADMIN, true, true},
+		{"managed: org admin cannot change provider", models.ADMIN, true, false},
+		{"managed: viewer cannot change provider", models.VIEWER, true, false},
+		{"self-hosted: org admin can change provider", models.ADMIN, false, true},
+		{"self-hosted: marble admin can change provider", models.MARBLE_ADMIN, false, true},
+		{"self-hosted: viewer cannot change provider (no ORGANIZATIONS_UPDATE)", models.VIEWER, false, false},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			creds := models.Credentials{
+				OrganizationId: orgId,
+				ActorIdentity:  models.Identity{UserId: "principal"},
+				Role:           tt.role,
+			}
+			e := EnforceSecurityOrganizationImpl{
+				EnforceSecurity: &EnforceSecurityImpl{Credentials: creds},
+				Credentials:     creds,
+			}
+
+			err := e.EditOrganizationScreeningProvider(models.Organization{Id: orgId}, tt.isManagedMarble)
+
+			if tt.allowed {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				assert.True(t, errors.Is(err, models.ForbiddenError),
+					"expected a ForbiddenError, got %v", err)
+			}
+		})
+	}
+}

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -365,6 +365,7 @@ func (usecases *UsecasesWithCreds) NewOrganizationUseCase() OrganizationUseCase 
 		usecases.NewExecutorFactory(),
 		usecases.NewFeatureAccessReader(),
 		usecases.Repositories.MarbleDbRepository,
+		usecases.license.IsManagedMarble,
 	)
 }
 


### PR DESCRIPTION
## What & why

Organizations choose a screening provider (OpenSanctions / LexisNexis) per feature via the `screening_providers` map, edited through `PATCH /organizations/:organization_id`. Today any org `ADMIN` (who holds `ORGANIZATIONS_UPDATE`) can change it.

This restricts that on **managed (SaaS)** deployments: only the **`MARBLE_ADMIN`** role may change the screening provider. On **self-hosted** deployments the org admin keeps the ability (still subject to the existing LexisNexis license-entitlement check).

## Approach

The rule is **mode-conditional** (MARBLE_ADMIN-only *on managed*; org admin allowed *on self-hosted*). A static role→permission table can't express that — a permission granted only to `MARBLE_ADMIN` would imply org admins never can, which is false for self-hosted. So it's a direct role check in a new `EnforceSecurityOrganization.EditScreeningProvider` method, matching the established Marble-admin pattern in `enforce_org_import_security.go`.

- Deployment mode (`IsManagedMarble`) is passed into the usecase **as a bool fact**, keeping `usecases/security/` free of any license/config dependency. This is the first authz check in that layer to branch on deployment mode.
- The check fires only when a provider value **actually changes**, so idempotent PATCHes that echo the current map, and edits to other org fields (timezone, thresholds, auto-assign), are unaffected.
- The self-hosted branch delegates to the existing `EditOrganization(org)`, making the method self-contained (both checks are pure in-memory).

## Behavior

| Deployment | Caller | Change provider? |
|---|---|---|
| Managed | org `ADMIN` | ❌ 403 |
| Managed | `MARBLE_ADMIN` | ✅ |
| Self-hosted | org `ADMIN` | ✅ |
| Any | no actual provider change | unaffected |

## Test plan

- New test covers managed/self-hosted × MARBLE_ADMIN / ADMIN / VIEWER

🤖 Generated with [Claude Code](https://claude.com/claude-code)