### PR TITLE
feat: marble server can serve prompt to other marble instance

### DIFF
--- a/api/handle_ai_prompts.go
+++ b/api/handle_ai_prompts.go
@@ -51,7 +51,6 @@ func handleAiPromptsDownload(uc usecases.Usecases) gin.HandlerFunc {
 		}
 
 		c.Header("Content-Type", "application/zip")
-		c.Header("Content-Disposition", `attachment; filename="ai-prompts.zip"`)
 		if _, err := io.Copy(c.Writer, zipReader); err != nil {
 			presentError(ctx, c, err)
 			return

--- a/api/handle_ai_prompts.go
+++ b/api/handle_ai_prompts.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -11,8 +12,7 @@ import (
 	"github.com/checkmarble/marble-backend/utils"
 )
 
-// aiPromptsLicenseKey extracts the caller's license key from the "Authorization: Bearer <key>"
-// header.
+// Extract the caller's license
 func aiPromptsLicenseKey(c *gin.Context) (string, error) {
 	key, err := utils.ParseAuthorizationBearerHeader(c.Request.Header)
 	if err != nil {
@@ -25,11 +25,10 @@ func aiPromptsLicenseKey(c *gin.Context) (string, error) {
 }
 
 // handleAiPromptsDownload streams a zip of the whole AI prompt bundle the caller's license is
-// entitled to, for the exact prompts_version requested (the caller always asks for one precise
-// version — its own hardcoded default, or an operator-configured pin — never "give me the
-// latest"; see PromptServingUsecase for the resolution rules). The zip contains only the
-// prompt files themselves — no manifest or version is reported back, since the caller already
-// knows which version it asked for. Only reachable on Marble SaaS.
+// entitled to, resolved for the caller's prompts_version (its own product Major.Minor).
+// Resolution is a backward search: exact Major.Minor
+// match wins, else the nearest earlier published one; never a newer one. The zip contains only the prompt files themselves.
+// Only reachable on Marble SaaS.
 func handleAiPromptsDownload(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -40,6 +39,10 @@ func handleAiPromptsDownload(uc usecases.Usecases) gin.HandlerFunc {
 		}
 
 		version := c.Query("prompts_version")
+		if version == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "prompts_version in query is required"))
+			return
+		}
 
 		usecase := uc.NewPromptServingUsecase()
 		zipReader, err := usecase.DownloadPrompts(ctx, licenseKey, version)

--- a/api/handle_ai_prompts.go
+++ b/api/handle_ai_prompts.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+// aiPromptsLicenseKey extracts the caller's license key from the "Authorization: Bearer <key>"
+// header.
+func aiPromptsLicenseKey(c *gin.Context) (string, error) {
+	key, err := utils.ParseAuthorizationBearerHeader(c.Request.Header)
+	if err != nil {
+		return "", err
+	}
+	if key == "" {
+		return "", models.UnAuthorizedError
+	}
+	return key, nil
+}
+
+// handleAiPromptsDownload streams a zip of the whole AI prompt bundle the caller's license is
+// entitled to, for the exact prompts_version requested (the caller always asks for one precise
+// version — its own hardcoded default, or an operator-configured pin — never "give me the
+// latest"; see PromptServingUsecase for the resolution rules). The zip contains only the
+// prompt files themselves — no manifest or version is reported back, since the caller already
+// knows which version it asked for. Only reachable on Marble SaaS.
+func handleAiPromptsDownload(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		licenseKey, err := aiPromptsLicenseKey(c)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		version := c.Query("prompts_version")
+
+		usecase := uc.NewPromptServingUsecase()
+		zipReader, err := usecase.DownloadPrompts(ctx, licenseKey, version)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.Header("Content-Type", "application/zip")
+		c.Header("Content-Disposition", `attachment; filename="ai-prompts.zip"`)
+		if _, err := io.Copy(c.Writer, zipReader); err != nil {
+			presentError(ctx, c, err)
+			return
+		}
+		c.Status(http.StatusOK)
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -69,6 +69,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 
 	if infra.IsMarbleSaasProject() {
 		r.POST("/metrics", tom, handleMetricsIngestion(uc))
+		r.GET("/ai-prompts/download", tom, handleAiPromptsDownload(uc))
 	}
 
 	// Public API initialization

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -197,6 +197,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
 	}
+	promptsDir := utils.GetEnv("PROMPTS_DIR", "")
 	bigQueryConfig := infra.BigQueryConfig{
 		ProjectID:      utils.GetEnv("BIGQUERY_PROJECT_ID", gcpConfig.ProjectId),
 		MetricsDataset: utils.GetEnv("BIGQUERY_METRICS_DATASET", infra.MetricsDataset),
@@ -406,6 +407,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithMarbleApiInternalUrl(apiConfig.MarbleApiInternalUrl),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
+		usecases.WithPromptsDir(promptsDir),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -9,27 +9,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"regexp"
-	"strconv"
-	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 
 	"github.com/checkmarble/marble-backend/models"
 )
-
-// promptVersionDirPattern matches a Major.Minor version directory at the root of promptsDir,
-// e.g. "v1.4". Prompt versions follow the Marble product's own release tags (not an
-// independent numbering), truncated to Major.Minor by the prompts-repo CI: every publish
-// targeting the same Major.Minor overwrites that one folder, so "latest for the Major.Minor"
-// is automatic by construction — there is no patch level to list or compare here.
-var promptVersionDirPattern = regexp.MustCompile(`^v\d+\.\d+$`)
-
-// requestedVersionPattern validates a caller-supplied version string (no "v" prefix), e.g.
-// "1.4". Checked before the string is ever used to build a filesystem path, so a malformed
-// or path-traversal value (e.g. "../secret") is rejected outright instead of reaching disk.
-var requestedVersionPattern = regexp.MustCompile(`^\d+\.\d+$`)
 
 // promptsLicenseValidator is the subset of PublicLicenseUseCase used by PromptServingUsecase,
 // so license validation (suspended/expired/not-found handling, metrics reporting) is not
@@ -78,7 +64,7 @@ func (uc PromptServingUsecase) validateEntitlement(ctx context.Context, licenseK
 // is reported back, since the caller already knows which version it asked for. The archive is
 // fully built (and every check run) before returning, so callers can set response headers only
 // once this call has succeeded, without risking a partially-written response.
-func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, version string) (io.Reader, error) {
+func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, version string) (_ io.Reader, err error) {
 	if err := uc.validateEntitlement(ctx, licenseKey); err != nil {
 		return nil, err
 	}
@@ -94,14 +80,19 @@ func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, 
 
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
+	// zw.Close() writes the zip's central directory - it must always run (even on an early
+	// return) and its error must be surfaced, but only when it's the sole failure: don't mask
+	// a more specific earlier error (e.g. from addDirToZip) with a secondary Close() failure.
+	defer func() {
+		if cerr := zw.Close(); cerr != nil && err == nil {
+			err = errors.Wrap(cerr, "could not finalize prompts zip")
+		}
+	}()
 
 	if err := addDirToZip(zw, baseDir, ""); err != nil {
 		return nil, err
 	}
 
-	if err := zw.Close(); err != nil {
-		return nil, errors.Wrap(err, "could not finalize prompts zip")
-	}
 	return &buf, nil
 }
 
@@ -114,12 +105,12 @@ func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, 
 // one — including the case where no version directory exists at all — the request fails
 // closed with models.NotFoundError.
 func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error) {
-	if !requestedVersionPattern.MatchString(version) {
-		return "", errors.Wrapf(models.BadParameterError, "invalid prompts version format: %s", version)
-	}
-	reqMajor, reqMinor, err := parseMajorMinor(version)
+	requestedVersion, err := semver.NewVersion(version)
 	if err != nil {
-		return "", errors.Wrapf(models.BadParameterError, "invalid prompts version: %s", version)
+		return "", errors.Wrapf(models.BadParameterError, "invalid version format: %s", version)
+	}
+	if requestedVersion.Patch() != 0 {
+		return "", errors.Wrapf(models.BadParameterError, "version must be Major.Minor, got %s", version)
 	}
 
 	entries, err := os.ReadDir(uc.promptsDir)
@@ -127,46 +118,25 @@ func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error
 		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.promptsDir)
 	}
 
