### PR TITLE
Fix not being able to assign a case to someone else if it is unassigned.

### DIFF
--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -843,7 +843,12 @@ func (usecase *CaseUseCase) AssignCase(ctx context.Context, req models.CaseAssig
 			return err
 		}
 
-		if err := usecase.PerformCaseActionSideEffects(ctx, tx, c); err != nil {
+		updatedCase, err := usecase.getCaseWithDetails(ctx, tx, req.CaseId)
+		if err != nil {
+			return err
+		}
+
+		if err := usecase.PerformCaseActionSideEffects(ctx, tx, updatedCase); err != nil {
 			return err
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Case assignment now uses the latest case details when triggering follow-up actions, helping ensure related updates reflect the newly assigned state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->