### PR TITLE
feat: serve full and delta file directly instead using signed URL

### DIFF
--- a/api/handle_continuous_screening.go
+++ b/api/handle_continuous_screening.go
@@ -8,7 +8,6 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/usecases/continuous_screening"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
@@ -409,7 +408,7 @@ func handleGetContinuousScreeningFull(uc usecases.Usecases) func(c *gin.Context)
 	}
 }
 
-func serveContinuousScreeningFileResult(c *gin.Context, result continuous_screening.ContinuousScreeningFileResult) {
+func serveContinuousScreeningFileResult(c *gin.Context, result models.ContinuousScreeningFileResult) {
 	if result.Blob != nil {
 		defer result.Blob.ReadCloser.Close()
 		c.Header("Content-Type", "application/x-ndjson")

--- a/api/handle_continuous_screening.go
+++ b/api/handle_continuous_screening.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/usecases/continuous_screening"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
@@ -378,12 +380,13 @@ func handleGetContinuousScreeningDelta(uc usecases.Usecases) func(c *gin.Context
 			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
 			return
 		}
+
 		usecase := uc.NewContinuousScreeningManifestUsecase()
-		url, err := usecase.GetContinuousScreeningDeltaUrl(ctx, orgId, deltaId)
+		result, err := usecase.GetContinuousScreeningDelta(ctx, orgId, deltaId)
 		if presentError(ctx, c, err) {
 			return
 		}
-		c.Redirect(http.StatusFound, url)
+		serveContinuousScreeningFileResult(c, result)
 	}
 }
 
@@ -398,10 +401,22 @@ func handleGetContinuousScreeningFull(uc usecases.Usecases) func(c *gin.Context)
 		}
 
 		usecase := uc.NewContinuousScreeningManifestUsecase()
-		url, err := usecase.GetContinuousScreeningFullUrl(ctx, orgId)
+		result, err := usecase.GetContinuousScreeningFull(ctx, orgId)
 		if presentError(ctx, c, err) {
 			return
 		}
-		c.Redirect(http.StatusFound, url)
+		serveContinuousScreeningFileResult(c, result)
 	}
+}
+
+func serveContinuousScreeningFileResult(c *gin.Context, result continuous_screening.ContinuousScreeningFileResult) {
+	if result.Blob != nil {
+		defer result.Blob.ReadCloser.Close()
+		c.Header("Content-Type", "application/x-ndjson")
+		if _, err := io.Copy(c.Writer, result.Blob.ReadCloser); err != nil {
+			_ = c.Error(err)
+		}
+		return
+	}
+	c.Redirect(http.StatusFound, result.RedirectURL)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -23,7 +23,8 @@ type ServerConfig struct {
 	otelSamplingRates            string
 	similarityThreshold          float64
 	enableTracing                bool
-	continuousScreeningBucketUrl string
+	continuousScreeningBucketUrl    string
+	csServeFilesDirectly            bool
 }
 
 func (config ServerConfig) Validate() error {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -231,6 +231,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		similarityThreshold:          utils.GetEnv("SIMILARITY_THRESHOLD", models.DEFAULT_SIMILARITY_THRESHOLD),
 		enableTracing:                utils.GetEnv("ENABLE_TRACING", false),
 		continuousScreeningBucketUrl: utils.GetEnv("CONTINUOUS_SCREENING_BUCKET_URL", ""),
+		csServeFilesDirectly:         utils.GetEnv("CONTINUOUS_SCREENING_SERVE_FILES_DIRECTLY", false),
 	}
 	if err := serverConfig.Validate(); err != nil {
 		utils.LogAndReportSentryError(ctx, err)
@@ -401,6 +402,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithAIAgentConfig(aiAgentConfig),
 		usecases.WithAnalyticsConfig(analyticsConfig),
 		usecases.WithContinuousScreeningBucketUrl(serverConfig.continuousScreeningBucketUrl),
+		usecases.WithCsServeFilesDirectly(serverConfig.csServeFilesDirectly),
 		usecases.WithMarbleApiInternalUrl(apiConfig.MarbleApiInternalUrl),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),

--- a/models/continuous_screening_files.go
+++ b/models/continuous_screening_files.go
@@ -1,5 +1,13 @@
 package models
 
+// ContinuousScreeningFileResult holds the result of a dataset file fetch.
+// Exactly one of RedirectURL or Blob is set depending on the server configuration.
+// When Blob is set, the caller is responsible for closing Blob.ReadCloser.
+type ContinuousScreeningFileResult struct {
+	RedirectURL string
+	Blob        *Blob
+}
+
 type ContinuousScreeningDeltaList struct {
 	Versions map[string]string `json:"versions"`
 }

--- a/usecases/continuous_screening/usecase_manifest.go
+++ b/usecases/continuous_screening/usecase_manifest.go
@@ -58,14 +58,6 @@ func NewContinuousScreeningManifestUsecase(
 	}
 }
 
