### PR TITLE
Use HTTP 202 Accepted when accepting an async upload.

### DIFF
--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -68,7 +68,7 @@ paths:
         content:
           text/csv:
       responses:
-        "200":
+        "202":
           description: Upload URL created
           content:
             application/json:

--- a/pubapi/v1/v1beta/ingestion.go
+++ b/pubapi/v1/v1beta/ingestion.go
@@ -1,6 +1,8 @@
 package v1beta
 
 import (
+	"net/http"
+
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pubapi"
 	"github.com/checkmarble/marble-backend/pubapi/types"
@@ -54,6 +56,6 @@ func HandleUploadCsv(uc usecases.Usecases) gin.HandlerFunc {
 			NewResponse(dto.AsyncUpload{
 				UploadUrl: signedUrl,
 			}).
-			Serve(c)
+			Serve(c, http.StatusAccepted)
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The CSV upload endpoint now returns **202 Accepted** for successful asynchronous upload requests, matching the actual async behavior.
  * The response body and schema remain unchanged, so integrations should continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->