### PR TITLE
fix: continuous screening repo check the wrong key

### DIFF
--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -23,7 +23,7 @@ func (repo *MarbleDbRepository) GetContinuousScreeningConfig(ctx context.Context
 	sql := NewQueryBuilder().
 		Select(columnsNames("c", dbmodels.SelectContinuousScreeningConfigColumnList)...).
 		From(dbmodels.TABLE_CONTINUOUS_SCREENING_CONFIGS + " c").
-		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'transaction_monitoring', 'opensanctions')").
+		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'continuous_monitoring', 'opensanctions')").
 		Where(squirrel.Eq{"c.id": Id})
 
 	return SqlToModel(ctx, exec, sql, dbmodels.AdaptContinuousScreeningConfig)
@@ -41,7 +41,7 @@ func (repo *MarbleDbRepository) GetContinuousScreeningConfigByStableId(ctx conte
 		Select(columnsNames("c", dbmodels.SelectContinuousScreeningConfigColumnList)...).
 		From(dbmodels.TABLE_CONTINUOUS_SCREENING_CONFIGS + " c").
 		Where(squirrel.Eq{"stable_id": stableId}).
-		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'transaction_monitoring', 'opensanctions')").
+		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'continuous_monitoring', 'opensanctions')").
 		OrderBy("c.created_at DESC").
 		Limit(1)
 
@@ -125,7 +125,7 @@ func (repo *MarbleDbRepository) ListContinuousScreeningConfigs(
 		Select(columnsNames("c", dbmodels.SelectContinuousScreeningConfigColumnList)...).
 		From(dbmodels.TABLE_CONTINUOUS_SCREENING_CONFIGS + " c").
 		Where(squirrel.Eq{"enabled": true}).
-		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'transaction_monitoring', 'opensanctions')").
+		InnerJoin(dbmodels.TABLE_ORGANIZATION + " o on c.org_id = o.id and c.provider = coalesce(o.screening_providers->>'continuous_monitoring', 'opensanctions')").
 		OrderBy("c.id")
 
 	return SqlToListOfModels(ctx, exec, query, dbmodels.AdaptContinuousScreeningConfig)


### PR DESCRIPTION
When testing the continuous screening feature, I discovered a bug in our SQL query that filters the CS configuration based on the organization’s screening provider configuration. 
The SQL query incorrectly checks the `transaction_monitoring` key instead of the `continuous_monitoring` key. 
Consequently, it is not possible to create a new monitored object attached to Lexinexis CS configuration because it cannot be found (if the transaction monitoring is configured with OpenSanctions).

This fix corrects the key used in the SQL query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected continuous screening configuration queries to properly retrieve configurations from the correct data source, ensuring accurate continuous monitoring setup and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->