### PR TITLE
fix: continuous screening use the entire dataset to screen new entity scope by object type

### DIFF
--- a/mocks/continuous_screening_repository.go
+++ b/mocks/continuous_screening_repository.go
@@ -446,6 +446,52 @@ func (m *ContinuousScreeningRepository) SetContinuousScreeningMatchEnriched(
 	return args.Error(0)
 }
 
+func (m *ContinuousScreeningRepository) GetEnrichedContinuousScreeningUpdateJob(
+	ctx context.Context,
+	exec repositories.Executor,
+	updateId uuid.UUID,
+) (models.EnrichedContinuousScreeningUpdateJob, error) {
+	args := m.Called(ctx, exec, updateId)
+	return args.Get(0).(models.EnrichedContinuousScreeningUpdateJob), args.Error(1)
+}
+
+func (m *ContinuousScreeningRepository) UpdateContinuousScreeningUpdateJob(
+	ctx context.Context,
+	exec repositories.Executor,
+	updateId uuid.UUID,
+	status models.ContinuousScreeningUpdateJobStatus,
+) error {
+	args := m.Called(ctx, exec, updateId, status)
+	return args.Error(0)
+}
+
+func (m *ContinuousScreeningRepository) GetContinuousScreeningJobOffset(
+	ctx context.Context,
+	exec repositories.Executor,
+	updateJobId uuid.UUID,
+) (*models.ContinuousScreeningJobOffset, error) {
+	args := m.Called(ctx, exec, updateJobId)
+	return args.Get(0).(*models.ContinuousScreeningJobOffset), args.Error(1)
+}
+
+func (m *ContinuousScreeningRepository) UpsertContinuousScreeningJobOffset(
+	ctx context.Context,
+	exec repositories.Executor,
+	offset models.CreateContinuousScreeningJobOffset,
+) error {
+	args := m.Called(ctx, exec, offset)
+	return args.Error(0)
+}
+
+func (m *ContinuousScreeningRepository) CreateContinuousScreeningJobError(
+	ctx context.Context,
+	exec repositories.Executor,
+	input models.CreateContinuousScreeningJobError,
+) error {
+	args := m.Called(ctx, exec, input)
+	return args.Error(0)
+}
+
 type ContinuousScreeningClientDbRepository struct {
 	mock.Mock
 }