-// ContinuousScreeningFileResult holds the result of a file fetch request.
-// Exactly one of RedirectURL or Blob is set depending on the server configuration.
-// When Blob is set, the caller is responsible for closing Blob.ReadCloser.
-type ContinuousScreeningFileResult struct {
-	RedirectURL string
-	Blob        *models.Blob
-}
-
 func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningCatalog(ctx context.Context) (models.CatalogResponse, error) {
 	exec := u.executorFactory.NewExecutor()
 
@@ -117,59 +109,59 @@ func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaList(
 func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningFull(
 	ctx context.Context,
 	orgId uuid.UUID,
-) (ContinuousScreeningFileResult, error) {
+) (models.ContinuousScreeningFileResult, error) {
 	exec := u.executorFactory.NewExecutor()
 
 	fullFile, err := u.repository.GetContinuousScreeningLatestDatasetFileByOrgId(ctx, exec, orgId,
 		models.ContinuousScreeningDatasetFileTypeFull)
 	if err != nil {
-		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get latest full dataset file")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get latest full dataset file")
 	}
 	if fullFile == nil {
-		return ContinuousScreeningFileResult{}, errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
 	}
 
 	if u.serveFilesDirectly {
 		blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
 		if err != nil {
-			return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read full dataset file blob")
+			return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read full dataset file blob")
 		}
-		return ContinuousScreeningFileResult{Blob: &blob}, nil
+		return models.ContinuousScreeningFileResult{Blob: &blob}, nil
 	}
 
 	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
 	if err != nil {
-		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for full dataset file")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for full dataset file")
 	}
-	return ContinuousScreeningFileResult{RedirectURL: url}, nil
+	return models.ContinuousScreeningFileResult{RedirectURL: url}, nil
 }
 
 func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDelta(
 	ctx context.Context,
 	orgId uuid.UUID,
 	deltaId uuid.UUID,
-) (ContinuousScreeningFileResult, error) {
+) (models.ContinuousScreeningFileResult, error) {
 	exec := u.executorFactory.NewExecutor()
 
 	delta, err := u.repository.GetContinuousScreeningDatasetFileById(ctx, exec, deltaId)
 	if err != nil {
-		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get continuous screening delta")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get continuous screening delta")
 	}
 	if delta.OrgId != orgId {
-		return ContinuousScreeningFileResult{}, errors.New("delta does not belong to the organization")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(models.ForbiddenError, "delta does not belong to the organization")
 	}
 
 	if u.serveFilesDirectly {
 		blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
 		if err != nil {
-			return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read delta file blob")
+			return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read delta file blob")
 		}
-		return ContinuousScreeningFileResult{Blob: &blob}, nil
+		return models.ContinuousScreeningFileResult{Blob: &blob}, nil
 	}
 
 	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
 	if err != nil {
-		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for delta file")
+		return models.ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for delta file")
 	}
-	return ContinuousScreeningFileResult{RedirectURL: url}, nil
+	return models.ContinuousScreeningFileResult{RedirectURL: url}, nil
 }

