### PR TITLE
fix: offloaded match payload is not sent after a match update

### DIFF
--- a/usecases/screening_usecase.go
+++ b/usecases/screening_usecase.go
@@ -889,7 +889,15 @@ func (uc ScreeningUsecase) UpdateMatchStatus(
 		},
 	)
 
-	return updatedMatch, err
+	if err != nil {
+		return models.ScreeningMatch{}, err
+	}
+
+	matches := []models.ScreeningMatch{updatedMatch}
+	if err := uc.hydrateAndSortMatches(ctx, data.decision.OrganizationId, matches); err != nil {
+		return models.ScreeningMatch{}, err
+	}
+	return matches[0], nil
 }
 
 func (uc ScreeningUsecase) CreateWhitelist(ctx context.Context, exec repositories.Executor,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved match status updates so errors no longer return partial match data.
  * Successful updates now return a fully hydrated and properly ordered match, keeping displayed results consistent with the latest status and score.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->