### PR TITLE
Batch upload UX improvements (errors and public API)

### DIFF
--- a/dto/upload_log_dto.go
+++ b/dto/upload_log_dto.go
@@ -21,11 +21,13 @@ func AdaptUploadLogDto(log models.UploadLog) UploadLogDto {
 		error = *log.Error
 	}
 
+	linesProcessed := max(log.LinesProcessed, log.RowsIngested)
+
 	return UploadLogDto{
 		Status:          string(log.UploadStatus),
 		StartedAt:       log.StartedAt,
 		FinishedAt:      log.FinishedAt,
-		LinesProcessed:  log.LinesProcessed,
+		LinesProcessed:  linesProcessed,
 		NumRowsIngested: log.RowsIngested,
 		Error:           error,
 	}

--- a/dto/upload_log_dto.go
+++ b/dto/upload_log_dto.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/utils"
 )
 
 type UploadLogDto struct {
@@ -16,19 +17,12 @@ type UploadLogDto struct {
 }
 
 func AdaptUploadLogDto(log models.UploadLog) UploadLogDto {
-	error := ""
-	if log.Error != nil {
-		error = *log.Error
-	}
-
-	linesProcessed := max(log.LinesProcessed, log.RowsIngested)
-
 	return UploadLogDto{
 		Status:          string(log.UploadStatus),
 		StartedAt:       log.StartedAt,
 		FinishedAt:      log.FinishedAt,
-		LinesProcessed:  linesProcessed,
+		LinesProcessed:  max(log.LinesProcessed, log.RowsIngested),
 		NumRowsIngested: log.RowsIngested,
-		Error:           error,
+		Error:           utils.Or(log.InputError, ""),
 	}
 }

--- a/mocks/task_queue_repository.go
+++ b/mocks/task_queue_repository.go
@@ -149,7 +149,7 @@ func (m *TaskQueueRepository) EnqueueCsvIngestionTask(
 	ctx context.Context,
 	tx repositories.Transaction,
 	organizationId uuid.UUID,
-	uploadLogId string,
+	uploadLogId uuid.UUID,
 	ingestionOptions models.IngestionOptions,
 ) error {
 	args := m.Called(ctx, tx, organizationId, uploadLogId, ingestionOptions)

--- a/models/river_job.go
+++ b/models/river_job.go
@@ -230,7 +230,7 @@ func (BatchExecutionCoordinatorArgs) Kind() string { return "batch_execution_coo
 
 // CSV ingestion job - processes a single upload log
 type CsvIngestionArgs struct {
-	UploadLogId      string           `json:"upload_log_id"`
+	UploadLogId      uuid.UUID        `json:"upload_log_id"`
 	IngestionOptions IngestionOptions `json:"ingestion_options"`
 }
 

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -17,6 +17,7 @@ type UploadLog struct {
 	FinishedAt     *time.Time
 	LinesProcessed int
 	RowsIngested   int
+	InputError     *string
 	Error          *string
 }
 
@@ -49,5 +50,6 @@ type UpdateUploadLogStatusInput struct {
 	CurrentUploadStatusCondition UploadStatus // for optimistic locking. Only rows matching this current status will be updated
 	FinishedAt                   *time.Time
 	NumRowsIngested              *int
+	InputError                   *string
 	Error                        *string
 }

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -6,8 +6,12 @@ import (
 	"github.com/google/uuid"
 )
 
+type UploadLogFilters struct {
+	Status *UploadStatus
+}
+
 type UploadLog struct {
-	Id             string
+	Id             uuid.UUID
 	OrganizationId uuid.UUID
 	UserId         string
 	FileName       string
@@ -45,7 +49,7 @@ func UploadStatusFrom(s string) UploadStatus {
 }
 
 type UpdateUploadLogStatusInput struct {
-	Id                           string
+	Id                           uuid.UUID
 	UploadStatus                 UploadStatus
 	CurrentUploadStatusCondition UploadStatus // for optimistic locking. Only rows matching this current status will be updated
 	FinishedAt                   *time.Time

--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -27,6 +27,47 @@ tags:
     description: Routes for record (data ingested into Marble)
 paths:
   /ingest/{objectType}/uploads:
+    get:
+      operationId: listBatchIngestionLogs
+      tags:
+        - Ingestion
+      security:
+        - BearerTokenAuth: []
+        - ApiKeyAuth: []
+      summary: List batch ingestion logs
+      parameters:
+        - name: objectType
+          description: Filter decisions by their scenario
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: status
+          description: Only show logs in a specific status
+          in: query
+          schema:
+            type: string
+            enum: [pending processing success failure]
+        - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/after"
+      responses:
+        "200":
+          description: List of batch ingestion events
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/BaseResponse"
+                  - $ref: "#/components/schemas/BasePagination"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BatchIngestionLog"
+        "400":
+          $ref: "#/components/responses/400"
+
     put:
       operationId: asyncIngestCsv 
       tags:
@@ -1446,6 +1487,36 @@ components:
             next_page_id:
               description: Value to use in pagination filter to request for the next page
               type: string
+
+    BatchIngestionLog:
+      title: Batch ingestion log
+      type: object
+      required:
+        - id
+        - status
+        - started_at
+        - rows_processed
+        - rows_ingested
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [pending, processing, success, failure]
+        started_at:
+          type: string
+          format: date-time
+        finished_at:
+          description: Time at which ingestion finished, will be `null` until completed.
+          type: string
+          format: date-time
+        rows_processed:
+          type: integer
+        rows_ingested:
+          type: integer
+        error:
+          type: string
 
     AsyncUploadCreated:
       title: Upload URL signed and generated

--- a/pubapi/v1/dto/ingestion.go
+++ b/pubapi/v1/dto/ingestion.go
@@ -1,5 +1,35 @@
 package dto
 
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/google/uuid"
+)
+
 type AsyncUpload struct {
 	UploadUrl string `json:"upload_url"`
+}
+
+type UploadLog struct {
+	Id            uuid.UUID  `json:"id"`
+	Status        string     `json:"status"`
+	StartedAt     time.Time  `json:"started_at"`
+	FinishedAt    *time.Time `json:"finished_at"`
+	RowsProcessed int        `json:"rows_processed"`
+	RowsIngested  int        `json:"rows_ingested"`
+	Error         string     `json:"error,omitempty"`
+}
+
+func AdaptUploadLog(log models.UploadLog) UploadLog {
+	return UploadLog{
+		Id:            log.Id,
+		Status:        string(log.UploadStatus),
+		StartedAt:     log.StartedAt,
+		FinishedAt:    log.FinishedAt,
+		RowsProcessed: max(log.LinesProcessed, log.RowsIngested),
+		RowsIngested:  log.RowsIngested,
+		Error:         pure_utils.PtrValueOrDefault(log.InputError, ""),
+	}
 }

--- a/pubapi/v1/params/ingestion.go
+++ b/pubapi/v1/params/ingestion.go
@@ -1,7 +1,24 @@
 package params
 
+import (
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi/types"
+)
+
 type IngestionParams struct {
 	SkipInitialScreening bool     `form:"skip_screening"`
 	MonitorObjects       bool     `form:"monitor"`
 	ContinuousConfigIds  []string `form:"monitoring_config_id" binding:"required_if=MonitorObjects true,omitempty,dive,uuid"`
+}
+
+type UploadLogParams struct {
+	types.PaginationParams
+
+	Status *models.UploadStatus `form:"status" binding:"oneof=pending processing success failure"`
+}
+
+func (p UploadLogParams) ToModel() models.UploadLogFilters {
+	return models.UploadLogFilters{
+		Status: p.Status,
+	}
 }

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -97,6 +97,7 @@ func BetaRoutes(conf pubapi.Config, unauthed *gin.RouterGroup, authMiddleware gi
 		root.GET("/cases/:caseId/ai_reviews/:aiReviewId", HandleGetAiCaseReviewById(uc))
 
 		root.PUT("/ingest/:objectType/uploads", v1beta.HandleUploadCsv(uc))
+		root.GET("/ingest/:objectType/uploads", v1beta.HandleBatchIngestionLog(uc))
 
 		// Graduated
 

--- a/pubapi/v1/v1beta/ingestion.go
+++ b/pubapi/v1/v1beta/ingestion.go
@@ -8,6 +8,7 @@ import (
 	"github.com/checkmarble/marble-backend/pubapi/types"
 	"github.com/checkmarble/marble-backend/pubapi/v1/dto"
 	"github.com/checkmarble/marble-backend/pubapi/v1/params"
+	"github.com/checkmarble/marble-backend/pure_utils"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/gin-gonic/gin"
@@ -57,5 +58,52 @@ func HandleUploadCsv(uc usecases.Usecases) gin.HandlerFunc {
 				UploadUrl: signedUrl,
 			}).
 			Serve(c, http.StatusAccepted)
+	}
+}
+
+var uploadLogPaginationDefaults = models.PaginationDefaults{
+	Limit:  25,
+	SortBy: models.DecisionSortingCreatedAt,
+	Order:  models.SortingOrderDesc,
+}
+
+func HandleBatchIngestionLog(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		recordType := c.Param("objectType")
+
+		var p params.UploadLogParams
+
+		if err := c.ShouldBindQuery(&p); err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		ingestionUsecase := pubapi.UsecasesWithCreds(ctx, uc).NewIngestionUseCase()
+
+		paging := p.PaginationParams.ToModel(uploadLogPaginationDefaults)
+		paging.Order = models.SortingOrderDesc
+
+		logs, err := ingestionUsecase.ListFilteredUploadLogs(ctx, orgId, recordType, p.ToModel(), paging)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+		}
+
+		nextPageId := ""
+
+		if len(logs.Items) > 0 {
+			nextPageId = logs.Items[len(logs.Items)-1].Id.String()
+		}
+
+		types.NewResponse(pure_utils.Map(logs.Items, dto.AdaptUploadLog)).
+			WithPagination(logs.HasNextPage, nextPageId).
+			Serve(c)
 	}
 }

--- a/repositories/dbmodels/db_upload_logs.go
+++ b/repositories/dbmodels/db_upload_logs.go
@@ -9,7 +9,7 @@ import (
 )
 
 type DBUploadLog struct {
-	Id              string     `db:"id"`
+	Id              uuid.UUID  `db:"id"`
 	OrganizationId  uuid.UUID  `db:"org_id"`
 	UserId          string     `db:"user_id"`
 	FileName        string     `db:"file_name"`

--- a/repositories/dbmodels/db_upload_logs.go
+++ b/repositories/dbmodels/db_upload_logs.go
@@ -19,6 +19,7 @@ type DBUploadLog struct {
 	FinishedAt      *time.Time `db:"finished_at"`
 	LinesProcessed  int        `db:"lines_processed"`
 	NumRowsIngested int        `db:"num_rows_ingested"`
+	InputError      *string    `db:"input_error"`
 	Error           *string    `db:"error"`
 }
 
@@ -38,6 +39,7 @@ func AdaptUploadLog(db DBUploadLog) (models.UploadLog, error) {
 		FinishedAt:     db.FinishedAt,
 		LinesProcessed: db.LinesProcessed,
 		RowsIngested:   db.NumRowsIngested,
+		InputError:     db.InputError,
 		Error:          db.Error,
 	}, nil
 }

--- a/repositories/migrations/20260709102700_add_input_error_to_upload_log.sql
+++ b/repositories/migrations/20260709102700_add_input_error_to_upload_log.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+
+alter table upload_logs
+    add column input_error text;
+
+-- +goose Down
+
+alter table upload_logs
+    drop column input_error;

--- a/repositories/task_queue_repository.go
+++ b/repositories/task_queue_repository.go
@@ -107,7 +107,7 @@ type TaskQueueRepository interface {
 		ctx context.Context,
 		tx Transaction,
 		organizationId uuid.UUID,
-		uploadLogId string,
+		uploadLogId uuid.UUID,
 		ingestionOptions models.IngestionOptions,
 	) error
 	EnqueueAsyncUploadTask(
@@ -610,7 +610,7 @@ func (r riverRepository) EnqueueCsvIngestionTask(
 	ctx context.Context,
 	tx Transaction,
 	organizationId uuid.UUID,
-	uploadLogId string,
+	uploadLogId uuid.UUID,
 	ingestionOptions models.IngestionOptions,
 ) error {
 	res, err := r.client.InsertTx(ctx, tx.RawTx(), models.CsvIngestionArgs{

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -13,9 +14,11 @@ import (
 type UploadLogRepository interface {
 	CreateUploadLog(ctx context.Context, exec Executor, log models.UploadLog) error
 	UpdateUploadLogStatus(ctx context.Context, exec Executor, input models.UpdateUploadLogStatusInput) (executed bool, err error)
-	UploadLogById(ctx context.Context, exec Executor, id string) (models.UploadLog, error)
+	UploadLogById(ctx context.Context, exec Executor, id uuid.UUID) (models.UploadLog, error)
 	AllUploadLogsByTable(ctx context.Context, exec Executor, organizationId uuid.UUID,
 		tableName string) ([]models.UploadLog, error)
+	ListUploadLogs(ctx context.Context, exec Executor, organizationId uuid.UUID,
+		tableName string, filters models.UploadLogFilters, pagination models.PaginationAndSorting) ([]models.UploadLog, error)
 }
 
 type UploadLogRepositoryImpl struct{}
@@ -104,7 +107,7 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(
 	return tag.RowsAffected() > 0, nil
 }
 
-func (repo *UploadLogRepositoryImpl) UploadLogById(ctx context.Context, exec Executor, id string) (models.UploadLog, error) {
+func (repo *UploadLogRepositoryImpl) UploadLogById(ctx context.Context, exec Executor, id uuid.UUID) (models.UploadLog, error) {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return models.UploadLog{}, err
 	}
@@ -144,6 +147,50 @@ func (repo *UploadLogRepositoryImpl) AllUploadLogsByTable(
 			Where(squirrel.Eq{"org_id": organizationId}).
 			Where(squirrel.Eq{"table_name": tableName}).
 			OrderBy("started_at DESC"),
+		dbmodels.AdaptUploadLog,
+	)
+}
+
+func (repo *UploadLogRepositoryImpl) ListUploadLogs(
+	ctx context.Context,
+	exec Executor,
+	organizationId uuid.UUID,
+	tableName string,
+	filters models.UploadLogFilters,
+	pagination models.PaginationAndSorting,
+) ([]models.UploadLog, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return nil, err
+	}
+
+	query := NewQueryBuilder().
+		Select(dbmodels.SelectUploadLogColumn...).
+		From(dbmodels.TABLE_UPLOAD_LOGS).
+		Where(squirrel.Eq{"org_id": organizationId}).
+		Where(squirrel.Eq{"table_name": tableName}).
+		OrderBy("started_at DESC, id DESC").
+		Limit(uint64(pagination.Limit))
+
+	if filters.Status != nil {
+		query = query.Where("status = ?", *filters.Status)
+	}
+
+	if pagination.OffsetId != "" {
+		offsetId, err := uuid.Parse(pagination.OffsetId)
+		if err != nil {
+			return nil, errors.Wrap(err, "provided upload log offset ID was not a UUID")
+		}
+		offsetLog, err := repo.UploadLogById(ctx, exec, offsetId)
+		if err != nil {
+			return nil, err
+		}
+		query = query.Where("(started_at, id) < (?, ?)", offsetLog.StartedAt, offsetLog.Id)
+	}
+
+	return SqlToListOfModels(
+		ctx,
+		exec,
+		query,
 		dbmodels.AdaptUploadLog,
 	)
 }

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -39,6 +39,7 @@ func (repo *UploadLogRepositoryImpl) CreateUploadLog(ctx context.Context, exec E
 				"started_at",
 				"finished_at",
 				"lines_processed",
+				"input_error",
 				"error",
 			).
 			Values(
@@ -51,6 +52,7 @@ func (repo *UploadLogRepositoryImpl) CreateUploadLog(ctx context.Context, exec E
 				log.StartedAt,
 				log.FinishedAt,
 				log.LinesProcessed,
+				log.InputError,
 				log.Error,
 			),
 	)
@@ -77,6 +79,9 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(
 	}
 	if input.NumRowsIngested != nil {
 		updateRequest = updateRequest.Set("num_rows_ingested", *input.NumRowsIngested)
+	}
+	if input.InputError != nil {
+		updateRequest = updateRequest.Set("input_error", *input.InputError)
 	}
 	if input.Error != nil {
 		updateRequest = updateRequest.Set("error", *input.Error)

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -88,7 +88,7 @@ type taskEnqueuer interface {
 		ctx context.Context,
 		tx repositories.Transaction,
 		organizationId uuid.UUID,
-		uploadLogId string,
+		uploadLogId uuid.UUID,
 		ingestionOptions models.IngestionOptions,
 	) error
 	EnqueueTriggerScoreComputation(
@@ -349,6 +349,37 @@ func (usecase *IngestionUseCase) ListUploadLogs(ctx context.Context,
 		usecase.executorFactory.NewExecutor(), organizationId, objectType)
 }
 
+func (usecase *IngestionUseCase) ListFilteredUploadLogs(
+	ctx context.Context,
+	organizationId uuid.UUID, objectType string,
+	filters models.UploadLogFilters,
+	pagination models.PaginationAndSorting,
+) (models.Paginated[models.UploadLog], error) {
+	if err := usecase.enforceSecurity.CanIngest(organizationId); err != nil {
+		return models.Paginated[models.UploadLog]{}, err
+	}
+
+	page := models.PaginationAndSorting{
+		OffsetId: pagination.OffsetId,
+		Sorting:  pagination.Sorting,
+		Order:    pagination.Order,
+		Limit:    pagination.Limit + 1,
+	}
+
+	logs, err := usecase.uploadLogRepository.ListUploadLogs(
+		ctx,
+		usecase.executorFactory.NewExecutor(), organizationId, objectType,
+		filters, page)
+	if err != nil {
+		return models.Paginated[models.UploadLog]{}, err
+	}
+
+	return models.Paginated[models.UploadLog]{
+		Items:       logs[:min(len(logs), pagination.Limit)],
+		HasNextPage: len(logs) > pagination.Limit,
+	}, nil
+}
+
 func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Context,
 	organizationId uuid.UUID, userId, objectType string, fileReader *csv.Reader,
 	ingestionOptions models.IngestionOptions,
@@ -456,7 +487,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 
 	return executor_factory.TransactionReturnValue(ctx,
 		usecase.transactionFactory, func(tx repositories.Transaction) (models.UploadLog, error) {
-			newUploadListId := pure_utils.NewId().String()
+			newUploadListId := pure_utils.NewId()
 			newUploadLoad := models.UploadLog{
 				Id:             newUploadListId,
 				UploadStatus:   models.UploadPending,
@@ -481,7 +512,7 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 // IngestDataFromCsvByUploadLogId processes a single upload log by its ID.
 // This is the main entry point for the CSV ingestion worker.
 func (usecase *IngestionUseCase) IngestDataFromCsvByUploadLogId(ctx context.Context,
-	uploadLogId string, ingestionOptions models.IngestionOptions,
+	uploadLogId uuid.UUID, ingestionOptions models.IngestionOptions,
 ) error {
 	logger := utils.LoggerFromContext(ctx)
 	logger.InfoContext(ctx, fmt.Sprintf("Start ingesting data from upload log %s", uploadLogId))

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -512,12 +512,15 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 		return nil
 	}
 
-	setToFailed := func(numRowsIngested int, ingestErr error) {
+	setToFailed := func(numRowsIngested int, inputErr error, ingestErr error) {
 		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
 		defer cancel()
 
-		errorString := ""
+		errorString, inputErrorString := "", ""
 
+		if inputErr != nil {
+			inputErrorString = strings.Join(errors.GetAllDetails(inputErr), ": ")
+		}
 		if ingestErr != nil {
 			errorString = ingestErr.Error()
 		}
@@ -530,6 +533,7 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 				CurrentUploadStatusCondition: models.UploadProcessing,
 				UploadStatus:                 models.UploadFailure,
 				NumRowsIngested:              &numRowsIngested,
+				InputError:                   &inputErrorString,
 				Error:                        &errorString,
 			})
 		if err != nil {
@@ -542,14 +546,14 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 		defer file.ReadCloser.Close()
 	}
 	if err != nil {
-		setToFailed(0, err)
+		setToFailed(0, nil, err)
 		return err
 	}
 
 	out := usecase.readFileIngestObjects(ctx, exec, file.FileName, file.ReadCloser, ingestionOptions)
-	if out.err != nil {
-		setToFailed(out.numRowsIngested, out.err)
-		return out.err
+	if out.inputErr != nil || out.err != nil {
+		setToFailed(out.numRowsIngested, out.inputErr, out.err)
+		return errors.Join(out.inputErr, out.err)
 	}
 
 	currentTime := time.Now()
@@ -568,6 +572,7 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 
 type ingestionResult struct {
 	numRowsIngested int
+	inputErr        error
 	err             error
 }
 
@@ -589,7 +594,7 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
 		fileNameElements := strings.Split(fileName, "/")
 		if len(fileNameElements) != 4 {
 			return ingestionResult{
-				err: fmt.Errorf("invalid filename %s: expecting format organizationId/tableName/timestamp.csv", fileName),
+				err: fmt.Errorf("invalid filename %s: expecting format organizationId/tableName/uuid", fileName),
 			}
 		}
 		organizationIdStr = fileNameElements[1]
@@ -598,7 +603,7 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
 		fileNameElements := strings.Split(fileName, "/")
 		if len(fileNameElements) != 3 {
 			return ingestionResult{
-				err: fmt.Errorf("invalid filename %s: expecting format organizationId/tableName/timestamp.csv", fileName),
+				inputErr: fmt.Errorf("invalid filename %s: expecting format organizationId/tableName/timestamp.csv", fileName),
 			}
 		}
 		organizationIdStr = fileNameElements[0]
@@ -679,7 +684,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 		if !field.Nullable {
 			if !slices.Contains(firstRow, name) {
 				return ingestionResult{
-					err: fmt.Errorf("missing required field %s in CSV", name),
+					inputErr: errors.WithDetailf(models.BadParameterError, "missing required field %s in CSV", name),
 				}
 			}
 		}
@@ -697,7 +702,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 		}
 
 		if err := validateContinuousScreeningConfigs(continuousScreeningConfigs, ingestionOptions.ContinuousScreeningIds, table.Name); err != nil {
-			return ingestionResult{err: err}
+			return ingestionResult{inputErr: errors.WithDetailf(err, "could not used provided continuous screening config: %v", err)}
 		}
 	}
 
@@ -726,7 +731,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 			if err != nil {
 				return ingestionResult{
 					numRowsIngested: total,
-					err:             fmt.Errorf("error parsing line %d of CSV: %w", objectIdx, err),
+					inputErr:        errors.WithDetailf(err, "error parsing field value in CSV at line %d: %v", objectIdx, err),
 				}
 			}
 			logger.DebugContext(iterationCtx, fmt.Sprintf("Object to ingest %d: %+v", objectIdx, object))

--- a/usecases/worker_jobs/async_upload_job.go
+++ b/usecases/worker_jobs/async_upload_job.go
@@ -27,7 +27,7 @@ type asyncUploadTaskEnqueuer interface {
 		ctx context.Context,
 		tx repositories.Transaction,
 		organizationId uuid.UUID,
-		uploadLogId string,
+		uploadLogId uuid.UUID,
 		ingestionOptions models.IngestionOptions,
 	) error
 }
@@ -88,7 +88,7 @@ func (w AsyncUploadWorker) Work(ctx context.Context, job *river.Job[models.Async
 	}
 
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
-		uploadLogId := pure_utils.NewId().String()
+		uploadLogId := pure_utils.NewId()
 
 		newUploadLoad := models.UploadLog{
 			Id:             uploadLogId,
@@ -115,7 +115,7 @@ func (w AsyncUploadWorker) Work(ctx context.Context, job *river.Job[models.Async
 func (w AsyncUploadWorker) createUploadError(ctx context.Context, job *river.Job[models.AsyncUploadArgs], err string) error {
 	return w.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
 		newUploadLoad := models.UploadLog{
-			Id:             pure_utils.NewId().String(),
+			Id:             pure_utils.NewId(),
 			UploadStatus:   models.UploadFailure,
 			OrganizationId: job.Args.OrgId,
 			FileName:       job.Args.Key,

--- a/usecases/worker_jobs/async_upload_job.go
+++ b/usecases/worker_jobs/async_upload_job.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	ASYNC_UPLOAD_START_TIMEOUT = 1 * time.Minute
+	ASYNC_UPLOAD_START_TIMEOUT = time.Minute
 	ASYNC_UPLOAD_TIMEOUT       = 15 * time.Minute
 	ASYNC_UPLOAD_TICK          = time.Minute
 	ASYNC_UPLOAD_MAX_SIZE      = 10 << 30 // 10 GB


### PR DESCRIPTION
* We need to present CSV input errors when asynchronously uploading a file for ingestion. This commit separate internal errors (still stored, but not exposed) and input errors that will be returned.
* Also, add an endpoint to the public API to list ingestion logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new upload/ingestion log view with filtering and pagination.
  * Upload log entries now include both processing progress and input-validation error details.

* **Bug Fixes**
  * Improved progress counts so reported rows processed are more accurate.
  * Fixed identifier handling to use UUIDs consistently, reducing mismatches across ingestion flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->