### PR TITLE
AI prompts Phase B: client-side loading via injectable fs.FS

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/usecases/ai_agent"
 	"github.com/checkmarble/marble-backend/usecases/auth"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
@@ -371,6 +373,16 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		return errors.Wrap(err, "failed to open ip enrichment database")
 	}
 
+	var aiPromptsFS fs.FS
+	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, config.Version, licenseConfig.LicenseKey)
+		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
+			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible",
+				"error", err.Error())
+			aiPromptsFS = nil
+		}
+	}
+
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),
 		usecases.WithApiVersion(config.Version),
@@ -393,6 +405,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
 		usecases.WithAIPromptsServingDir(aiPromptsServingDir),
+		usecases.WithAIPromptsFS(aiPromptsFS),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -374,7 +374,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 	}
 
 	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+	if license.LicenseValidationCode == models.VALID {
 		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, config.Version, licenseConfig.LicenseKey)
 		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
 			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible",

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -21,6 +22,7 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/usecases/ai_agent"
 	"github.com/checkmarble/marble-backend/usecases/continuous_screening"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/worker_jobs"
@@ -338,6 +340,17 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		return errors.Wrap(err, "failed to open ip enrichment database")
 	}
 
+	aiPromptsServingDir := utils.GetEnv("AI_PROMPTS_SERVING_DIR", "")
+	var aiPromptsFS fs.FS
+	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, apiVersion, licenseConfig.LicenseKey)
+		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
+			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavailable",
+				"error", err.Error())
+			aiPromptsFS = nil
+		}
+	}
+
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),
 		usecases.WithIngestionBucketUrl(workerConfig.ingestionBucketUrl),
@@ -357,6 +370,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		usecases.WithCsCreateFullDatasetInterval(workerConfig.CreateFullDatasetInterval),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
+		usecases.WithAIPromptsFS(aiPromptsFS),
 	)
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, uc)
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -342,7 +342,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 
 	aiPromptsServingDir := utils.GetEnv("AI_PROMPTS_SERVING_DIR", "")
 	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+	if license.LicenseValidationCode == models.VALID {
 		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, apiVersion, licenseConfig.LicenseKey)
 		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
 			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavailable",

--- a/infra/ai_prompts.go
+++ b/infra/ai_prompts.go
@@ -1,0 +1,233 @@
+package infra
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/avast/retry-go/v4"
+	"github.com/cockroachdb/errors"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+// aiPromptsServerURLDefault is a var, not a const, so tests in this package can point it at an
+// httptest.Server instead of the real Marble SaaS endpoint.
+var aiPromptsServerURLDefault = "https://api.checkmarble.com"
+
+// Resolution is a three-tier priority, all-or-nothing (the first tier that applies wins,
+// the others are not tried):
+//
+//  1. AI_PROMPTS_EXECUTION_DIR env var, if set: used as-is, no resolution, no network.
+//     Can be used for staging pointing the latest version of prompts or self hosted instances
+//     to use it own prompts instead of the Marble one.
+//  2. promptsServingDir, if non-empty: this instance already has the private prompts bucket
+//     mounted locally (production's case - it needs the mount anyway to host the
+//     download-serving endpoint). The right vX.Y folder is resolved in-process, using the
+//     exact same backward-search algorithm the serving endpoint uses, against version. No
+//     network call at all - this avoids production making an HTTP call back to itself, which
+//     would deadlock on a cold start.
+//  3. Network download: only reached when neither of the above applies (a genuine external
+//     self-hosted client with no local mount). Calls the download-serving endpoint on
+//     aiPromptsServerURLDefault, using licenseKey and version. The zip response is checked
+//     against models.AiAgentPromptPaths - every expected prompt must be present and readable,
+//     or the download is rejected outright - then kept entirely in memory as an fs.FS, never
+//     written to disk.
+func InitAiPromptsFS(ctx context.Context, promptsServingDir, version, licenseKey string) fs.FS {
+	logger := utils.LoggerFromContext(ctx)
+
+	// Tier 1: explicit local override, used as-is, no resolution, no network.
+	if dir := utils.GetEnv("AI_PROMPTS_EXECUTION_DIR", ""); dir != "" {
+		info, err := os.Stat(dir)
+		if err != nil {
+			logger.WarnContext(ctx, "AI_PROMPTS_EXECUTION_DIR is set but not readable, ai prompts unavailable",
+				"path", dir, "error", err.Error())
+			return nil
+		}
+		if !info.IsDir() {
+			logger.WarnContext(ctx, "AI_PROMPTS_EXECUTION_DIR is set but is not a directory, ai prompts unavailable",
+				"path", dir)
+			return nil
+		}
+		logger.InfoContext(ctx, "using local ai prompts execution directory", "path", dir)
+		return os.DirFS(dir)
+	}
+
+	// Tier 2: this instance already has the bucket mounted locally (e.g. production, which
+	// needs it anyway to host the download-serving endpoint) - resolve in-process, no network,
+	// no self-call, and it automatically tracks new releases.
+	if promptsServingDir != "" {
+		best, err := resolveLocalPromptsVersion(promptsServingDir, version)
+		if err != nil {
+			logger.WarnContext(ctx, "could not resolve ai prompts from local serving directory, ai prompts unavailable",
+				"path", promptsServingDir, "version", version, "error", err.Error())
+			return nil
+		}
+		logger.InfoContext(ctx, "using local ai prompts serving directory", "path", promptsServingDir, "version", best)
+		return os.DirFS(filepath.Join(promptsServingDir, best))
+	}
+
+	// Tier 3: genuine external self-hosted client, no local mount - download over the network.
+	// A Marble SaaS instance reaching this point is a misconfiguration: it should always have
+	// tier 1 (staging) or tier 2 (production) set up
+	if IsMarbleSaasProject() {
+		logger.WarnContext(ctx, "marble saas instance is falling through to ai prompts network download - "+
+			"AI_PROMPTS_EXECUTION_DIR or promptsServingDir should be configured")
+	}
+	return downloadAiPromptsFS(ctx, version, licenseKey)
+}
+
+// resolveLocalPromptsVersion lists the vX.Y directories under promptsServingDir and picks the
+// best one for version, using the same backward-search algorithm as the download-serving
+// endpoint (pure_utils.ResolveBestPromptVersion).
+func resolveLocalPromptsVersion(promptsServingDir, version string) (string, error) {
+	entries, err := os.ReadDir(promptsServingDir)
+	if err != nil {
+		return "", err
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+
+	best, err := pure_utils.ResolveBestPromptVersion(names, version)
+	if err != nil {
+		return "", err
+	}
+	if best == "" {
+		return "", errors.Newf("no ai prompts version available for %s in %s", version, promptsServingDir)
+	}
+	return best, nil
+}
+
+// aiPromptsDownloadTimeout bounds each individual download attempt, so a Marble SaaS endpoint
+// that never responds can't hang startup indefinitely.
+const aiPromptsDownloadTimeout = 30 * time.Second
+
+// download the prompts zip for version from the Marble SaaS download-serving endpoint,
+// authenticated with licenseKey.
+func downloadAiPromptsFS(ctx context.Context, version, licenseKey string) fs.FS {
+	logger := utils.LoggerFromContext(ctx)
+
+	if licenseKey == "" {
+		logger.InfoContext(ctx, "no license configured, ai prompts unavailable")
+		return nil
+	}
+
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		logger.InfoContext(ctx, "non-semver version, skipping ai prompts download", "version", version, "error", err.Error())
+		return nil
+	}
+	majorMinor := fmt.Sprintf("%d.%d", v.Major(), v.Minor())
+
+	downloadURL, err := url.Parse(aiPromptsServerURLDefault)
+	if err != nil {
+		logger.WarnContext(ctx, "could not parse ai prompts server url, ai prompts unavailable", "error", err.Error())
+		return nil
+	}
+	downloadURL = downloadURL.JoinPath("ai-prompts", "download")
+	query := downloadURL.Query()
+	query.Set("prompts_version", majorMinor)
+	downloadURL.RawQuery = query.Encode()
+
+	logger.InfoContext(ctx, "downloading ai prompts", "url", downloadURL.String(), "version", majorMinor)
+
+	var promptsFS fs.FS
+	err = retry.Do(
+		func() error {
+			attemptCtx, cancel := context.WithTimeout(ctx, aiPromptsDownloadTimeout)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, downloadURL.String(), nil)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Authorization", "Bearer "+licenseKey)
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode >= http.StatusInternalServerError {
+				return errors.Newf("received status code %d", resp.StatusCode)
+			}
+			if resp.StatusCode != http.StatusOK {
+				return retry.Unrecoverable(errors.Newf("received status code %d", resp.StatusCode))
+			}
+
+			data, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			fsys, err := zipToPromptsFS(data)
+			if err != nil {
+				return err
+			}
+			promptsFS = fsys
+			return nil
+		},
+		retry.Attempts(3),
+		retry.LastErrorOnly(true),
+		retry.Delay(100*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
+		retry.Context(ctx),
+	)
+	if err != nil {
+		logger.WarnContext(ctx, "could not download ai prompts, ai prompts unavailable", "error", err.Error())
+		return nil
+	}
+
+	return promptsFS
+}
+
+// zipToPromptsFS parses data as a zip archive and fills a models.AiAgentPromptsMapFS with
+// exactly the files in models.AiAgentExpectedFiles, read from the archive by name. Anything
+// present in the zip but not in the manifest is ignored.
+//
+// The two failure modes it can return are deliberately distinguished, since only one of them
+// is worth retrying (see downloadAiPromptsFS, which calls this from inside its retry.Do):
+//   - the archive fails to parse, or an expected file's content fails to read (e.g. a checksum
+//     mismatch) - both look like a truncated/corrupted download, so the error is returned as-is
+//     and downloadAiPromptsFS's retry.Do will retry it.
+//   - an expected file is simply absent from an otherwise well-formed archive - a content
+//     mismatch (wrong version bundled, stale manifest) that no retry will fix, so it's wrapped
+//     in retry.Unrecoverable to fail fast.
+func zipToPromptsFS(data []byte) (fs.FS, error) {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, errors.Wrap(err, "could not parse ai prompts zip archive")
+	}
+
+	files := make(models.AiAgentPromptsMapFS, len(models.AiAgentExpectedFiles))
+	for _, path := range models.AiAgentExpectedFiles {
+		f, err := zr.Open(path)
+		if err != nil {
+			return nil, retry.Unrecoverable(errors.Wrapf(err, "ai prompts zip archive is missing an expected file %s", path))
+		}
+		content, err := io.ReadAll(f)
+		f.Close()
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not read expected file %s from ai prompts zip archive", path)
+		}
+		files[path] = content
+	}
+	return files, nil
+}