-	bestName := ""
-	bestMajor, bestMinor := -1, -1
+	var bestVersion *semver.Version
 	for _, e := range entries {
-		if !e.IsDir() || !promptVersionDirPattern.MatchString(e.Name()) {
-			continue // ignores the coexisting flat legacy files entirely — they don't match
+		if !e.IsDir() {
+			continue // Ignore non-directory entries
 		}
-		maj, min, err := parseMajorMinor(strings.TrimPrefix(e.Name(), "v"))
+		entryVersion, err := semver.NewVersion(e.Name())
 		if err != nil {
-			continue
+			continue // entry is not a prompt version directory
 		}
-		if maj > reqMajor || (maj == reqMajor && min > reqMinor) {
-			continue // never resolve forward
-		}
-		if maj > bestMajor || (maj == bestMajor && min > bestMinor) {
-			bestMajor, bestMinor = maj, min
-			bestName = e.Name()
+		if requestedVersion.Compare(entryVersion) >= 0 && (bestVersion == nil || entryVersion.Compare(bestVersion) > 0) {
+			bestVersion = entryVersion
 		}
 	}
 
-	if bestName == "" {
+	if bestVersion == nil {
 		// No matching/precedent version folder
 		return "", errors.Wrap(models.NotFoundError, "no prompts version available")
 	}
-	return filepath.Join(uc.promptsDir, bestName), nil
-}
-
-func parseMajorMinor(v string) (int, int, error) {
-	parts := strings.Split(v, ".")
-	if len(parts) != 2 {
-		return 0, 0, errors.Newf("expected major.minor, got %q", v)
-	}
-	maj, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, err
-	}
-	min, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, err
-	}
-	return maj, min, nil
+	return filepath.Join(uc.promptsDir, bestVersion.Original()), nil
 }
 
 func addFileToZip(zw *zip.Writer, srcPath, zipName string) error {

--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -10,6 +10,8 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
@@ -17,29 +19,17 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 )
 
-// aiPromptResources is the canonical list of AI prompt resources: the folders and top-level
-// files served as part of the bundle when present. In v1 a single entitlement (CaseAiAssist)
-// grants access to all of them. A resource missing under the resolved version directory is
-// silently skipped (older bundles may not have every folder a newer client knows about).
-var aiPromptResources = []string{
-	"case_review",
-	"kyc_enrichment",
-	"rule",
-	"screening_hit_suggestion",
-	"system.md",
-	"ai_agent_models.json",
-}
-
-// promptVersionDirPattern matches a version directory at the root of promptsDir, e.g.
-// "v1.0.0". Prompts have their own independent semver line (not the product's), where MAJOR
-// signals a breaking structural change (renamed template var, changed JSON schema, restructured
-// folder), MINOR a backward-compatible addition, and PATCH content-only changes.
-var promptVersionDirPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+// promptVersionDirPattern matches a Major.Minor version directory at the root of promptsDir,
+// e.g. "v1.4". Prompt versions follow the Marble product's own release tags (not an
+// independent numbering), truncated to Major.Minor by the prompts-repo CI: every publish
+// targeting the same Major.Minor overwrites that one folder, so "latest for the Major.Minor"
+// is automatic by construction — there is no patch level to list or compare here.
+var promptVersionDirPattern = regexp.MustCompile(`^v\d+\.\d+$`)
 
 // requestedVersionPattern validates a caller-supplied version string (no "v" prefix), e.g.
-// "1.0.0". Checked before the string is ever used to build a filesystem path, so a malformed
+// "1.4". Checked before the string is ever used to build a filesystem path, so a malformed
 // or path-traversal value (e.g. "../secret") is rejected outright instead of reaching disk.
-var requestedVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+var requestedVersionPattern = regexp.MustCompile(`^\d+\.\d+$`)
 
 // promptsLicenseValidator is the subset of PublicLicenseUseCase used by PromptServingUsecase,
 // so license validation (suspended/expired/not-found handling, metrics reporting) is not
@@ -49,9 +39,7 @@ type promptsLicenseValidator interface {
 }
 
 // PromptServingUsecase serves the private AI prompt files to license-holding clients
