### PR TITLE
fix: wrong step order execution when deleting/creating a field with same name

### DIFF
--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -1053,16 +1053,6 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 		// 12. Org schema mutations (add/delete physical columns)
 		return usecase.transactionFactory.TransactionInOrgSchema(
 			ctx, table.OrganizationID, func(orgTx repositories.Transaction) error {
-				for _, f := range input.FieldsToAdd {
-					if f.Name == "object_id" || f.Name == "updated_at" {
-						continue
-					}
-					if err := usecase.organizationSchemaRepository.CreateField(
-						ctx, orgTx, table.Name, f); err != nil {
-						return err
-					}
-				}
-
 				for _, field := range deletedFields {
 					if err := usecase.organizationSchemaRepository.DeleteField(
 						ctx, orgTx, table.Name, field.Name); err != nil {
@@ -1073,6 +1063,16 @@ func (usecase *usecase) UpdateDataModelTableComposite(
 				for _, field := range archivedFields {
 					if err := usecase.organizationSchemaRepository.RenameField(
 						ctx, orgTx, table.Name, field.Name); err != nil {
+						return err
+					}
+				}
+
+				for _, f := range input.FieldsToAdd {
+					if f.Name == "object_id" || f.Name == "updated_at" {
+						continue
+					}
+					if err := usecase.organizationSchemaRepository.CreateField(
+						ctx, orgTx, table.Name, f); err != nil {
 						return err
 					}
 				}


### PR DESCRIPTION
In the same query, deleting and creating the same field won’t create the field in the organization’s database. However, the field is correctly referenced in the data model metadata within the Marble schema. For the user, the field is correctly created and displayed, the ingestion will fail because the field is not present in the organization database.

The order of operations is incorrect, and there’s a mismatch between the steps. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted data model updates so existing fields are no longer removed or renamed during schema changes.
  * New fields continue to be added as expected, while reserved columns remain protected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->