--- a/infra/ai_prompts_test.go
+++ b/infra/ai_prompts_test.go
@@ -1,0 +1,312 @@
+package infra
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"io/fs"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+// failIfHitServer returns an httptest.Server that fails the test if it's ever hit - used to
+// assert a tier that should short-circuit before the network never actually calls out.
+func failIfHitServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected network call to %s", r.URL.String())
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+}
+
+// useAiPromptsServerURL points aiPromptsServerURLDefault at an httptest.Server for the
+// duration of the test, restoring the original value afterwards.
+func useAiPromptsServerURL(t *testing.T, url string) {
+	t.Helper()
+	original := aiPromptsServerURLDefault
+	aiPromptsServerURLDefault = url
+	t.Cleanup(func() { aiPromptsServerURLDefault = original })
+}
+
+func writePromptsZip(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for name, content := range files {
+		f, err := zw.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write([]byte(content))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func readFileFromFS(t *testing.T, fsys fs.FS, name string) string {
+	t.Helper()
+	b, err := fs.ReadFile(fsys, name)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// writeFullPromptsZip builds a zip archive containing every path in the expected-prompts
+// manifest, so a tier-3 test can exercise a download that passes zipToPromptsFS's
+// all-expected-files-present verification. overrides lets a test control the content of
+// specific paths (e.g. models.AiAgentSystemPromptPath) to assert on afterwards.
+func writeFullPromptsZip(t *testing.T, overrides map[string]string) []byte {
+	t.Helper()
+	files := make(map[string]string, len(models.AiAgentExpectedFiles))
+	for _, path := range models.AiAgentExpectedFiles {
+		files[path] = "content for " + path
+	}
+	maps.Copy(files, overrides)
+	return writePromptsZip(t, files)
+}
+
+func Test_InitAiPromptsFS_Tier1_ExecutionDir(t *testing.T) {
+	t.Run("execution dir set and readable is used as-is", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "system.md"), []byte("hello"), 0o644))
+		t.Setenv("AI_PROMPTS_EXECUTION_DIR", dir)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		require.NotNil(t, fsys)
+		assert.Equal(t, "hello", readFileFromFS(t, fsys, "system.md"))
+	})
+
+	t.Run("execution dir set but not readable yields nil", func(t *testing.T) {
+		t.Setenv("AI_PROMPTS_EXECUTION_DIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		assert.Nil(t, fsys)
+	})
+}
+
+func Test_InitAiPromptsFS_Tier2_ServingDir(t *testing.T) {
+	t.Run("resolves the right version directory locally, no network", func(t *testing.T) {
+		server := failIfHitServer(t)
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		dir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "v1.0"), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "v1.4"), 0o755))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "v2.1"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "v1.0", "system.md"), []byte("v1.0"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "v1.4", "system.md"), []byte("v1.4"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "v2.1", "system.md"), []byte("v1.4"), 0o644))
+
+		fsys := InitAiPromptsFS(context.Background(), dir, "1.9", "some-key")
+		require.NotNil(t, fsys)
+		assert.Equal(t, "v1.4", readFileFromFS(t, fsys, "system.md"))
+	})
+
+	t.Run("empty serving dir content yields nil", func(t *testing.T) {
+		dir := t.TempDir()
+		fsys := InitAiPromptsFS(context.Background(), dir, "1.0", "some-key")
+		assert.Nil(t, fsys)
+	})
+
+	t.Run("unreadable serving dir yields nil", func(t *testing.T) {
+		fsys := InitAiPromptsFS(context.Background(), filepath.Join(t.TempDir(), "missing"), "1.0", "some-key")
+		assert.Nil(t, fsys)
+	})
+}
+
+func Test_InitAiPromptsFS_Tier3_Network(t *testing.T) {
+	t.Run("downloads and unzips the prompts bundle", func(t *testing.T) {
+		zipBytes := writeFullPromptsZip(t, map[string]string{models.AiAgentSystemPromptPath: "downloaded content"})
+		var gotAuth, gotVersion string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			gotVersion = r.URL.Query().Get("prompts_version")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(zipBytes)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.2.3", "the-license-key")
+		require.NotNil(t, fsys)
+		assert.Equal(t, "downloaded content", readFileFromFS(t, fsys, models.AiAgentSystemPromptPath))
+		assert.Equal(t, "Bearer the-license-key", gotAuth)
+		assert.Equal(t, "1.2", gotVersion)
+	})
+
+	t.Run("download missing an expected prompt file is rejected entirely", func(t *testing.T) {
+		files := make(map[string]string, len(models.AiAgentExpectedFiles)-1)
+		for _, path := range models.AiAgentExpectedFiles[1:] { // omit the first expected path
+			files[path] = "content"
+		}
+		zipBytes := writePromptsZip(t, files)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(zipBytes)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		assert.Nil(t, fsys)
+	})
+
+	t.Run("non-200 response yields nil", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		assert.Nil(t, fsys)
+	})
+
+	t.Run("5xx response is retried and succeeds once the server recovers", func(t *testing.T) {
+		zipBytes := writeFullPromptsZip(t, map[string]string{models.AiAgentSystemPromptPath: "downloaded after retry"})
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			if callCount < 3 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(zipBytes)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		require.NotNil(t, fsys)
+		assert.Equal(t, "downloaded after retry", readFileFromFS(t, fsys, models.AiAgentSystemPromptPath))
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("non-retryable 4xx response is not retried", func(t *testing.T) {
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		assert.Nil(t, fsys)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("truncated/corrupted zip body is retried and succeeds once the server recovers", func(t *testing.T) {
+		zipBytes := writeFullPromptsZip(t, map[string]string{models.AiAgentSystemPromptPath: "downloaded after retry"})
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			if callCount < 3 {
+				_, _ = w.Write([]byte("not a valid zip archive"))
+				return
+			}
+			_, _ = w.Write(zipBytes)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		require.NotNil(t, fsys)
+		assert.Equal(t, "downloaded after retry", readFileFromFS(t, fsys, models.AiAgentSystemPromptPath))
+		assert.Equal(t, 3, callCount)
+	})
+
+	t.Run("well-formed zip missing an expected file is not retried", func(t *testing.T) {
+		files := make(map[string]string, len(models.AiAgentExpectedFiles)-1)
+		for _, path := range models.AiAgentExpectedFiles[1:] { // omit the first expected path
+			files[path] = "content"
+		}
+		zipBytes := writePromptsZip(t, files)
+		var callCount int
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(zipBytes)
+		}))
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "some-key")
+		assert.Nil(t, fsys)
+		assert.Equal(t, 1, callCount)
+	})
+
+	t.Run("unparseable version skips the network entirely", func(t *testing.T) {
+		server := failIfHitServer(t)
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "dev", "some-key")
+		assert.Nil(t, fsys)
+	})
+
+	t.Run("empty license key skips the network entirely", func(t *testing.T) {
+		server := failIfHitServer(t)
+		defer server.Close()
+		useAiPromptsServerURL(t, server.URL)
+
+		fsys := InitAiPromptsFS(context.Background(), "", "1.0", "")
+		assert.Nil(t, fsys)
+	})
+}
+
+func Test_zipToPromptsFS(t *testing.T) {
+	t.Run("all expected files present and readable succeeds", func(t *testing.T) {
+		zipBytes := writeFullPromptsZip(t, map[string]string{models.AiAgentSystemPromptPath: "system content"})
+
+		fsys, err := zipToPromptsFS(zipBytes)
+		require.NoError(t, err)
+		require.NotNil(t, fsys)
+		assert.Equal(t, "system content", readFileFromFS(t, fsys, models.AiAgentSystemPromptPath))
+	})
+
+	t.Run("a single missing expected file is an unrecoverable error", func(t *testing.T) {
+		files := make(map[string]string, len(models.AiAgentExpectedFiles)-1)
+		for _, path := range models.AiAgentExpectedFiles[1:] {
+			files[path] = "content"
+		}
+		zipBytes := writePromptsZip(t, files)
+
+		fsys, err := zipToPromptsFS(zipBytes)
+		assert.Nil(t, fsys)
+		require.Error(t, err)
+		assert.True(t, retry.IsRecoverable(err) == false, "missing expected file should be unrecoverable")
+	})
+
+	t.Run("extra unlisted files in the archive are ignored", func(t *testing.T) {
+		files := map[string]string{"some/unrelated/asset.png": "binary-ish content"}
+		for _, path := range models.AiAgentExpectedFiles {
+			files[path] = "content"
+		}
+		zipBytes := writePromptsZip(t, files)
+
+		fsys, err := zipToPromptsFS(zipBytes)
+		require.NoError(t, err)
+		require.NotNil(t, fsys)
+		_, statErr := fs.Stat(fsys, "some/unrelated/asset.png")
+		assert.Error(t, statErr)
+	})
+
+	t.Run("corrupted zip bytes fail closed with a recoverable error, not a panic", func(t *testing.T) {
+		fsys, err := zipToPromptsFS([]byte("this is not a zip file"))
+		assert.Nil(t, fsys)
+		require.Error(t, err)
+		assert.True(t, retry.IsRecoverable(err), "corrupted archive should be retried")
+	})
+}

