### PR TITLE
chore: change variable env name

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -197,7 +197,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		LicenseKey:             utils.GetEnv("LICENSE_KEY", ""),
 		KillIfReadLicenseError: utils.GetEnv("KILL_IF_READ_LICENSE_ERROR", false),
 	}
-	promptsDir := utils.GetEnv("PROMPTS_DIR", "")
+	aiPromptsServingDir := utils.GetEnv("AI_PROMPTS_SERVING_DIR", "")
 	bigQueryConfig := infra.BigQueryConfig{
 		ProjectID:      utils.GetEnv("BIGQUERY_PROJECT_ID", gcpConfig.ProjectId),
 		MetricsDataset: utils.GetEnv("BIGQUERY_METRICS_DATASET", infra.MetricsDataset),
@@ -407,7 +407,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithMarbleApiInternalUrl(apiConfig.MarbleApiInternalUrl),
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
-		usecases.WithPromptsDir(promptsDir),
+		usecases.WithAIPromptsServingDir(aiPromptsServingDir),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -27,14 +27,14 @@ type promptsLicenseValidator interface {
 // PromptServingUsecase serves the private AI prompt files to license-holding clients
 // (self-hosted premium deployments downloading prompts at runtime)
 type PromptServingUsecase struct {
-	licenseValidator promptsLicenseValidator
-	promptsDir       string
+	licenseValidator    promptsLicenseValidator
+	aiPromptsServingDir string
 }
 
-func NewPromptServingUsecase(licenseValidator promptsLicenseValidator, promptsDir string) PromptServingUsecase {
+func NewPromptServingUsecase(licenseValidator promptsLicenseValidator, aiPromptsServingDir string) PromptServingUsecase {
 	return PromptServingUsecase{
-		licenseValidator: licenseValidator,
-		promptsDir:       promptsDir,
+		licenseValidator:    licenseValidator,
+		aiPromptsServingDir: aiPromptsServingDir,
 	}
 }
 
@@ -69,7 +69,7 @@ func (uc PromptServingUsecase) DownloadPrompts(ctx context.Context, licenseKey, 
 		return nil, err
 	}
 
-	if uc.promptsDir == "" {
+	if uc.aiPromptsServingDir == "" {
 		return nil, errors.Wrap(models.MissingRequirement, "ai prompts are not configured on this server")
 	}
 
@@ -113,9 +113,9 @@ func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error
 		return "", errors.Wrapf(models.BadParameterError, "version must be Major.Minor, got %s", version)
 	}
 
-	entries, err := os.ReadDir(uc.promptsDir)
+	entries, err := os.ReadDir(uc.aiPromptsServingDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.promptsDir)
+		return "", errors.Wrapf(err, "could not list prompts directory %s", uc.aiPromptsServingDir)
 	}
 
 	var bestVersion *semver.Version
@@ -136,7 +136,7 @@ func (uc PromptServingUsecase) resolvePromptsBase(version string) (string, error
 		// No matching/precedent version folder
 		return "", errors.Wrap(models.NotFoundError, "no prompts version available")
 	}
-	return filepath.Join(uc.promptsDir, bestVersion.Original()), nil
+	return filepath.Join(uc.aiPromptsServingDir, bestVersion.Original()), nil
 }
 
 func addFileToZip(zw *zip.Writer, srcPath, zipName string) error {

--- a/usecases/prompt_serving_usecase_test.go
+++ b/usecases/prompt_serving_usecase_test.go
@@ -122,33 +122,33 @@ func Test_PromptServingUsecase_DownloadPrompts_Authorization(t *testing.T) {
 	dir := writePromptsFixture(t)
 
 	tests := []struct {
-		name       string
-		promptsDir string
-		validation stubLicenseValidator
-		wantErr    error
+		name                string
+		aiPromptsServingDir string
+		validation          stubLicenseValidator
+		wantErr             error
 	}{
 		{
-			name:       "invalid license",
-			promptsDir: dir,
-			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.NOT_FOUND}},
-			wantErr:    models.ForbiddenError,
+			name:                "invalid license",
+			aiPromptsServingDir: dir,
+			validation:          stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.NOT_FOUND}},
+			wantErr:             models.ForbiddenError,
 		},
 		{
-			name:       "valid license without AI entitlement",
-			promptsDir: dir,
-			validation: stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.VALID}},
-			wantErr:    models.MissingLicenseEntitlementError,
+			name:                "valid license without AI entitlement",
+			aiPromptsServingDir: dir,
+			validation:          stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.VALID}},
+			wantErr:             models.MissingLicenseEntitlementError,
 		},
 		{
-			name:       "no prompts directory configured on this server",
-			promptsDir: "",
-			validation: stubLicenseValidator{validation: validLicenseWithAi()},
-			wantErr:    models.MissingRequirement,
+			name:                "no prompts directory configured on this server",
+			aiPromptsServingDir: "",
+			validation:          stubLicenseValidator{validation: validLicenseWithAi()},
+			wantErr:             models.MissingRequirement,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			uc := NewPromptServingUsecase(tt.validation, tt.promptsDir)
+			uc := NewPromptServingUsecase(tt.validation, tt.aiPromptsServingDir)
 			_, err := uc.DownloadPrompts(context.Background(), "some-key", "")
 			require.Error(t, err)
 			assert.True(t, errors.Is(err, tt.wantErr))

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -55,7 +55,7 @@ type Usecases struct {
 	allowInsecureWebhookURLs     bool   // Allow HTTP webhook URLs (dev only)
 	webhookIPWhitelist           string // Comma-separated CIDR ranges to whitelist for webhooks
 	screeningOffloadingEnabled   bool
-	promptsDir                   string
+	aiPromptsServingDir          string
 
 	coordsEnricher *rgeo.Rgeo
 	ipEnricher     *maxminddb.Reader
@@ -237,9 +237,9 @@ func WithScreeningOffloadingEnabled(enabled bool) Option {
 	}
 }
 
-func WithPromptsDir(dir string) Option {
+func WithAIPromptsServingDir(dir string) Option {
 	return func(o *options) {
-		o.promptsDir = dir
+		o.aiPromptsServingDir = dir
 	}
 }
 
@@ -270,7 +270,7 @@ type options struct {
 	screeningOffloadingEnabled   bool
 	webhookIPWhitelist           string
 	ipEnricher                   *maxminddb.Reader
-	promptsDir                   string
+	aiPromptsServingDir          string
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -310,7 +310,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		allowInsecureWebhookURLs:     o.allowInsecureWebhookURLs,
 		webhookIPWhitelist:           o.webhookIPWhitelist,
 		screeningOffloadingEnabled:   o.screeningOffloadingEnabled,
-		promptsDir:                   o.promptsDir,
+		aiPromptsServingDir:          o.aiPromptsServingDir,
 
 		coordsEnricher: coordsEnricher,
 		ipEnricher:     o.ipEnricher,
@@ -594,7 +594,7 @@ func (usecases *Usecases) NewPromptServingUsecase() PromptServingUsecase {
 	licenseUsecase := usecases.NewLicenseUsecase()
 	return NewPromptServingUsecase(
 		&licenseUsecase,
-		usecases.promptsDir,
+		usecases.aiPromptsServingDir,
 	)
 }
 


### PR DESCRIPTION
After the 1.5 release, this PR will be merged and rename a variable to be more descriptive https://github.com/checkmarble/marble-backend/pull/1850

Before the release 1.5, I decided to rename the variable and prepare the Terraform PR for the release. This move prevents us from renaming the variable after the 1.5 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt downloads now use a dedicated AI prompts serving directory setting.
  * The app can be configured with a new directory option for serving AI prompts.

* **Bug Fixes**
  * Prompt serving now reads from the updated directory setting consistently during downloads and version resolution.

* **Tests**
  * Updated coverage to reflect the new prompt-serving configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->