-// (self-hosted premium deployments downloading prompts at runtime). It is only reachable
-// on Marble SaaS (see the IsMarbleSaasProject-gated routes in api/routes.go), and it reads
-// prompts from promptsDir (the bucket mounted on the SaaS instance).
+// (self-hosted premium deployments downloading prompts at runtime)
 type PromptServingUsecase struct {
 	licenseValidator promptsLicenseValidator
 	promptsDir       string
@@ -65,39 +53,38 @@ func NewPromptServingUsecase(licenseValidator promptsLicenseValidator, promptsDi
 }
 
 // validateEntitlement checks that licenseKey is valid and entitled to the AI feature.
-// It returns models.NotFoundError for an invalid license, an unentitled license, and a
-// server with no prompts configured alike, so a caller can never distinguish these cases.
 func (uc PromptServingUsecase) validateEntitlement(ctx context.Context, licenseKey string) error {
-	if uc.promptsDir == "" {
-		return errors.Wrap(models.NotFoundError, "ai prompts are not configured on this server")
-	}
-
 	license, err := uc.licenseValidator.ValidateLicense(ctx, licenseKey, uuid.Nil)
 	if err != nil {
 		return errors.Wrap(err, "could not validate license")
 	}
 	if license.LicenseValidationCode != models.VALID {
-		return errors.Wrap(models.NotFoundError, "invalid license")
+		return errors.Wrap(models.ForbiddenError, "invalid license")
 	}
 	if !license.CaseAiAssist {
-		return errors.Wrap(models.NotFoundError, "license is not entitled to the ai feature")
+		return errors.Wrap(models.MissingLicenseEntitlementError, "license is not entitled to the ai feature")
 	}
 	return nil
 }
 
-// DownloadPrompts builds and returns a zip archive of the whole entitled AI prompt bundle
-// (every resource in aiPromptResources found under the exact version requested), after
-// checking licenseKey is entitled to the AI feature. There is no "give me the latest
-// compatible" resolution: the caller always asks for one exact version (its own hardcoded
-// default, or an operator-configured pin) so the version actually served is always fully
-// explicit and reproducible. The archive contains only the prompt files themselves — no
-// manifest/version metadata is reported back: the caller already knows which version it asked
-// for. The archive is fully built (and every check run) before returning, so callers can set
-// response headers only once this call has succeeded, without risking a partially-written
-// response.
+// DownloadPrompts builds and returns a zip archive of the whole content of the Major.Minor
+// directory resolved for version, after checking licenseKey is entitled to the AI feature.
+// Everything under that directory is zipped as-is (no fixed resource list to keep in sync) —
+// a new version can introduce a new folder or file and it's included automatically. version is
+// always the caller's own product Major.Minor, auto-detected — there is no manual pin/override.
+// Resolution is a backward search: an exact Major.Minor match wins, otherwise the nearest
+// earlier published Major.Minor is used (never a newer one); if none qualifies, the request
+// fails. The archive contains only the prompt files themselves — no manifest/version metadata
+// is reported back, since the caller already knows which version it asked for. The archive is
+// fully built (and every check run) before returning, so callers can set response headers only
+// once this call has succeeded, without risking a partially-written response.
 func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, version string) (io.Reader, error) {
 	if err := uc.validateEntitlement(ctx, licenseKey); err != nil {
 		return nil, err
+	}
+
+	if uc.promptsDir == "" {
+		return nil, errors.Wrap(models.MissingRequirement, "ai prompts are not configured on this server")
 	}
 
 	baseDir, err := uc.resolvePromptsBase(version)
@@ -108,21 +95,8 @@ func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, 
 	var buf bytes.Buffer
 	zw := zip.NewWriter(&buf)
 
-	for _, resource := range aiPromptResources {
-		resourcePath := filepath.Join(baseDir, resource)
-		info, err := os.Stat(resourcePath)
-		if err != nil {
-			continue // not present in this version's bundle: skip, not an error
-		}
-
-		if info.IsDir() {
-			err = addDirToZip(zw, resourcePath, resource)
-		} else {
-			err = addFileToZip(zw, resourcePath, resource)
-		}
-		if err != nil {
-			return nil, err
-		}
+	if err := addDirToZip(zw, baseDir, ""); err != nil {
+		return nil, err
 	}
 
 	if err := zw.Close(); err != nil {
@@ -131,61 +105,68 @@ func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, 
 	return &buf, nil
 }
 
-// resolvePromptsBase determines which directory to serve prompts from. There is no "closest
-// compatible" search: version is either an exact match (the caller always asks for one precise
-// version, never a range) or the request fails.
-//
-//   - version well-formed and `promptsDir/v<version>/` exists → serve it.
-//   - Otherwise, if promptsDir has no version-looking subdirectories at all (today's flat
-//     layout, before the prompts-repo CI adopts per-version publishing), serve promptsDir
-//     as-is, ignoring version entirely — a smooth transition path, not a permanent behavior:
-//     once any version directory exists, this fallback stops applying.
-//   - Otherwise: version was malformed → models.BadParameterError; version was empty →
-//     models.BadParameterError (a versioned bucket requires an explicit version); version was
-//     well-formed but no matching directory exists → models.NotFoundError.
-//
-// version is validated against requestedVersionPattern before ever being used to build a
-// filesystem path, so it cannot be used for path traversal (e.g. "../secret").
+// resolvePromptsBase picks which Major.Minor directory to serve. Resolution is "exact
+// Major.Minor, else nearest earlier available Major.Minor" (a backward search): among the
+// versioned directories present, the greatest one that is <= the requested version wins. It
+// never resolves forward to a newer version — a product major bump doesn't imply a
+// prompt-breaking change, so crossing a major boundary backward is fine, but resolving forward
+// to something the caller didn't ask for is not. If no available version is <= the requested
+// one — including the case where no version directory exists at all — the request fails
+// closed with models.NotFoundError.
 func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error) {
-	if version != "" {
-		if !requestedVersionPattern.MatchString(version) {
-			return "", errors.Wrapf(models.BadParameterError, "invalid prompts version format: %s", version)
-		}
-		candidate := filepath.Join(uc.promptsDir, "v"+version)
-		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
-			return candidate, nil
-		}
+	if !requestedVersionPattern.MatchString(version) {
+		return "", errors.Wrapf(models.BadParameterError, "invalid prompts version format: %s", version)
+	}
+	reqMajor, reqMinor, err := parseMajorMinor(version)
+	if err != nil {
+		return "", errors.Wrapf(models.BadParameterError, "invalid prompts version: %s", version)
 	}
 
-	hasVersions, err := hasAnyPromptVersionDir(uc.promptsDir)
+	entries, err := os.ReadDir(uc.promptsDir)
 	if err != nil {
 		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.promptsDir)
 	}
-	if !hasVersions {
-		return uc.promptsDir, nil
-	}
 
-	if version == "" {
-		return "", errors.Wrap(models.BadParameterError, "prompts version is required")
-	}
-	return "", errors.Wrapf(models.NotFoundError, "prompts version %s not found", version)
-}
-
-// hasAnyPromptVersionDir reports whether promptsDir contains at least one versioned
-// subdirectory. Used only to distinguish "versioning not adopted yet in this bucket" (serve
-// the flat layout as-is) from "versioning adopted, but the requested version doesn't exist"
-// (a real 404, not something to silently paper over).
-func hasAnyPromptVersionDir(promptsDir string) (bool, error) {
-	entries, err := os.ReadDir(promptsDir)
-	if err != nil {
-		return false, err
-	}
+	bestName := ""
+	bestMajor, bestMinor := -1, -1
 	for _, e := range entries {
-		if e.IsDir() && promptVersionDirPattern.MatchString(e.Name()) {
-			return true, nil
+		if !e.IsDir() || !promptVersionDirPattern.MatchString(e.Name()) {
+			continue // ignores the coexisting flat legacy files entirely — they don't match
+		}
+		maj, min, err := parseMajorMinor(strings.TrimPrefix(e.Name(), "v"))
+		if err != nil {
+			continue
+		}
+		if maj > reqMajor || (maj == reqMajor && min > reqMinor) {
+			continue // never resolve forward
+		}
+		if maj > bestMajor || (maj == bestMajor && min > bestMinor) {
+			bestMajor, bestMinor = maj, min
+			bestName = e.Name()
 		}
 	}
-	return false, nil
+
+	if bestName == "" {
+		// No matching/precedent version folder
+		return "", errors.Wrap(models.NotFoundError, "no prompts version available")
+	}
+	return filepath.Join(uc.promptsDir, bestName), nil
+}
+
+func parseMajorMinor(v string) (int, int, error) {
+	parts := strings.Split(v, ".")
+	if len(parts) != 2 {
+		return 0, 0, errors.Newf("expected major.minor, got %q", v)
+	}
+	maj, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	min, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return maj, min, nil
 }
 
 func addFileToZip(zw *zip.Writer, srcPath, zipName string) error {

--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -1,0 +1,225 @@
+package usecases
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+// aiPromptResources is the canonical list of AI prompt resources: the folders and top-level
+// files served as part of the bundle when present. In v1 a single entitlement (CaseAiAssist)
+// grants access to all of them. A resource missing under the resolved version directory is
+// silently skipped (older bundles may not have every folder a newer client knows about).
+var aiPromptResources = []string{
+	"case_review",
+	"kyc_enrichment",
+	"rule",
+	"screening_hit_suggestion",
+	"system.md",
+	"ai_agent_models.json",
+}
+
+// promptVersionDirPattern matches a version directory at the root of promptsDir, e.g.
+// "v1.0.0". Prompts have their own independent semver line (not the product's), where MAJOR
+// signals a breaking structural change (renamed template var, changed JSON schema, restructured
+// folder), MINOR a backward-compatible addition, and PATCH content-only changes.
+var promptVersionDirPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// requestedVersionPattern validates a caller-supplied version string (no "v" prefix), e.g.
+// "1.0.0". Checked before the string is ever used to build a filesystem path, so a malformed
+// or path-traversal value (e.g. "../secret") is rejected outright instead of reaching disk.
+var requestedVersionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// promptsLicenseValidator is the subset of PublicLicenseUseCase used by PromptServingUsecase,
+// so license validation (suspended/expired/not-found handling, metrics reporting) is not
+// duplicated here and tests can stub it without a real license repository.
+type promptsLicenseValidator interface {
+	ValidateLicense(ctx context.Context, licenseKey string, deploymentId uuid.UUID) (models.LicenseValidation, error)
+}
+
+// PromptServingUsecase serves the private AI prompt files to license-holding clients
+// (self-hosted premium deployments downloading prompts at runtime). It is only reachable
+// on Marble SaaS (see the IsMarbleSaasProject-gated routes in api/routes.go), and it reads
+// prompts from promptsDir (the bucket mounted on the SaaS instance).
+type PromptServingUsecase struct {
+	licenseValidator promptsLicenseValidator
+	promptsDir       string
+}
+
+func NewPromptServingUsecase(licenseValidator promptsLicenseValidator, promptsDir string) PromptServingUsecase {
+	return PromptServingUsecase{
+		licenseValidator: licenseValidator,
+		promptsDir:       promptsDir,
+	}
+}
+
+// validateEntitlement checks that licenseKey is valid and entitled to the AI feature.
+// It returns models.NotFoundError for an invalid license, an unentitled license, and a
+// server with no prompts configured alike, so a caller can never distinguish these cases.
+func (uc PromptServingUsecase) validateEntitlement(ctx context.Context, licenseKey string) error {
+	if uc.promptsDir == "" {
+		return errors.Wrap(models.NotFoundError, "ai prompts are not configured on this server")
+	}
+
+	license, err := uc.licenseValidator.ValidateLicense(ctx, licenseKey, uuid.Nil)
+	if err != nil {
+		return errors.Wrap(err, "could not validate license")
+	}
+	if license.LicenseValidationCode != models.VALID {
+		return errors.Wrap(models.NotFoundError, "invalid license")
+	}
+	if !license.CaseAiAssist {
+		return errors.Wrap(models.NotFoundError, "license is not entitled to the ai feature")
+	}
+	return nil
+}
+
+// DownloadPrompts builds and returns a zip archive of the whole entitled AI prompt bundle
+// (every resource in aiPromptResources found under the exact version requested), after
+// checking licenseKey is entitled to the AI feature. There is no "give me the latest
+// compatible" resolution: the caller always asks for one exact version (its own hardcoded
+// default, or an operator-configured pin) so the version actually served is always fully
+// explicit and reproducible. The archive contains only the prompt files themselves — no
+// manifest/version metadata is reported back: the caller already knows which version it asked
+// for. The archive is fully built (and every check run) before returning, so callers can set
+// response headers only once this call has succeeded, without risking a partially-written
+// response.
+func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, version string) (io.Reader, error) {
+	if err := uc.validateEntitlement(ctx, licenseKey); err != nil {
+		return nil, err
+	}
+
+	baseDir, err := uc.resolvePromptsBase(version)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	for _, resource := range aiPromptResources {
+		resourcePath := filepath.Join(baseDir, resource)
+		info, err := os.Stat(resourcePath)
+		if err != nil {
+			continue // not present in this version's bundle: skip, not an error
+		}
+
+		if info.IsDir() {
+			err = addDirToZip(zw, resourcePath, resource)
+		} else {
+			err = addFileToZip(zw, resourcePath, resource)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if err := zw.Close(); err != nil {
+		return nil, errors.Wrap(err, "could not finalize prompts zip")
+	}
+	return &buf, nil
+}
+
+// resolvePromptsBase determines which directory to serve prompts from. There is no "closest
+// compatible" search: version is either an exact match (the caller always asks for one precise
+// version, never a range) or the request fails.
+//
+//   - version well-formed and `promptsDir/v<version>/` exists → serve it.
+//   - Otherwise, if promptsDir has no version-looking subdirectories at all (today's flat
+//     layout, before the prompts-repo CI adopts per-version publishing), serve promptsDir
+//     as-is, ignoring version entirely — a smooth transition path, not a permanent behavior:
+//     once any version directory exists, this fallback stops applying.
+//   - Otherwise: version was malformed → models.BadParameterError; version was empty →
+//     models.BadParameterError (a versioned bucket requires an explicit version); version was
+//     well-formed but no matching directory exists → models.NotFoundError.
+//
+// version is validated against requestedVersionPattern before ever being used to build a
+// filesystem path, so it cannot be used for path traversal (e.g. "../secret").
+func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error) {
+	if version != "" {
+		if !requestedVersionPattern.MatchString(version) {
+			return "", errors.Wrapf(models.BadParameterError, "invalid prompts version format: %s", version)
+		}
+		candidate := filepath.Join(uc.promptsDir, "v"+version)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate, nil
+		}
+	}
+
+	hasVersions, err := hasAnyPromptVersionDir(uc.promptsDir)
+	if err != nil {
+		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.promptsDir)
+	}
+	if !hasVersions {
+		return uc.promptsDir, nil
+	}
+
+	if version == "" {
+		return "", errors.Wrap(models.BadParameterError, "prompts version is required")
+	}
+	return "", errors.Wrapf(models.NotFoundError, "prompts version %s not found", version)
+}
+
+// hasAnyPromptVersionDir reports whether promptsDir contains at least one versioned
+// subdirectory. Used only to distinguish "versioning not adopted yet in this bucket" (serve
+// the flat layout as-is) from "versioning adopted, but the requested version doesn't exist"
+// (a real 404, not something to silently paper over).
+func hasAnyPromptVersionDir(promptsDir string) (bool, error) {
+	entries, err := os.ReadDir(promptsDir)
+	if err != nil {
+		return false, err
+	}
+	for _, e := range entries {
+		if e.IsDir() && promptVersionDirPattern.MatchString(e.Name()) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func addFileToZip(zw *zip.Writer, srcPath, zipName string) error {
+	f, err := zw.Create(zipName)
+	if err != nil {
+		return errors.Wrapf(err, "could not create %s in zip", zipName)
+	}
+
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return errors.Wrapf(err, "could not open prompt file %s", srcPath)
+	}
+	defer src.Close()
+
+	if _, err := io.Copy(f, src); err != nil {
+		return errors.Wrapf(err, "could not write %s to zip", zipName)
+	}
+	return nil
+}
+
+func addDirToZip(zw *zip.Writer, srcDir, zipRoot string) error {
+	return filepath.WalkDir(srcDir, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, filePath)
+		if err != nil {
+			return err
+		}
+		// zip entry names always use "/", regardless of the OS path separator.
+		zipName := path.Join(zipRoot, filepath.ToSlash(rel))
+		return addFileToZip(zw, filePath, zipName)
+	})
+}