--- a/models/ai_agent_config.go
+++ b/models/ai_agent_config.go
@@ -3,7 +3,7 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"os"
+	"io/fs"
 )
 
 // AiAgentModelConfig represents the configuration for AI agent models
@@ -15,26 +15,28 @@ type AiAgentModelConfig struct {
 	PromptModels map[string]string `json:"prompt_models"`
 }
 
-// LoadAiAgentModelConfig loads the AI agent model configuration from a JSON file
-// The default model is provided by the caller depends on the provider it uses
-func LoadAiAgentModelConfig(configPath string, defaultModel string) (*AiAgentModelConfig, error) {
-	if configPath == "" {
-		// Return default configuration if no path is provided
+// LoadAiAgentModelConfig loads the AI agent model configuration from AiAgentModelConfigFileName
+// at the root of promptsFS. The default model is provided by the caller depends on the provider
+// it uses. If promptsFS is nil (no prompts filesystem available), the default configuration is
+// returned.
+func LoadAiAgentModelConfig(promptsFS fs.FS, defaultModel string) (*AiAgentModelConfig, error) {
+	if promptsFS == nil {
+		// Return default configuration if no prompts filesystem is available
 		return &AiAgentModelConfig{
 			DefaultModel: defaultModel,
 			PromptModels: make(map[string]string),
 		}, nil
 	}
 
-	file, err := os.Open(configPath)
+	file, err := promptsFS.Open(AiAgentModelConfigFileName)
 	if err != nil {
-		return nil, fmt.Errorf("could not open AI agent config file %s: %w", configPath, err)
+		return nil, fmt.Errorf("could not open AI agent config file %s: %w", AiAgentModelConfigFileName, err)
 	}
 	defer file.Close()
 
 	var config AiAgentModelConfig
 	if err := json.NewDecoder(file).Decode(&config); err != nil {
-		return nil, fmt.Errorf("could not decode AI agent config file %s: %w", configPath, err)
+		return nil, fmt.Errorf("could not decode AI agent config file %s: %w", AiAgentModelConfigFileName, err)
 	}
 
 	// Set default model if not specified

--- a/models/ai_agent_prompts.go
+++ b/models/ai_agent_prompts.go
@@ -1,0 +1,115 @@
+package models
+
+import (
+	"bytes"
+	"io/fs"
+	"path"
+	"time"
+)
+
+// Path constants for every prompt file the ai_agent package reads from a prompts filesystem,
+// root-relative (see usecases/ai_agent's readPrompt/preparePrompt). Single source of truth,
+// shared by infra (fills/validates a downloaded prompts zip against them) and usecases/ai_agent
+// (reads them at runtime, validates a resolved prompts fs.FS against them at startup).
+const (
+	AiAgentModelConfigFileName                                 = "ai_agent_models.json"
+	AiAgentSystemPromptPath                                    = "system.md"
+	AiAgentCaseReviewPromptPath                                = "case_review/case_review.md"
+	AiAgentCaseReviewDataModelObjectFieldReadOptionsPromptPath = "case_review/data_model_object_field_read_options.md"
+	AiAgentCaseReviewDataModelSummaryPromptPath                = "case_review/data_model_summary.md"
+	AiAgentCaseReviewCustomReportInstructionPath               = "case_review/instruction_custom_report.md"
+	AiAgentCaseReviewLanguageInstructionPath                   = "case_review/instruction_language.md"
+	AiAgentCaseReviewStructureInstructionPath                  = "case_review/instruction_structure.md"
+	AiAgentCaseReviewRuleDefinitionsPromptPath                 = "case_review/rule_definitions.md"
+	AiAgentCaseReviewRuleThresholdValuesPromptPath             = "case_review/rule_threshold_values.md"
+	AiAgentCaseReviewSanityCheckPromptPath                     = "case_review/sanity_check.md"
+	AiAgentKYCInstructionPath                                  = "kyc_enrichment/instruction.md"
+	AiAgentKYCPromptEnrichPath                                 = "kyc_enrichment/prompt_enrich.md"
+	AiAgentRuleDescriptionPromptPath                           = "rule/rule_description.md"
+	AiAgentRuleGenerationStep1PromptPath                       = "rule/rule_generation_step1.md"
+	AiAgentRuleGenerationStep2PromptPath                       = "rule/rule_generation_step2.md"
+	AiAgentScreeningHitEvaluatePromptPath                      = "screening_hit_suggestion/evaluate_match.md"
+	AiAgentScreeningHitSystemPromptPath                        = "screening_hit_suggestion/system.md"
+)
+
+// AiAgentPromptPaths is the deterministic, exhaustive manifest of every markdown prompt file
+// above - deliberately an explicit list rather than something derived by walking a directory,
+// so a missing entry can be caught (at download time, or at startup validation) instead of
+// surfacing later as a per-job failure. Does not include AiAgentModelConfigFileName (a separate,
+// JSON, not markdown, file) - see AiAgentExpectedFiles for the combined manifest.
+var AiAgentExpectedFiles = []string{
+	AiAgentModelConfigFileName,
+	AiAgentSystemPromptPath,
+	AiAgentCaseReviewPromptPath,
+	AiAgentCaseReviewDataModelObjectFieldReadOptionsPromptPath,
+	AiAgentCaseReviewDataModelSummaryPromptPath,
+	AiAgentCaseReviewCustomReportInstructionPath,
+	AiAgentCaseReviewLanguageInstructionPath,
+	AiAgentCaseReviewStructureInstructionPath,
+	AiAgentCaseReviewRuleDefinitionsPromptPath,
+	AiAgentCaseReviewRuleThresholdValuesPromptPath,
+	AiAgentCaseReviewSanityCheckPromptPath,
+	AiAgentKYCInstructionPath,
+	AiAgentKYCPromptEnrichPath,
+	AiAgentRuleDescriptionPromptPath,
+	AiAgentRuleGenerationStep1PromptPath,
+	AiAgentRuleGenerationStep2PromptPath,
+	AiAgentScreeningHitEvaluatePromptPath,
+	AiAgentScreeningHitSystemPromptPath,
+}
+
+// AiAgentPromptsMapFS is a minimal, read-only, in-memory fs.FS backed by a name -> content map.
+// It exists so a downloaded ai prompts bundle (see infra.InitAiPromptsFS) can be held entirely
+// in memory - filled deterministically against AiAgentExpectedFiles, never a generic dump of
+// arbitrary content - without touching disk or depending on a testing-only package.
+type AiAgentPromptsMapFS map[string][]byte
+
+func (m AiAgentPromptsMapFS) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	content, ok := m[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return &aiAgentPromptsMapFile{Reader: bytes.NewReader(content), name: name, size: int64(len(content))}, nil
+}
+
+// ReadFile implements fs.ReadFileFS, the fast path fs.ReadFile uses when available - a plain
+// map lookup instead of Open+ReadAll+Close.
+func (m AiAgentPromptsMapFS) ReadFile(name string) ([]byte, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrInvalid}
+	}
+	content, ok := m[name]
+	if !ok {
+		return nil, &fs.PathError{Op: "readfile", Path: name, Err: fs.ErrNotExist}
+	}
+	out := make([]byte, len(content))
+	copy(out, content)
+	return out, nil
+}
+
+type aiAgentPromptsMapFile struct {
+	*bytes.Reader
+	name string
+	size int64
+}
+
+func (f *aiAgentPromptsMapFile) Stat() (fs.FileInfo, error) {
+	return aiAgentPromptsMapFileInfo{name: f.name, size: f.size}, nil
+}
+
+func (f *aiAgentPromptsMapFile) Close() error { return nil }
+
+type aiAgentPromptsMapFileInfo struct {
+	name string
+	size int64
+}
+
+func (fi aiAgentPromptsMapFileInfo) Name() string       { return path.Base(fi.name) }
+func (fi aiAgentPromptsMapFileInfo) Size() int64        { return fi.size }
+func (fi aiAgentPromptsMapFileInfo) Mode() fs.FileMode  { return 0o444 }
+func (fi aiAgentPromptsMapFileInfo) ModTime() time.Time { return time.Time{} }
+func (fi aiAgentPromptsMapFileInfo) IsDir() bool        { return false }
+func (fi aiAgentPromptsMapFileInfo) Sys() any           { return nil }

--- a/models/ai_agent_prompts_test.go
+++ b/models/ai_agent_prompts_test.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AiAgentPromptsMapFS(t *testing.T) {
+	fsys := AiAgentPromptsMapFS{
+		"system.md":              []byte("system content"),
+		"case_review/summary.md": []byte("summary content"),
+	}
+
+	t.Run("ReadFile returns the content of a present path", func(t *testing.T) {
+		content, err := fsys.ReadFile("system.md")
+		require.NoError(t, err)
+		assert.Equal(t, "system content", string(content))
+	})
+
+	t.Run("ReadFile returns fs.ErrNotExist for a missing path", func(t *testing.T) {
+		_, err := fsys.ReadFile("does/not/exist.md")
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("fs.ReadFile takes the ReadFileFS fast path", func(t *testing.T) {
+		content, err := fs.ReadFile(fsys, "case_review/summary.md")
+		require.NoError(t, err)
+		assert.Equal(t, "summary content", string(content))
+	})
+
+	t.Run("Open returns a readable file with correct Stat size and name", func(t *testing.T) {
+		f, err := fsys.Open("system.md")
+		require.NoError(t, err)
+		defer f.Close()
+
+		info, err := f.Stat()
+		require.NoError(t, err)
+		assert.Equal(t, "system.md", info.Name())
+		assert.Equal(t, int64(len("system content")), info.Size())
+		assert.False(t, info.IsDir())
+
+		buf := make([]byte, info.Size())
+		n, err := f.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, "system content", string(buf[:n]))
+	})
+
+	t.Run("Open returns fs.ErrNotExist for a missing path", func(t *testing.T) {
+		_, err := fsys.Open("missing.md")
+		assert.ErrorIs(t, err, fs.ErrNotExist)
+	})
+
+	t.Run("Open rejects an invalid fs path", func(t *testing.T) {
+		_, err := fsys.Open("../escape.md")
+		assert.ErrorIs(t, err, fs.ErrInvalid)
+	})
+}

--- a/pure_utils/prompt_version.go
+++ b/pure_utils/prompt_version.go
@@ -1,0 +1,33 @@
+package pure_utils
+
+import (
+	"github.com/Masterminds/semver"
+)
+
+// ResolveBestPromptVersion picks, among availableDirNames (candidate "vX.Y"-style names, not
+// yet filtered to valid version-looking entries), the greatest one <= requestedVersion (a
+// backward search: an exact match wins, otherwise the nearest earlier available version is
+// used - never a newer one). Returns "" (not an error) if nothing qualifies, including when
+// availableDirNames is empty - callers decide how to treat that (e.g. map it to a not-found
+// error, or to "no local prompts available").
+func ResolveBestPromptVersion(availableDirNames []string, requestedVersion string) (string, error) {
+	reqV, err := semver.NewVersion(requestedVersion)
+	if err != nil {
+		return "", err
+	}
+
+	var bestVersion *semver.Version
+	for _, name := range availableDirNames {
+		v, err := semver.NewVersion(name)
+		if err != nil {
+			continue // not a version-looking name
+		}
+		if reqV.Compare(v) >= 0 && (bestVersion == nil || v.Compare(bestVersion) > 0) {
+			bestVersion = v
+		}
+	}
+	if bestVersion != nil {
+		return bestVersion.Original(), nil
+	}
+	return "", nil
+}

--- a/pure_utils/prompt_version_test.go
+++ b/pure_utils/prompt_version_test.go
@@ -1,0 +1,51 @@
+package pure_utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ResolveBestPromptVersion(t *testing.T) {
+	t.Run("exact match wins", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.0", "v1.1", "v2.0"}, "1.1")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.1", best)
+	})
+
+	t.Run("backward search: nearest earlier available, never forward, can cross a major", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.0", "v1.1", "v2.0"}, "1.5")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.1", best)
+	})
+
+	t.Run("request above everything resolves to the nearest earlier, no ceiling", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.0", "v1.1", "v2.0"}, "3.0")
+		require.NoError(t, err)
+		assert.Equal(t, "v2.0", best)
+	})
+
+	t.Run("request below everything resolves to nothing", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.0", "v1.1"}, "0.9")
+		require.NoError(t, err)
+		assert.Equal(t, "", best)
+	})
+
+	t.Run("empty candidate list resolves to nothing, not an error", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion(nil, "1.0")
+		require.NoError(t, err)
+		assert.Equal(t, "", best)
+	})
+
+	t.Run("non-version-looking entries are skipped, not fatal", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"main", "latest", "v1.0", "notes.txt"}, "1.5")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.0", best)
+	})
+
+	t.Run("malformed requested version is an error", func(t *testing.T) {
+		_, err := ResolveBestPromptVersion([]string{"v1.0"}, "not-a-version")
+		require.Error(t, err)
+	})
+}

