### PR TITLE
POC: Model Context Protocol (MCP) server for case/decision reporting

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/infra"
+	mcpserver "github.com/checkmarble/marble-backend/mcp"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pubapi"
 	pubapiv1 "github.com/checkmarble/marble-backend/pubapi/v1"
@@ -85,6 +86,12 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken), uc)
 		pubapiv1.BetaRoutes(cfg, r.Group("/v1beta"),
 			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken), uc)
+	}
+
+	// MCP server (POC)
+	{
+		mcpserver.Routes(uc, conf.AppVersion, r.Group("/mcp"),
+			auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken))
 	}
 
 	// Screening Indexer endpoints

--- a/dto/case_dto.go
+++ b/dto/case_dto.go
@@ -193,7 +193,7 @@ type CaseDecisionListPaginationDto struct {
 }
 
 type CaseMassUpdateDto struct {
-	Action      string                     `json:"action" binding:"required,oneof=close reopen assign move_to_inbox"`
+	Action      string                     `json:"action" binding:"required,oneof=close reopen assign unassign move_to_inbox"`
 	CaseIds     []uuid.UUID                `json:"case_ids" binding:"required,dive,uuid"`
 	Assign      *CaseMassUpdateAssignDto   `json:"assign" binding:"required_if=Action assign"`
 	MoveToInbox *CaseMassUpdateMoveToInbox `json:"move_to_inbox" binding:"required_if=Action move_to_inbox"`

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
+	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/oapi-codegen/oapi-codegen/v2 v2.7.1
 	github.com/oapi-codegen/runtime v1.4.1
@@ -197,6 +198,7 @@ require (
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -265,7 +267,9 @@ require (
 	github.com/samber/lo v1.51.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/segmentio/backo-go v1.1.0 // indirect
+	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
@@ -288,6 +292,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/yudai/gojsondiff v1.0.0 // indirect
 	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -372,6 +372,8 @@ github.com/google/go-replayers/grpcreplay v1.3.0/go.mod h1:v6NgKtkijC0d3e3RW8il6
 github.com/google/go-replayers/httpreplay v1.2.0 h1:VM1wEyyjaoU53BwrOnaf9VhAyQQEEioJvFYxYcLRKzk=
 github.com/google/go-replayers/httpreplay v1.2.0/go.mod h1:WahEFFZZ7a1P4VM1qEeHy+tME4bwyqPcwWbNlUI1Mcg=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+DQPd0=
+github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/martian/v3 v3.3.3 h1:DIhPTQrbPkgs2yJYdXU/eNACCG5DVQjySNRNlflZ9Fc=
 github.com/google/martian/v3 v3.3.3/go.mod h1:iEPrYcgCF7jA9OtScMFQyAlZZ4YXTKEtJ1E6RWzmBA0=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
@@ -500,6 +502,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
+github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -617,8 +621,12 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/analytics-go/v3 v3.3.0 h1:8VOMaVGBW03pdBrj1CMFfY9o/rnjJC+1wyQHlVxjw5o=
 github.com/segmentio/analytics-go/v3 v3.3.0/go.mod h1:p8owAF8X+5o27jmvUognuXxdtqvSGtD0ZrfY2kcS9bE=
+github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
+github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/segmentio/backo-go v1.1.0 h1:cJIfHQUdmLsd8t9IXqf5J8SdrOMn9vMa7cIvOavHAhc=
 github.com/segmentio/backo-go v1.1.0/go.mod h1:ckenwdf+v/qbyhVdNPWHnqh2YdJBED1O9cidYyM5J18=
+github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=
+github.com/segmentio/encoding v0.5.4/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
@@ -704,6 +712,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 h1:6fRhSjgLCkTD3JnJxvaJ4Sj+TYblw757bqYgZaOq5ZY=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=

--- a/mcp/http_handler.go
+++ b/mcp/http_handler.go
@@ -1,0 +1,19 @@
+package mcp
+
+import (
+	"net/http"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+// NewHTTPHandler wraps the MCP server in a streamable-HTTP http.Handler,
+// mountable behind Gin via gin.WrapH.
+func NewHTTPHandler(uc usecases.Usecases, version string) http.Handler {
+	server := NewServer(uc, version)
+
+	return sdkmcp.NewStreamableHTTPHandler(func(*http.Request) *sdkmcp.Server {
+		return server
+	}, nil)
+}

--- a/mcp/routes.go
+++ b/mcp/routes.go
@@ -1,0 +1,17 @@
+package mcp
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+// Routes mounts the MCP streamable-HTTP endpoint on group, behind
+// authMiddleware. It mirrors the pattern used for the public API v1 group
+// in api/api/routes.go, reusing the same Gin authentication middleware.
+func Routes(uc usecases.Usecases, version string, group *gin.RouterGroup, authMiddleware gin.HandlerFunc) {
+	handler := NewHTTPHandler(uc, version)
+
+	group.Use(authMiddleware)
+	group.Any("", gin.WrapH(handler))
+}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -1,0 +1,27 @@
+package mcp
+
+import (
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+// NewServer builds the MCP server exposing Marble reporting/action tools.
+//
+// A single *sdkmcp.Server instance is shared across all MCP sessions; each
+// tool handler pulls the caller's org-scoped credentials from ctx (populated
+// by the Gin auth middleware that fronts this server, see mcp/routes.go),
+// so no per-session/per-credential server instances are needed.
+func NewServer(uc usecases.Usecases, version string) *sdkmcp.Server {
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "marble-backend",
+		Version: version,
+	}, nil)
+
+	registerDebugTools(server, uc)
+	registerReportingTools(server, uc)
+	registerEntityTools(server, uc)
+	registerActionTools(server, uc)
+
+	return server
+}

--- a/mcp/tools_actions.go
+++ b/mcp/tools_actions.go
@@ -1,0 +1,73 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/pubapi"
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+type caseBulkAssignInput struct {
+	CaseIds    []string `json:"case_ids" jsonschema:"list of case ids (uuid) to update"`
+	Action     string   `json:"action" jsonschema:"one of: assign, unassign"`
+	AssigneeId string   `json:"assignee_id,omitempty" jsonschema:"required when action=assign: user id to assign the cases to"`
+}
+
+type caseBulkAssignOutput struct {
+	Success   bool `json:"success"`
+	CaseCount int  `json:"case_count"`
+}
+
+// registerActionTools registers the only mutation exposed to the MCP client:
+// batch case assign/unassign, built on top of CaseUseCase.MassUpdate (the
+// existing mass-update pattern used by the internal API's mass-update
+// endpoint).
+func registerActionTools(server *sdkmcp.Server, uc usecases.Usecases) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "case_bulk_assign",
+		Description: "Batch assign or unassign a list of cases to/from a user.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in caseBulkAssignInput) (*sdkmcp.CallToolResult, caseBulkAssignOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+
+		caseIds := make([]uuid.UUID, 0, len(in.CaseIds))
+		for _, idStr := range in.CaseIds {
+			id, err := uuid.Parse(idStr)
+			if err != nil {
+				return nil, caseBulkAssignOutput{}, fmt.Errorf("invalid case id %q: %w", idStr, err)
+			}
+			caseIds = append(caseIds, id)
+		}
+
+		massUpdateReq := dto.CaseMassUpdateDto{
+			Action:  in.Action,
+			CaseIds: caseIds,
+		}
+
+		switch in.Action {
+		case "assign":
+			if in.AssigneeId == "" {
+				return nil, caseBulkAssignOutput{}, fmt.Errorf("assignee_id is required when action=assign")
+			}
+			assigneeId, err := uuid.Parse(in.AssigneeId)
+			if err != nil {
+				return nil, caseBulkAssignOutput{}, fmt.Errorf("invalid assignee_id: %w", err)
+			}
+			massUpdateReq.Assign = &dto.CaseMassUpdateAssignDto{AssigneeId: assigneeId}
+		case "unassign":
+		default:
+			return nil, caseBulkAssignOutput{}, fmt.Errorf("unknown action %q, must be assign or unassign", in.Action)
+		}
+
+		caseUC := withCreds.NewCaseUseCase()
+		if err := caseUC.MassUpdate(ctx, massUpdateReq); err != nil {
+			return nil, caseBulkAssignOutput{}, err
+		}
+
+		return nil, caseBulkAssignOutput{Success: true, CaseCount: len(caseIds)}, nil
+	})
+}