--- a/usecases/prompt_serving_usecase_test.go
+++ b/usecases/prompt_serving_usecase_test.go
@@ -44,7 +44,8 @@ func writeCaseReviewPrompt(t *testing.T, root, content string) {
 }
 
 // writePromptsFixture creates a flat (legacy, unversioned) prompts directory under
-// t.TempDir(), matching a subset of aiPromptResources, and returns its path.
+// t.TempDir() and returns its path. Represents the flat legacy files that coexist with (but
+// are never read by) the versioned resolution logic.
 func writePromptsFixture(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -54,8 +55,8 @@ func writePromptsFixture(t *testing.T) string {
 	return dir
 }
 
-// writeVersionedPromptsFixture creates <tempdir>/vX.Y.Z/ subdirectories, one per entry in
-// versions (full directory names, e.g. "v1.0.0"), each containing a case_review prompt whose
+// writeVersionedPromptsFixture creates <tempdir>/vX.Y/ subdirectories, one per entry in
+// versions (full directory names, e.g. "v1.0"), each containing a case_review prompt whose
 // content identifies its own version, so tests can assert exactly which version was served
 // (there is no reported version field to check: the response is just the prompt files).
 func writeVersionedPromptsFixture(t *testing.T, versions ...string) string {
@@ -124,21 +125,25 @@ func Test_PromptServingUsecase_DownloadPrompts_Authorization(t *testing.T) {
 		name       string
 		promptsDir string
 		validation stubLicenseValidator
+		wantErr    error
 	}{
 		{
 			name:       "invalid license",
 			promptsDir: dir,
 			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.NOT_FOUND}},
+			wantErr:    models.ForbiddenError,
 		},
 		{
 			name:       "valid license without AI entitlement",
 			promptsDir: dir,
 			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.VALID}},