--- a/usecases/ai_agent/ai_agent_usecase.go
+++ b/usecases/ai_agent/ai_agent_usecase.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"os"
+	"io/fs"
 	"strings"
 	"sync"
 
@@ -192,6 +192,7 @@ type AiAgentUsecase struct {
 	featureAccessReader                featureAccessReader
 	config                             infra.AIAgentConfiguration
 	caseManagerBucketUrl               string
+	promptsFS                          fs.FS
 
 	caseReviewAdapter *llmberjack.Llmberjack
 	enrichmentAdapter *llmberjack.Llmberjack
@@ -222,6 +223,7 @@ func NewAiAgentUsecase(
 	screeningUsecase AiAgentScreeningUsecase,
 	config infra.AIAgentConfiguration,
 	caseManagerBucketUrl string,
+	promptsFS fs.FS,
 ) AiAgentUsecase {
 	return AiAgentUsecase{
 		enforceSecurityCase:                enforceSecurityCase,
@@ -247,6 +249,7 @@ func NewAiAgentUsecase(
 		featureAccessReader:                featureAccessReader,
 		config:                             config,
 		caseManagerBucketUrl:               caseManagerBucketUrl,
+		promptsFS:                          promptsFS,
 	}
 }
 
@@ -433,25 +436,26 @@ func (uc *AiAgentUsecase) GetCaseDataZip(ctx context.Context, caseId string) (io
 	return pr, nil
 }
 
-func readPrompt(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", errors.Wrapf(err, "could not open prompt file %s", path)
+// readPrompt reads a prompt file by name (root-relative, no leading "/") from the usecase's
+// injected prompts filesystem. Returns an error if no prompts filesystem was resolved at
+// process startup (see infra.InitAiPromptsFS).
+func (uc *AiAgentUsecase) readPrompt(name string) (string, error) {
+	if uc.promptsFS == nil {
+		return "", errors.Errorf("cannot read prompt %s: ai prompts filesystem is not available", name)
 	}
-	defer file.Close()
 
-	promptBytes, err := io.ReadAll(file)
+	promptBytes, err := fs.ReadFile(uc.promptsFS, name)
 	if err != nil {
-		return "", errors.Wrapf(err, "could not read prompt file %s", path)
+		return "", errors.Wrapf(err, "could not read prompt file %s", name)
 	}
 	return string(promptBytes), nil
 }
 
 // Prepare the request for the LLM, the prompt comes from a file and need to be templated.
 // The file contains some variables that are replaced by the data provided by the caller.
-func preparePrompt(promptPath string, data map[string]any) (prompt string, err error) {
+func (uc *AiAgentUsecase) preparePrompt(promptPath string, data map[string]any) (prompt string, err error) {
 	// Load prompt from file, do each time in case prompt configuration changes
-	promptContent, err := readPrompt(promptPath)
+	promptContent, err := uc.readPrompt(promptPath)
 	if err != nil {
 		return "", errors.Wrap(err, "could not read prompt file")
 	}
@@ -518,7 +522,7 @@ func providerForModel(model string) string {
 func (uc *AiAgentUsecase) preparePromptWithModel(promptPath string, data map[string]any) (provider string, model string, prompt string, err error) {
 	// Load model configuration on each call
 	// Give the possibility to change the prompt without reloading the application
-	modelConfig, err := models.LoadAiAgentModelConfig("prompts/ai_agent_models.json", uc.config.MainAgentDefaultModel)
+	modelConfig, err := models.LoadAiAgentModelConfig(uc.promptsFS, uc.config.MainAgentDefaultModel)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "could not load AI agent model configuration")
 	}
@@ -526,7 +530,7 @@ func (uc *AiAgentUsecase) preparePromptWithModel(promptPath string, data map[str
 	model = modelConfig.GetModelForPrompt(promptPath)
 	provider = providerForModel(model)
 
-	prompt, err = preparePrompt(promptPath, data)
+	prompt, err = uc.preparePrompt(promptPath, data)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "could not prepare prompt")
 	}

--- a/usecases/ai_agent/ai_agent_usecase_test.go
+++ b/usecases/ai_agent/ai_agent_usecase_test.go
@@ -33,7 +33,8 @@ func TestPreparePrompt_StringTypes(t *testing.T) {
 		"description": "Test Description",
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}
@@ -63,7 +64,8 @@ func TestPreparePrompt_StringPointers(t *testing.T) {
 		"nullValue": (*string)(nil),
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}
@@ -91,7 +93,8 @@ func TestPreparePrompt_AgentPrinter(t *testing.T) {
 		"printer": mockAgentPrinter{value: "custom printed value"},
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}
@@ -120,7 +123,8 @@ func TestPreparePrompt_ComplexTypes(t *testing.T) {
 		},
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}
@@ -146,7 +150,8 @@ func TestPreparePrompt_HTMLCharacters(t *testing.T) {
 		"content": `<script>alert("test")</script> & "quotes"`,
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}
@@ -179,7 +184,8 @@ Complex: {{ .complex }}`
 		"complex": []string{"a", "b", "c"},
 	}
 
-	result, err := preparePrompt(promptPath, data)
+	uc := AiAgentUsecase{promptsFS: os.DirFS(tmpDir)}
+	result, err := uc.preparePrompt("test_prompt.txt", data)
 	if err != nil {
 		t.Fatalf("preparePrompt failed: %v", err)
 	}

--- a/usecases/ai_agent/ai_case_review.go
+++ b/usecases/ai_agent/ai_case_review.go
@@ -33,18 +33,17 @@ const (
 
 var ReviewLevelEnum = []string{"probable_false_positive", "investigate", "escalate"}
 
-// Constants for the case review prompt paths
 const (
-	PROMPT_CASE_REVIEW_PATH                          = "prompts/case_review/case_review.md"
-	PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS_PATH = "prompts/case_review/data_model_object_field_read_options.md"
-	PROMPT_DATA_MODEL_SUMMARY_PATH                   = "prompts/case_review/data_model_summary.md"
-	PROMPT_RULE_DEFINITIONS_PATH                     = "prompts/case_review/rule_definitions.md"
-	PROMPT_RULE_THRESHOLD_VALUES_PATH                = "prompts/case_review/rule_threshold_values.md"
-	PROMPT_SANITY_CHECK_PATH                         = "prompts/case_review/sanity_check.md"
-	INSTRUCTION_CUSTOM_REPORT_PATH                   = "prompts/case_review/instruction_custom_report.md"
-	INSTRUCTION_LANGUAGE_PATH                        = "prompts/case_review/instruction_language.md"
-	INSTRUCTION_STRUCTURE_PATH                       = "prompts/case_review/instruction_structure.md"
-	SYSTEM_PROMPT_PATH                               = "prompts/system.md"
+	PROMPT_CASE_REVIEW_PATH                          = models.AiAgentCaseReviewPromptPath
+	PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS_PATH = models.AiAgentCaseReviewDataModelObjectFieldReadOptionsPromptPath
+	PROMPT_DATA_MODEL_SUMMARY_PATH                   = models.AiAgentCaseReviewDataModelSummaryPromptPath
+	PROMPT_RULE_DEFINITIONS_PATH                     = models.AiAgentCaseReviewRuleDefinitionsPromptPath
+	PROMPT_RULE_THRESHOLD_VALUES_PATH                = models.AiAgentCaseReviewRuleThresholdValuesPromptPath
+	PROMPT_SANITY_CHECK_PATH                         = models.AiAgentCaseReviewSanityCheckPromptPath
+	INSTRUCTION_CUSTOM_REPORT_PATH                   = models.AiAgentCaseReviewCustomReportInstructionPath
+	INSTRUCTION_LANGUAGE_PATH                        = models.AiAgentCaseReviewLanguageInstructionPath
+	INSTRUCTION_STRUCTURE_PATH                       = models.AiAgentCaseReviewStructureInstructionPath
+	SYSTEM_PROMPT_PATH                               = models.AiAgentSystemPromptPath
 )
 
 type sanityCheckOutput struct {
@@ -450,7 +449,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 	}
 
 	// Define the system instruction for prompt
-	systemInstruction, err := readPrompt(SYSTEM_PROMPT_PATH)
+	systemInstruction, err := uc.readPrompt(SYSTEM_PROMPT_PATH)
 	if err != nil {
 		logger.DebugContext(ctx, "could not read system instruction", "error", err)
 		systemInstruction = "You are a compliance officer or fraud analyst. You are given a case and you need to review it step by step. Reply factually to instructions in markdown format."
@@ -842,7 +841,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 	if len(instructions) == 0 {
 		logger.DebugContext(ctx, "No custom instructions for organization, skip this part")
 	} else {
-		customReportInstruction, err := readPrompt(INSTRUCTION_CUSTOM_REPORT_PATH)
+		customReportInstruction, err := uc.readPrompt(INSTRUCTION_CUSTOM_REPORT_PATH)
 		if err != nil {
 			logger.DebugContext(ctx, "could not read custom report instruction", "error", err)
 			customReportInstruction = "Transform the case review according to the instructions. Return only the transformed content without explanations or preambles."

--- a/usecases/ai_agent/ai_enrichment.go
+++ b/usecases/ai_agent/ai_enrichment.go
@@ -10,15 +10,15 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/utils"
-	"github.com/google/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/google/uuid"
 )
 
 const ENRICHMENT_DEFAULT_MODEL = "sonar-pro"
 
 const (
-	INSTRUCTION_PATH   = "prompts/kyc_enrichment/instruction.md"
-	PROMPT_ENRICH_PATH = "prompts/kyc_enrichment/prompt_enrich.md"
+	INSTRUCTION_PATH   = models.AiAgentKYCInstructionPath
+	PROMPT_ENRICH_PATH = models.AiAgentKYCPromptEnrichPath
 )
 
 var ErrKYCEnrichmentNotEnabled = errors.New("kyc enrichment is not enabled")
@@ -142,11 +142,11 @@ func (uc *AiAgentUsecase) enrichData(
 		*aiSetting.KYCEnrichmentSetting.CustomInstructions != "" {
 		instructionData["custom_instructions"] = *aiSetting.KYCEnrichmentSetting.CustomInstructions
 	}
-	instruction, err := preparePrompt(INSTRUCTION_PATH, instructionData)
+	instruction, err := uc.preparePrompt(INSTRUCTION_PATH, instructionData)
 	if err != nil {
 		return models.AiEnrichmentKYC{}, errors.Wrap(err, "failed to read instruction")
 	}
-	prompt, err := preparePrompt(PROMPT_ENRICH_PATH, map[string]any{
+	prompt, err := uc.preparePrompt(PROMPT_ENRICH_PATH, map[string]any{
 		"data": string(data),
 	})
 	if err != nil {

--- a/usecases/ai_agent/ai_rule_assist.go
+++ b/usecases/ai_agent/ai_rule_assist.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	RULE_DESCRIPTION_PROMPT_PATH      = "prompts/rule/rule_description.md"
-	RULE_GENERATION_PROMPT_STEP1_PATH = "prompts/rule/rule_generation_step1.md"
-	RULE_GENERATION_PROMPT_STEP2_PATH = "prompts/rule/rule_generation_step2.md"
+	RULE_DESCRIPTION_PROMPT_PATH      = models.AiAgentRuleDescriptionPromptPath
+	RULE_GENERATION_PROMPT_STEP1_PATH = models.AiAgentRuleGenerationStep1PromptPath
+	RULE_GENERATION_PROMPT_STEP2_PATH = models.AiAgentRuleGenerationStep2PromptPath
 )
 
 // GenerateRule generates a rule AST from a natural language instruction

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	PROMPT_SCREENING_HIT_EVALUATE_PATH   = "prompts/screening_hit_suggestion/evaluate_match.md"
-	SCREENING_HIT_SYSTEM_PROMPT_PATH     = "prompts/screening_hit_suggestion/system.md"
+	PROMPT_SCREENING_HIT_EVALUATE_PATH   = models.AiAgentScreeningHitEvaluatePromptPath
+	SCREENING_HIT_SYSTEM_PROMPT_PATH     = models.AiAgentScreeningHitSystemPromptPath
 	SCREENING_HIT_SUGGESTION_BLOB_PREFIX = "ai_screening_reviews"
 )
 
@@ -94,7 +94,7 @@ func (uc *AiAgentUsecase) AnalyseScreeningHits(ctx context.Context, screeningId 
 	}
 
 	// Read system prompt
-	systemInstruction, err := readPrompt(SCREENING_HIT_SYSTEM_PROMPT_PATH)
+	systemInstruction, err := uc.readPrompt(SCREENING_HIT_SYSTEM_PROMPT_PATH)
 	if err != nil {
 		logger.DebugContext(ctx, "could not read screening hit system instruction", "error", err)
 		systemInstruction = "You are a compliance screening analyst. Assess whether each screening hit is a true positive or false positive."

--- a/usecases/ai_agent/prompts_manifest.go
+++ b/usecases/ai_agent/prompts_manifest.go
@@ -1,0 +1,26 @@
+package ai_agent
+
+import (
+	"io/fs"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/cockroachdb/errors"
+)
+
+// Validate the prompts for the AI agent against the expected files used by AI usecases.
+func ValidatePromptsFS(promptsFS fs.FS) error {
+	if promptsFS == nil {
+		return errors.New("ai prompts filesystem is not available")
+	}
+
+	var missing []string
+	for _, path := range models.AiAgentExpectedFiles {
+		if _, err := fs.ReadFile(promptsFS, path); err != nil {
+			missing = append(missing, path)
+		}
+	}
+	if len(missing) > 0 {
+		return errors.Newf("missing or unreadable ai prompt files: %v", missing)
+	}
+	return nil
+}

--- a/usecases/ai_agent/prompts_manifest_test.go
+++ b/usecases/ai_agent/prompts_manifest_test.go
@@ -1,0 +1,53 @@
+package ai_agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeAllExpectedPrompts(t *testing.T, dir string) {
+	t.Helper()
+	for _, path := range models.AiAgentExpectedFiles {
+		full := filepath.Join(dir, path)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+		require.NoError(t, os.WriteFile(full, []byte("content"), 0o644))
+	}
+}
+
+func Test_ValidatePromptsFS(t *testing.T) {
+	t.Run("nil fs is reported as an error", func(t *testing.T) {
+		err := ValidatePromptsFS(nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("all expected prompts present and readable passes", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAllExpectedPrompts(t, dir)
+
+		err := ValidatePromptsFS(os.DirFS(dir))
+		assert.NoError(t, err)
+	})
+
+	t.Run("a missing prompt file is reported", func(t *testing.T) {
+		dir := t.TempDir()
+		writeAllExpectedPrompts(t, dir)
+		require.NoError(t, os.Remove(filepath.Join(dir, SYSTEM_PROMPT_PATH)))
+
+		err := ValidatePromptsFS(os.DirFS(dir))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), SYSTEM_PROMPT_PATH)
+	})
+
+	t.Run("empty fs reports every expected path as missing", func(t *testing.T) {
+		err := ValidatePromptsFS(os.DirFS(t.TempDir()))
+		require.Error(t, err)
+		for _, path := range models.AiAgentExpectedFiles {
+			assert.Contains(t, err.Error(), path)
+		}
+	})
+}

--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
 )
 
 // promptsLicenseValidator is the subset of PublicLicenseUseCase used by PromptServingUsecase,
@@ -115,25 +116,25 @@ func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error
 		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.aiPromptsServingDir)
 	}
 
-	var bestVersion *semver.Version
+	dirNames := make([]string, 0, len(entries))
 	for _, e := range entries {
-		if !e.IsDir() {
-			continue // Ignore non-directory entries
-		}
-		entryVersion, err := semver.NewVersion(e.Name())
-		if err != nil {
-			continue // entry is not a prompt version directory
-		}
-		if requestedVersion.Compare(entryVersion) >= 0 && (bestVersion == nil || entryVersion.Compare(bestVersion) > 0) {
-			bestVersion = entryVersion
+		if e.IsDir() {
+			dirNames = append(dirNames, e.Name())
 		}
 	}
 
-	if bestVersion == nil {
+	// requestedVersion was already validated above; the error here can only come from a
+	// malformed entry in dirNames, which ResolveBestPromptVersion already skips rather than
+	// erroring on - so err is always nil in practice, but still checked defensively.
+	best, err := pure_utils.ResolveBestPromptVersion(dirNames, requestedVersion.Original())
+	if err != nil {
+		return "", errors.Wrapf(models.BadParameterError, "invalid version format: %s", version)
+	}
+	if best == "" {
 		// No matching/precedent version folder
 		return "", errors.Wrap(models.NotFoundError, "no prompts version available")
 	}
-	return filepath.Join(uc.aiPromptsServingDir, bestVersion.Original()), nil
+	return filepath.Join(uc.aiPromptsServingDir, best), nil
 }
 
 func addFileToZip(zw *zip.Writer, srcPath, zipName string) error {

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -1,6 +1,7 @@
 package usecases
 
 import (
+	"io/fs"
 	"time"
 
 	"github.com/authenticvision/rgeo"
@@ -54,6 +55,7 @@ type Usecases struct {
 	webhookIPWhitelist           string // Comma-separated CIDR ranges to whitelist for webhooks
 	screeningOffloadingEnabled   bool
 	aiPromptsServingDir          string
+	aiPromptsFS                  fs.FS
 
 	coordsEnricher *rgeo.Rgeo
 	ipEnricher     *maxminddb.Reader
@@ -224,6 +226,12 @@ func WithAIPromptsServingDir(dir string) Option {
 	}
 }
 
+func WithAIPromptsFS(aiPromptsFS fs.FS) Option {
+	return func(o *options) {
+		o.aiPromptsFS = aiPromptsFS
+	}
+}
+
 type options struct {
 	appName                      string
 	apiVersion                   string
@@ -250,6 +258,7 @@ type options struct {
 	webhookIPWhitelist           string
 	ipEnricher                   *maxminddb.Reader
 	aiPromptsServingDir          string
+	aiPromptsFS                  fs.FS
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -288,6 +297,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		webhookIPWhitelist:           o.webhookIPWhitelist,
 		screeningOffloadingEnabled:   o.screeningOffloadingEnabled,
 		aiPromptsServingDir:          o.aiPromptsServingDir,
+		aiPromptsFS:                  o.aiPromptsFS,
 
 		coordsEnricher: coordsEnricher,
 		ipEnricher:     o.ipEnricher,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -828,6 +828,7 @@ func (usecases *UsecasesWithCreds) NewAiAgentUsecase() ai_agent.AiAgentUsecase {
 		utils.Ptr(usecases.NewScreeningUsecase()),
 		usecases.aiAgentConfig,
 		usecases.caseManagerBucketUrl, // TODO: I think we could avoid passing the caseManagerBucketURL here only for the creation of the model
+		usecases.aiPromptsFS,
 	)
 }
 


### PR DESCRIPTION
## Summary

Phase B of self-hosted AI prompt distribution (Phase A: the SaaS-side download-serving endpoint, PR #1841). This makes the *reading* side of `usecases/ai_agent/*` use an injected `fs.FS` instead of hardcoded `os.Open("prompts/...")` calls relative to the process working directory.

`infra.InitAiPromptsFS` resolves the prompts filesystem once at startup, in priority order:
1. **`AI_PROMPTS_EXECUTION_DIR`** env var, if set — used as-is, no resolution, no network (staging's mechanism, pointed at a mounted bucket's stable `main/` folder).
2. **`AI_PROMPTS_SERVING_DIR`** (the existing serving-dir config, reused) — if this instance already has the private prompts bucket mounted locally (production's case), the right `vX.Y` folder is resolved in-process against its own detected version, with no network call. This avoids production calling its own download endpoint on a cold start, which would deadlock.
3. **Network download** — a genuine external self-hosted client with no local mount downloads the bundle from the SaaS endpoint, license-gated, with retries (`avast/retry-go`, matching the existing convention) on network errors and 5xx responses.

`cmd/server.go` and `cmd/worker.go` only run this resolution (and the startup validation below) when `license.CaseAiAssist` is true — a deployment without the AI entitlement never attempts a local lookup or a network call, and never logs a "prompts unavailable" warning for a feature it isn't licensed for.

A deterministic manifest (`models.AiAgentExpectedFiles`, single source of truth for every prompt path the code reads) drives two verification steps:
- **At download time**, inside the retry loop: the zip is filled against the manifest, with two failure modes deliberately told apart — a corrupted/truncated archive (fails to parse, or a file's content fails its checksum) is retried, since that looks like a bad transfer; an expected file simply absent from an otherwise well-formed archive fails immediately (`retry.Unrecoverable`), since that's a content mismatch (wrong version, stale manifest) no retry will fix.
- **At server/worker startup**: `ai_agent.ValidatePromptsFS` checks the resolved `fs.FS` (whichever tier produced it) against the same manifest, logging a warning immediately if something's missing, instead of surfacing it later as a per-job failure.

The downloaded bundle is held entirely in memory via a small map-backed `fs.FS` (`models.AiAgentPromptsMapFS`) — never written to disk.

If no prompts filesystem is available, worker jobs (`async_case_review.go`, `async_screening_suggestion.go`) return the error and let River's normal retry policy handle it, rather than cancelling the job outright — a worker restarted with prompts correctly resolved can still make an already-queued job succeed on a later attempt.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` all clean
- [x] `go test ./...` passes across the whole repo
- [x] Manual verification on a deployed instance (staging/self-hosted)
    - [x] AI_PROMPTS_EXECUTION_DIR like on staging 
    - [x] AI_PROMPTS_SERVING_DIR like on prod
    - [x] Network download: need to launch a server on local and, change the prod URL to check to check the flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * AI prompts can now be loaded from a validated filesystem source, including local overrides and automatic version-matched prompt bundles.
  * Added support for loading AI agent configuration from bundled prompt resources.

* **Bug Fixes**
  * Server/worker now warn and continue startup if prompt validation fails (instead of failing unexpectedly).
  * Improved prompt bundle download reliability with retry behavior and fail-closed handling when archives are incomplete.

* **Tests**
  * Added comprehensive coverage for prompt tiering, validation, retry logic, and prompt-file manifest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->