### PR TITLE
chore: use copy() for slice assignment in decision screening

### DIFF
--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -132,10 +132,7 @@ func (usecase *DecisionUsecase) GetDecision(ctx context.Context, decisionId stri
 	}
 
 	decision.ScreeningExecutions = make([]models.ScreeningWithMatches, len(scs))
-
-	for idx, sc := range scs {
-		decision.ScreeningExecutions[idx] = sc
-	}
+	copy(decision.ScreeningExecutions, scs)
 
 	return decision, nil
 }


### PR DESCRIPTION
Address linting warning by using the built-in `copy()` function instead of a manual loop for slice assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how decision screening results are copied into the final response, maintaining the same output while streamlining internal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->