--- a/usecases/continuous_screening/usecase_manifest.go
+++ b/usecases/continuous_screening/usecase_manifest.go
@@ -37,6 +37,7 @@ type ContinuousScreeningManifestUsecase struct {
 	blobRepository               repositories.BlobRepository
 	marbleBackendUrl             string
 	continuousScreeningBucketUrl string
+	serveFilesDirectly           bool
 }
 
 func NewContinuousScreeningManifestUsecase(
@@ -45,6 +46,7 @@ func NewContinuousScreeningManifestUsecase(
 	blobRepository repositories.BlobRepository,
 	marbleBackendUrl string,
 	continuousScreeningBucketUrl string,
+	serveFilesDirectly bool,
 ) *ContinuousScreeningManifestUsecase {
 	return &ContinuousScreeningManifestUsecase{
 		executorFactory:              executorFactory,
@@ -52,7 +54,16 @@ func NewContinuousScreeningManifestUsecase(
 		blobRepository:               blobRepository,
 		marbleBackendUrl:             marbleBackendUrl,
 		continuousScreeningBucketUrl: continuousScreeningBucketUrl,
+		serveFilesDirectly:           serveFilesDirectly,
 	}
+}
+
+// ContinuousScreeningFileResult holds the result of a file fetch request.
+// Exactly one of RedirectURL or Blob is set depending on the server configuration.
+// When Blob is set, the caller is responsible for closing Blob.ReadCloser.
+type ContinuousScreeningFileResult struct {
+	RedirectURL string
+	Blob        *models.Blob
 }
 
 func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningCatalog(ctx context.Context) (models.CatalogResponse, error) {
@@ -103,50 +114,62 @@ func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaList(
 	}, nil
 }
 
-func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDeltaUrl(
+func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningFull(
 	ctx context.Context,
 	orgId uuid.UUID,
-	deltaId uuid.UUID,
-) (string, error) {
-	exec := u.executorFactory.NewExecutor()
-
-	delta, err := u.repository.GetContinuousScreeningDatasetFileById(ctx, exec, deltaId)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get continuous screening delta")
-	}
-
-	if delta.OrgId != orgId {
-		return "", errors.New("delta does not belong to the organization")
-	}
-
-	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to generate signed url for delta file")
-	}
-
-	return url, nil
-}
-
-func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningFullUrl(
-	ctx context.Context,
-	orgId uuid.UUID,
-) (string, error) {
+) (ContinuousScreeningFileResult, error) {
 	exec := u.executorFactory.NewExecutor()
 
 	fullFile, err := u.repository.GetContinuousScreeningLatestDatasetFileByOrgId(ctx, exec, orgId,
 		models.ContinuousScreeningDatasetFileTypeFull)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get latest full dataset file")
+		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get latest full dataset file")
+	}
+	if fullFile == nil {
+		return ContinuousScreeningFileResult{}, errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
 	}
 
-	if fullFile == nil {
-		return "", errors.Wrap(models.NotFoundError, "no full dataset file found for organization")
+	if u.serveFilesDirectly {
+		blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
+		if err != nil {
+			return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read full dataset file blob")
+		}
+		return ContinuousScreeningFileResult{Blob: &blob}, nil
 	}
 
 	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, fullFile.FilePath)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to generate signed url for full dataset file")
+		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for full dataset file")
+	}
+	return ContinuousScreeningFileResult{RedirectURL: url}, nil
+}
+
+func (u *ContinuousScreeningManifestUsecase) GetContinuousScreeningDelta(
+	ctx context.Context,
+	orgId uuid.UUID,
+	deltaId uuid.UUID,
+) (ContinuousScreeningFileResult, error) {
+	exec := u.executorFactory.NewExecutor()
+
+	delta, err := u.repository.GetContinuousScreeningDatasetFileById(ctx, exec, deltaId)
+	if err != nil {
+		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to get continuous screening delta")
+	}
+	if delta.OrgId != orgId {
+		return ContinuousScreeningFileResult{}, errors.New("delta does not belong to the organization")
 	}
 
-	return url, nil
+	if u.serveFilesDirectly {
+		blob, err := u.blobRepository.GetBlob(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
+		if err != nil {
+			return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to read delta file blob")
+		}
+		return ContinuousScreeningFileResult{Blob: &blob}, nil
+	}
+
+	url, err := u.blobRepository.GenerateSignedUrl(ctx, u.continuousScreeningBucketUrl, delta.FilePath)
+	if err != nil {
+		return ContinuousScreeningFileResult{}, errors.Wrap(err, "failed to generate signed url for delta file")
+	}
+	return ContinuousScreeningFileResult{RedirectURL: url}, nil
 }

--- a/usecases/continuous_screening/usecase_manifest_test.go
+++ b/usecases/continuous_screening/usecase_manifest_test.go
@@ -40,6 +40,7 @@ func (suite *ContinuousScreeningManifestTestSuite) makeUsecase() *ContinuousScre
 		suite.blobRepository,
 		suite.marbleBackendUrl,
 		suite.continuousScreeningBucketUrl,
+		false,
 	)
 }
 

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -48,6 +48,7 @@ type Usecases struct {
 	aiAgentConfig                infra.AIAgentConfiguration
 	analyticsConfig              infra.AnalyticsConfig
 	continuousScreeningBucketUrl string
+	csServeFilesDirectly         bool
 	marbleApiInternalUrl         string
 	csCreateFullDatasetInterval  time.Duration
 	webhookSystemMigrated        bool   // True when migrated to new internal webhook system
@@ -179,6 +180,12 @@ func WithContinuousScreeningBucketUrl(bucket string) Option {
 	}
 }
 
