### PR TITLE
Public API and webhooks around user scoring

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -55,6 +55,7 @@ var validWebhookEventTypes = []WebhookEventType{
 	WebhookEventType_AsyncDecisionFailed,
 	WebhookEventType_ContinuousScreeningCreated,
 	WebhookEventType_ContinuousScreeningMatchReviewed,
+	WebhookEventType_ScoringRiskLevelChangedChanged,
 }
 
 type WebhookEventContent struct {

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -38,7 +38,7 @@ const (
 	WebhookEventType_AsyncDecisionFailed              WebhookEventType = "async_decision.failed"
 	WebhookEventType_ContinuousScreeningCreated       WebhookEventType = "continuous_screening.created"
 	WebhookEventType_ContinuousScreeningMatchReviewed WebhookEventType = "continuous_screening.match_reviewed"
-	WebhookEventType_ScoringScoreChanged              WebhookEventType = "scoring_score_changed"
+	WebhookEventType_ScoringRiskLevelChangedChanged   WebhookEventType = "user_scoring.risk_level_changed"
 )
 
 var validWebhookEventTypes = []WebhookEventType{
@@ -243,7 +243,7 @@ func NewWebhookEventAsyncDecisionFailed(data AsyncDecisionExecution) WebhookEven
 }
 
 func NewWebhookScoringScoreChanged(score ScoringScore) WebhookEventContent {
-	return newWebhookContent(WebhookEventType_ScoringScoreChanged, WebhookEventData{
+	return newWebhookContent(WebhookEventType_ScoringRiskLevelChangedChanged, WebhookEventData{
 		Score: &score,
 	})
 }

--- a/models/webhook.go
+++ b/models/webhook.go
@@ -38,6 +38,7 @@ const (
 	WebhookEventType_AsyncDecisionFailed              WebhookEventType = "async_decision.failed"
 	WebhookEventType_ContinuousScreeningCreated       WebhookEventType = "continuous_screening.created"
 	WebhookEventType_ContinuousScreeningMatchReviewed WebhookEventType = "continuous_screening.match_reviewed"
+	WebhookEventType_ScoringScoreChanged              WebhookEventType = "scoring_score_changed"
 )
 
 var validWebhookEventTypes = []WebhookEventType{
@@ -75,6 +76,7 @@ type WebhookEventData struct {
 	AsyncDecisionExecution   *AsyncDecisionExecution
 	ContinuousScreening      *ContinuousScreeningWithMatches
 	ContinuousScreeningMatch *ContinuousScreeningMatch
+	Score                    *ScoringScore
 }
 
 type WebhookEvent struct {
@@ -238,6 +240,12 @@ func NewWebhookEventAsyncDecisionFailed(data AsyncDecisionExecution) WebhookEven
 			Timestamp: time.Now(),
 		},
 	}
+}
+
+func NewWebhookScoringScoreChanged(score ScoringScore) WebhookEventContent {
+	return newWebhookContent(WebhookEventType_ScoringScoreChanged, WebhookEventData{
+		Score: &score,
+	})
 }
 
 type Webhook struct {

--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -25,6 +25,8 @@ tags:
     description: Routes for continuous screenings
   - name: Record
     description: Routes for record (data ingested into Marble)
+  - name: User scoring
+    description: Routes for user scoring
 paths:
   /ingest/{objectType}/uploads:
     get:
@@ -1365,6 +1367,72 @@ paths:
         "400":
           $ref: "#/components/responses/400"
 
+  /risk-levels/{objectType}/{objectId}:
+    get:
+      operationId: getActiveRiskLevel
+      tags:
+        - User scoring
+      security:
+        - BearerTokenAuth: []
+        - ApiKeyAuth: []
+      summary: Retrieve a record's active risk level
+      responses:
+        "200":
+          description: Current risk level
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/BaseResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/RecordRiskLevel"
+        "400":
+          $ref: "#/components/responses/400"
+        "404":
+          $ref: "#/components/responses/404"
+
+    post:
+      operationId: overrideRiskLevel
+      tags:
+        - User scoring
+      security:
+        - BearerTokenAuth: []
+        - ApiKeyAuth: []
+      summary: Override a record's risj level
+      parameters:
+        - name: objectType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: objectId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: risk_level
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: New risk level
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/BaseResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/RecordRiskLevel"
+        "400":
+          $ref: "#/components/responses/400"
+        "404":
+          $ref: "#/components/responses/404"
+
 components:
   securitySchemes:
     BearerTokenAuth:
@@ -2087,3 +2155,28 @@ components:
                   type: string
                   format: uri
                   description: URL to supporting evidence for the risk tag
+
+    RecordRiskLevel:
+      title: Record risk level
+      type: object
+      required:
+        - source
+        - risk_level
+        - current
+        - created_at
+      properties:
+        source:
+          type: string
+          enum: [initial, ruleset, override]
+        risk_level:
+          type: integer
+        current:
+          type: boolean
+        overridden_by:
+          $ref: "#/components/schemas/Ref"
+        created_at:
+          type: string
+          format: date-time
+        stale_at:
+          type: string
+          format: date-time

--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -71,7 +71,7 @@ paths:
           $ref: "#/components/responses/400"
 
     put:
-      operationId: asyncIngestCsv 
+      operationId: asyncIngestCsv
       tags:
         - Ingestion
       security:
@@ -1376,6 +1376,17 @@ paths:
         - BearerTokenAuth: []
         - ApiKeyAuth: []
       summary: Retrieve a record's active risk level
+      parameters:
+        - name: objectType
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: objectId
+          in: path
+          required: true
+          schema:
+            type: string
       responses:
         "200":
           description: Current risk level
@@ -1400,7 +1411,7 @@ paths:
       security:
         - BearerTokenAuth: []
         - ApiKeyAuth: []
-      summary: Override a record's risj level
+      summary: Override a record's risk level
       parameters:
         - name: objectType
           in: path
@@ -1414,6 +1425,7 @@ paths:
             type: string
         - name: risk_level
           in: query
+          required: true
           schema:
             type: integer
       responses:

--- a/pubapi/v1/dto/score.go
+++ b/pubapi/v1/dto/score.go
@@ -1,0 +1,32 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+)
+
+type RiskLevel struct {
+	Source       string     `json:"source"`
+	RiskLevel    int        `json:"risk_level"`
+	Current      bool       `json:"current"`
+	OverriddenBy *Ref       `json:"overridden_by,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	StaleAt      *time.Time `json:"stale_at,omitempty"`
+}
+
+func AdaptRiskLevel(rl models.ScoringScore, overriddenBy *Ref) RiskLevel {
+	return RiskLevel{
+		Source:       string(rl.Source),
+		RiskLevel:    rl.RiskLevel,
+		Current:      rl.DeletedAt == nil,
+		CreatedAt:    rl.CreatedAt,
+		OverriddenBy: overriddenBy,
+		StaleAt: func() *time.Time {
+			if rl.DeletedAt != nil {
+				return nil
+			}
+			return rl.StaleAt
+		}(),
+	}
+}

--- a/pubapi/v1/dto/webhooks.go
+++ b/pubapi/v1/dto/webhooks.go
@@ -37,6 +37,7 @@ type WebhookEventData struct {
 	AsyncDecision       *AsyncDecisionExecution   `json:"async_decision,omitzero"`
 	ContinuousScreening *ContinuousScreening      `json:"continuous_screening,omitzero"`
 	Match               *ContinuousScreeningMatch `json:"match,omitzero"`
+	RiskLevel           *RiskLevel                `json:"risk_level,omitzero"`
 }
 
 func AdaptWebhookEventData(
@@ -101,6 +102,9 @@ func AdaptWebhookEventData(
 			ContinuousScreening: applyWebhookEventData(m.Content.ContinuousScreening, AdaptContinuousScreening),
 			Match: applyWebhookEventData(m.Content.ContinuousScreeningMatch, func(match models.ContinuousScreeningMatch) ContinuousScreeningMatch {
 				return AdaptContinuousScreeningMatch(matchTriggerType, match)
+			}),
+			RiskLevel: applyWebhookEventData(m.Content.Score, func(rl models.ScoringScore) RiskLevel {
+				return AdaptRiskLevel(rl, nil)
 			}),
 		},
 		Timestamp: m.Timestamp,

--- a/pubapi/v1/params/scoring.go
+++ b/pubapi/v1/params/scoring.go
@@ -1,0 +1,5 @@
+package params
+
+type RiskLevelOverrideParams struct {
+	RiskLevel int `form:"risk_level"`
+}

--- a/pubapi/v1/routes.go
+++ b/pubapi/v1/routes.go
@@ -99,6 +99,9 @@ func BetaRoutes(conf pubapi.Config, unauthed *gin.RouterGroup, authMiddleware gi
 		root.PUT("/ingest/:objectType/uploads", v1beta.HandleUploadCsv(uc))
 		root.GET("/ingest/:objectType/uploads", v1beta.HandleBatchIngestionLog(uc))
 
+		root.GET("/risk-levels/:objectType/:objectId", v1beta.HandleGetObjectRiskLevel(uc))
+		root.POST("/risk-levels/:objectType/:objectId", v1beta.HandleOverrideObjectRiskLevel(uc))
+
 		// Graduated
 
 		root.POST("/ingest/:objectType", HandleIngestObject(uc, false))

--- a/pubapi/v1/v1beta/scoring.go
+++ b/pubapi/v1/v1beta/scoring.go
@@ -1,0 +1,126 @@
+package v1beta
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
+	"github.com/checkmarble/marble-backend/pubapi/types"
+	"github.com/checkmarble/marble-backend/pubapi/v1/dto"
+	"github.com/checkmarble/marble-backend/pubapi/v1/params"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+func HandleGetObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		uc := pubapi.UsecasesWithCreds(ctx, uc)
+		scoringUsecase := uc.NewScoringScoresUsecase()
+
+		record := models.ScoringRecordRef{
+			OrgId:      orgId,
+			RecordType: c.Param("objectType"),
+			RecordId:   c.Param("objectId"),
+		}
+
+		opts := models.RefreshScoreOptions{
+			RefreshOlderThan:    time.Hour,
+			RefreshInBackground: true,
+		}
+
+		score, _, err := scoringUsecase.GetActiveScore(ctx, record, false, opts)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+		if score == nil {
+			types.NewErrorResponse().Serve(c, http.StatusNotFound)
+			return
+		}
+
+		overridenBy, err := userOrApiKey(ctx, uc, score.OverriddenBy)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		types.NewResponse(dto.AdaptRiskLevel(*score, overridenBy)).
+			Serve(c)
+	}
+}
+
+func HandleOverrideObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		orgId, err := utils.OrganizationIdFromRequest(c.Request)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		var p params.RiskLevelOverrideParams
+
+		if err := c.ShouldBindQuery(&p); err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		uc := pubapi.UsecasesWithCreds(ctx, uc)
+		scoringUsecase := uc.NewScoringScoresUsecase()
+
+		req := models.InsertScoreRequest{
+			OrgId:      orgId,
+			RecordType: c.Param("objectType"),
+			RecordId:   c.Param("objectId"),
+			RiskLevel:  p.RiskLevel,
+			Source:     models.ScoreSourceOverride,
+		}
+
+		score, err := scoringUsecase.OverrideScore(ctx, req)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		overridenBy, err := userOrApiKey(ctx, uc, score.OverriddenBy)
+		if err != nil {
+			types.NewErrorResponse().WithError(err).Serve(c)
+			return
+		}
+
+		types.NewResponse(dto.AdaptRiskLevel(score, overridenBy)).
+			Serve(c, http.StatusCreated)
+	}
+}
+
+func userOrApiKey(ctx context.Context, uc *usecases.UsecasesWithCreds, id *uuid.UUID) (*dto.Ref, error) {
+	if id == nil {
+		return nil, nil
+	}
+
+	userUsecase := uc.NewUserUseCase()
+
+	user, err := userUsecase.GetUser(ctx, id.String())
+	if err != nil && !errors.Is(err, models.NotFoundError) {
+		return nil, err
+	}
+	if err == nil {
+		return new(dto.AdaptUserRef(user)), nil
+	}
+
+	return &dto.Ref{Id: id.String(), Name: "api_key"}, nil
+}

--- a/usecases/scoring/scoring_jobs/triggered_score_computation_test.go
+++ b/usecases/scoring/scoring_jobs/triggered_score_computation_test.go
@@ -76,6 +76,7 @@ func (s *TriggeredScoreComputationWorkerTestSuite) makeScoreUsecase() scoring.Sc
 		ast_eval.EvaluateAstExpression{
 			AstEvaluationEnvironmentFactory: noopAstEvaluationEnvironmentFactory,
 		},
+		nil,
 	)
 }
 

--- a/usecases/scoring/scoring_scores_usecase.go
+++ b/usecases/scoring/scoring_scores_usecase.go
@@ -283,18 +283,20 @@ func (uc ScoringScoresUsecase) tryRefreshScore(ctx context.Context, activeScore 
 			return nil, err
 		}
 
-		if err := uc.offloadedReadWriter.OffloadScoreComputation(ctx, scoreRuleset, score, scoreEvaluationsSer); err != nil {
-			return nil, errors.Wrap(err, "could not offload score computation")
+		if req.IgnoredByCooldown {
+			webhookEventId = new(pure_utils.NewId())
+
+			if err := uc.webhookSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+				Id:             webhookEventId.String(),
+				OrganizationId: score.OrgId,
+				EventContent:   models.NewWebhookScoringScoreChanged(score),
+			}); err != nil {
+				return nil, errors.Wrap(err, "could not send score change webhook")
+			}
 		}
 
-		webhookEventId = new(pure_utils.NewId())
-
-		if err := uc.webhookSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
-			Id:             webhookEventId.String(),
-			OrganizationId: score.OrgId,
-			EventContent:   models.NewWebhookScoringScoreChanged(score),
-		}); err != nil {
-			return nil, errors.Wrap(err, "could not send score change webhook")
+		if err := uc.offloadedReadWriter.OffloadScoreComputation(ctx, scoreRuleset, score, scoreEvaluationsSer); err != nil {
+			return nil, errors.Wrap(err, "could not offload score computation")
 		}
 
 		return &score, nil

--- a/usecases/scoring/scoring_scores_usecase.go
+++ b/usecases/scoring/scoring_scores_usecase.go
@@ -25,6 +25,11 @@ type featureAccessReader interface {
 	) (models.OrganizationFeatureAccess, error)
 }
 
+type webhookSender interface {
+	CreateWebhookEvent(ctx context.Context, tx repositories.Transaction, input models.WebhookEventCreate) error
+	SendWebhookEventAsync(ctx context.Context, webhookEventId string)
+}
+
 type ScoringScoresUsecase struct {
 	enforceSecurity        security.EnforceSecurityScoring
 	executorFactory        executor_factory.ExecutorFactory
@@ -37,6 +42,7 @@ type ScoringScoresUsecase struct {
 	ingestedDataReader     scoringIngestedDataReader
 	taskQueueRepository    repositories.TaskQueueRepository
 	evaluateAst            ast_eval.EvaluateAstExpression
+	webhookSender          webhookSender
 }
 
 func NewScoringScoresUsecase(
@@ -51,6 +57,7 @@ func NewScoringScoresUsecase(
 	ingestedDataReader scoringIngestedDataReader,
 	taskQueueRepository repositories.TaskQueueRepository,
 	evaluateAst ast_eval.EvaluateAstExpression,
+	webhookSender webhookSender,
 ) ScoringScoresUsecase {
 	return ScoringScoresUsecase{
 		enforceSecurity:        enforceSecurity,
@@ -64,6 +71,7 @@ func NewScoringScoresUsecase(
 		ingestedDataReader:     ingestedDataReader,
 		taskQueueRepository:    taskQueueRepository,
 		evaluateAst:            evaluateAst,
+		webhookSender:          webhookSender,
 	}
 }
 
@@ -198,7 +206,9 @@ func (uc ScoringScoresUsecase) GetActiveScore(ctx context.Context, record models
 }
 
 func (uc ScoringScoresUsecase) tryRefreshScore(ctx context.Context, activeScore *models.ScoringScore, record models.ScoringRecordRef, opts models.RefreshScoreOptions) (*models.ScoringScore, error) {
-	return executor_factory.TransactionReturnValue(ctx, uc.transactionFactory, func(tx repositories.Transaction) (*models.ScoringScore, error) {
+	var webhookEventId *uuid.UUID
+
+	score, err := executor_factory.TransactionReturnValue(ctx, uc.transactionFactory, func(tx repositories.Transaction) (*models.ScoringScore, error) {
 		// We do not compute the score in the background if we do not have a
 		// currently active score. In this case, we fall back to synchronous
 		// computing.
@@ -277,8 +287,24 @@ func (uc ScoringScoresUsecase) tryRefreshScore(ctx context.Context, activeScore 
 			return nil, errors.Wrap(err, "could not offload score computation")
 		}
 
+		webhookEventId = new(pure_utils.NewId())
+
+		if err := uc.webhookSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+			Id:             webhookEventId.String(),
+			OrganizationId: score.OrgId,
+			EventContent:   models.NewWebhookScoringScoreChanged(score),
+		}); err != nil {
+			return nil, errors.Wrap(err, "could not send score change webhook")
+		}
+
 		return &score, nil
 	})
+
+	if err == nil && webhookEventId != nil {
+		uc.webhookSender.SendWebhookEventAsync(ctx, webhookEventId.String())
+	}
+
+	return score, err
 }
 
 func (uc ScoringScoresUsecase) OverrideScore(ctx context.Context, req models.InsertScoreRequest) (models.ScoringScore, error) {
@@ -324,9 +350,29 @@ func (uc ScoringScoresUsecase) OverrideScore(ctx context.Context, req models.Ins
 		}
 	}
 
+	var webhookEventId *uuid.UUID
+
 	score, err := executor_factory.TransactionReturnValue(ctx, uc.transactionFactory, func(tx repositories.Transaction) (models.ScoringScore, error) {
-		return uc.repository.InsertScore(ctx, tx, req)
+		score, err := uc.repository.InsertScore(ctx, tx, req)
+		if err != nil {
+			return models.ScoringScore{}, err
+		}
+		webhookEventId = new(pure_utils.NewId())
+
+		if err := uc.webhookSender.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+			Id:             webhookEventId.String(),
+			OrganizationId: score.OrgId,
+			EventContent:   models.NewWebhookScoringScoreChanged(score),
+		}); err != nil {
+			return models.ScoringScore{}, errors.Wrap(err, "could not send score change webhook")
+		}
+
+		return score, nil
 	})
+
+	if err == nil && webhookEventId != nil {
+		uc.webhookSender.SendWebhookEventAsync(ctx, webhookEventId.String())
+	}
 
 	return score, err
 }

--- a/usecases/scoring/scoring_scores_usecase.go
+++ b/usecases/scoring/scoring_scores_usecase.go
@@ -132,7 +132,7 @@ func (uc ScoringScoresUsecase) InternalComputeScore(ctx context.Context, exec re
 }
 
 func (uc ScoringScoresUsecase) GetScoreHistory(ctx context.Context, record models.ScoringRecordRef) ([]models.ScoringScore, error) {
-	if err := uc.isScoringEnabled(ctx, record.OrgId); err != nil {
+	if err := uc.isScoringEnabled(ctx, uc.enforceSecurity.OrgId()); err != nil {
 		return nil, err
 	}
 

--- a/usecases/scoring/scoring_scores_usecase_test.go
+++ b/usecases/scoring/scoring_scores_usecase_test.go
@@ -31,6 +31,7 @@ type TryRefreshScoreTestSuite struct {
 	dataModelRepo       *mocks.DataModelRepository
 	ingestedDataReader  *mocks.IngestedDataReader
 	featureAccessReader *mocks.FeatureAccessReader
+	webhookSender       *mocks.WebhookEventsUsecase
 
 	orgId      uuid.UUID
 	recordType string
@@ -53,6 +54,7 @@ func (s *TryRefreshScoreTestSuite) SetupTest() {
 	s.dataModelRepo = new(mocks.DataModelRepository)
 	s.ingestedDataReader = new(mocks.IngestedDataReader)
 	s.featureAccessReader = new(mocks.FeatureAccessReader)
+	s.webhookSender = new(mocks.WebhookEventsUsecase)
 
 	s.orgId = pure_utils.NewId()
 	s.recordType = "account"
@@ -72,6 +74,7 @@ func (s *TryRefreshScoreTestSuite) makeUsecase() ScoringScoresUsecase {
 		repository:          s.repository,
 		taskQueueRepository: s.taskQueue,
 		featureAccessReader: s.featureAccessReader,
+		webhookSender:       s.webhookSender,
 	}
 }
 
@@ -239,6 +242,9 @@ func (s *TryRefreshScoreTestSuite) TestTryRefreshScore_Stale_ComputeAndInsert_Ha
 		Return([]models.DataModelObject{obj}, nil)
 	s.repository.On("InsertScore", s.ctx, s.transaction, expectedReq).
 		Return(inserted, nil)
+	s.webhookSender.On("CreateWebhookEvent", s.ctx, s.transaction, mock.Anything).
+		Return(nil)
+	s.webhookSender.On("SendWebhookEventAsync", s.ctx, mock.Anything).Once()
 
 	uc := s.makeUsecaseWithCompute()
 	result, err := uc.tryRefreshScore(s.ctx, current, s.record, opts)

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -1264,6 +1264,7 @@ func (usecases *UsecasesWithCreds) NewScoringScoresUsecase() scoring.ScoringScor
 		usecases.Repositories.IngestedDataReadRepository,
 		usecases.Repositories.TaskQueueRepository,
 		usecases.NewEvaluateAstExpression(),
+		usecases.NewWebhookEventsUsecase(),
 	)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated endpoints to **get** and **override** an object’s active scoring risk level.
  * Extended scoring webhook notifications to include **risk level** details in the event payload.
* **Bug Fixes**
  * Risk level retrieval now returns **404** when no active score exists, and more accurately reflects **current vs. stale/overridden** status.
  * Webhook delivery now happens only **after** successful refreshes and overrides.
* **Chores**
  * Updated API contracts and test coverage to support the new risk-level endpoints and webhook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->