+			wantErr:    models.MissingLicenseEntitlementError,
 		},
 		{
 			name:       "no prompts directory configured on this server",
 			promptsDir: "",
 			validation: stubLicenseValidator{validation: validLicenseWithAi()},
+			wantErr:    models.MissingRequirement,
 		},
 	}
 	for _, tt := range tests {
@@ -146,65 +151,42 @@ func Test_PromptServingUsecase_DownloadPrompts_Authorization(t *testing.T) {
 			uc := NewPromptServingUsecase(tt.validation, tt.promptsDir)
 			_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
 			require.Error(t, err)
-			assert.True(t, errors.Is(err, models.NotFoundError))
+			assert.True(t, errors.Is(err, tt.wantErr))
 		})
 	}
 
-	t.Run("license server error is propagated but not surfaced as not-found", func(t *testing.T) {
+	t.Run("license server error is propagated as-is, not mapped to a specific error type", func(t *testing.T) {
 		uc := NewPromptServingUsecase(stubLicenseValidator{err: errors.New("boom")}, dir)
 		_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
 		require.Error(t, err)
-		assert.False(t, errors.Is(err, models.NotFoundError))
+		assert.False(t, errors.Is(err, models.ForbiddenError))
+		assert.False(t, errors.Is(err, models.MissingLicenseEntitlementError))
 	})
 }
 
-func Test_PromptServingUsecase_DownloadPrompts_LegacyFlatLayout(t *testing.T) {
-	dir := writePromptsFixture(t)
-	uc := NewPromptServingUsecase(stubLicenseValidator{validation: validLicenseWithAi()}, dir)
-	wantNames := []string{"case_review/case_review.md", "system.md", "ai_agent_models.json"}
-
-	t.Run("well-formed version with no matching directory falls back to the flat bundle", func(t *testing.T) {
-		names := zipEntryNames(t, downloadPrompts(t, uc, "1.4.2"))
-		assert.ElementsMatch(t, wantNames, names)
-		assert.NotContains(t, names, "manifest.json")
-	})
-
-	t.Run("empty version also falls back to the flat bundle", func(t *testing.T) {
-		names := zipEntryNames(t, downloadPrompts(t, uc, ""))
-		assert.ElementsMatch(t, wantNames, names)
-	})
-
-	t.Run("malformed version is rejected even in flat/legacy mode", func(t *testing.T) {
-		_, err := uc.DownloadPrompts(context.Background(), "some-key", "not-a-version")
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, models.BadParameterError))
-	})
-}
-
-func Test_PromptServingUsecase_DownloadPrompts_ExactVersionResolution(t *testing.T) {
+func Test_PromptServingUsecase_DownloadPrompts_VersionResolution(t *testing.T) {
 	validated := stubLicenseValidator{validation: validLicenseWithAi()}
-	dir := writeVersionedPromptsFixture(t, "v1.0.0", "v1.1.0", "v2.0.0")
+	dir := writeVersionedPromptsFixture(t, "v1.0", "v1.1", "v2.0")
 	uc := NewPromptServingUsecase(validated, dir)
 
 	t.Run("exact match is served", func(t *testing.T) {
-		content := downloadCaseReviewContent(t, uc, "1.1.0")
-		assert.Equal(t, "prompt for v1.1.0", content)
+		content := downloadCaseReviewContent(t, uc, "1.1")
+		assert.Equal(t, "prompt for v1.1", content)
 	})
 
-	t.Run("another available version is served exactly, no resolution to 'latest'", func(t *testing.T) {
-		content := downloadCaseReviewContent(t, uc, "1.0.0")
-		assert.Equal(t, "prompt for v1.0.0", content)
+	t.Run("backward search: nearest earlier available, never forward, can cross a major", func(t *testing.T) {
+		// v2.0 exists in the bucket, but requesting 1.5 (absent) must resolve to v1.1, not v2.0.
+		content := downloadCaseReviewContent(t, uc, "1.5")
+		assert.Equal(t, "prompt for v1.1", content)
 	})
 
-	t.Run("version absent from a versioned bucket is not found, never a fallback", func(t *testing.T) {
-		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.5.0")
-		require.Error(t, err)
-		assert.True(t, errors.Is(err, models.NotFoundError))
+	t.Run("request above everything resolves to the nearest earlier, no ceiling", func(t *testing.T) {
+		content := downloadCaseReviewContent(t, uc, "3.0")
+		assert.Equal(t, "prompt for v2.0", content)
 	})
 
-	t.Run("a newer major that happens to exist is never silently substituted", func(t *testing.T) {
-		// v2.0.0 exists in the bucket, but requesting v1.9.0 (absent) must not resolve to it.
-		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.9.0")
+	t.Run("request below everything is not found, no fallback", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "0.9")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, models.NotFoundError))
 	})
@@ -216,7 +198,7 @@ func Test_PromptServingUsecase_DownloadPrompts_ExactVersionResolution(t *testing
 	})
 
 	t.Run("malformed version is rejected", func(t *testing.T) {
-		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.9")
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.9.3")
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, models.BadParameterError))
 	})
@@ -226,15 +208,32 @@ func Test_PromptServingUsecase_DownloadPrompts_ExactVersionResolution(t *testing
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, models.BadParameterError))
 	})