+func WithCsServeFilesDirectly(v bool) Option {
+	return func(o *options) {
+		o.csServeFilesDirectly = v
+	}
+}
+
 func WithMarbleApiInternalUrl(url string) Option {
 	return func(o *options) {
 		o.marbleApiInternalUrl = url
@@ -248,6 +255,7 @@ type options struct {
 	aiAgentConfig                infra.AIAgentConfiguration
 	analyticsConfig              infra.AnalyticsConfig
 	continuousScreeningBucketUrl string
+	csServeFilesDirectly         bool
 	marbleApiInternalUrl         string
 	csCreateFullDatasetInterval  time.Duration
 	webhookSystemMigrated        bool
@@ -287,6 +295,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		aiAgentConfig:                o.aiAgentConfig,
 		analyticsConfig:              o.analyticsConfig,
 		continuousScreeningBucketUrl: o.continuousScreeningBucketUrl,
+		csServeFilesDirectly:         o.csServeFilesDirectly,
 		marbleApiInternalUrl:         o.marbleApiInternalUrl,
 		csCreateFullDatasetInterval:  o.csCreateFullDatasetInterval,
 		webhookSystemMigrated:        o.webhookSystemMigrated,
@@ -639,6 +648,7 @@ func (usecases *Usecases) NewContinuousScreeningManifestUsecase() *continuous_sc
 		usecases.Repositories.BlobRepository,
 		usecases.marbleApiInternalUrl,
 		usecases.continuousScreeningBucketUrl,
+		usecases.csServeFilesDirectly,
 	)
 }
 


### PR DESCRIPTION
Instead of serving a signed URL for continuous screening files (delta and full) to the screening indexer, introduce a hidden variable to determine the handler’s behavior. This variable will decide whether to send a signed URL (default behavior) or directly serve the content when calling the endpoint.

This feature will be particularly useful for debugging the continuous screening functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Continuous screening endpoints can now stream dataset files directly as NDJSON, controlled by `CONTINUOUS_SCREENING_SERVE_FILES_DIRECTLY`.
  * Signed-URL behavior is preserved when inline serving is disabled.
* **Bug Fixes**
  * Improved error handling for missing latest full datasets and forbidden delta requests.
* **Refactor**
  * Updated continuous screening usecase APIs to return either a redirect URL or the file payload.
* **Tests**
  * Adjusted continuous screening usecase tests for the new configuration flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->