### PR TITLE
WIP: more reliable batch exec

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -415,6 +415,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	river.AddWorker(workers, adminUc.NewCsvIngestionWorker())
 	river.AddWorker(workers, adminUc.NewAsyncUploadWorker())
 	river.AddWorker(workers, adminUc.NewScheduledExecutionWorker())
+	river.AddWorker(workers, adminUc.NewBatchExecutionCoordinatorWorker())
 	river.AddWorker(workers, adminUc.NewContinuousScreeningMatchEnrichmentWorker())
 	river.AddWorker(workers, adminUc.NewGenerateThumbnailWorker())
 

--- a/mocks/ingested_data_read_repository_mock.go
+++ b/mocks/ingested_data_read_repository_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"io"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -25,6 +26,13 @@ func (m *IngestedDataReader) ListAllObjectIdsFromTable(ctx context.Context,
 ) ([]string, error) {
 	args := m.Called(ctx, exec, tableName, filters)
 	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *IngestedDataReader) StreamAllObjectIdsFromTable(ctx context.Context,
+	exec repositories.Executor, w io.Writer, tableName string, filters ...models.Filter,
+) (int64, error) {
+	args := m.Called(ctx, exec, w, tableName, filters)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 func (m *IngestedDataReader) QueryIngestedObjectByInternalId(ctx context.Context,

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -166,6 +166,16 @@ func (m *TaskQueueRepository) EnqueueScheduledExecutionTask(
 	return args.Error(0)
 }
 
+func (m *TaskQueueRepository) EnqueueBatchExecutionCoordinator(
+	ctx context.Context,
+	tx repositories.Transaction,
+	organizationId uuid.UUID,
+	scheduledExecutionId string,
+) error {
+	args := m.Called(ctx, tx, organizationId, scheduledExecutionId)
+	return args.Error(0)
+}
+
 func (m *TaskQueueRepository) EnqueueGenerateThumbnailTask(
 	ctx context.Context,
 	tx repositories.Transaction,

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -221,8 +221,7 @@ type ScheduledExecutionArgs struct {
 
 func (ScheduledExecutionArgs) Kind() string { return "scheduled_execution" }
 
-// Batch execution coordinator (v2) - drives one scheduled execution by walking its GCS
-// manifest of object ids in batches, instead of fanning out one job + one row per object.
+// Drives one scheduled execution by walking its object-id manifest in blob storage in batches.
 type BatchExecutionCoordinatorArgs struct {
 	ScheduledExecutionId string `json:"scheduled_execution_id"`
 }

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -221,6 +221,14 @@ type ScheduledExecutionArgs struct {
 
 func (ScheduledExecutionArgs) Kind() string { return "scheduled_execution" }
 
+// Batch execution coordinator (v2) - drives one scheduled execution by walking its GCS
+// manifest of object ids in batches, instead of fanning out one job + one row per object.
+type BatchExecutionCoordinatorArgs struct {
+	ScheduledExecutionId string `json:"scheduled_execution_id"`
+}
+
+func (BatchExecutionCoordinatorArgs) Kind() string { return "batch_execution_coordinator" }
+
 // CSV ingestion job - processes a single upload log
 type CsvIngestionArgs struct {
 	UploadLogId      string           `json:"upload_log_id"`

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -23,7 +23,8 @@ type ScheduledExecution struct {
 	Scenario                   Scenario
 	Manual                     bool
 
-	// Batch execution v2 (manifest + coordinator). Zero/nil for legacy executions.
+	// Set when the execution is processed from an object-id manifest in blob storage. Nil/zero
+	// when it is processed with one decision row and job per object.
 	ManifestBlobKey       *string
 	ManifestByteOffset    int64
 	ManifestRowsProcessed int64

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -217,12 +217,6 @@ type ListDecisionsToCreateFilters struct {
 	Status               []DecisionToCreateStatus
 }
 
-// ScheduledExecutionFailedObject is one hard-failed object recorded by the v2 coordinator.
-type ScheduledExecutionFailedObject struct {
-	ObjectId string
-	Error    string
-}
-
 type DecisionToCreateCountMetadata struct {
 	Created                  int
 	TriggerConditionMismatch int

--- a/models/scheduled_scenario_executions.go
+++ b/models/scheduled_scenario_executions.go
@@ -22,6 +22,12 @@ type ScheduledExecution struct {
 	NumberOfPlannedDecisions   *int
 	Scenario                   Scenario
 	Manual                     bool
+
+	// Batch execution v2 (manifest + coordinator). Zero/nil for legacy executions.
+	ManifestBlobKey       *string
+	ManifestByteOffset    int64
+	ManifestRowsProcessed int64
+	Deadline              *time.Time
 }
 
 type PaginatedScheduledExecutions struct {
@@ -81,6 +87,20 @@ type UpdateScheduledExecutionStatusInput struct {
 type UpdateScheduledExecutionInput struct {
 	Id                       string
 	NumberOfPlannedDecisions *int
+	ManifestBlobKey          *string
+	Deadline                 *time.Time
+}
+
+// AdvanceScheduledExecutionManifestInput records progress of the v2 coordinator after a
+// batch is persisted: the manifest cursor and the running totals, written atomically with
+// the decision inserts so a crash resumes exactly where it left off. Values are absolute
+// (the coordinator is the single writer and tracks cumulative counts).
+type AdvanceScheduledExecutionManifestInput struct {
+	Id                         string
+	ManifestByteOffset         int64
+	ManifestRowsProcessed      int64
+	NumberOfCreatedDecisions   int
+	NumberOfEvaluatedDecisions int
 }
 
 type CreateScheduledExecutionInput struct {
@@ -194,6 +214,12 @@ const (
 type ListDecisionsToCreateFilters struct {
 	ScheduledExecutionId string
 	Status               []DecisionToCreateStatus
+}
+
+// ScheduledExecutionFailedObject is one hard-failed object recorded by the v2 coordinator.
+type ScheduledExecutionFailedObject struct {
+	ObjectId string
+	Error    string
 }
 
 type DecisionToCreateCountMetadata struct {

--- a/repositories/dbmodels/db_scheduled_executions.go
+++ b/repositories/dbmodels/db_scheduled_executions.go
@@ -21,6 +21,10 @@ type DBScheduledExecution struct {
 	NumberOfEvaluatedDecisions int        `db:"number_of_evaluated_decisions"`
 	NumberOfPlannedDecisions   *int       `db:"number_of_planned_decisions"`
 	Manual                     bool       `db:"manual"`
+	ManifestBlobKey            *string    `db:"manifest_blob_key"`
+	ManifestByteOffset         int64      `db:"manifest_byte_offset"`
+	ManifestRowsProcessed      int64      `db:"manifest_rows_processed"`
+	Deadline                   *time.Time `db:"deadline"`
 }
 
 const TABLE_SCHEDULED_EXECUTIONS = "scheduled_executions"
@@ -44,5 +48,9 @@ func AdaptScheduledExecution(db DBScheduledExecution, scenario models.Scenario,
 		NumberOfPlannedDecisions:   db.NumberOfPlannedDecisions,
 		Scenario:                   scenario,
 		Manual:                     db.Manual,
+		ManifestBlobKey:            db.ManifestBlobKey,
+		ManifestByteOffset:         db.ManifestByteOffset,
+		ManifestRowsProcessed:      db.ManifestRowsProcessed,
+		Deadline:                   db.Deadline,
 	}
 }

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"maps"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -294,6 +295,9 @@ func (repo *IngestedDataReadRepositoryImpl) ListAllObjectIdsFromTable(
 // StreamAllObjectIdsFromTable streams the matching object ids straight from the DB cursor
 // into w, one id per line, instead of materializing them all in memory. It returns the
 // number of ids written. Used to build the batch-execution manifest.
+//
+// Each id is written as a Go-quoted string (strconv.Quote) so that an id containing a newline
+// or other control character cannot break the one-id-per-line framing the reader relies on.
 func (repo *IngestedDataReadRepositoryImpl) StreamAllObjectIdsFromTable(
 	ctx context.Context,
 	exec Executor,
@@ -332,7 +336,7 @@ func (repo *IngestedDataReadRepositoryImpl) StreamAllObjectIdsFromTable(
 		if err = rows.Scan(&objectId); err != nil {
 			return 0, fmt.Errorf("error while scanning row: %w", err)
 		}
-		if _, err = buf.WriteString(objectId); err != nil {
+		if _, err = buf.WriteString(strconv.Quote(objectId)); err != nil {
 			return 0, fmt.Errorf("error while writing object id to manifest: %w", err)
 		}
 		if err = buf.WriteByte('\n'); err != nil {

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -1,8 +1,10 @@
 package repositories
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"maps"
 	"slices"
 	"time"
@@ -28,6 +30,13 @@ type IngestedDataReadRepository interface {
 		tableName string,
 		filters ...models.Filter,
 	) ([]string, error)
+	StreamAllObjectIdsFromTable(
+		ctx context.Context,
+		exec Executor,
+		w io.Writer,
+		tableName string,
+		filters ...models.Filter,
+	) (int64, error)
 	QueryIngestedObjectByInternalId(
 		ctx context.Context,
 		exec Executor,
@@ -280,6 +289,67 @@ func (repo *IngestedDataReadRepositoryImpl) ListAllObjectIdsFromTable(
 	}
 
 	return output, nil
+}
+
+// StreamAllObjectIdsFromTable streams the matching object ids straight from the DB cursor
+// into w, one id per line, instead of materializing them all in memory. It returns the
+// number of ids written. Used to build the batch-execution manifest.
+func (repo *IngestedDataReadRepositoryImpl) StreamAllObjectIdsFromTable(
+	ctx context.Context,
+	exec Executor,
+	w io.Writer,
+	tableName string,
+	filters ...models.Filter,
+) (int64, error) {
+	if err := validateClientDbExecutor(exec); err != nil {
+		return 0, err
+	}
+
+	qualifiedTableName := pgIdentifierWithSchema(exec, tableName)
+	q := NewQueryBuilder().
+		Select("object_id").
+		From(qualifiedTableName).
+		Where(rowIsValid(qualifiedTableName))
+	for _, f := range filters {
+		sql, args := f.ToSql()
+		q = q.Where(sql, args...)
+	}
+
+	sql, args, err := q.ToSql()
+	if err != nil {
+		return 0, fmt.Errorf("error while building SQL query: %w", err)
+	}
+	rows, err := exec.Query(ctx, sql, args...)
+	if err != nil {
+		return 0, fmt.Errorf("error while querying DB: %w", err)
+	}
+	defer rows.Close()
+
+	buf := bufio.NewWriter(w)
+	var count int64
+	var objectId string
+	for rows.Next() {
+		if err = rows.Scan(&objectId); err != nil {
+			return 0, fmt.Errorf("error while scanning row: %w", err)
+		}
+		if _, err = buf.WriteString(objectId); err != nil {
+			return 0, fmt.Errorf("error while writing object id to manifest: %w", err)
+		}
+		if err = buf.WriteByte('\n'); err != nil {
+			return 0, fmt.Errorf("error while writing object id to manifest: %w", err)
+		}
+		count++
+	}
+
+	if err = rows.Err(); err != nil {
+		return 0, fmt.Errorf("error while iterating over rows: %w", err)
+	}
+
+	if err = buf.Flush(); err != nil {
+		return 0, fmt.Errorf("error while flushing manifest writer: %w", err)
+	}
+
+	return count, nil
 }
 
 func (repo *IngestedDataReadRepositoryImpl) QueryIngestedObjectByInternalId(

--- a/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
+++ b/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+-- Scalable batch execution v2: a scheduled execution is driven by a single looping
+-- coordinator that walks a GCS manifest of object ids instead of fanning out one
+-- river job + one decisions_to_create row per object.
+--
+-- manifest_blob_key      : GCS key of the newline-delimited object-id manifest (NULL for the legacy path).
+-- manifest_byte_offset   : resume cursor into the manifest, always aligned to a line boundary.
+-- manifest_rows_processed : number of object ids consumed from the manifest so far.
+-- deadline               : wall-clock ceiling for the whole run; the only termination on sustained retryable failure.
+alter table scheduled_executions
+    add column manifest_blob_key       text,
+    add column manifest_byte_offset    bigint      not null default 0,
+    add column manifest_rows_processed bigint      not null default 0,
+    add column deadline                timestamptz;
+
+-- Lightweight sidecar for hard failures. The coordinator advances in-order and stops
+-- on a hard failure, so this stays small. No FK so deleting an execution never blocks
+-- on it and the type stays decoupled.
+create table scheduled_execution_failures (
+    id                     uuid        primary key default gen_random_uuid(),
+    scheduled_execution_id uuid        not null,
+    object_id              text        not null,
+    error                  text        not null,
+    created_at             timestamptz not null default now()
+);
+
+create index scheduled_execution_failures_exec_idx
+    on scheduled_execution_failures (scheduled_execution_id);
+
+-- +goose Down
+drop table scheduled_execution_failures;
+
+alter table scheduled_executions
+    drop column manifest_blob_key,
+    drop column manifest_byte_offset,
+    drop column manifest_rows_processed,
+    drop column deadline;

--- a/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
+++ b/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
@@ -1,12 +1,11 @@
 -- +goose Up
--- Scalable batch execution v2: a scheduled execution is driven by a single looping
--- coordinator that walks a GCS manifest of object ids instead of fanning out one
--- river job + one decisions_to_create row per object.
+-- Lets a scheduled execution be processed from a manifest of object ids in blob storage,
+-- walked by a single looping coordinator job.
 --
--- manifest_blob_key      : GCS key of the newline-delimited object-id manifest (NULL for the legacy path).
--- manifest_byte_offset   : resume cursor into the manifest, always aligned to a line boundary.
+-- manifest_blob_key       : blob key of the newline-delimited object-id manifest (NULL when not used).
+-- manifest_byte_offset    : resume cursor into the manifest, always aligned to a line boundary.
 -- manifest_rows_processed : number of object ids consumed from the manifest so far.
--- deadline               : wall-clock ceiling for the whole run; the only termination on sustained retryable failure.
+-- deadline                : wall-clock ceiling for the whole run.
 alter table scheduled_executions
     add column manifest_blob_key       text,
     add column manifest_byte_offset    bigint      not null default 0,

--- a/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
+++ b/repositories/migrations/20260626120000_scheduled_execution_manifest.sql
@@ -12,22 +12,7 @@ alter table scheduled_executions
     add column manifest_rows_processed bigint      not null default 0,
     add column deadline                timestamptz;
 
--- Lightweight sidecar for hard failures. The coordinator advances in-order and stops
--- on a hard failure, so this stays small. No FK so deleting an execution never blocks
--- on it and the type stays decoupled.
-create table scheduled_execution_failures (
-    id                     uuid        primary key default gen_random_uuid(),
-    scheduled_execution_id uuid        not null,
-    object_id              text        not null,
-    error                  text        not null,
-    created_at             timestamptz not null default now()
-);
-
-create index scheduled_execution_failures_exec_idx
-    on scheduled_execution_failures (scheduled_execution_id);
-
 -- +goose Down
-drop table scheduled_execution_failures;
 
 alter table scheduled_executions
     drop column manifest_blob_key,

--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -192,6 +192,60 @@ func (repo *MarbleDbRepository) UpdateScheduledExecution(
 		query = query.
 			Set("number_of_planned_decisions", *input.NumberOfPlannedDecisions)
 	}
+	if input.ManifestBlobKey != nil {
+		query = query.Set("manifest_blob_key", *input.ManifestBlobKey)
+	}
+	if input.Deadline != nil {
+		query = query.Set("deadline", *input.Deadline)
+	}
+
+	return ExecBuilder(ctx, exec, query)
+}
+
+// AdvanceScheduledExecutionManifest moves the v2 coordinator's manifest cursor and
+// progress counters forward. It is meant to run in the same transaction as the batch's
+// decision inserts so the offset and the persisted decisions commit together.
+func (repo *MarbleDbRepository) AdvanceScheduledExecutionManifest(
+	ctx context.Context,
+	exec Executor,
+	input models.AdvanceScheduledExecutionManifestInput,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_SCHEDULED_EXECUTIONS).
+		Set("manifest_byte_offset", input.ManifestByteOffset).
+		Set("manifest_rows_processed", input.ManifestRowsProcessed).
+		Set("number_of_created_decisions", input.NumberOfCreatedDecisions).
+		Set("number_of_evaluated_decisions", input.NumberOfEvaluatedDecisions).
+		Where("id = ?", input.Id)
+
+	return ExecBuilder(ctx, exec, query)
+}
+
+// InsertScheduledExecutionFailures records the object ids the coordinator could not
+// evaluate. The coordinator stops on hard failures, so this stays small.
+func (repo *MarbleDbRepository) InsertScheduledExecutionFailures(
+	ctx context.Context,
+	exec Executor,
+	scheduledExecutionId string,
+	failures []models.ScheduledExecutionFailedObject,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+
+	query := NewQueryBuilder().
+		Insert("scheduled_execution_failures").
+		Columns("scheduled_execution_id", "object_id", "error")
+	for _, f := range failures {
+		query = query.Values(scheduledExecutionId, f.ObjectId, f.Error)
+	}
 
 	return ExecBuilder(ctx, exec, query)
 }

--- a/repositories/scheduled_executions.go
+++ b/repositories/scheduled_executions.go
@@ -225,31 +225,6 @@ func (repo *MarbleDbRepository) AdvanceScheduledExecutionManifest(
 	return ExecBuilder(ctx, exec, query)
 }
 
-// InsertScheduledExecutionFailures records the object ids the coordinator could not
-// evaluate. The coordinator stops on hard failures, so this stays small.
-func (repo *MarbleDbRepository) InsertScheduledExecutionFailures(
-	ctx context.Context,
-	exec Executor,
-	scheduledExecutionId string,
-	failures []models.ScheduledExecutionFailedObject,
-) error {
-	if err := validateMarbleDbExecutor(exec); err != nil {
-		return err
-	}
-	if len(failures) == 0 {
-		return nil
-	}
-
-	query := NewQueryBuilder().
-		Insert("scheduled_execution_failures").
-		Columns("scheduled_execution_id", "object_id", "error")
-	for _, f := range failures {
-		query = query.Values(scheduledExecutionId, f.ObjectId, f.Error)
-	}
-
-	return ExecBuilder(ctx, exec, query)
-}
-
 func (repo *MarbleDbRepository) StoreDecisionsToCreate(
 	ctx context.Context,
 	exec Executor,

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -124,6 +124,12 @@ type TaskQueueRepository interface {
 		organizationId uuid.UUID,
 		scheduledExecutionId string,
 	) error
+	EnqueueBatchExecutionCoordinator(
+		ctx context.Context,
+		tx Transaction,
+		organizationId uuid.UUID,
+		scheduledExecutionId string,
+	) error
 	EnqueueContinuousScreeningMatchEnrichmentTask(
 		ctx context.Context,
 		tx Transaction,
@@ -668,6 +674,34 @@ func (r riverRepository) EnqueueScheduledExecutionTask(
 
 	logger := utils.LoggerFromContext(ctx)
 	logger.DebugContext(ctx, "Enqueued scheduled execution task",
+		"scheduled_execution_id", scheduledExecutionId, "job_id", res.Job.ID)
+	return nil
+}
+
+func (r riverRepository) EnqueueBatchExecutionCoordinator(
+	ctx context.Context,
+	tx Transaction,
+	organizationId uuid.UUID,
+	scheduledExecutionId string,
+) error {
+	res, err := r.client.InsertTx(ctx, tx.RawTx(), models.BatchExecutionCoordinatorArgs{
+		ScheduledExecutionId: scheduledExecutionId,
+	}, &river.InsertOpts{
+		// The coordinator loops to completion in a single run; errors are handled in-loop and
+		// it only returns an error on process shutdown, so a generous attempt count lets it
+		// resume from its committed offset across several deploys.
+		MaxAttempts: 30,
+		Queue:       organizationId.String(),
+		UniqueOpts: river.UniqueOpts{
+			ByArgs: true,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	logger := utils.LoggerFromContext(ctx)
+	logger.DebugContext(ctx, "Enqueued batch execution coordinator",
 		"scheduled_execution_id", scheduledExecutionId, "job_id", res.Job.ID)
 	return nil
 }

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -420,7 +420,34 @@ func (usecases *UsecasesWithCreds) NewRunScheduledExecution() worker_jobs.RunSch
 		usecases.NewTransactionFactory(),
 		usecases.Repositories.TaskQueueRepository,
 		usecases.Repositories.ScenarioPublicationRepository,
+		usecases.Repositories.BlobRepository,
+		usecases.offloadingBucketUrl,
 	)
+}
+
+func (usecases *UsecasesWithCreds) NewBatchExecutionCoordinator() *worker_jobs.BatchExecutionCoordinator {
+	c := worker_jobs.NewBatchExecutionCoordinator(
+		usecases.Repositories.MarbleDbRepository,
+		usecases.NewExecutorFactory(),
+		usecases.NewTransactionFactory(),
+		usecases.Repositories.MarbleDbRepository,
+		usecases.Repositories.IngestedDataReadRepository,
+		usecases.Repositories.MarbleDbRepository,
+		usecases.NewOffloadedReader(),
+		usecases.Repositories.BlobRepository,
+		usecases.offloadingBucketUrl,
+		usecases.NewWebhookEventsUsecase(),
+		usecases.NewScenarioFetcher(),
+		usecases.NewPhantomDecisionUseCase(),
+		usecases.NewScenarioEvaluator(),
+		usecases.Repositories.MarbleDbRepository,
+		usecases.Repositories.TaskQueueRepository,
+	)
+	return &c
+}
+
+func (usecases *UsecasesWithCreds) NewBatchExecutionCoordinatorWorker() *worker_jobs.BatchExecutionCoordinatorWorker {
+	return worker_jobs.NewBatchExecutionCoordinatorWorker(usecases.NewBatchExecutionCoordinator())
 }
 
 func (usecases *UsecasesWithCreds) NewScheduledExecutionUsecase() ScheduledExecutionUsecase {

--- a/usecases/worker_jobs/batch_execution_coordinator.go
+++ b/usecases/worker_jobs/batch_execution_coordinator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
+	"strconv"
 	"strings"
 	"time"
 
@@ -26,31 +27,34 @@ import (
 )
 
 const (
-	// batchExecBatchSize is the number of object ids read from the manifest per loop iteration.
+	// batchExecBatchSize is the number of decisions evaluated concurrently in a batch execution.
+	batchExecBatchSize = 20
+
+	// batchExecCommitBatchSize is the number of object ids read from the manifest per loop iteration.
 	// They are evaluated concurrently and the surviving decisions are inserted in a single
 	// transaction together with the manifest cursor advance. Kept small to bound the number of
 	// rows written per transaction.
-	batchExecBatchSize = 50
+	batchExecCommitBatchSize = 50
 
 	// batchExecPerIterTimeout caps a single loop iteration so a wedged DB/blob/screening
 	// call cannot hang the coordinator until the whole-job timeout. A timeout is retryable.
-	batchExecPerIterTimeout = 10 * time.Minute
+	batchExecPerIterTimeout = 1 * time.Minute
 
 	// batchExecDefaultRunDuration is the wall-clock budget for a whole run when no deadline
 	// was recorded at setup. The deadline is the only termination on sustained failure.
-	batchExecDefaultRunDuration = 12 * time.Hour
+	batchExecDefaultRunDuration = 9 * time.Minute
+
+	scheduledExecutionFullMaxRuntime = 24 * time.Hour
 
 	// Coordinator job timeout: must comfortably exceed the run deadline so River's stuck-job
 	// rescuer never double-runs a healthy coordinator.
-	batchExecJobTimeout = batchExecDefaultRunDuration + time.Hour
+	batchExecJobTimeout = batchExecDefaultRunDuration + batchExecPerIterTimeout + time.Second*20
 
-	batchExecBackoffBase  = 1 * time.Second
+	batchExecBackoffBase  = 5 * time.Second
 	batchExecBackoffCap   = 2 * time.Minute
 	batchExecSentryEveryN = 20
 )
 
-// batchCoordinatorRepository is the marble-db surface the coordinator needs. MarbleDbRepository
-// satisfies it.
 type batchCoordinatorRepository interface {
 	GetScheduledExecution(ctx context.Context, exec repositories.Executor, id string) (models.ScheduledExecution, error)
 	UpdateScheduledExecutionStatus(
@@ -63,18 +67,9 @@ type batchCoordinatorRepository interface {
 		exec repositories.Executor,
 		input models.AdvanceScheduledExecutionManifestInput,
 	) error
-	InsertScheduledExecutionFailures(
-		ctx context.Context,
-		exec repositories.Executor,
-		scheduledExecutionId string,
-		failures []models.ScheduledExecutionFailedObject,
-	) error
 	GetAnalyticsSettings(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (map[string]analytics.Settings, error)
 }
 
-// BatchExecutionCoordinator drives a single scheduled execution by walking an object-id
-// manifest in batches, evaluating and storing decisions, and advancing a resumable cursor in
-// the same transaction as the inserts.
 type BatchExecutionCoordinator struct {
 	repository                 batchCoordinatorRepository
 	executorFactory            executor_factory.ExecutorFactory
@@ -129,20 +124,6 @@ func NewBatchExecutionCoordinator(
 	}
 }
 
-// hardError marks a failure the coordinator must NOT retry: an invariant it checks itself, or
-// a recovered panic. Everything else is presumed retryable (a transient dependency error).
-type hardError struct{ err error }
-
-func (e hardError) Error() string { return e.err.Error() }
-func (e hardError) Unwrap() error { return e.err }
-
-func hardf(format string, args ...any) error { return hardError{errors.Newf(format, args...)} }
-
-func isHardError(err error) bool {
-	var h hardError
-	return errors.As(err, &h)
-}
-
 // batchInvariants holds the per-run context (scenario, data model, pivots, client DB handle)
 // loaded once and reused for every object in every batch, rather than reloaded per object.
 type batchInvariants struct {
@@ -163,8 +144,7 @@ type evalOutcome struct {
 	scenarioExecution models.ScenarioExecution
 	evalParams        evaluate_scenario.ScenarioEvaluationParameters
 	object            models.ClientObject
-	retryErr          error
-	hardErr           error
+	error             error
 }
 
 type BatchExecutionCoordinatorWorker struct {
@@ -193,32 +173,40 @@ func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionI
 	ctx = utils.StoreLoggerInContext(ctx, logger)
 	exec := c.executorFactory.NewExecutor()
 
-	se, err := c.repository.GetScheduledExecution(ctx, exec, scheduledExecutionId)
+	setupCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	defer cancel()
+
+	se, err := c.repository.GetScheduledExecution(setupCtx, exec, scheduledExecutionId)
 	if err != nil {
 		return errors.Wrap(err, "could not load scheduled execution in batch coordinator")
 	}
 	if se.ManifestBlobKey == nil {
 		// Invariant: the coordinator only ever runs for v2 executions, which always have a
 		// manifest. Mark failed rather than spin.
-		return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, []models.ScheduledExecutionFailedObject{
-			{ObjectId: "(setup)", Error: "batch coordinator started for an execution without a manifest"},
-		})
+		return c.markFailed(ctx, se.Id, errors.New("batch coordinator started for an execution without a manifest"))
 	}
 
-	inv, err := c.loadInvariants(ctx, exec, se)
-	if err != nil {
-		if isHardError(err) {
-			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, []models.ScheduledExecutionFailedObject{
-				{ObjectId: "(setup)", Error: err.Error()},
-			})
+	if se.Deadline == nil {
+		return c.markFailed(ctx, se.Id, errors.New("invariant violated: job scheduled for v2 batch execution must have a deadline set"))
+	}
+
+	// A context timeout during the job execution leads to a snooze and retry, the next execution can mark it as failed if the deadline is passed
+	if time.Now().After(*se.Deadline) {
+		if se.ManifestRowsProcessed >= int64(*se.NumberOfPlannedDecisions) {
+			return c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{Id: se.Id, Status: models.ScheduledExecutionSuccess})
+		} else {
+			logger.InfoContext(ctx, "Scheduled execution not completed after the deadline, marking as failed")
+			return c.markFailed(ctx, se.Id, errors.New("Scheduled execution not completed after the deadline"))
 		}
+	}
+
+	inv, err := c.loadInvariants(setupCtx, exec, se)
+	if err != nil {
 		return errors.Wrap(err, "could not load batch invariants")
 	}
 
-	deadline := time.Now().Add(batchExecDefaultRunDuration)
-	if se.Deadline != nil {
-		deadline = *se.Deadline
-	}
+	ctx, cancel = context.WithTimeout(ctx, batchExecDefaultRunDuration)
+	defer cancel()
 
 	var planned int64
 	if se.NumberOfPlannedDecisions != nil {
@@ -230,32 +218,46 @@ func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionI
 	created := se.NumberOfCreatedDecisions
 	evaluated := se.NumberOfEvaluatedDecisions
 	consecutiveFailures := 0
-	var lastErr error
+
+	// Keep a single manifest reader open across the slice and read batches sequentially from it,
+	// rather than reopening the blob for every batch. The reader is reopened only when it is nil:
+	// at slice start, and after any error that leaves the offset unadvanced (the reader has by
+	// then consumed bytes past the committed offset, so it must be re-seeked there).
+	var manifestCloser io.Closer
+	var manifestReader *bufio.Reader
+	defer func() {
+		if manifestCloser != nil {
+			_ = manifestCloser.Close()
+		}
+	}()
+	resetManifestReader := func() {
+		if manifestCloser != nil {
+			_ = manifestCloser.Close()
+			manifestCloser = nil
+		}
+		manifestReader = nil
+	}
+	openManifestReader := func() error {
+		blob, err := c.blobRepository.GetBlob(ctx, c.manifestBucketUrl, *se.ManifestBlobKey,
+			repositories.WithBeginOffset(offset))
+		if err != nil {
+			return errors.Wrapf(err, "could not open manifest %s at offset %d", *se.ManifestBlobKey, offset)
+		}
+		manifestCloser = blob.ReadCloser
+		manifestReader = bufio.NewReader(blob.ReadCloser)
+		return nil
+	}
 
 	for {
 		if ctx.Err() != nil {
-			// Process shutting down (deploy). Return the error so River reschedules and we
-			// resume from the committed offset.
-			return ctx.Err()
+			logger.InfoContext(ctx, fmt.Sprintf("Per-job timeout of %s reached for scheduled execution coordinator job, snoozing 5 sec before reexecuting", batchExecDefaultRunDuration))
+			return river.JobSnooze(time.Second * 5)
 		}
 
-		if time.Now().After(deadline) {
-			logger.WarnContext(ctx, "batch execution reached its deadline before completing, marking failed")
-			marker := "(deadline)"
-			errStr := "run deadline exceeded"
-			if lastErr != nil {
-				errStr = fmt.Sprintf("run deadline exceeded, last error: %s", lastErr.Error())
-			}
-			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure,
-				[]models.ScheduledExecutionFailedObject{{ObjectId: marker, Error: errStr}})
-		}
-
-		// Re-read status before each batch so a cancellation (status flipped away from
-		// Processing) stops the run promptly. One job to stop, not N.
+		// Re-read status before each batch so a cancellation (status flipped away from processing) stops the run promptly.
 		current, err := c.repository.GetScheduledExecution(ctx, exec, scheduledExecutionId)
 		if err != nil {
-			lastErr = err
-			c.handleRetryable(ctx, err, &consecutiveFailures)
+			c.logAndSleepWithBackoff(ctx, err, &consecutiveFailures)
 			continue
 		}
 		if current.Status != models.ScheduledExecutionProcessing {
@@ -266,42 +268,43 @@ func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionI
 
 		if rows >= planned {
 			logger.InfoContext(ctx, fmt.Sprintf("batch execution complete: %d decisions created, %d evaluated", created, evaluated))
-			return c.finalize(ctx, exec, se, models.ScheduledExecutionSuccess, nil)
+			return c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{Id: se.Id, Status: models.ScheduledExecutionSuccess})
 		}
 
-		// One per-iteration context bounds the whole iteration — manifest read, concurrent
-		// evaluation, and the persistence transaction — so no single wedged operation hangs the
-		// coordinator until the whole-job timeout. Derived from the job ctx so a deploy still
-		// propagates cancellation. A timeout here is just another retryable error.
-		batchCtx, cancel := context.WithTimeout(ctx, batchExecPerIterTimeout)
+		if manifestReader == nil {
+			if err := openManifestReader(); err != nil {
+				c.logAndSleepWithBackoff(ctx, err, &consecutiveFailures)
+				continue
+			}
+		}
 
-		ids, newOffset, err := c.readManifestBatch(batchCtx, *se.ManifestBlobKey, offset, batchExecBatchSize)
+		ids, consumed, err := readManifestBatch(manifestReader, batchExecCommitBatchSize)
 		if err != nil {
-			cancel()
-			lastErr = err
-			c.handleRetryable(ctx, err, &consecutiveFailures)
+			resetManifestReader()
+			c.logAndSleepWithBackoff(ctx, err, &consecutiveFailures)
 			continue
 		}
 		if len(ids) == 0 {
 			// Manifest drained earlier than the planned count predicted. Finalize rather than
 			// loop forever; log because counts should have matched.
-			cancel()
 			logger.WarnContext(ctx, fmt.Sprintf(
 				"manifest exhausted at %d rows but %d were planned; finalizing", rows, planned))
-			return c.finalize(ctx, exec, se, models.ScheduledExecutionSuccess, nil)
+			return c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{Id: se.Id, Status: models.ScheduledExecutionSuccess})
 		}
+		newOffset := offset + consumed
 
-		results, hardFailures, retryErr := c.evaluateBatch(batchCtx, inv, ids)
+		// One per-iteration context bounds evaluation and the persistence transaction — so no
+		// single wedged operation hangs the coordinator until the whole-job timeout. Derived from
+		// the job ctx so a deploy still propagates cancellation. A timeout here is retryable.
+		batchCtx, cancel := context.WithTimeout(ctx, batchExecPerIterTimeout)
+
+		results, retryErr := c.evaluateBatch(batchCtx, inv, ids)
 		if retryErr != nil {
 			cancel()
-			lastErr = retryErr
-			c.handleRetryable(ctx, retryErr, &consecutiveFailures)
+			// Offset is not advanced, so the reader (now past this batch) must re-seek to it.
+			resetManifestReader()
+			c.logAndSleepWithBackoff(ctx, retryErr, &consecutiveFailures)
 			continue
-		}
-		if len(hardFailures) > 0 {
-			cancel()
-			logger.ErrorContext(ctx, fmt.Sprintf("hard failure evaluating batch, marking execution failed: %s", hardFailures[0].Error))
-			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, hardFailures)
 		}
 
 		batchCreated := 0
@@ -342,10 +345,10 @@ func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionI
 		})
 		cancel()
 		if err != nil {
-			// Store or advance failed: nothing committed, do not advance our cursors. Retry the
-			// same batch after backoff.
-			lastErr = err
-			c.handleRetryable(ctx, err, &consecutiveFailures)
+			// Store or advance failed: nothing committed, do not advance our cursors. The reader
+			// has consumed this batch, so re-seek it to the committed offset and retry.
+			resetManifestReader()
+			c.logAndSleepWithBackoff(ctx, err, &consecutiveFailures)
 			continue
 		}
 
@@ -355,7 +358,6 @@ func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionI
 		created += batchCreated
 		evaluated += batchEvaluated
 		consecutiveFailures = 0
-		lastErr = nil
 
 		for _, wid := range webhookIds {
 			c.webhookEventsSender.SendWebhookEventAsync(ctx, wid)
@@ -383,8 +385,14 @@ func (c *BatchExecutionCoordinator) loadInvariants(
 	}
 	table, ok := dataModel.Tables[scenario.TriggerObjectType]
 	if !ok {
-		return batchInvariants{}, hardf(
-			"trigger object type %s not found in data model", scenario.TriggerObjectType)
+		err = c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{
+			Id:     se.Id,
+			Status: models.ScheduledExecutionFailure,
+		})
+		if err != nil {
+			utils.LogAndReportSentryError(ctx, err)
+		}
+		return batchInvariants{}, river.JobCancel(err)
 	}
 
 	pivotsMeta, err := c.dataModelRepository.ListPivots(ctx, exec, scenario.OrganizationId, nil, true, false)
@@ -409,52 +417,41 @@ func (c *BatchExecutionCoordinator) loadInvariants(
 	}, nil
 }
 
-// readManifestBatch reads up to batchSize object ids from the manifest starting at a
-// line-aligned byte offset, returning the ids and the new (still line-aligned) offset.
-func (c *BatchExecutionCoordinator) readManifestBatch(
-	ctx context.Context,
-	key string,
-	offset int64,
-	batchSize int,
-) (ids []string, newOffset int64, err error) {
-	blob, err := c.blobRepository.GetBlob(ctx, c.manifestBucketUrl, key, repositories.WithBeginOffset(offset))
-	if err != nil {
-		return nil, offset, errors.Wrapf(err, "could not open manifest %s at offset %d", key, offset)
-	}
-	defer blob.ReadCloser.Close()
-
-	reader := bufio.NewReader(blob.ReadCloser)
-	consumed := int64(0)
+// readManifestBatch reads up to batchSize object ids from reader and returns them along with
+// the number of bytes consumed, so the caller can advance its byte offset. Each manifest line
+// is a Go-quoted id (see StreamAllObjectIdsFromTable); reads stop at EOF or batchSize.
+func readManifestBatch(reader *bufio.Reader, batchSize int) (ids []string, consumed int64, err error) {
 	ids = make([]string, 0, batchSize)
 	for len(ids) < batchSize {
 		line, readErr := reader.ReadString('\n')
 		if len(line) > 0 {
 			consumed += int64(len(line))
 			if trimmed := strings.TrimRight(line, "\n"); trimmed != "" {
-				ids = append(ids, trimmed)
+				id, unquoteErr := strconv.Unquote(trimmed)
+				if unquoteErr != nil {
+					return nil, 0, errors.Wrapf(unquoteErr, "corrupt manifest line %q", trimmed)
+				}
+				ids = append(ids, id)
 			}
 		}
 		if readErr == io.EOF {
 			break
 		}
 		if readErr != nil {
-			return nil, offset, errors.Wrapf(readErr, "error reading manifest %s", key)
+			return nil, 0, errors.Wrap(readErr, "error reading manifest")
 		}
 	}
 
-	return ids, offset + consumed, nil
+	return ids, consumed, nil
 }
 
-// evaluateBatch evaluates every object in the batch concurrently (P = K), outside any
-// transaction so the screening HTTP calls never hold a tx open. Classification: a retryable
-// error anywhere aborts the whole batch for retry (precedence over hard failures, since a
-// genuine hard failure recurs and is caught once the transient one clears); hard failures
-// (invariants, recovered panics) stop the run.
 func (c *BatchExecutionCoordinator) evaluateBatch(
 	ctx context.Context,
 	inv batchInvariants,
 	ids []string,
-) (results []evalOutcome, hardFailures []models.ScheduledExecutionFailedObject, retryErr error) {
+) (results []evalOutcome, err error) {
+	batchCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	outcomes := make([]evalOutcome, len(ids))
 	var g errgroup.Group
 	g.SetLimit(batchExecBatchSize)
@@ -462,10 +459,14 @@ func (c *BatchExecutionCoordinator) evaluateBatch(
 		g.Go(func() (err error) {
 			defer func() {
 				if r := recover(); r != nil {
-					outcomes[i] = evalOutcome{objectId: id, hardErr: hardf("panic evaluating object %s: %v", id, r)}
+					outcomes[i] = evalOutcome{objectId: id, error: errors.Newf("panic evaluating object %s: %v", id, r)}
 				}
 			}()
-			outcomes[i] = c.evaluateObject(ctx, inv, id)
+			outcomes[i] = c.evaluateObject(batchCtx, inv, id)
+			if outcomes[i].error != nil {
+				// on any error, cancel the context. The whole batch is retried
+				cancel()
+			}
 			return nil
 		})
 	}
@@ -473,24 +474,20 @@ func (c *BatchExecutionCoordinator) evaluateBatch(
 
 	for _, o := range outcomes {
 		switch {
-		case o.retryErr != nil:
-			if retryErr == nil {
-				retryErr = o.retryErr
+		case o.error != nil:
+			// any error will cause some more context canceled errors because they cancel the context -- preferably keep the initial error and return it
+			if err == nil || !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+				err = o.error
 			}
-		case o.hardErr != nil:
-			hardFailures = append(hardFailures, models.ScheduledExecutionFailedObject{
-				ObjectId: o.objectId,
-				Error:    o.hardErr.Error(),
-			})
 		default:
 			results = append(results, o)
 		}
 	}
 
-	if retryErr != nil {
-		return nil, nil, retryErr
+	if err != nil {
+		return nil, err
 	}
-	return results, hardFailures, nil
+	return results, nil
 }
 
 func (c *BatchExecutionCoordinator) evaluateObject(
@@ -500,7 +497,7 @@ func (c *BatchExecutionCoordinator) evaluateObject(
 ) evalOutcome {
 	objectMap, err := c.ingestedDataReadRepository.QueryIngestedObject(ctx, inv.clientDb, inv.table, objectId)
 	if err != nil {
-		return evalOutcome{objectId: objectId, retryErr: errors.Wrapf(err, "error querying ingested object %s", objectId)}
+		return evalOutcome{objectId: objectId, error: errors.Wrapf(err, "error querying ingested object %s", objectId)}
 	}
 	if len(objectMap) == 0 {
 		utils.LogAndReportSentryError(ctx, errors.Newf("object %s not found in table %s", objectId, inv.table.Name))
@@ -535,7 +532,7 @@ func (c *BatchExecutionCoordinator) evaluateObject(
 
 	triggerPassed, scenarioExecution, err := c.scenarioEvaluator.EvalScenario(ctx, evalParams)
 	if err != nil {
-		return evalOutcome{objectId: objectId, retryErr: errors.Wrapf(err, "error evaluating scenario for object %s", objectId)}
+		return evalOutcome{objectId: objectId, error: errors.Wrapf(err, "error evaluating scenario for object %s", objectId)}
 	}
 
 	return evalOutcome{
@@ -639,30 +636,29 @@ func (c *BatchExecutionCoordinator) testRunCallback(
 	}
 }
 
-// finalize sets the terminal status (and records any hard failures) for the run.
-func (c *BatchExecutionCoordinator) finalize(
+func (c *BatchExecutionCoordinator) markFailed(
 	ctx context.Context,
-	exec repositories.Executor,
-	se models.ScheduledExecution,
-	status models.ScheduledExecutionStatus,
-	failures []models.ScheduledExecutionFailedObject,
+	id string,
+	err error,
 ) error {
-	if len(failures) > 0 {
-		if err := c.repository.InsertScheduledExecutionFailures(ctx, exec, se.Id, failures); err != nil {
-			utils.LogAndReportSentryError(ctx, errors.Wrap(err, "could not record batch execution failures"))
-		}
-	}
-
-	return c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{
-		Id:     se.Id,
-		Status: status,
+	repoErr := c.repository.UpdateScheduledExecutionStatus(ctx, c.executorFactory.NewExecutor(), models.UpdateScheduledExecutionStatusInput{
+		Id:     id,
+		Status: models.ScheduledExecutionFailure,
 	})
+	if repoErr != nil {
+		utils.LogAndReportSentryError(ctx, repoErr)
+	}
+	return river.JobCancel(err)
 }
 
-// handleRetryable keeps the run in the loop on a presumed-retryable error: log every time,
+// logAndSleepWithBackoff keeps the run in the loop on a presumed-retryable error: log every time,
 // report to Sentry throttled, and back off (ctx-aware) before retrying the same offset. The
 // deadline check is what eventually terminates a run that never recovers.
-func (c *BatchExecutionCoordinator) handleRetryable(ctx context.Context, err error, consecutiveFailures *int) {
+func (c *BatchExecutionCoordinator) logAndSleepWithBackoff(ctx context.Context, err error, consecutiveFailures *int) {
+	// return early on canceled context, it is handled at the beginning of the loop
+	if ctx.Err() != nil {
+		return
+	}
 	*consecutiveFailures++
 	logger := utils.LoggerFromContext(ctx)
 	logger.ErrorContext(ctx, fmt.Sprintf("retryable error in batch coordinator (consecutive: %d): %s",

--- a/usecases/worker_jobs/batch_execution_coordinator.go
+++ b/usecases/worker_jobs/batch_execution_coordinator.go
@@ -26,10 +26,10 @@ import (
 )
 
 const (
-	// batchExecBatchSize is the number of object ids read from the manifest per loop
-	// iteration. They are evaluated concurrently (P = K) and the surviving decisions are
-	// inserted in a single transaction together with the manifest cursor advance. Kept well
-	// under the ~100 ceiling to bound per-transaction write pressure.
+	// batchExecBatchSize is the number of object ids read from the manifest per loop iteration.
+	// They are evaluated concurrently and the surviving decisions are inserted in a single
+	// transaction together with the manifest cursor advance. Kept small to bound the number of
+	// rows written per transaction.
 	batchExecBatchSize = 50
 
 	// batchExecPerIterTimeout caps a single loop iteration so a wedged DB/blob/screening
@@ -50,7 +50,7 @@ const (
 )
 
 // batchCoordinatorRepository is the marble-db surface the coordinator needs. MarbleDbRepository
-// satisfies it. Deliberately leaner than asyncDecisionWorkerRepository: no decisions_to_create.
+// satisfies it.
 type batchCoordinatorRepository interface {
 	GetScheduledExecution(ctx context.Context, exec repositories.Executor, id string) (models.ScheduledExecution, error)
 	UpdateScheduledExecutionStatus(
@@ -72,9 +72,9 @@ type batchCoordinatorRepository interface {
 	GetAnalyticsSettings(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (map[string]analytics.Settings, error)
 }
 
-// BatchExecutionCoordinator drives a single scheduled execution (v2 path): it walks the
-// object-id manifest in batches, evaluating and storing decisions, advancing a resumable
-// cursor in the same transaction as the inserts.
+// BatchExecutionCoordinator drives a single scheduled execution by walking an object-id
+// manifest in batches, evaluating and storing decisions, and advancing a resumable cursor in
+// the same transaction as the inserts.
 type BatchExecutionCoordinator struct {
 	repository                 batchCoordinatorRepository
 	executorFactory            executor_factory.ExecutorFactory
@@ -143,8 +143,8 @@ func isHardError(err error) bool {
 	return errors.As(err, &h)
 }
 
-// batchInvariants holds the per-run context loaded once and reused for every object in every
-// batch — this amortization (vs reloading per object) is the throughput win over the v1 path.
+// batchInvariants holds the per-run context (scenario, data model, pivots, client DB handle)
+// loaded once and reused for every object in every batch, rather than reloaded per object.
 type batchInvariants struct {
 	scenario             models.Scenario
 	scenarioIterationId  string
@@ -167,7 +167,6 @@ type evalOutcome struct {
 	hardErr           error
 }
 
-// BatchExecutionCoordinatorWorker is the River worker wrapping the coordinator.
 type BatchExecutionCoordinatorWorker struct {
 	river.WorkerDefaults[models.BatchExecutionCoordinatorArgs]
 	coordinator *BatchExecutionCoordinator
@@ -602,8 +601,9 @@ func (c *BatchExecutionCoordinator) storeDecision(
 	return []string{webhookEventId}, nil
 }
 
-// testRunCallback mirrors the v1 worker's phantom test-run piggyback: if an active test run
-// exists, a phantom decision is evaluated against it after the batch commits.
+// testRunCallback returns a function, to be run after the batch commits, that evaluates a
+// phantom decision against any active test run for the scenario. Returns nil when there is
+// nothing to evaluate (the object was not found).
 func (c *BatchExecutionCoordinator) testRunCallback(
 	ctx context.Context,
 	inv batchInvariants,

--- a/usecases/worker_jobs/batch_execution_coordinator.go
+++ b/usecases/worker_jobs/batch_execution_coordinator.go
@@ -1,0 +1,696 @@
+package worker_jobs
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/analytics"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/decision_phantom"
+	"github.com/checkmarble/marble-backend/usecases/evaluate_scenario"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/checkmarble/marble-backend/usecases/scenarios"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
+	"github.com/riverqueue/river"
+	"github.com/twpayne/go-geos"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// batchExecBatchSize is the number of object ids read from the manifest per loop
+	// iteration. They are evaluated concurrently (P = K) and the surviving decisions are
+	// inserted in a single transaction together with the manifest cursor advance. Kept well
+	// under the ~100 ceiling to bound per-transaction write pressure.
+	batchExecBatchSize = 50
+
+	// batchExecPerIterTimeout caps a single loop iteration so a wedged DB/blob/screening
+	// call cannot hang the coordinator until the whole-job timeout. A timeout is retryable.
+	batchExecPerIterTimeout = 10 * time.Minute
+
+	// batchExecDefaultRunDuration is the wall-clock budget for a whole run when no deadline
+	// was recorded at setup. The deadline is the only termination on sustained failure.
+	batchExecDefaultRunDuration = 12 * time.Hour
+
+	// Coordinator job timeout: must comfortably exceed the run deadline so River's stuck-job
+	// rescuer never double-runs a healthy coordinator.
+	batchExecJobTimeout = batchExecDefaultRunDuration + time.Hour
+
+	batchExecBackoffBase  = 1 * time.Second
+	batchExecBackoffCap   = 2 * time.Minute
+	batchExecSentryEveryN = 20
+)
+
+// batchCoordinatorRepository is the marble-db surface the coordinator needs. MarbleDbRepository
+// satisfies it. Deliberately leaner than asyncDecisionWorkerRepository: no decisions_to_create.
+type batchCoordinatorRepository interface {
+	GetScheduledExecution(ctx context.Context, exec repositories.Executor, id string) (models.ScheduledExecution, error)
+	UpdateScheduledExecutionStatus(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.UpdateScheduledExecutionStatusInput,
+	) error
+	AdvanceScheduledExecutionManifest(
+		ctx context.Context,
+		exec repositories.Executor,
+		input models.AdvanceScheduledExecutionManifestInput,
+	) error
+	InsertScheduledExecutionFailures(
+		ctx context.Context,
+		exec repositories.Executor,
+		scheduledExecutionId string,
+		failures []models.ScheduledExecutionFailedObject,
+	) error
+	GetAnalyticsSettings(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (map[string]analytics.Settings, error)
+}
+
+// BatchExecutionCoordinator drives a single scheduled execution (v2 path): it walks the
+// object-id manifest in batches, evaluating and storing decisions, advancing a resumable
+// cursor in the same transaction as the inserts.
+type BatchExecutionCoordinator struct {
+	repository                 batchCoordinatorRepository
+	executorFactory            executor_factory.ExecutorFactory
+	transactionFactory         executor_factory.TransactionFactory
+	dataModelRepository        repositories.DataModelRepository
+	ingestedDataReadRepository repositories.IngestedDataReadRepository
+	decisionRepository         repositories.DecisionRepository
+	offloadedReader            repositories.OffloadedReadWriter
+	blobRepository             repositories.BlobRepository
+	manifestBucketUrl          string
+	webhookEventsSender        webhookEventsUsecase
+	scenarioFetcher            scenarios.ScenarioFetcher
+	phantomDecision            decision_phantom.PhantomDecisionUsecase
+	scenarioEvaluator          ScenarioEvaluator
+	screeningRepository        decisionWorkerScreeningWriter
+	taskQueueRepository        repositories.TaskQueueRepository
+}
+
+func NewBatchExecutionCoordinator(
+	repository batchCoordinatorRepository,
+	executorFactory executor_factory.ExecutorFactory,
+	transactionFactory executor_factory.TransactionFactory,
+	dataModelRepository repositories.DataModelRepository,
+	ingestedDataReadRepository repositories.IngestedDataReadRepository,
+	decisionRepository repositories.DecisionRepository,
+	offloadedReader repositories.OffloadedReadWriter,
+	blobRepository repositories.BlobRepository,
+	manifestBucketUrl string,
+	webhookEventsSender webhookEventsUsecase,
+	scenarioFetcher scenarios.ScenarioFetcher,
+	phantom decision_phantom.PhantomDecisionUsecase,
+	scenarioEvaluator ScenarioEvaluator,
+	screeningRepository decisionWorkerScreeningWriter,
+	taskQueueRepository repositories.TaskQueueRepository,
+) BatchExecutionCoordinator {
+	return BatchExecutionCoordinator{
+		repository:                 repository,
+		executorFactory:            executorFactory,
+		transactionFactory:         transactionFactory,
+		dataModelRepository:        dataModelRepository,
+		ingestedDataReadRepository: ingestedDataReadRepository,
+		decisionRepository:         decisionRepository,
+		offloadedReader:            offloadedReader,
+		blobRepository:             blobRepository,
+		manifestBucketUrl:          manifestBucketUrl,
+		webhookEventsSender:        webhookEventsSender,
+		scenarioFetcher:            scenarioFetcher,
+		phantomDecision:            phantom,
+		scenarioEvaluator:          scenarioEvaluator,
+		screeningRepository:        screeningRepository,
+		taskQueueRepository:        taskQueueRepository,
+	}
+}
+
+// hardError marks a failure the coordinator must NOT retry: an invariant it checks itself, or
+// a recovered panic. Everything else is presumed retryable (a transient dependency error).
+type hardError struct{ err error }
+
+func (e hardError) Error() string { return e.err.Error() }
+func (e hardError) Unwrap() error { return e.err }
+
+func hardf(format string, args ...any) error { return hardError{errors.Newf(format, args...)} }
+
+func isHardError(err error) bool {
+	var h hardError
+	return errors.As(err, &h)
+}
+
+// batchInvariants holds the per-run context loaded once and reused for every object in every
+// batch — this amortization (vs reloading per object) is the throughput win over the v1 path.
+type batchInvariants struct {
+	scenario             models.Scenario
+	scenarioIterationId  string
+	dataModel            models.DataModel
+	table                models.Table
+	pivots               []models.Pivot
+	clientDb             repositories.Executor
+	scheduledExecutionId string
+}
+
+// evalOutcome is the result of evaluating one object, outside any transaction.
+type evalOutcome struct {
+	objectId          string
+	triggerPassed     bool
+	skipped           bool // object not found in the table; counts as evaluated, not created
+	scenarioExecution models.ScenarioExecution
+	evalParams        evaluate_scenario.ScenarioEvaluationParameters
+	object            models.ClientObject
+	retryErr          error
+	hardErr           error
+}
+
+// BatchExecutionCoordinatorWorker is the River worker wrapping the coordinator.
+type BatchExecutionCoordinatorWorker struct {
+	river.WorkerDefaults[models.BatchExecutionCoordinatorArgs]
+	coordinator *BatchExecutionCoordinator
+}
+
+func NewBatchExecutionCoordinatorWorker(coordinator *BatchExecutionCoordinator) *BatchExecutionCoordinatorWorker {
+	return &BatchExecutionCoordinatorWorker{coordinator: coordinator}
+}
+
+func (w *BatchExecutionCoordinatorWorker) Timeout(job *river.Job[models.BatchExecutionCoordinatorArgs]) time.Duration {
+	return batchExecJobTimeout
+}
+
+func (w *BatchExecutionCoordinatorWorker) Work(ctx context.Context, job *river.Job[models.BatchExecutionCoordinatorArgs]) error {
+	return w.coordinator.Run(ctx, job.Args.ScheduledExecutionId)
+}
+
+// Run drives the scheduled execution to completion (or to its deadline). It returns an error
+// only when the run should be retried by River as a whole (e.g. process shutdown mid-run, so
+// it resumes from the committed offset). Terminal outcomes (success, cancellation, deadline,
+// hard failure) set the final status themselves and return nil.
+func (c *BatchExecutionCoordinator) Run(ctx context.Context, scheduledExecutionId string) error {
+	logger := utils.LoggerFromContext(ctx).With("scheduled_execution_id", scheduledExecutionId)
+	ctx = utils.StoreLoggerInContext(ctx, logger)
+	exec := c.executorFactory.NewExecutor()
+
+	se, err := c.repository.GetScheduledExecution(ctx, exec, scheduledExecutionId)
+	if err != nil {
+		return errors.Wrap(err, "could not load scheduled execution in batch coordinator")
+	}
+	if se.ManifestBlobKey == nil {
+		// Invariant: the coordinator only ever runs for v2 executions, which always have a
+		// manifest. Mark failed rather than spin.
+		return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, []models.ScheduledExecutionFailedObject{
+			{ObjectId: "(setup)", Error: "batch coordinator started for an execution without a manifest"},
+		})
+	}
+
+	inv, err := c.loadInvariants(ctx, exec, se)
+	if err != nil {
+		if isHardError(err) {
+			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, []models.ScheduledExecutionFailedObject{
+				{ObjectId: "(setup)", Error: err.Error()},
+			})
+		}
+		return errors.Wrap(err, "could not load batch invariants")
+	}
+
+	deadline := time.Now().Add(batchExecDefaultRunDuration)
+	if se.Deadline != nil {
+		deadline = *se.Deadline
+	}
+
+	var planned int64
+	if se.NumberOfPlannedDecisions != nil {
+		planned = int64(*se.NumberOfPlannedDecisions)
+	}
+
+	offset := se.ManifestByteOffset
+	rows := se.ManifestRowsProcessed
+	created := se.NumberOfCreatedDecisions
+	evaluated := se.NumberOfEvaluatedDecisions
+	consecutiveFailures := 0
+	var lastErr error
+
+	for {
+		if ctx.Err() != nil {
+			// Process shutting down (deploy). Return the error so River reschedules and we
+			// resume from the committed offset.
+			return ctx.Err()
+		}
+
+		if time.Now().After(deadline) {
+			logger.WarnContext(ctx, "batch execution reached its deadline before completing, marking failed")
+			marker := "(deadline)"
+			errStr := "run deadline exceeded"
+			if lastErr != nil {
+				errStr = fmt.Sprintf("run deadline exceeded, last error: %s", lastErr.Error())
+			}
+			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure,
+				[]models.ScheduledExecutionFailedObject{{ObjectId: marker, Error: errStr}})
+		}
+
+		// Re-read status before each batch so a cancellation (status flipped away from
+		// Processing) stops the run promptly. One job to stop, not N.
+		current, err := c.repository.GetScheduledExecution(ctx, exec, scheduledExecutionId)
+		if err != nil {
+			lastErr = err
+			c.handleRetryable(ctx, err, &consecutiveFailures)
+			continue
+		}
+		if current.Status != models.ScheduledExecutionProcessing {
+			logger.InfoContext(ctx, fmt.Sprintf(
+				"batch execution no longer processing (status %s), coordinator exiting", current.Status))
+			return nil
+		}
+
+		if rows >= planned {
+			logger.InfoContext(ctx, fmt.Sprintf("batch execution complete: %d decisions created, %d evaluated", created, evaluated))
+			return c.finalize(ctx, exec, se, models.ScheduledExecutionSuccess, nil)
+		}
+
+		// One per-iteration context bounds the whole iteration — manifest read, concurrent
+		// evaluation, and the persistence transaction — so no single wedged operation hangs the
+		// coordinator until the whole-job timeout. Derived from the job ctx so a deploy still
+		// propagates cancellation. A timeout here is just another retryable error.
+		batchCtx, cancel := context.WithTimeout(ctx, batchExecPerIterTimeout)
+
+		ids, newOffset, err := c.readManifestBatch(batchCtx, *se.ManifestBlobKey, offset, batchExecBatchSize)
+		if err != nil {
+			cancel()
+			lastErr = err
+			c.handleRetryable(ctx, err, &consecutiveFailures)
+			continue
+		}
+		if len(ids) == 0 {
+			// Manifest drained earlier than the planned count predicted. Finalize rather than
+			// loop forever; log because counts should have matched.
+			cancel()
+			logger.WarnContext(ctx, fmt.Sprintf(
+				"manifest exhausted at %d rows but %d were planned; finalizing", rows, planned))
+			return c.finalize(ctx, exec, se, models.ScheduledExecutionSuccess, nil)
+		}
+
+		results, hardFailures, retryErr := c.evaluateBatch(batchCtx, inv, ids)
+		if retryErr != nil {
+			cancel()
+			lastErr = retryErr
+			c.handleRetryable(ctx, retryErr, &consecutiveFailures)
+			continue
+		}
+		if len(hardFailures) > 0 {
+			cancel()
+			logger.ErrorContext(ctx, fmt.Sprintf("hard failure evaluating batch, marking execution failed: %s", hardFailures[0].Error))
+			return c.finalize(ctx, exec, se, models.ScheduledExecutionFailure, hardFailures)
+		}
+
+		batchCreated := 0
+		batchEvaluated := len(results)
+		var webhookIds []string
+		var callbacks []func()
+
+		err = c.transactionFactory.Transaction(batchCtx, func(tx repositories.Transaction) error {
+			// Reset accumulators so a retry of the same batch (tx rollback) starts clean.
+			batchCreated = 0
+			webhookIds = nil
+			callbacks = nil
+			for _, r := range results {
+				if r.skipped || !r.triggerPassed {
+					if cb := c.testRunCallback(ctx, inv, r, false); cb != nil {
+						callbacks = append(callbacks, cb)
+					}
+					continue
+				}
+				wid, err := c.storeDecision(batchCtx, tx, inv, r)
+				if err != nil {
+					return err
+				}
+				webhookIds = append(webhookIds, wid...)
+				if cb := c.testRunCallback(ctx, inv, r, true); cb != nil {
+					callbacks = append(callbacks, cb)
+				}
+				batchCreated++
+			}
+
+			return c.repository.AdvanceScheduledExecutionManifest(batchCtx, tx, models.AdvanceScheduledExecutionManifestInput{
+				Id:                         scheduledExecutionId,
+				ManifestByteOffset:         newOffset,
+				ManifestRowsProcessed:      rows + int64(len(ids)),
+				NumberOfCreatedDecisions:   created + batchCreated,
+				NumberOfEvaluatedDecisions: evaluated + batchEvaluated,
+			})
+		})
+		cancel()
+		if err != nil {
+			// Store or advance failed: nothing committed, do not advance our cursors. Retry the
+			// same batch after backoff.
+			lastErr = err
+			c.handleRetryable(ctx, err, &consecutiveFailures)
+			continue
+		}
+
+		// Committed. Advance the in-memory cursors, fire post-commit side effects, reset backoff.
+		offset = newOffset
+		rows += int64(len(ids))
+		created += batchCreated
+		evaluated += batchEvaluated
+		consecutiveFailures = 0
+		lastErr = nil
+
+		for _, wid := range webhookIds {
+			c.webhookEventsSender.SendWebhookEventAsync(ctx, wid)
+		}
+		for _, cb := range callbacks {
+			cb()
+		}
+	}
+}
+
+func (c *BatchExecutionCoordinator) loadInvariants(
+	ctx context.Context,
+	exec repositories.Executor,
+	se models.ScheduledExecution,
+) (batchInvariants, error) {
+	scenarioAndIteration, err := c.scenarioFetcher.FetchScenarioAndIteration(ctx, exec, se.ScenarioIterationId)
+	if err != nil {
+		return batchInvariants{}, err
+	}
+	scenario := scenarioAndIteration.Scenario
+
+	dataModel, err := c.dataModelRepository.GetDataModel(ctx, exec, scenario.OrganizationId, false, true)
+	if err != nil {
+		return batchInvariants{}, err
+	}
+	table, ok := dataModel.Tables[scenario.TriggerObjectType]
+	if !ok {
+		return batchInvariants{}, hardf(
+			"trigger object type %s not found in data model", scenario.TriggerObjectType)
+	}
+
+	pivotsMeta, err := c.dataModelRepository.ListPivots(ctx, exec, scenario.OrganizationId, nil, true, false)
+	if err != nil {
+		return batchInvariants{}, err
+	}
+	pivots := models.FindPivotsForTable(pivotsMeta, scenario.TriggerObjectType, dataModel)
+
+	clientDb, err := c.executorFactory.NewClientDbExecutor(ctx, scenario.OrganizationId)
+	if err != nil {
+		return batchInvariants{}, err
+	}
+
+	return batchInvariants{
+		scenario:             scenario,
+		scenarioIterationId:  se.ScenarioIterationId,
+		dataModel:            dataModel,
+		table:                table,
+		pivots:               pivots,
+		clientDb:             clientDb,
+		scheduledExecutionId: se.Id,
+	}, nil
+}
+
+// readManifestBatch reads up to batchSize object ids from the manifest starting at a
+// line-aligned byte offset, returning the ids and the new (still line-aligned) offset.
+func (c *BatchExecutionCoordinator) readManifestBatch(
+	ctx context.Context,
+	key string,
+	offset int64,
+	batchSize int,
+) (ids []string, newOffset int64, err error) {
+	blob, err := c.blobRepository.GetBlob(ctx, c.manifestBucketUrl, key, repositories.WithBeginOffset(offset))
+	if err != nil {
+		return nil, offset, errors.Wrapf(err, "could not open manifest %s at offset %d", key, offset)
+	}
+	defer blob.ReadCloser.Close()
+
+	reader := bufio.NewReader(blob.ReadCloser)
+	consumed := int64(0)
+	ids = make([]string, 0, batchSize)
+	for len(ids) < batchSize {
+		line, readErr := reader.ReadString('\n')
+		if len(line) > 0 {
+			consumed += int64(len(line))
+			if trimmed := strings.TrimRight(line, "\n"); trimmed != "" {
+				ids = append(ids, trimmed)
+			}
+		}
+		if readErr == io.EOF {
+			break
+		}
+		if readErr != nil {
+			return nil, offset, errors.Wrapf(readErr, "error reading manifest %s", key)
+		}
+	}
+
+	return ids, offset + consumed, nil
+}
+
+// evaluateBatch evaluates every object in the batch concurrently (P = K), outside any
+// transaction so the screening HTTP calls never hold a tx open. Classification: a retryable
+// error anywhere aborts the whole batch for retry (precedence over hard failures, since a
+// genuine hard failure recurs and is caught once the transient one clears); hard failures
+// (invariants, recovered panics) stop the run.
+func (c *BatchExecutionCoordinator) evaluateBatch(
+	ctx context.Context,
+	inv batchInvariants,
+	ids []string,
+) (results []evalOutcome, hardFailures []models.ScheduledExecutionFailedObject, retryErr error) {
+	outcomes := make([]evalOutcome, len(ids))
+	var g errgroup.Group
+	g.SetLimit(batchExecBatchSize)
+	for i, id := range ids {
+		g.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					outcomes[i] = evalOutcome{objectId: id, hardErr: hardf("panic evaluating object %s: %v", id, r)}
+				}
+			}()
+			outcomes[i] = c.evaluateObject(ctx, inv, id)
+			return nil
+		})
+	}
+	_ = g.Wait()
+
+	for _, o := range outcomes {
+		switch {
+		case o.retryErr != nil:
+			if retryErr == nil {
+				retryErr = o.retryErr
+			}
+		case o.hardErr != nil:
+			hardFailures = append(hardFailures, models.ScheduledExecutionFailedObject{
+				ObjectId: o.objectId,
+				Error:    o.hardErr.Error(),
+			})
+		default:
+			results = append(results, o)
+		}
+	}
+
+	if retryErr != nil {
+		return nil, nil, retryErr
+	}
+	return results, hardFailures, nil
+}
+
+func (c *BatchExecutionCoordinator) evaluateObject(
+	ctx context.Context,
+	inv batchInvariants,
+	objectId string,
+) evalOutcome {
+	objectMap, err := c.ingestedDataReadRepository.QueryIngestedObject(ctx, inv.clientDb, inv.table, objectId)
+	if err != nil {
+		return evalOutcome{objectId: objectId, retryErr: errors.Wrapf(err, "error querying ingested object %s", objectId)}
+	}
+	if len(objectMap) == 0 {
+		utils.LogAndReportSentryError(ctx, errors.Newf("object %s not found in table %s", objectId, inv.table.Name))
+		return evalOutcome{objectId: objectId, skipped: true}
+	}
+
+	// Scheduled executions are read from the database whereas the engine was built for JSON
+	// input; untype special types (geolocations, IP addresses, metadata fields).
+	for idx := range objectMap {
+		for k, v := range objectMap[idx].Data {
+			if strings.Contains(k, ".metadata") {
+				delete(objectMap[idx].Data, k)
+				continue
+			}
+			switch typed := v.(type) {
+			case *geos.Geom:
+				objectMap[idx].Data[k] = fmt.Sprintf("%f,%f", typed.Y(), typed.X())
+			case netip.Prefix:
+				objectMap[idx].Data[k] = typed.Addr().String()
+			}
+		}
+	}
+
+	object := models.ClientObject{TableName: inv.table.Name, Data: objectMap[0].Data}
+	evalParams := evaluate_scenario.ScenarioEvaluationParameters{
+		Scenario:          inv.scenario,
+		TargetIterationId: &inv.scenarioIterationId,
+		ClientObject:      object,
+		DataModel:         inv.dataModel,
+		Pivots:            inv.pivots,
+	}
+
+	triggerPassed, scenarioExecution, err := c.scenarioEvaluator.EvalScenario(ctx, evalParams)
+	if err != nil {
+		return evalOutcome{objectId: objectId, retryErr: errors.Wrapf(err, "error evaluating scenario for object %s", objectId)}
+	}
+
+	return evalOutcome{
+		objectId:          objectId,
+		triggerPassed:     triggerPassed,
+		scenarioExecution: scenarioExecution,
+		evalParams:        evalParams,
+		object:            object,
+	}
+}
+
+// storeDecision persists one evaluated decision and its side records inside the batch tx.
+func (c *BatchExecutionCoordinator) storeDecision(
+	ctx context.Context,
+	tx repositories.Transaction,
+	inv batchInvariants,
+	o evalOutcome,
+) ([]string, error) {
+	decision := models.AdaptScenarExecToDecision(o.scenarioExecution, o.object, &inv.scheduledExecutionId)
+
+	analyticsFields := c.scenarioEvaluator.GetDataAccessor(o.evalParams).
+		GetAnalyticsFields(ctx, tx, c.repository, o.evalParams)
+
+	err := c.decisionRepository.StoreDecision(
+		ctx,
+		tx,
+		c.offloadedReader,
+		decision,
+		inv.scenario.OrganizationId,
+		decision.DecisionId.String(),
+		analyticsFields,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "error storing decision in batch coordinator")
+	}
+
+	for _, sce := range decision.ScreeningExecutions {
+		matchesToInsert, offloadErr := c.offloadedReader.OffloadScreeningMatches(ctx, sce)
+		if offloadErr != nil {
+			return nil, errors.Wrap(offloadErr, "could not offload screening match payloads in batch coordinator")
+		}
+		sce.Matches = matchesToInsert
+		if err := c.screeningRepository.InsertScreening(ctx, tx, sce); err != nil {
+			return nil, errors.Wrap(err, "error storing screening execution in batch coordinator")
+		}
+	}
+
+	webhookEventId := pure_utils.NewId().String()
+	err = c.webhookEventsSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+		Id:             webhookEventId,
+		OrganizationId: decision.OrganizationId,
+		EventContent:   models.NewWebhookEventDecisionCreated(decision),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.taskQueueRepository.EnqueueDecisionWorkflowTask(ctx, tx, decision.OrganizationId, decision.DecisionId.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return []string{webhookEventId}, nil
+}
+
+// testRunCallback mirrors the v1 worker's phantom test-run piggyback: if an active test run
+// exists, a phantom decision is evaluated against it after the batch commits.
+func (c *BatchExecutionCoordinator) testRunCallback(
+	ctx context.Context,
+	inv batchInvariants,
+	o evalOutcome,
+	triggered bool,
+) func() {
+	if o.skipped {
+		return nil
+	}
+	return func() {
+		evalParams := o.evalParams
+		evalParams.TargetIterationId = nil
+		if triggered {
+			evalParams.CachedScreenings = pure_utils.MapSliceToMap(
+				o.scenarioExecution.ScreeningExecutions,
+				func(scm models.ScreeningWithMatches) (string, models.ScreeningWithMatches) {
+					return o.scenarioExecution.ScenarioIterationId.String(), scm
+				},
+			)
+		}
+		phantomInput := models.CreatePhantomDecisionInput{
+			OrganizationId: inv.scenario.OrganizationId,
+			Scenario:       inv.scenario,
+			ClientObject:   o.object,
+		}
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		logger := utils.LoggerFromContext(ctx).With("phantom_decisions_with_scenario_id", phantomInput.Scenario.Id)
+		if _, _, errPhantom := c.phantomDecision.CreatePhantomDecision(ctx, phantomInput, evalParams); errPhantom != nil {
+			logger.ErrorContext(ctx, fmt.Sprintf("Error when creating phantom decisions with scenario id %s: %s",
+				phantomInput.Scenario.Id, errPhantom.Error()))
+		}
+	}
+}
+
+// finalize sets the terminal status (and records any hard failures) for the run.
+func (c *BatchExecutionCoordinator) finalize(
+	ctx context.Context,
+	exec repositories.Executor,
+	se models.ScheduledExecution,
+	status models.ScheduledExecutionStatus,
+	failures []models.ScheduledExecutionFailedObject,
+) error {
+	if len(failures) > 0 {
+		if err := c.repository.InsertScheduledExecutionFailures(ctx, exec, se.Id, failures); err != nil {
+			utils.LogAndReportSentryError(ctx, errors.Wrap(err, "could not record batch execution failures"))
+		}
+	}
+
+	return c.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{
+		Id:     se.Id,
+		Status: status,
+	})
+}
+
+// handleRetryable keeps the run in the loop on a presumed-retryable error: log every time,
+// report to Sentry throttled, and back off (ctx-aware) before retrying the same offset. The
+// deadline check is what eventually terminates a run that never recovers.
+func (c *BatchExecutionCoordinator) handleRetryable(ctx context.Context, err error, consecutiveFailures *int) {
+	*consecutiveFailures++
+	logger := utils.LoggerFromContext(ctx)
+	logger.ErrorContext(ctx, fmt.Sprintf("retryable error in batch coordinator (consecutive: %d): %s",
+		*consecutiveFailures, err.Error()))
+
+	if *consecutiveFailures == 1 || *consecutiveFailures%batchExecSentryEveryN == 0 {
+		utils.LogAndReportSentryError(ctx, err)
+	}
+
+	delay := batchExecBackoffDelay(*consecutiveFailures)
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+}
+
+func batchExecBackoffDelay(consecutiveFailures int) time.Duration {
+	if consecutiveFailures < 1 {
+		consecutiveFailures = 1
+	}
+	delay := batchExecBackoffBase
+	for i := 1; i < consecutiveFailures && delay < batchExecBackoffCap; i++ {
+		delay *= 2
+	}
+	if delay > batchExecBackoffCap {
+		delay = batchExecBackoffCap
+	}
+	return delay
+}

--- a/usecases/worker_jobs/run_scheduled_execution.go
+++ b/usecases/worker_jobs/run_scheduled_execution.go
@@ -162,11 +162,12 @@ func (usecase *RunScheduledExecution) ExecuteScheduledExecutionById(
 		)
 	}
 
-	// v2 batch execution (manifest + looping coordinator), gated per-org. Runs in parallel with
-	// the legacy per-object job fan-out below.
+	// When enabled for the org, process the execution by streaming a manifest of object ids to
+	// blob storage and handing off to a single looping coordinator, rather than inserting one
+	// row and one job per object below.
 	if batchExecV2EnabledForOrg(scenario.OrganizationId) {
 		if usecase.manifestBucketUrl == "" {
-			logger.WarnContext(ctx, "v2 batch execution is enabled for this org but no manifest bucket is configured; falling back to the legacy path")
+			logger.WarnContext(ctx, "manifest-based batch execution is enabled for this org but no manifest bucket is configured; using per-object execution instead")
 		} else {
 			return usecase.executeViaManifest(ctx, exec, db, scheduledExecution, scenario, filters)
 		}
@@ -243,9 +244,8 @@ func (usecase *RunScheduledExecution) ExecuteScheduledExecutionById(
 	return nil
 }
 
-// batchExecV2EnabledForOrg gates the v2 manifest+coordinator path per organization. The
-// allowlist is read from SCHEDULED_EXEC_V2_ORGS (comma-separated org UUIDs, or "*" for all),
-// mirroring the existing OFFLOADING_ONLY_ORG env convention. No DB column, no plumbing.
+// batchExecV2EnabledForOrg reports whether an organization uses manifest-based batch execution.
+// The allowlist is read from SCHEDULED_EXEC_V2_ORGS: comma-separated org UUIDs, or "*" for all.
 func batchExecV2EnabledForOrg(orgId uuid.UUID) bool {
 	v := strings.TrimSpace(os.Getenv("SCHEDULED_EXEC_V2_ORGS"))
 	if v == "" {
@@ -262,9 +262,9 @@ func batchExecV2EnabledForOrg(orgId uuid.UUID) bool {
 	return false
 }
 
-// executeViaManifest sets up a v2 batch execution: it streams the matching object ids into a
-// GCS manifest, records the planned count + deadline + manifest key, then enqueues a single
-// looping coordinator job to process it. No per-object rows, no per-object jobs.
+// executeViaManifest streams the matching object ids into a manifest blob, records the planned
+// count, deadline, and manifest key on the execution, then enqueues a single coordinator job to
+// process it.
 func (usecase *RunScheduledExecution) executeViaManifest(
 	ctx context.Context,
 	exec repositories.Executor,

--- a/usecases/worker_jobs/run_scheduled_execution.go
+++ b/usecases/worker_jobs/run_scheduled_execution.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -73,6 +75,12 @@ type taskQueueRepository interface {
 		organizationId uuid.UUID,
 		scheduledExecutionId string,
 	) error
+	EnqueueBatchExecutionCoordinator(
+		ctx context.Context,
+		tx repositories.Transaction,
+		organizationId uuid.UUID,
+		scheduledExecutionId string,
+	) error
 }
 
 type RunScheduledExecution struct {
@@ -82,6 +90,8 @@ type RunScheduledExecution struct {
 	ingestedDataReadRepository     repositories.IngestedDataReadRepository
 	transactionFactory             executor_factory.TransactionFactory
 	taskQueueRepository            taskQueueRepository
+	blobRepository                 repositories.BlobRepository
+	manifestBucketUrl              string
 }
 
 func NewRunScheduledExecution(
@@ -91,6 +101,8 @@ func NewRunScheduledExecution(
 	transactionFactory executor_factory.TransactionFactory,
 	taskQueueRepository taskQueueRepository,
 	scenarioPublicationsRepository repositories.ScenarioPublicationRepository,
+	blobRepository repositories.BlobRepository,
+	manifestBucketUrl string,
 ) *RunScheduledExecution {
 	return &RunScheduledExecution{
 		repository:                     repository,
@@ -99,6 +111,8 @@ func NewRunScheduledExecution(
 		transactionFactory:             transactionFactory,
 		taskQueueRepository:            taskQueueRepository,
 		scenarioPublicationsRepository: scenarioPublicationsRepository,
+		blobRepository:                 blobRepository,
+		manifestBucketUrl:              manifestBucketUrl,
 	}
 }
 
@@ -146,6 +160,16 @@ func (usecase *RunScheduledExecution) ExecuteScheduledExecutionById(
 			*liveVersion.TriggerConditionAstExpression,
 			models.TableIdentifier{Table: scenario.TriggerObjectType, Schema: db.DatabaseSchema().Schema},
 		)
+	}
+
+	// v2 batch execution (manifest + looping coordinator), gated per-org. Runs in parallel with
+	// the legacy per-object job fan-out below.
+	if batchExecV2EnabledForOrg(scenario.OrganizationId) {
+		if usecase.manifestBucketUrl == "" {
+			logger.WarnContext(ctx, "v2 batch execution is enabled for this org but no manifest bucket is configured; falling back to the legacy path")
+		} else {
+			return usecase.executeViaManifest(ctx, exec, db, scheduledExecution, scenario, filters)
+		}
 	}
 
 	objectIds, err := usecase.ingestedDataReadRepository.ListAllObjectIdsFromTable(ctx, db, scenario.TriggerObjectType, filters...)
@@ -216,6 +240,88 @@ func (usecase *RunScheduledExecution) ExecuteScheduledExecutionById(
 
 	logger.InfoContext(ctx, fmt.Sprintf("Inserted %d decisions to be executed", nbPlannedDecisions))
 
+	return nil
+}
+
+// batchExecV2EnabledForOrg gates the v2 manifest+coordinator path per organization. The
+// allowlist is read from SCHEDULED_EXEC_V2_ORGS (comma-separated org UUIDs, or "*" for all),
+// mirroring the existing OFFLOADING_ONLY_ORG env convention. No DB column, no plumbing.
+func batchExecV2EnabledForOrg(orgId uuid.UUID) bool {
+	v := strings.TrimSpace(os.Getenv("SCHEDULED_EXEC_V2_ORGS"))
+	if v == "" {
+		return false
+	}
+	if v == "*" {
+		return true
+	}
+	for _, part := range strings.Split(v, ",") {
+		if strings.TrimSpace(part) == orgId.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// executeViaManifest sets up a v2 batch execution: it streams the matching object ids into a
+// GCS manifest, records the planned count + deadline + manifest key, then enqueues a single
+// looping coordinator job to process it. No per-object rows, no per-object jobs.
+func (usecase *RunScheduledExecution) executeViaManifest(
+	ctx context.Context,
+	exec repositories.Executor,
+	db repositories.Executor,
+	scheduledExecution models.ScheduledExecution,
+	scenario models.Scenario,
+	filters []models.Filter,
+) error {
+	logger := utils.LoggerFromContext(ctx)
+
+	manifestKey := fmt.Sprintf("scheduled_executions/%s/manifest.txt", scheduledExecution.Id)
+	writer, err := usecase.blobRepository.OpenStream(ctx, usecase.manifestBucketUrl, manifestKey, "manifest.txt")
+	if err != nil {
+		return fmt.Errorf("error opening manifest writer: %w", err)
+	}
+
+	count, streamErr := usecase.ingestedDataReadRepository.StreamAllObjectIdsFromTable(
+		ctx, db, writer, scenario.TriggerObjectType, filters...)
+	// Always close to flush/commit the blob, even on error.
+	closeErr := writer.Close()
+	if streamErr != nil {
+		return fmt.Errorf("error streaming object ids to manifest: %w", streamErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("error finalizing manifest blob: %w", closeErr)
+	}
+
+	nbPlanned := int(count)
+	deadline := time.Now().Add(batchExecDefaultRunDuration)
+	err = usecase.repository.UpdateScheduledExecution(ctx, exec, models.UpdateScheduledExecutionInput{
+		Id:                       scheduledExecution.Id,
+		NumberOfPlannedDecisions: &nbPlanned,
+		ManifestBlobKey:          &manifestKey,
+		Deadline:                 &deadline,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = usecase.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{
+		Id:     scheduledExecution.Id,
+		Status: models.ScheduledExecutionProcessing,
+	})
+	if err != nil {
+		return err
+	}
+
+	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		return usecase.taskQueueRepository.EnqueueBatchExecutionCoordinator(
+			ctx, tx, scenario.OrganizationId, scheduledExecution.Id)
+	})
+	if err != nil {
+		return err
+	}
+
+	logger.InfoContext(ctx, fmt.Sprintf(
+		"Batch execution v2: wrote manifest with %d objects and enqueued coordinator", nbPlanned))
 	return nil
 }
 

--- a/usecases/worker_jobs/run_scheduled_execution.go
+++ b/usecases/worker_jobs/run_scheduled_execution.go
@@ -169,7 +169,7 @@ func (usecase *RunScheduledExecution) ExecuteScheduledExecutionById(
 		if usecase.manifestBucketUrl == "" {
 			logger.WarnContext(ctx, "manifest-based batch execution is enabled for this org but no manifest bucket is configured; using per-object execution instead")
 		} else {
-			return usecase.executeViaManifest(ctx, exec, db, scheduledExecution, scenario, filters)
+			return usecase.executeViaManifest(ctx, db, scheduledExecution, scenario, filters)
 		}
 	}
 
@@ -262,12 +262,15 @@ func batchExecV2EnabledForOrg(orgId uuid.UUID) bool {
 	return false
 }
 
+func batchExecutionManifestFileKey(id string) string {
+	return fmt.Sprintf("scheduled_executions/%s/manifest.txt", id)
+}
+
 // executeViaManifest streams the matching object ids into a manifest blob, records the planned
 // count, deadline, and manifest key on the execution, then enqueues a single coordinator job to
 // process it.
 func (usecase *RunScheduledExecution) executeViaManifest(
 	ctx context.Context,
-	exec repositories.Executor,
 	db repositories.Executor,
 	scheduledExecution models.ScheduledExecution,
 	scenario models.Scenario,
@@ -275,11 +278,12 @@ func (usecase *RunScheduledExecution) executeViaManifest(
 ) error {
 	logger := utils.LoggerFromContext(ctx)
 
-	manifestKey := fmt.Sprintf("scheduled_executions/%s/manifest.txt", scheduledExecution.Id)
+	manifestKey := batchExecutionManifestFileKey(scheduledExecution.Id)
 	writer, err := usecase.blobRepository.OpenStream(ctx, usecase.manifestBucketUrl, manifestKey, "manifest.txt")
 	if err != nil {
 		return fmt.Errorf("error opening manifest writer: %w", err)
 	}
+	defer writer.Close()
 
 	count, streamErr := usecase.ingestedDataReadRepository.StreamAllObjectIdsFromTable(
 		ctx, db, writer, scenario.TriggerObjectType, filters...)
@@ -293,26 +297,26 @@ func (usecase *RunScheduledExecution) executeViaManifest(
 	}
 
 	nbPlanned := int(count)
-	deadline := time.Now().Add(batchExecDefaultRunDuration)
-	err = usecase.repository.UpdateScheduledExecution(ctx, exec, models.UpdateScheduledExecutionInput{
-		Id:                       scheduledExecution.Id,
-		NumberOfPlannedDecisions: &nbPlanned,
-		ManifestBlobKey:          &manifestKey,
-		Deadline:                 &deadline,
-	})
-	if err != nil {
-		return err
-	}
-
-	err = usecase.repository.UpdateScheduledExecutionStatus(ctx, exec, models.UpdateScheduledExecutionStatusInput{
-		Id:     scheduledExecution.Id,
-		Status: models.ScheduledExecutionProcessing,
-	})
-	if err != nil {
-		return err
-	}
+	deadline := time.Now().Add(scheduledExecutionFullMaxRuntime)
 
 	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		err = usecase.repository.UpdateScheduledExecution(ctx, tx, models.UpdateScheduledExecutionInput{
+			Id:                       scheduledExecution.Id,
+			NumberOfPlannedDecisions: &nbPlanned,
+			ManifestBlobKey:          &manifestKey,
+			Deadline:                 &deadline,
+		})
+		if err != nil {
+			return err
+		}
+
+		err = usecase.repository.UpdateScheduledExecutionStatus(ctx, tx, models.UpdateScheduledExecutionStatusInput{
+			Id:     scheduledExecution.Id,
+			Status: models.ScheduledExecutionProcessing,
+		})
+		if err != nil {
+			return err
+		}
 		return usecase.taskQueueRepository.EnqueueBatchExecutionCoordinator(
 			ctx, tx, scenario.OrganizationId, scheduledExecution.Id)
 	})


### PR DESCRIPTION
## Intent
Today's batch execution breaks at larger batch sizes.
A few elements:
- on a batch exec on 1M transactions, inserting as many decisions_to_create and river_jobs is a real tax on DB performance while those commit, which causes slowdowns for other workflows.
- there is no fast way to cancel the X00k remaining river jobs if for whatever reason the "global" job is stopped / marked as failed
- significant overhead of getting basic data out of the database, on every individual decision
- counting remaining decisions efficiently is complicated
- throughput is tightly linked to the setting of river workers per queue in the org, because every decision is a job
- object_ids matching the trigger condition filters (those that can be pre-evaluated, so simple filters on field values) are all held in memory, which causes memory usage spikes where we could easily stream

## Main changes
Introduces an alternative pathway for batch job execution (for now, feature flagger per organization) that foregoes the main inconvenients described above.
- streams the target object_ids to a bucket file
- starts a river job that processes decisions, using only one queue slot
- the job walks the file by batches of (currently) 50 objects, evaluating decisions (currently with max 10 concurrency), before writing progress advance and taking the next 50
- a global max duration for all decisions to be computed, at 24h

In terms of sequencing:
- the job has a 10min deadline, after which it snoozes itself briefly to rerun
- the relatively short duration is so that a stuck job can be quickly recovered by the river master if it becomes stuck (e.g. worker restart)
- in a 10min window, the job has time to advance multiple slices of decisions
- In case of errors, retry within the loop with exponential backoff (lightweight circuit breaker)

## Limitations to explore
- Every iteration of 50 decisions has 1min to complete. This should be plenty with 10 max concurrency, but could be blocking in very marginal cases? The value can still be discussed.
- Contrary to before, decisions are now created strictly sequentially. There is no more "peaking ahead" in case a given decision consistently fails.
   - We had early discussions about a dead letter queue, but there was no obvious idea to keep the simplicity of "one file listing decisions remaining to create" + transparent retries with circuit breaking in case of unexpected (possibly transient) errors + retry failing decisions last after all the others have been attempted
   - My impression is that we can only choose 2 out of 3: "no tx per tx bookkeeping of remaining decisions", "transparent retries on transient errors", "complete as many decisions as possible then come back for missing ones" - but we can discuss it further