--- a/mcp/tools_debug.go
+++ b/mcp/tools_debug.go
@@ -1,0 +1,38 @@
+package mcp
+
+import (
+	"context"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/checkmarble/marble-backend/utils"
+)
+
+type whoamiInput struct{}
+
+type whoamiOutput struct {
+	Authenticated  bool   `json:"authenticated"`
+	OrganizationId string `json:"organization_id,omitempty"`
+	Role           string `json:"role,omitempty"`
+}
+
+// registerDebugTools registers a diagnostic tool useful for verifying which
+// organization/role a given API key is authenticated as before running the
+// other tools.
+func registerDebugTools(server *sdkmcp.Server, _ usecases.Usecases) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "whoami",
+		Description: "Debug tool: reports the organization and role the current MCP session is authenticated as.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in whoamiInput) (*sdkmcp.CallToolResult, whoamiOutput, error) {
+		creds, ok := utils.CredentialsFromCtx(ctx)
+		if !ok {
+			return nil, whoamiOutput{Authenticated: false}, nil
+		}
+		return nil, whoamiOutput{
+			Authenticated:  true,
+			OrganizationId: creds.OrganizationId.String(),
+			Role:           creds.Role.String(),
+		}, nil
+	})
+}

--- a/mcp/tools_entity.go
+++ b/mcp/tools_entity.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+type entityOverviewInput struct {
+	ObjectType          string `json:"object_type" jsonschema:"the ingested data model table name the entity belongs to"`
+	ObjectId            string `json:"object_id" jsonschema:"the entity's unique object id"`
+	WithScoreEvaluation bool   `json:"with_score_evaluation,omitempty" jsonschema:"include the rule-by-rule score evaluation breakdown"`
+}
+
+type riskScoreSummary struct {
+	RiskLevel int        `json:"risk_level"`
+	Source    string     `json:"source"`
+	CreatedAt time.Time  `json:"created_at"`
+	StaleAt   *time.Time `json:"stale_at,omitempty"`
+}
+
+type annotationSummary struct {
+	Id             string    `json:"id"`
+	AnnotationType string    `json:"annotation_type"`
+	AnnotatedBy    *string   `json:"annotated_by,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+}
+
+type groupedAnnotationsSummary struct {
+	Comments []annotationSummary `json:"comments"`
+	Tags     []annotationSummary `json:"tags"`
+	Files    []annotationSummary `json:"files"`
+	RiskTags []annotationSummary `json:"risk_tags"`
+}
+
+func adaptAnnotationSummaries(annotations []models.EntityAnnotation) []annotationSummary {
+	summaries := make([]annotationSummary, 0, len(annotations))
+	for _, a := range annotations {
+		var annotatedBy *string
+		if a.AnnotatedBy != nil {
+			s := string(*a.AnnotatedBy)
+			annotatedBy = &s
+		}
+		summaries = append(summaries, annotationSummary{
+			Id:             a.Id,
+			AnnotationType: a.AnnotationType.String(),
+			AnnotatedBy:    annotatedBy,
+			CreatedAt:      a.CreatedAt,
+		})
+	}
+	return summaries
+}
+
+func adaptGroupedAnnotations(grouped models.GroupedEntityAnnotations) groupedAnnotationsSummary {
+	return groupedAnnotationsSummary{
+		Comments: adaptAnnotationSummaries(grouped.Comments),
+		Tags:     adaptAnnotationSummaries(grouped.Tags),
+		Files:    adaptAnnotationSummaries(grouped.Files),
+		RiskTags: adaptAnnotationSummaries(grouped.RiskTags),
+	}
+}
+
+type continuousScreeningMatchSummary struct {
+	Id                   string    `json:"id"`
+	OpenSanctionEntityId string    `json:"open_sanction_entity_id"`
+	Status               string    `json:"status"`
+	CreatedAt            time.Time `json:"created_at"`
+}
+
+type continuousScreeningSummary struct {
+	Status          string                            `json:"status"`
+	Provider        string                            `json:"provider"`
+	NumberOfMatches int                               `json:"number_of_matches"`
+	CreatedAt       time.Time                         `json:"created_at"`
+	UpdatedAt       time.Time                         `json:"updated_at"`
+	Matches         []continuousScreeningMatchSummary `json:"matches"`
+}
+
+func adaptContinuousScreeningSummary(cs *models.ContinuousScreeningWithMatches) *continuousScreeningSummary {
+	if cs == nil {
+		return nil
+	}
+
+	matches := make([]continuousScreeningMatchSummary, 0, len(cs.Matches))
+	for _, m := range cs.Matches {
+		matches = append(matches, continuousScreeningMatchSummary{
+			Id:                   m.Id.String(),
+			OpenSanctionEntityId: m.OpenSanctionEntityId,
+			Status:               m.Status.String(),
+			CreatedAt:            m.CreatedAt,
+		})
+	}
+
+	return &continuousScreeningSummary{
+		Status:          cs.Status.String(),
+		Provider:        string(cs.Provider),
+		NumberOfMatches: cs.NumberOfMatches,
+		CreatedAt:       cs.CreatedAt,
+		UpdatedAt:       cs.UpdatedAt,
+		Matches:         matches,
+	}
+}
+
+type entityOverviewOutput struct {
+	ObjectType               string                      `json:"object_type"`
+	ObjectId                 string                      `json:"object_id"`
+	RiskScore                *riskScoreSummary           `json:"risk_score,omitempty"`
+	Cases                    []caseSummary               `json:"cases"`
+	ContinuousScreeningCases []caseSummary               `json:"continuous_screening_cases"`
+	Annotations              groupedAnnotationsSummary   `json:"annotations"`
+	ContinuousScreening      *continuousScreeningSummary `json:"continuous_screening,omitempty"`
+}
+
+// registerEntityTools registers the "customer hub" entity lookup tool. It
+// composes several existing usecases directly in the handler, the same way
+// api/handle_client_data.go composes them for the internal HTTP API -- no
+// new orchestrating usecase is introduced.
+func registerEntityTools(server *sdkmcp.Server, uc usecases.Usecases) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "entity_overview",
+		Description: "Look up an ingested entity (customer hub object) by object_type/object_id: its risk score, " +
+			"linked cases (including continuous screening cases), and annotations (comments, tags, risk tags).",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in entityOverviewInput) (*sdkmcp.CallToolResult, entityOverviewOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+		orgId := withCreds.Credentials.OrganizationId
+
+		out := entityOverviewOutput{
+			ObjectType: in.ObjectType,
+			ObjectId:   in.ObjectId,
+		}
+
+		scoringUC := withCreds.NewScoringScoresUsecase()
+		score, _, err := scoringUC.GetActiveScore(ctx, models.ScoringRecordRef{
+			OrgId:      orgId,
+			RecordType: in.ObjectType,
+			RecordId:   in.ObjectId,
+		}, in.WithScoreEvaluation, models.RefreshScoreOptions{})
+		if err != nil && !errors.Is(err, models.NotFoundError) {
+			return nil, entityOverviewOutput{}, err
+		}
+		if score != nil {
+			out.RiskScore = &riskScoreSummary{
+				RiskLevel: score.RiskLevel,
+				Source:    string(score.Source),
+				CreatedAt: score.CreatedAt,
+				StaleAt:   score.StaleAt,
+			}
+		}
+
+		caseUC := withCreds.NewCaseUseCase()
+
+		cases, err := caseUC.GetEntityRelatedCases(ctx, in.ObjectType, in.ObjectId)
+		if err != nil {
+			return nil, entityOverviewOutput{}, err
+		}
+		out.Cases = adaptCaseSummaries(cases)
+
+		csCases, err := caseUC.GetRelatedContinuousScreeningCasesByObjectAttr(ctx, orgId, in.ObjectType, in.ObjectId)
+		if err != nil {
+			return nil, entityOverviewOutput{}, err
+		}
+		out.ContinuousScreeningCases = adaptCaseSummaries(csCases)
+
+		annotationUC := withCreds.NewEntityAnnotationUsecase()
+		annotations, err := annotationUC.List(ctx, models.EntityAnnotationRequest{
+			OrgId:      orgId,
+			ObjectType: in.ObjectType,
+			ObjectId:   in.ObjectId,
+		})
+		if err != nil {
+			return nil, entityOverviewOutput{}, err
+		}
+		out.Annotations = adaptGroupedAnnotations(models.GroupAnnotationsByType(annotations))
+
+		exec := withCreds.NewExecutorFactory().NewExecutor()
+		cs, err := withCreds.Repositories.MarbleDbRepository.GetContinuousScreeningByObjectId(
+			ctx, exec, in.ObjectId, in.ObjectType, orgId, nil, false)
+		if err != nil {
+			return nil, entityOverviewOutput{}, err
+		}
+		out.ContinuousScreening = adaptContinuousScreeningSummary(cs)
+
+		return nil, out, nil
+	})
+}

--- a/mcp/tools_reporting.go
+++ b/mcp/tools_reporting.go
@@ -1,0 +1,386 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pubapi"
+	"github.com/checkmarble/marble-backend/usecases"
+)
+
+type caseSummary struct {
+	Id             string    `json:"id"`
+	Name           string    `json:"name"`
+	Status         string    `json:"status"`
+	Outcome        string    `json:"outcome"`
+	AssignedTo     *string   `json:"assigned_to,omitempty"`
+	InboxId        string    `json:"inbox_id"`
+	CreatedAt      time.Time `json:"created_at"`
+	DecisionsCount int       `json:"decisions_count"`
+}
+
+func adaptCaseSummaries(cases []models.Case) []caseSummary {
+	summaries := make([]caseSummary, 0, len(cases))
+	for _, c := range cases {
+		var assignedTo *string
+		if c.AssignedTo != nil {
+			s := string(*c.AssignedTo)
+			assignedTo = &s
+		}
+		summaries = append(summaries, caseSummary{
+			Id:             c.Id,
+			Name:           c.Name,
+			Status:         string(c.Status),
+			Outcome:        string(c.Outcome),
+			AssignedTo:     assignedTo,
+			InboxId:        c.InboxId.String(),
+			CreatedAt:      c.CreatedAt,
+			DecisionsCount: c.DecisionsCount,
+		})
+	}
+	return summaries
+}
+
+type listUsersInput struct{}
+
+type userSummary struct {
+	Id       string `json:"id"`
+	Email    string `json:"email"`
+	FullName string `json:"full_name"`
+	Role     string `json:"role"`
+}
+
+type listUsersOutput struct {
+	Users []userSummary `json:"users"`
+}
+
+type listCasesInput struct {
+	Status     []string   `json:"status,omitempty" jsonschema:"filter on case status (pending, investigating, closed)"`
+	InboxId    string     `json:"inbox_id,omitempty" jsonschema:"filter on inbox id (uuid)"`
+	AssigneeId string     `json:"assignee_id,omitempty" jsonschema:"filter on the user id cases are assigned to"`
+	StartDate  *time.Time `json:"start_date,omitempty"`
+	EndDate    *time.Time `json:"end_date,omitempty"`
+	Limit      int        `json:"limit,omitempty" jsonschema:"max number of cases to return, default 100"`
+}
+
+type listCasesOutput struct {
+	Cases       []caseSummary `json:"cases"`
+	HasNextPage bool          `json:"has_next_page"`
+}
+
+type caseAssignmentStatsInput struct{}
+
+type assigneeCaseCount struct {
+	UserId    *string `json:"user_id,omitempty"`
+	FullName  string  `json:"full_name,omitempty"`
+	Email     string  `json:"email,omitempty"`
+	CaseCount int     `json:"case_count"`
+}
+
+type caseAssignmentStatsOutput struct {
+	Assignees []assigneeCaseCount `json:"assignees"`
+}
+
+type caseAnalyticsQueryInput struct {
+	Metric         string    `json:"metric" jsonschema:"one of: cases_created, cases_false_positive_rate, cases_duration, sar_completed, open_cases_by_age, sar_delay, sar_delay_distribution, case_status_by_date, case_status_by_inbox"`
+	Start          time.Time `json:"start"`
+	End            time.Time `json:"end"`
+	InboxId        string    `json:"inbox_id,omitempty" jsonschema:"filter on inbox id (uuid)"`
+	AssignedUserId *string   `json:"assigned_user_id,omitempty"`
+	Timezone       string    `json:"timezone,omitempty" jsonschema:"IANA timezone name, defaults to UTC"`
+}
+
+type decisionStatsQueryInput struct {
+	Start   time.Time `json:"start"`
+	End     time.Time `json:"end"`
+	GroupBy []string  `json:"group_by,omitempty" jsonschema:"dimensions to break down by, any of: day, outcome, assignee. Defaults to all three."`
+}
+
+type decisionStatsBucket struct {
+	Date       *time.Time `json:"date,omitempty"`
+	Outcome    *string    `json:"outcome,omitempty"`
+	AssigneeId *string    `json:"assignee_id,omitempty"`
+	Count      int        `json:"count"`
+}
+
+type decisionStatsQueryOutput struct {
+	Buckets []decisionStatsBucket `json:"buckets"`
+}
+
+type decisionStatsBucketKey struct {
+	date     time.Time
+	outcome  string
+	assignee string
+}
+
+// registerReportingTools registers the read-only reporting tools that need
+// no new SQL: they wrap existing usecases (ListUsers, CaseUseCase.ListCases,
+// CaseAnalyticsUsecase).
+func registerReportingTools(server *sdkmcp.Server, uc usecases.Usecases) {
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "list_users",
+		Description: "List the users of the caller's organization, for building a user id -> name/email lookup table.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in listUsersInput) (*sdkmcp.CallToolResult, listUsersOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+		exec := withCreds.NewExecutorFactory().NewExecutor()
+
+		users, err := withCreds.Repositories.MarbleDbRepository.ListUsers(ctx, exec, &withCreds.Credentials.OrganizationId)
+		if err != nil {
+			return nil, listUsersOutput{}, err
+		}
+
+		summaries := make([]userSummary, 0, len(users))
+		for _, u := range users {
+			summaries = append(summaries, userSummary{
+				Id:       string(u.UserId),
+				Email:    u.Email,
+				FullName: u.FullName(),
+				Role:     u.Role.String(),
+			})
+		}
+
+		return nil, listUsersOutput{Users: summaries}, nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "list_cases",
+		Description: "List cases for the caller's organization, with optional filters. Use as a drill-down for open-ended follow-up questions.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in listCasesInput) (*sdkmcp.CallToolResult, listCasesOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+
+		pagination := models.NewDefaultPaginationAndSorting(models.CasesSortingCreatedAt.String())
+		if in.Limit > 0 {
+			pagination.Limit = in.Limit
+		}
+
+		filters := models.CaseFilters{}
+		if len(in.Status) > 0 {
+			statuses := make([]models.CaseStatus, 0, len(in.Status))
+			for _, s := range in.Status {
+				statuses = append(statuses, models.CaseStatus(s))
+			}
+			filters.Statuses = statuses
+		}
+		if in.InboxId != "" {
+			inboxId, err := uuid.Parse(in.InboxId)
+			if err != nil {
+				return nil, listCasesOutput{}, fmt.Errorf("invalid inbox_id: %w", err)
+			}
+			filters.InboxIds = []uuid.UUID{inboxId}
+		}
+		if in.AssigneeId != "" {
+			filters.AssigneeId = models.UserId(in.AssigneeId)
+		}
+		if in.StartDate != nil {
+			filters.StartDate = *in.StartDate
+		}
+		if in.EndDate != nil {
+			filters.EndDate = *in.EndDate
+		}
+
+		caseUC := withCreds.NewCaseUseCase()
+		page, err := caseUC.ListCases(ctx, withCreds.Credentials.OrganizationId, pagination, filters)
+		if err != nil {
+			return nil, listCasesOutput{}, err
+		}
+
+		return nil, listCasesOutput{
+			Cases:       adaptCaseSummaries(page.Cases),
+			HasNextPage: page.HasNextPage,
+		}, nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name:        "case_assignment_stats",
+		Description: "Count how many cases are currently assigned to each user in the caller's organization (includes an unassigned bucket).",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in caseAssignmentStatsInput) (*sdkmcp.CallToolResult, caseAssignmentStatsOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+
+		caseUC := withCreds.NewCaseUseCase()
+		counts, err := caseUC.CountCasesByAssignee(ctx, models.CaseFilters{})
+		if err != nil {
+			return nil, caseAssignmentStatsOutput{}, err
+		}
+
+		exec := withCreds.NewExecutorFactory().NewExecutor()
+		users, err := withCreds.Repositories.MarbleDbRepository.ListUsers(ctx, exec, &withCreds.Credentials.OrganizationId)
+		if err != nil {
+			return nil, caseAssignmentStatsOutput{}, err
+		}
+		userById := make(map[string]models.User, len(users))
+		for _, u := range users {
+			userById[string(u.UserId)] = u
+		}
+
+		assignees := make([]assigneeCaseCount, 0, len(counts))
+		for _, c := range counts {
+			entry := assigneeCaseCount{CaseCount: c.CaseCount}
+			if c.AssignedTo != nil {
+				id := string(*c.AssignedTo)
+				entry.UserId = &id
+				if u, ok := userById[id]; ok {
+					entry.FullName = u.FullName()
+					entry.Email = u.Email
+				}
+			}
+			assignees = append(assignees, entry)
+		}
+
+		return nil, caseAssignmentStatsOutput{Assignees: assignees}, nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "decision_stats_query",
+		Description: "Count decisions in a date range, broken down by any combination of day, outcome, and assignee " +
+			"(the assignee of the decision's case, if any). Use group_by to pick the dimensions; omitted dimensions are summed together.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in decisionStatsQueryInput) (*sdkmcp.CallToolResult, decisionStatsQueryOutput, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+
+		groupBy := in.GroupBy
+		if len(groupBy) == 0 {
+			groupBy = []string{"day", "outcome", "assignee"}
+		}
+		byDay := slices.Contains(groupBy, "day")
+		byOutcome := slices.Contains(groupBy, "outcome")
+		byAssignee := slices.Contains(groupBy, "assignee")
+
+		decisionUC := withCreds.NewDecisionUsecase()
+		rows, err := decisionUC.StatsByDayOutcomeUser(ctx, withCreds.Credentials.OrganizationId, in.Start, in.End)
+		if err != nil {
+			return nil, decisionStatsQueryOutput{}, err
+		}
+
+		counts := make(map[decisionStatsBucketKey]int)
+		for _, row := range rows {
+			var k decisionStatsBucketKey
+			if byDay {
+				k.date = row.Date
+			}
+			if byOutcome {
+				k.outcome = row.Outcome
+			}
+			if byAssignee && row.AssignedTo != nil {
+				k.assignee = string(*row.AssignedTo)
+			}
+			counts[k] += row.Count
+		}
+
+		buckets := make([]decisionStatsBucket, 0, len(counts))
+		for k, count := range counts {
+			bucket := decisionStatsBucket{Count: count}
+			if byDay {
+				bucket.Date = &k.date
+			}
+			if byOutcome {
+				bucket.Outcome = &k.outcome
+			}
+			if byAssignee && k.assignee != "" {
+				bucket.AssigneeId = &k.assignee
+			}
+			buckets = append(buckets, bucket)
+		}
+
+		sort.Slice(buckets, func(i, j int) bool {
+			a, b := buckets[i], buckets[j]
+			if a.Date != nil && b.Date != nil && !a.Date.Equal(*b.Date) {
+				return a.Date.Before(*b.Date)
+			}
+			ao, bo := "", ""
+			if a.Outcome != nil {
+				ao = *a.Outcome
+			}
+			if b.Outcome != nil {
+				bo = *b.Outcome
+			}
+			if ao != bo {
+				return ao < bo
+			}
+			aa, ba := "", ""
+			if a.AssigneeId != nil {
+				aa = *a.AssigneeId
+			}
+			if b.AssigneeId != nil {
+				ba = *b.AssigneeId
+			}
+			return aa < ba
+		})
+
+		return nil, decisionStatsQueryOutput{Buckets: buckets}, nil
+	})
+
+	sdkmcp.AddTool(server, &sdkmcp.Tool{
+		Name: "case_analytics_query",
+		Description: "Run a case analytics aggregate query (case counts, resolution duration, status breakdowns, SAR delay, etc). " +
+			"For mean case resolution time, use metric=cases_duration and compute sum(sum_days)/sum(count_cases) over the returned rows.",
+	}, func(ctx context.Context, req *sdkmcp.CallToolRequest, in caseAnalyticsQueryInput) (*sdkmcp.CallToolResult, any, error) {
+		withCreds := pubapi.UsecasesWithCreds(ctx, uc)
+
+		tz := in.Timezone
+		if tz == "" {
+			tz = "UTC"
+		}
+
+		var inboxId *uuid.UUID
+		if in.InboxId != "" {
+			parsed, err := uuid.Parse(in.InboxId)
+			if err != nil {
+				return nil, nil, fmt.Errorf("invalid inbox_id: %w", err)
+			}
+			inboxId = &parsed
+		}
+
+		filters := dto.CaseAnalyticsFilters{
+			OrgId:          withCreds.Credentials.OrganizationId,
+			TimezoneName:   tz,
+			Start:          in.Start,
+			End:            in.End,
+			InboxId:        inboxId,
+			AssignedUserId: in.AssignedUserId,
+		}
+		if err := filters.Validate(); err != nil {
+			return nil, nil, err
+		}
+
+		analyticsUC := withCreds.NewCaseAnalyticsUsecase()
+
+		var (
+			result any
+			err    error
+		)
+		switch in.Metric {
+		case "cases_created":
+			result, err = analyticsUC.CasesCreatedByTimeStats(ctx, filters)
+		case "cases_false_positive_rate":
+			result, err = analyticsUC.CasesFalsePositiveRateByTimeStats(ctx, filters)
+		case "cases_duration":
+			result, err = analyticsUC.CasesDurationByTimeStats(ctx, filters)
+		case "sar_completed":
+			result, err = analyticsUC.SarCompletedCount(ctx, filters)
+		case "open_cases_by_age":
+			result, err = analyticsUC.OpenCasesByAge(ctx, filters)
+		case "sar_delay":
+			result, err = analyticsUC.SarDelayByTimeStats(ctx, filters)
+		case "sar_delay_distribution":
+			result, err = analyticsUC.SarDelayDistribution(ctx, filters)
+		case "case_status_by_date":
+			result, err = analyticsUC.CaseStatusByDate(ctx, filters)
+		case "case_status_by_inbox":
+			result, err = analyticsUC.CaseStatusByInbox(ctx, filters)
+		default:
+			return nil, nil, fmt.Errorf("unknown metric %q", in.Metric)
+		}
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, result, nil
+	})
+}

--- a/models/case.go
+++ b/models/case.go
@@ -192,6 +192,11 @@ type CaseListPage struct {
 	HasNextPage bool
 }
 
+type CaseAssigneeCount struct {
+	AssignedTo *UserId
+	CaseCount  int
+}
+
 const CasesSortingCreatedAt = SortingFieldCreatedAt
 
 func ValidateCaseStatuses(statuses []string) ([]CaseStatus, error) {
@@ -288,6 +293,7 @@ const (
 	CaseMassUpdateClose       CaseMassUpdateAction = "close"
 	CaseMassUpdateReopen      CaseMassUpdateAction = "reopen"
 	CaseMassUpdateAssign      CaseMassUpdateAction = "assign"
+	CaseMassUpdateUnassign    CaseMassUpdateAction = "unassign"
 	CaseMassUpdateMoveToInbox CaseMassUpdateAction = "move_to_inbox"
 	CaseMassUpdateUnknown     CaseMassUpdateAction = "unknown"
 )
@@ -304,6 +310,8 @@ func CaseMassUpdateActionFromString(s string) CaseMassUpdateAction {
 		return CaseMassUpdateReopen
 	case "assign":
 		return CaseMassUpdateAssign
+	case "unassign":
+		return CaseMassUpdateUnassign
 	case "move_to_inbox":
 		return CaseMassUpdateMoveToInbox
 	default:

--- a/models/decision.go
+++ b/models/decision.go
@@ -225,6 +225,13 @@ type DecisionListPage struct {
 	HasNextPage bool
 }
 
+type DecisionStatRow struct {
+	Date       time.Time
+	Outcome    string
+	AssignedTo *UserId
+	Count      int
+}
+
 const DecisionSortingCreatedAt SortingField = SortingFieldCreatedAt
 
 type DecisionWorkflowFilters struct {

--- a/repositories/case_mass_update_repository.go
+++ b/repositories/case_mass_update_repository.go
@@ -62,6 +62,24 @@ func (repo *MarbleDbRepository) CaseMassAssign(ctx context.Context, tx Transacti
 	return caseMassUpdateExecAndReturnedChanged(ctx, tx, query)
 }
 
+func (repo *MarbleDbRepository) CaseMassUnassign(ctx context.Context, tx Transaction, caseIds []uuid.UUID) ([]uuid.UUID, error) {
+	if err := validateMarbleDbExecutor(tx); err != nil {
+		return nil, err
+	}
+
+	query := NewQueryBuilder().
+		Update(dbmodels.TABLE_CASES).
+		Set("assigned_to", nil).
+		Set("boost", nil).
+		Where(squirrel.And{
+			squirrel.Eq{"id": caseIds},
+			squirrel.NotEq{"assigned_to": nil},
+		}).
+		Suffix("returning id")
+
+	return caseMassUpdateExecAndReturnedChanged(ctx, tx, query)
+}
+
 func (repo *MarbleDbRepository) CaseMassMoveToInbox(ctx context.Context, tx Transaction, caseIds []uuid.UUID, inboxId uuid.UUID) ([]uuid.UUID, error) {
 	if err := validateMarbleDbExecutor(tx); err != nil {
 		return nil, err

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -798,3 +798,47 @@ func (repo *MarbleDbRepository) CountCasesByOrg(ctx context.Context, exec Execut
 
 	return countByHelper(ctx, exec, query, orgIds)
 }
+
+// CasesCountByAssignee returns, for the given org (and optional filters), the
+// number of cases grouped by assignee. Unassigned cases are grouped under a
+// nil AssignedTo.
+func (repo *MarbleDbRepository) CasesCountByAssignee(ctx context.Context, exec Executor,
+	filters models.CaseFilters,
+) ([]models.CaseAssigneeCount, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return nil, err
+	}
+
+	query := NewQueryBuilder().
+		Select("assigned_to, count(*) as case_count").
+		From(dbmodels.TABLE_CASES).
+		Where(squirrel.Eq{"org_id": filters.OrganizationId}).
+		GroupBy("assigned_to")
+
+	if len(filters.Statuses) > 0 {
+		query = query.Where(squirrel.Eq{"status": filters.Statuses})
+	}
+	if len(filters.InboxIds) > 0 {
+		query = query.Where(squirrel.Eq{"inbox_id": filters.InboxIds})
+	}
+	if !filters.StartDate.IsZero() {
+		query = query.Where(squirrel.GtOrEq{"created_at": filters.StartDate})
+	}
+	if !filters.EndDate.IsZero() {
+		query = query.Where(squirrel.LtOrEq{"created_at": filters.EndDate})
+	}
+
+	return SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (models.CaseAssigneeCount, error) {
+		var assignedTo *string
+		var count int
+		if err := row.Scan(&assignedTo, &count); err != nil {
+			return models.CaseAssigneeCount{}, err
+		}
+		var userId *models.UserId
+		if assignedTo != nil {
+			uid := models.UserId(*assignedTo)
+			userId = &uid
+		}
+		return models.CaseAssigneeCount{AssignedTo: userId, CaseCount: count}, nil
+	})
+}

--- a/repositories/decisions_repository.go
+++ b/repositories/decisions_repository.go
@@ -832,3 +832,44 @@ func (repo *MarbleDbRepository) CountDecisionsByOrg(ctx context.Context, exec Ex
 
 	return countByHelper(ctx, exec, query, orgIds)
 }
+
+// DecisionStatsByDayOutcomeUser returns decision counts for the given org and
+// date range, broken down by day, outcome, and the assignee of the decision's
+// case (nil if the decision has no case, or the case is unassigned).
+func (repo *MarbleDbRepository) DecisionStatsByDayOutcomeUser(ctx context.Context, exec Executor,
+	orgId uuid.UUID, start, end time.Time,
+) ([]models.DecisionStatRow, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return nil, err
+	}
+
+	query := NewQueryBuilder().
+		Select(
+			"date_trunc('day', d.created_at) as date",
+			"d.outcome",
+			"c.assigned_to",
+			"count(*) as count",
+		).
+		From(dbmodels.TABLE_DECISIONS + " d").
+		LeftJoin(dbmodels.TABLE_CASES + " c on c.id = d.case_id").
+		Where(squirrel.Eq{"d.org_id": orgId}).
+		Where(squirrel.GtOrEq{"d.created_at": start}).
+		Where(squirrel.Lt{"d.created_at": end}).
+		GroupBy("date, d.outcome, c.assigned_to")
+
+	return SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (models.DecisionStatRow, error) {
+		var date time.Time
+		var outcome string
+		var assignedTo *string
+		var count int
+		if err := row.Scan(&date, &outcome, &assignedTo, &count); err != nil {
+			return models.DecisionStatRow{}, err
+		}
+		var userId *models.UserId
+		if assignedTo != nil {
+			uid := models.UserId(*assignedTo)
+			userId = &uid
+		}
+		return models.DecisionStatRow{Date: date, Outcome: outcome, AssignedTo: userId, Count: count}, nil
+	})
+}

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -90,7 +90,11 @@ type CaseUseCaseRepository interface {
 		status models.CaseStatus) ([]uuid.UUID, error)
 	CaseMassAssign(ctx context.Context, tx repositories.Transaction, caseIds []uuid.UUID,
 		assigneeId uuid.UUID) ([]uuid.UUID, error)
+	CaseMassUnassign(ctx context.Context, tx repositories.Transaction, caseIds []uuid.UUID) ([]uuid.UUID, error)
 	CaseMassMoveToInbox(ctx context.Context, tx repositories.Transaction, caseIds []uuid.UUID, inboxId uuid.UUID) ([]uuid.UUID, error)
+
+	CasesCountByAssignee(ctx context.Context, exec repositories.Executor,
+		filters models.CaseFilters) ([]models.CaseAssigneeCount, error)
 
 	// Continuous screenings
 	ListContinuousScreeningsWithMatchesByCaseId(
@@ -351,6 +355,30 @@ func (usecase *CaseUseCase) GetCase(ctx context.Context, caseId string) (models.
 	}
 
 	return c, nil
+}
+
+func (usecase *CaseUseCase) CountCasesByAssignee(ctx context.Context, filters models.CaseFilters) ([]models.CaseAssigneeCount, error) {
+	exec := usecase.executorFactory.NewExecutor()
+	orgId := usecase.enforceSecurity.OrgId()
+
+	availableInboxIds, err := usecase.getAvailableInboxIds(ctx, exec, orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	repoFilters := filters
+	repoFilters.OrganizationId = orgId
+	if len(filters.InboxIds) > 0 {
+		for _, inboxId := range filters.InboxIds {
+			if !slices.Contains(availableInboxIds, inboxId) {
+				return nil, errors.Wrap(models.ForbiddenError, fmt.Sprintf("inbox %s is not accessible", inboxId))
+			}
+		}
+	} else {
+		repoFilters.InboxIds = availableInboxIds
+	}
+
+	return usecase.repository.CasesCountByAssignee(ctx, exec, repoFilters)
 }
 
 func (usecase *CaseUseCase) GetEntityRelatedCases(ctx context.Context, objectType, objectId string) ([]models.Case, error) {
@@ -2510,6 +2538,23 @@ func (usecase *CaseUseCase) MassUpdate(ctx context.Context, req dto.CaseMassUpda
 					EventType:     models.CaseAssigned,
 					PreviousValue: (*string)(sourceCases[updatedId.String()].AssignedTo),
 					NewValue:      utils.Ptr(req.Assign.AssigneeId.String()),
+				}
+			}
+
+		case models.CaseMassUpdateUnassign:
+			updatedIds, err := usecase.repository.CaseMassUnassign(ctx, tx, req.CaseIds)
+			if err != nil {
+				return errors.Wrap(err, "could not unassign cases in mass update")
+			}
+
+			for _, updatedId := range updatedIds {
+				events[updatedId.String()] = models.CreateCaseEventAttributes{
+					OrgId:         orgId,
+					UserId:        userId,
+					CaseId:        updatedId.String(),
+					EventType:     models.CaseAssigned,
+					PreviousValue: (*string)(sourceCases[updatedId.String()].AssignedTo),
+					NewValue:      nil,
 				}
 			}
 

--- a/usecases/decision_usecase.go
+++ b/usecases/decision_usecase.go
@@ -56,6 +56,8 @@ type DecisionUsecaseRepository interface {
 		paginationAndSorting models.PaginationAndSorting,
 		filters models.DecisionFilters,
 	) ([]models.Decision, error)
+	DecisionStatsByDayOutcomeUser(ctx context.Context, exec repositories.Executor,
+		orgId uuid.UUID, start, end time.Time) ([]models.DecisionStatRow, error)
 
 	GetScenarioById(ctx context.Context, exec repositories.Executor, scenarioId string, screeningProvider models.ScreeningProvider) (models.Scenario, error)
 
@@ -156,6 +158,22 @@ func (usecase *DecisionUsecase) GetDecisionsByOutcomeAndScore(ctx context.Contex
 	}
 
 	return decisions, nil
+}
+
+func (usecase *DecisionUsecase) StatsByDayOutcomeUser(
+	ctx context.Context,
+	organizationId uuid.UUID,
+	start, end time.Time,
+) ([]models.DecisionStatRow, error) {
+	if err := usecase.enforceSecurity.Permission(models.DECISION_READ); err != nil {
+		return nil, err
+	}
+	if err := usecase.enforceSecurity.ReadOrganization(organizationId); err != nil {
+		return nil, err
+	}
+
+	exec := usecase.executorFactory.NewExecutor()
+	return usecase.repository.DecisionStatsByDayOutcomeUser(ctx, exec, organizationId, start, end)
 }
 
 func (usecase *DecisionUsecase) ListDecisions(


### PR DESCRIPTION
## Summary
- Adds a proof-of-concept MCP server, mounted at `/mcp` in the existing Gin router (`api/routes.go`), reusing the same `auth.AuthedBy(utils.PublicApiKey, utils.ApiKeyAsBearerToken)` middleware as the public API v1 group — every tool call is org-scoped via the caller's Marble API key, exactly like `pubapi/v1`.
- Goal: let Claude (or any MCP client) answer natural-language reporting/analytics questions and perform a couple of write actions against case/decision data, without building a bespoke dashboard.
- New package `mcp/` registers 8 tools:
  - `list_users`, `list_cases` — thin wrappers on existing repos/usecases, no new SQL.
  - `case_analytics_query` — dispatches to the existing `CaseAnalyticsUsecase` (mean case-resolution time derivable from `cases_duration`, no new SQL).
  - `case_assignment_stats` — new `CasesCountByAssignee` repo method + usecase method, joined with `list_users` for name/email.
  - `decision_stats_query` — new `DecisionStatsByDayOutcomeUser` repo method + usecase method; the tool pivots results by day/outcome/assignee per the caller's requested `group_by`.
  - `entity_overview` — "customer hub" lookup composing `ScoringScoresUsecase`, `CaseUseCase` (entity-related + continuous-screening cases), `EntityAnnotationUsecase`, and `GetContinuousScreeningByObjectId`, with slim output DTOs (see note below).
  - `case_bulk_assign` — batch assign/unassign, built on `CaseUseCase.MassUpdate` with a new `unassign` action (added to `models.CaseMassUpdateAction`, `dto.CaseMassUpdateDto`, and `repositories.CaseMassUnassign`). This also enables `"unassign"` on the existing `POST /cases/mass-update` REST endpoint as a small side effect.
  - `whoami` — diagnostic tool reporting the org/role the current API key resolves to.
- Credential propagation: Gin's auth middleware attaches `models.Credentials` to the request context before the request reaches the MCP HTTP handler (`gin.WrapH`); the go-sdk's session is rooted in that same context at `initialize` time, so every tool handler can call `pubapi.UsecasesWithCreds(ctx, uc)` exactly like any other handler. Verified empirically with two separate orgs/API keys — no cross-org data leakage on read or write paths.
- One schema gotcha worth flagging for future tools: `uuid.UUID` fields serialize as `[16]byte` under the SDK's JSON-schema inference (not as strings), which breaks both input validation and output validation. Fixed by using plain `string` for UUIDs in tool I/O structs (parsed/formatted manually) instead of `uuid.UUID`.

## Test plan
- [x] `go build ./...` and `go test ./...` pass.
- [x] `gofmt -l` clean on all changed/new files.
- [x] Manual end-to-end verification against a local server + Postgres + Firebase emulator: MCP `initialize` → `tools/list` → `tools/call` for all 8 tools via curl.
- [x] Cross-org isolation verified on both read tools (`list_cases`, `case_assignment_stats`) and the write tool (`case_bulk_assign`) using two distinct API keys/orgs — org B cannot read or mutate org A's cases.
- [x] `case_bulk_assign` verified in both directions (assign/unassign) and cross-checked against the DB; also smoke-tested the new `unassign` action via the existing `POST /cases/mass-update` REST endpoint.
- [ ] Not yet tested against a real MCP client (Claude Desktop/claude.ai) — see plan notes on `mcp-remote` bridging for a follow-up POC session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)