+
+	t.Run("a bucket with zero version directories never falls back to the flat legacy files", func(t *testing.T) {
+		flatDir := writePromptsFixture(t)
+		flatUc := NewPromptServingUsecase(validated, flatDir)
+		_, err := flatUc.DownloadPrompts(context.Background(), "some-key", "1.4")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.NotFoundError))
+	})
 }
 
-func Test_PromptServingUsecase_DownloadPrompts_SkipsResourcesMissingFromResolvedVersion(t *testing.T) {
-	// Only contains case_review/ under v1.0.0; system.md, rule/, etc. are absent for it.
-	dir := writeVersionedPromptsFixture(t, "v1.0.0")
+func Test_PromptServingUsecase_DownloadPrompts_ZipsWhateverIsInTheResolvedVersionDirectory(t *testing.T) {
+	// There is no fixed resource list: whatever exists under the resolved version directory is
+	// zipped, so a version can bring an entirely new folder/file and it's included automatically
+	// without any code change here.
+	dir := writeVersionedPromptsFixture(t, "v1.0")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "v1.0", "brand_new_feature"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "v1.0", "brand_new_feature", "prompt.md"), []byte("new"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "v1.0", "system.md"), []byte("system"), 0o644))
+
 	uc := NewPromptServingUsecase(stubLicenseValidator{validation: validLicenseWithAi()}, dir)
 
-	names := zipEntryNames(t, downloadPrompts(t, uc, "1.0.0"))
-	assert.Contains(t, names, "case_review/case_review.md")
-	assert.NotContains(t, names, "system.md")
-	assert.NotContains(t, names, "manifest.json")
+	names := zipEntryNames(t, downloadPrompts(t, uc, "1.0"))
+	assert.ElementsMatch(t, []string{
+		"case_review/case_review.md",
+		"brand_new_feature/prompt.md",
+		"system.md",
+	}, names)
 }