--- a/models/opensanctions.go
+++ b/models/opensanctions.go
@@ -12,6 +12,10 @@ import (
 
 const OPEN_SANCTIONS_OUTDATED_DATASET_LEEWAY = 1 * time.Hour
 
+// FTM property used to tag an org-dataset entity with its source table name,
+// enabling per-config filtering in dataset-update queries.
+const ContinuousScreeningObjectTypeProperty = "programId"
+
 // Row structure representing a dataset in the OpenSanctions catalog
 // Note: I didn't declare all fields, only those needed for our logic, don't hesitate to add more if needed
 type OpenSanctionsRawDataset struct {
@@ -67,6 +71,10 @@ type OpenSanctionsQuery struct {
 	// cf: `exclude_entity_ids` in the OpenSanctions query
 	WhitelistedEntityIds []string
 	UseScopedIndex       bool
+	// Restrict matches to org-dataset entities from these source tables.
+	// Map to the `programId` property
+	// Empty = no restriction. Set only for dataset-update (direction B) queries.
+	ObjectTypes []string
 }
 
 type OpenSanctionsCheckQuery struct {

--- a/repositories/screening/provider_opensanctions.go
+++ b/repositories/screening/provider_opensanctions.go
@@ -46,10 +46,16 @@ func (p ScreeningOpenSanctionsProvider) SearchRequest(ctx context.Context,
 	}
 
 	for _, subquery := range query.Queries {
-		q.Queries[pure_utils.NewId().String()] = openSanctionsRequestQuery{
+		rq := openSanctionsRequestQuery{
 			Schema:     subquery.Type,
 			Properties: subquery.Filters,
 		}
+		if len(query.ObjectTypes) > 0 {
+			rq.Filters = map[string][][]string{
+				"properties." + models.ContinuousScreeningObjectTypeProperty: {query.ObjectTypes},
+			}
+		}
+		q.Queries[pure_utils.NewId().String()] = rq
 	}
 
 	scope := p.Config.Scope(models.ScreeningProviderOpenSanctions)

--- a/repositories/screening/screening_repository_test.go
+++ b/repositories/screening/screening_repository_test.go
@@ -2,6 +2,7 @@ package screening
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"
@@ -326,6 +327,53 @@ func TestOpenSanctionsSuccessfulFullResponseWithThresholdOverride(t *testing.T) 
 			t.Error("payloads did not contain required text")
 		}
 	}
+}
+
+func TestOpenSanctionsSearchRequest_ObjectTypesFilter(t *testing.T) {
+	repo := getMockedOpenSanctionsRepository("", "", "")
+	provider := repo.GetProvider(models.ScreeningProviderOpenSanctions)
+
+	baseQuery := models.OpenSanctionsQuery{
+		Queries: []models.OpenSanctionsCheckQuery{
+			{
+				Type:    "Person",
+				Filters: models.OpenSanctionsFilter{"name": []string{"John Doe"}},
+			},
+		},
+		OrgConfig: models.OrganizationOpenSanctionsConfig{},
+	}
+
+	t.Run("sets programId filter when ObjectTypes is non-empty", func(t *testing.T) {
+		query := baseQuery
+		query.ObjectTypes = []string{"person_A", "person_B"}
+
+		_, body, err := provider.SearchRequest(context.TODO(), &query)
+		assert.NoError(t, err)
+
+		var req openSanctionsRequest
+		assert.NoError(t, json.Unmarshal(body, &req))
+		assert.Len(t, req.Queries, 1)
+		for _, subquery := range req.Queries {
+			assert.Equal(t,
+				[][]string{{"person_A", "person_B"}},
+				subquery.Filters["properties."+models.ContinuousScreeningObjectTypeProperty],
+			)
+		}
+	})
+
+	t.Run("omits programId filter when ObjectTypes is empty", func(t *testing.T) {
+		query := baseQuery
+		query.ObjectTypes = nil
+
+		_, body, err := provider.SearchRequest(context.TODO(), &query)
+		assert.NoError(t, err)
+
+		var req openSanctionsRequest
+		assert.NoError(t, json.Unmarshal(body, &req))
+		for _, subquery := range req.Queries {
+			assert.Empty(t, subquery.Filters)
+		}
+	})
 }
 
 func TestDatasetOutdatedDetector(t *testing.T) {

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -506,6 +506,9 @@ func (w *ApplyDeltaFileWorker) buildOpenSanctionQuery(
 
 	// Upstream -> Organization record searches should not contain topics filters
 	delete(filters, "topics")
+	// programId is reserved on org-dataset entities to carry the source table name;
+	// strip it from the incoming record's scoring properties to avoid noise.
+	delete(filters, "programId")
 
 	return models.OpenSanctionsQuery{
 		OrgConfig: models.OrganizationOpenSanctionsConfig{
@@ -521,6 +524,7 @@ func (w *ApplyDeltaFileWorker) buildOpenSanctionQuery(
 		WhitelistedEntityIds: whitelistedEntityIds,
 		Scope:                orgCustomDatasetName(updateJob.OrgId),
 		Partition:            true,
+		ObjectTypes:          updateJob.Config.ObjectTypes,
 	}, nil
 }
 

--- a/usecases/continuous_screening/worker_apply_delta_file_test.go
+++ b/usecases/continuous_screening/worker_apply_delta_file_test.go
@@ -1,15 +1,19 @@
 package continuous_screening
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"strings"
 	"testing"
 	"testing/iotest"
 
+	"github.com/checkmarble/marble-backend/mocks"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories/httpmodels"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // matchesFilters (LexisNexis): a record matches when at least one enabled
@@ -114,4 +118,49 @@ func TestWork_JsonDecoderOffsetBehavior(t *testing.T) {
 	finalProgress := savedOffset + jsonReader2.InputOffset()
 	assert.Equal(t, int64(len(record1)+1+len(record2)+1+len(record3)), finalProgress,
 		"Phase 3 final progress should match records + intermediate newlines")
+}
+
+func TestBuildOpenSanctionQuery(t *testing.T) {
+	orgId := uuid.New()
+	repo := new(mocks.ContinuousScreeningRepository)
+	repo.On("SearchScreeningMatchWhitelistByIds", mock.Anything, mock.Anything,
+		orgId, mock.Anything, mock.Anything).
+		Return([]models.ScreeningWhitelist{}, nil)
+	worker := &ApplyDeltaFileWorker{repository: repo}
+
+	record := models.OpenSanctionsDeltaFileRecord{
+		Entity: models.OpenSanctionsDeltaFileEntity{
+			Id:     "entity-123",
+			Schema: "Person",
+			Properties: map[string][]string{
+				"name":      {"John Doe"},
+				"topics":    {"sanction"},
+				"programId": {"GlobalSanctions"},
+			},
+		},
+	}
+
+	job := models.EnrichedContinuousScreeningUpdateJob{
+		ContinuousScreeningUpdateJob: models.ContinuousScreeningUpdateJob{OrgId: orgId},
+		Config: models.ContinuousScreeningConfig{
+			OrgId:          orgId,
+			ObjectTypes:    []string{"person_A"},
+			MatchThreshold: 80,
+			MatchLimit:     50,
+		},
+	}
+
+	query, err := worker.buildOpenSanctionQuery(context.Background(), nil, job, record)
+	assert.NoError(t, err)
+
+	// ObjectTypes threaded from config
+	assert.Equal(t, []string{"person_A"}, query.ObjectTypes)
+
+	// programId stripped from scoring properties
+	assert.Empty(t, query.Queries[0].Filters["programId"],
+		"programId should be stripped from scoring properties")
+
+	// topics stripped too (existing behaviour)
+	assert.Empty(t, query.Queries[0].Filters["topics"],
+		"topics should be stripped from scoring properties")
 }

--- a/usecases/continuous_screening/worker_create_full_dataset.go
+++ b/usecases/continuous_screening/worker_create_full_dataset.go
@@ -820,6 +820,10 @@ func buildDatasetEntity(
 		}
 	}
 
+	// Tag the entity with its source table name so dataset-update queries can filter
+	// per-config using a hard keyword filter on properties.programId.
+	properties[models.ContinuousScreeningObjectTypeProperty] = []string{track.ObjectType}
+
 	// Add metadata in `notes` property
 	metadata := models.EntityNoteMetadata{
 		ObjectId:   track.ObjectId,

--- a/usecases/continuous_screening/worker_create_full_dataset_test.go
+++ b/usecases/continuous_screening/worker_create_full_dataset_test.go
@@ -287,6 +287,10 @@ func TestBuildDatasetEntity_Metadata(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "obj-123", metadata.ObjectId)
 	assert.Equal(t, "customer", metadata.ObjectType)
+
+	programIdVal, ok := result.Properties[models.ContinuousScreeningObjectTypeProperty]
+	assert.True(t, ok, "programId property should exist")
+	assert.Equal(t, []string{track.ObjectType}, programIdVal)
 }
 
 func TestGenerateNextVersion(t *testing.T) {


### PR DESCRIPTION
## Problem

When two tables (person_A, person_B) are both mapped to the same FTM entity type (Person) and each has its own screening config with a separate inbox, the dataset-update jobs mixed matches across tables. Alerts in inbox A would surface hits on entities that originated from person_B, and vice-versa.

Root cause: all org entities are indexed into a single Yente dataset (`marble_org_{orgId}`) with no per-table discriminator, and the dataset-update query had no filter to restrict results to the tables a given config actually monitors.

## Solution

Tag every indexed Marble entity with its source table name in the programId FTM property (a keyword-type field, exact hard-filterable in ES). Then, when a per-config dataset-update job builds its search query, inject a hard filter on `properties.programId` using the config's ObjectTypes.

- models/opensanctions.go — add `ContinuousScreeningObjectTypeProperty` constant and ObjectTypes []string field on OpenSanctionsQuery
- worker_create_full_dataset.go — write programId = [objectType] on every entity in full and delta dataset files
- worker_apply_delta_file.go — strip the incoming record's own programId from scoring properties (prevents noise); set ObjectTypes from config.ObjectTypes on the query
- provider_opensanctions.go — emit filters["properties.programId"] per subquery when ObjectTypes is non-empty; gated so all other OpenSanctions callers are unaffected

The filter uses the same hard-filter mechanism already used by the LexisNexis provider. No job-level redesign needed — jobs were already per-config.

## Notes

Existing indexed dataset files do not carry programId and will need a reindex script (separate follow-up) before the fix takes full effect in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Continuous screening queries can now filter by object type, enabling restriction to specific source tables.
  * Screening entities are now tagged with their source object type for improved data organization.

* **Tests**
  * Added tests validating object type filtering and entity source tagging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->