--- a/usecases/prompt_serving_usecase_test.go
+++ b/usecases/prompt_serving_usecase_test.go
@@ -1,0 +1,240 @@
+package usecases
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+// stubLicenseValidator is a minimal stand-in for PublicLicenseUseCase, implementing
+// promptsLicenseValidator directly so tests don't need a real license repository.
+type stubLicenseValidator struct {
+	validation models.LicenseValidation
+	err        error
+}
+
+func (s stubLicenseValidator) ValidateLicense(
+	ctx context.Context, licenseKey string, deploymentId uuid.UUID,
+) (models.LicenseValidation, error) {
+	return s.validation, s.err
+}
+
+func validLicenseWithAi() models.LicenseValidation {
+	return models.LicenseValidation{
+		LicenseValidationCode: models.VALID,
+		LicenseEntitlements:   models.LicenseEntitlements{CaseAiAssist: true},
+	}
+}
+
+func writeCaseReviewPrompt(t *testing.T, root, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "case_review"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "case_review", "case_review.md"), []byte(content), 0o644))
+}
+
+// writePromptsFixture creates a flat (legacy, unversioned) prompts directory under
+// t.TempDir(), matching a subset of aiPromptResources, and returns its path.
+func writePromptsFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	writeCaseReviewPrompt(t, dir, "case review prompt")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "system.md"), []byte("system prompt"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ai_agent_models.json"), []byte(`{"default_model":"x"}`), 0o644))
+	return dir
+}
+
+// writeVersionedPromptsFixture creates <tempdir>/vX.Y.Z/ subdirectories, one per entry in
+// versions (full directory names, e.g. "v1.0.0"), each containing a case_review prompt whose
+// content identifies its own version, so tests can assert exactly which version was served
+// (there is no reported version field to check: the response is just the prompt files).
+func writeVersionedPromptsFixture(t *testing.T, versions ...string) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, v := range versions {
+		writeCaseReviewPrompt(t, filepath.Join(root, v), "prompt for "+v)
+	}
+	return root
+}
+
+// downloadCaseReviewContent runs DownloadPrompts and returns the raw content of
+// case_review/case_review.md (present in every fixture above), the only signal available for
+// which version was actually served now that no manifest is reported.
+func downloadCaseReviewContent(t *testing.T, uc PromptServingUsecase, version string) string {
+	t.Helper()
+	zr := unzip(t, downloadPrompts(t, uc, version))
+	for _, f := range zr.File {
+		if f.Name == "case_review/case_review.md" {
+			return string(readZipFile(t, f))
+		}
+	}
+	return ""
+}
+
+func downloadPrompts(t *testing.T, uc PromptServingUsecase, version string) io.Reader {
+	t.Helper()
+	r, err := uc.DownloadPrompts(context.Background(), "some-key", version)
+	require.NoError(t, err)
+	return r
+}
+
+func zipEntryNames(t *testing.T, r io.Reader) []string {
+	t.Helper()
+	zr := unzip(t, r)
+	var names []string
+	for _, f := range zr.File {
+		names = append(names, f.Name)
+	}
+	return names
+}
+
+func unzip(t *testing.T, r io.Reader) *zip.Reader {
+	t.Helper()
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+	return zr
+}
+
+func readZipFile(t *testing.T, f *zip.File) []byte {
+	t.Helper()
+	rc, err := f.Open()
+	require.NoError(t, err)
+	defer rc.Close()
+	b, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	return b
+}
+
+func Test_PromptServingUsecase_DownloadPrompts_Authorization(t *testing.T) {
+	dir := writePromptsFixture(t)
+
+	tests := []struct {
+		name       string
+		promptsDir string
+		validation stubLicenseValidator
+	}{
+		{
+			name:       "invalid license",
+			promptsDir: dir,
+			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.NOT_FOUND}},
+		},
+		{
+			name:       "valid license without AI entitlement",
+			promptsDir: dir,
+			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.VALID}},
+		},
+		{
+			name:       "no prompts directory configured on this server",
+			promptsDir: "",
+			validation: stubLicenseValidator{validation: validLicenseWithAi()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := NewPromptServingUsecase(tt.validation, tt.promptsDir)
+			_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, models.NotFoundError))
+		})
+	}
+
+	t.Run("license server error is propagated but not surfaced as not-found", func(t *testing.T) {
+		uc := NewPromptServingUsecase(stubLicenseValidator{err: errors.New("boom")}, dir)
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, models.NotFoundError))
+	})
+}
+
+func Test_PromptServingUsecase_DownloadPrompts_LegacyFlatLayout(t *testing.T) {
+	dir := writePromptsFixture(t)
+	uc := NewPromptServingUsecase(stubLicenseValidator{validation: validLicenseWithAi()}, dir)
+	wantNames := []string{"case_review/case_review.md", "system.md", "ai_agent_models.json"}
+
+	t.Run("well-formed version with no matching directory falls back to the flat bundle", func(t *testing.T) {
+		names := zipEntryNames(t, downloadPrompts(t, uc, "1.4.2"))
+		assert.ElementsMatch(t, wantNames, names)
+		assert.NotContains(t, names, "manifest.json")
+	})
+
+	t.Run("empty version also falls back to the flat bundle", func(t *testing.T) {
+		names := zipEntryNames(t, downloadPrompts(t, uc, ""))
+		assert.ElementsMatch(t, wantNames, names)
+	})
+
+	t.Run("malformed version is rejected even in flat/legacy mode", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "not-a-version")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.BadParameterError))
+	})
+}
+
+func Test_PromptServingUsecase_DownloadPrompts_ExactVersionResolution(t *testing.T) {
+	validated := stubLicenseValidator{validation: validLicenseWithAi()}
+	dir := writeVersionedPromptsFixture(t, "v1.0.0", "v1.1.0", "v2.0.0")
+	uc := NewPromptServingUsecase(validated, dir)
+
+	t.Run("exact match is served", func(t *testing.T) {
+		content := downloadCaseReviewContent(t, uc, "1.1.0")
+		assert.Equal(t, "prompt for v1.1.0", content)
+	})
+
+	t.Run("another available version is served exactly, no resolution to 'latest'", func(t *testing.T) {
+		content := downloadCaseReviewContent(t, uc, "1.0.0")
+		assert.Equal(t, "prompt for v1.0.0", content)
+	})
+
+	t.Run("version absent from a versioned bucket is not found, never a fallback", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.5.0")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.NotFoundError))
+	})
+
+	t.Run("a newer major that happens to exist is never silently substituted", func(t *testing.T) {
+		// v2.0.0 exists in the bucket, but requesting v1.9.0 (absent) must not resolve to it.
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.9.0")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.NotFoundError))
+	})
+
+	t.Run("empty version is rejected once the bucket has adopted versioning", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.BadParameterError))
+	})
+
+	t.Run("malformed version is rejected", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "1.9")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.BadParameterError))
+	})
+
+	t.Run("path traversal attempt is rejected before touching the filesystem", func(t *testing.T) {
+		_, err := uc.DownloadPrompts(context.Background(), "some-key", "../../etc/passwd")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, models.BadParameterError))
+	})
+}
+
+func Test_PromptServingUsecase_DownloadPrompts_SkipsResourcesMissingFromResolvedVersion(t *testing.T) {
+	// Only contains case_review/ under v1.0.0; system.md, rule/, etc. are absent for it.
+	dir := writeVersionedPromptsFixture(t, "v1.0.0")
+	uc := NewPromptServingUsecase(stubLicenseValidator{validation: validLicenseWithAi()}, dir)
+
+	names := zipEntryNames(t, downloadPrompts(t, uc, "1.0.0"))
+	assert.Contains(t, names, "case_review/case_review.md")
+	assert.NotContains(t, names, "system.md")
+	assert.NotContains(t, names, "manifest.json")
+}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -55,6 +55,7 @@ type Usecases struct {
 	allowInsecureWebhookURLs     bool   // Allow HTTP webhook URLs (dev only)
 	webhookIPWhitelist           string // Comma-separated CIDR ranges to whitelist for webhooks
 	screeningOffloadingEnabled   bool
+	promptsDir                   string
 
 	coordsEnricher *rgeo.Rgeo
 	ipEnricher     *maxminddb.Reader
@@ -236,6 +237,12 @@ func WithScreeningOffloadingEnabled(enabled bool) Option {
 	}
 }
 
+func WithPromptsDir(dir string) Option {
+	return func(o *options) {
+		o.promptsDir = dir
+	}
+}
+
 type options struct {
 	appName                      string
 	apiVersion                   string
@@ -263,6 +270,7 @@ type options struct {
 	screeningOffloadingEnabled   bool
 	webhookIPWhitelist           string
 	ipEnricher                   *maxminddb.Reader
+	promptsDir                   string
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -302,6 +310,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		allowInsecureWebhookURLs:     o.allowInsecureWebhookURLs,
 		webhookIPWhitelist:           o.webhookIPWhitelist,
 		screeningOffloadingEnabled:   o.screeningOffloadingEnabled,
+		promptsDir:                   o.promptsDir,
 
 		coordsEnricher: coordsEnricher,
 		ipEnricher:     o.ipEnricher,
@@ -578,6 +587,14 @@ func (usecases *Usecases) NewLicenseUsecase() PublicLicenseUseCase {
 		usecases.Repositories.MetricsIngestionRepository,
 		usecases.Repositories.MarbleDbRepository,
 		usecases.license,
+	)
+}
+
+func (usecases *Usecases) NewPromptServingUsecase() PromptServingUsecase {
+	licenseUsecase := usecases.NewLicenseUsecase()
+	return NewPromptServingUsecase(
+		&licenseUsecase,
+		usecases.promptsDir,
 	)
 }
 


### PR DESCRIPTION
## Summary

Adds a new endpoint so Marble SaaS can serve the private AI prompt bundle to self-hosted premium Marble instances over HTTP, replacing manual prompt-file setup for self-hosted deployments. Prompts stay private (SaaS-only endpoint, license-gated) while self-hosted clients can fetch exactly the version compatible with their own release.

Companion change (GCS upload side): https://github.com/checkmarble/marble-llm-prompt/pull/38

## GCS directory structure

Prompt bundles are published into GCS under a folder per product **Major.Minor** version:

```
<bucket>/
  v1.3/
    case_review/...
    kyc_enrichment/...
    rule/...
    screening_hit_suggestion/...
    system.md
    ai_agent_models.json
  v1.4/
    ...same layout, this Major.Minor's content...
  case_review/          <- flat, unversioned (see below)
  system.md
  ai_agent_models.json
  ...
```

- One folder per Major.Minor (not per patch): every CI publish targeting the same Major.Minor **overwrites** that folder, so "latest for the Major.Minor" is automatic — there's no patch level to track or compare.
- Versioning follows the *product's* own release tags (truncated to Major.Minor by the prompts-repo CI), not an independent numbering. Not every release needs a new prompt folder — if prompt content didn't change, a version can be skipped entirely.
- The **flat files at the bucket root are untouched** by this change — they're read directly by Marble's own SaaS backend for its own internal AI feature usage, a separate concern from this endpoint. A later PR will migrate that internal usage onto the versioned layout too and retire the flat files.
- This endpoint **never reads the flat files**, only versioned folders — see resolution logic below.

## `PROMPTS_DIR` and the GCS mount

`PROMPTS_DIR` (new env var, wired via `usecases.WithPromptsDir`) tells the server where to read prompts from. On Marble SaaS, this points at the **GCS bucket mounted directly into the container** (GCS FUSE / a Cloud Run volume mount) — not something fetched over the network per request. `PromptServingUsecase` just walks that mounted directory tree with regular filesystem calls (`os.ReadDir`, `filepath.WalkDir`), so serving a request is a cheap local read, not a GCS API call.

If `PROMPTS_DIR` isn't configured at all, every request fails with `models.MissingRequirement` — this is treated as a Marble-side deployment misconfiguration (not a per-client condition), since it means the SaaS forgot to mount/configure its own prompts bucket.

## Endpoint & resolution

```
GET /ai-prompts/download?prompts_version=<major.minor>
Authorization: Bearer <license-key>
```

- SaaS-only: registered inside the existing `infra.IsMarbleSaasProject()`-gated block in `api/routes.go`.
- Auth: license key via `Authorization: Bearer`, validated and required to carry the `CaseAiAssist` entitlement — a single flag gates the whole prompt bundle, no per-resource granularity.
- `prompts_version` is **required**, always the caller's own product Major.Minor (no manual pin/override — self-hosted clients auto-detect their own build version). Resolution (`PromptServingUsecase.resolvePromptsBase`):
  - Exact Major.Minor match → served.
  - No exact match → the **nearest earlier published** Major.Minor is used instead (a backward search; can cross a major boundary, since a product major bump doesn't imply a prompt-breaking change). Never resolves *forward* to something newer than requested.
  - Nothing available `<=` the requested version → `404`.

## Response

`Content-Type: application/zip`. The body contains **everything found under the resolved version folder, as-is** — there's no fixed resource list to keep in sync with what the prompts repo publishes, so a new version can introduce a brand-new folder or file and it's included automatically without any backend code change. No manifest or version metadata is embedded in the response: the caller already knows exactly which version it asked for.

## How a Marble client should use this (self-hosted, client-side work tracked separately)

The self-hosted client integration isn't built in this PR, but the intended usage is:

1. On every process start (server and worker each do this independently), call this endpoint with the client's own detected product Major.Minor.
2. The response is a zip byte stream — unzip it **directly into memory**. Go's `archive/zip.Reader`, constructed over the downloaded bytes, is itself an `fs.FS`, so no temp files or disk writes are needed at all.
3. Use that in-memory `fs.FS` as the prompt source for the lifetime of that process. No local caching/persistence across restarts by design — the payload is small and the read is cheap, so simplicity wins over avoiding a repeat fetch on the next start.

## Testing

- `usecases/prompt_serving_usecase_test.go`: license/entitlement gating, exact-match and backward-search version resolution (including crossing a major boundary and failing closed when nothing qualifies), path-traversal/malformed-input rejection, and that the zip includes whatever is actually present in the resolved directory (including a brand-new, previously-unlisted folder).
- `go build`, `go vet`, `golangci-lint run`, full `go test ./...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to download AI prompt bundles as a streamed ZIP (`GET /ai-prompts/download`), requiring a `prompts_version` query parameter.
  * Made prompt bundle storage configurable at runtime via `PROMPTS_DIR`.
* **Bug Fixes**
  * Enforced license entitlement checks before serving downloads.
  * Updated version handling to Major.Minor semantics (rejects patch versions) with nearest-earlier selection and no fallback to legacy layouts; added safer validation for invalid/unsafe versions.
* **Tests**
  * Added coverage for authorization handling, version resolution rules, and ZIP contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->