### PR TITLE
feat: simplify Ai configuration and allow custom configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,8 +185,6 @@ KILL_IF_READ_LICENSE_ERROR=false
 # AI_AGENT_MAIN_AGENT_URL=
 # API key of the AI provider
 # AI_AGENT_MAIN_AGENT_KEY=
-# Default model to use for the AI agent (e.g. gemini-2.5-flash)
-# AI_AGENT_MAIN_AGENT_DEFAULT_MODEL=
 # Backend of the AI provider (for aistudio) gemini or vertex
 # AI_AGENT_MAIN_AGENT_BACKEND=
 # Project ID of the AI provider (for aistudio)
@@ -195,6 +193,10 @@ KILL_IF_READ_LICENSE_ERROR=false
 # AI_AGENT_MAIN_AGENT_LOCATION=
 # API key of the Perplexity API (for enrichment)
 # AI_AGENT_PERPLEXITY_API_KEY=
+# Path to a local JSON file overriding the light/heavy AI agent models (default_light_model,
+# default_heavy_model, and/or per-feature overrides). Merged field by field on top of the
+# resolved ai_agent_models.json, every field is optional and falls back to the base's value.
+# AI_AGENT_MODELS_CONFIG_OVERRIDE_FILE=
 
 MARBLE_API_INTERNAL_URL=https://api.internal.checkmarble.com
 # Token used to authenticate the screening indexer to access the dataset files. Use openssl to generate one.

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"context"
+	"io/fs"
 
+	"github.com/checkmarble/marble-backend/infra"
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/usecases/ai_agent"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
 )
@@ -52,4 +55,34 @@ func IsWebhookSystemMigrated(ctx context.Context, repositories repositories.Repo
 	}
 
 	return metadata.Value == "true"
+}
+
+// Configure the AI prompts filesystem and AI agent model configuration
+func configAiResource(
+	ctx context.Context,
+	license models.LicenseValidation,
+	licenseConfig models.LicenseConfiguration,
+	aiAgentConfig infra.AIAgentConfiguration,
+	aiPromptsServingDir string,
+	version string,
+) (fs.FS, *models.AiAgentModelConfig) {
+	var aiPromptsFS fs.FS
+	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, version, licenseConfig.LicenseKey)
+		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
+			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible",
+				"error", err.Error())
+			aiPromptsFS = nil
+		}
+	}
+
+	aiAgentModelConfig, err := models.LoadAiAgentModelConfig(aiPromptsFS, aiAgentConfig.ModelsConfigOverridePath)
+	if err != nil {
+		if aiPromptsFS != nil {
+			utils.LoggerFromContext(ctx).WarnContext(ctx, "failed to load ai agent model configuration, ai features are unavailable",
+				"error", err.Error())
+		}
+		aiAgentModelConfig = nil
+	}
+	return aiPromptsFS, aiAgentModelConfig
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -57,6 +57,7 @@ func IsWebhookSystemMigrated(ctx context.Context, repositories repositories.Repo
 	return metadata.Value == "true"
 }
 
+// Configure AI resources, return (nil, nil) if the license is not valid or the prompts filesystem fails validation.
 func configAiResources(
 	ctx context.Context,
 	license models.LicenseValidation,
@@ -65,19 +66,21 @@ func configAiResources(
 	aiPromptsServingDir string,
 	version string,
 ) (fs.FS, *models.AiAgentModelConfig) {
-	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID {
-		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, version, licenseConfig.LicenseKey)
-		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
-			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible", "error", err.Error())
-			aiPromptsFS = nil
-		}
+	if license.LicenseValidationCode != models.VALID {
+		return nil, nil
+	}
+
+	aiPromptsFS := infra.InitAiPromptsFS(ctx, aiPromptsServingDir, version, licenseConfig.LicenseKey)
+	if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
+		utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible", "error", err.Error())
+		return nil, nil
 	}
 
 	aiAgentModelConfig, err := models.LoadAiAgentModelConfig(aiPromptsFS, aiAgentConfig.ModelsConfigOverridePath)
 	if err != nil {
 		utils.LoggerFromContext(ctx).WarnContext(ctx, "failed to load ai agent model configuration, ai features are unavailable", "error", err.Error())
-		aiAgentModelConfig = nil
+		return nil, nil
 	}
+
 	return aiPromptsFS, aiAgentModelConfig
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -57,8 +57,7 @@ func IsWebhookSystemMigrated(ctx context.Context, repositories repositories.Repo
 	return metadata.Value == "true"
 }
 
-// Configure the AI prompts filesystem and AI agent model configuration
-func configAiResource(
+func configAiResources(
 	ctx context.Context,
 	license models.LicenseValidation,
 	licenseConfig models.LicenseConfiguration,
@@ -67,21 +66,17 @@ func configAiResource(
 	version string,
 ) (fs.FS, *models.AiAgentModelConfig) {
 	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID && license.CaseAiAssist {
+	if license.LicenseValidationCode == models.VALID {
 		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, version, licenseConfig.LicenseKey)
 		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
-			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible",
-				"error", err.Error())
+			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible", "error", err.Error())
 			aiPromptsFS = nil
 		}
 	}
 
 	aiAgentModelConfig, err := models.LoadAiAgentModelConfig(aiPromptsFS, aiAgentConfig.ModelsConfigOverridePath)
 	if err != nil {
-		if aiPromptsFS != nil {
-			utils.LoggerFromContext(ctx).WarnContext(ctx, "failed to load ai agent model configuration, ai features are unavailable",
-				"error", err.Error())
-		}
+		utils.LoggerFromContext(ctx).WarnContext(ctx, "failed to load ai agent model configuration, ai features are unavailable", "error", err.Error())
 		aiAgentModelConfig = nil
 	}
 	return aiPromptsFS, aiAgentModelConfig

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -202,15 +202,15 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		MainAgentProviderType: infra.AIAgentProviderTypeFromString(
 			utils.GetEnv("AI_AGENT_MAIN_AGENT_PROVIDER_TYPE", "openai"),
 		),
-		MainAgentURL:          utils.GetEnv("AI_AGENT_MAIN_AGENT_URL", ""),
-		MainAgentKey:          utils.GetEnv("AI_AGENT_MAIN_AGENT_KEY", ""),
-		MainAgentDefaultModel: utils.GetEnv("AI_AGENT_MAIN_AGENT_DEFAULT_MODEL", "gemini-2.5-flash"),
+		MainAgentURL: utils.GetEnv("AI_AGENT_MAIN_AGENT_URL", ""),
+		MainAgentKey: utils.GetEnv("AI_AGENT_MAIN_AGENT_KEY", ""),
 		MainAgentBackend: infra.AIAgentProviderBackendFromString(
 			utils.GetEnv("AI_AGENT_MAIN_AGENT_BACKEND", ""),
 		),
-		MainAgentProject:  utils.GetEnv("AI_AGENT_MAIN_AGENT_PROJECT", gcpConfig.ProjectId),
-		MainAgentLocation: utils.GetEnv("AI_AGENT_MAIN_AGENT_LOCATION", ""),
-		PerplexityAPIKey:  utils.GetEnv("AI_AGENT_PERPLEXITY_API_KEY", ""),
+		MainAgentProject:         utils.GetEnv("AI_AGENT_MAIN_AGENT_PROJECT", gcpConfig.ProjectId),
+		MainAgentLocation:        utils.GetEnv("AI_AGENT_MAIN_AGENT_LOCATION", ""),
+		PerplexityAPIKey:         utils.GetEnv("AI_AGENT_PERPLEXITY_API_KEY", ""),
+		ModelsConfigOverridePath: utils.GetEnv("AI_AGENT_MODELS_CONFIG_OVERRIDE_FILE", ""),
 	}
 
 	serverConfig := ServerConfig{
@@ -406,6 +406,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
 		usecases.WithAIPromptsServingDir(aiPromptsServingDir),
 		usecases.WithAIPromptsFS(aiPromptsFS),
+		usecases.WithAIAgentModelConfig(aiAgentModelConfig),
 	)
 
 	////////////////////////////////////////////////////////////

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -17,7 +16,6 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/usecases/ai_agent"
 	"github.com/checkmarble/marble-backend/usecases/auth"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
@@ -373,15 +371,7 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 		return errors.Wrap(err, "failed to open ip enrichment database")
 	}
 
-	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID {
-		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, config.Version, licenseConfig.LicenseKey)
-		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
-			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavaible",
-				"error", err.Error())
-			aiPromptsFS = nil
-		}
-	}
+	aiPromptsFS, aiAgentModelConfig := configAiResources(ctx, license, licenseConfig, aiAgentConfig, aiPromptsServingDir, config.Version)
 
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -148,15 +148,15 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		MainAgentProviderType: infra.AIAgentProviderTypeFromString(
 			utils.GetEnv("AI_AGENT_MAIN_AGENT_PROVIDER_TYPE", "openai"),
 		),
-		MainAgentURL:          utils.GetEnv("AI_AGENT_MAIN_AGENT_URL", ""),
-		MainAgentKey:          utils.GetEnv("AI_AGENT_MAIN_AGENT_KEY", ""),
-		MainAgentDefaultModel: utils.GetEnv("AI_AGENT_MAIN_AGENT_DEFAULT_MODEL", "gemini-2.5-flash"),
+		MainAgentURL: utils.GetEnv("AI_AGENT_MAIN_AGENT_URL", ""),
+		MainAgentKey: utils.GetEnv("AI_AGENT_MAIN_AGENT_KEY", ""),
 		MainAgentBackend: infra.AIAgentProviderBackendFromString(
 			utils.GetEnv("AI_AGENT_MAIN_AGENT_BACKEND", ""),
 		),
-		MainAgentProject:  utils.GetEnv("AI_AGENT_MAIN_AGENT_PROJECT", gcpConfig.ProjectId),
-		MainAgentLocation: utils.GetEnv("AI_AGENT_MAIN_AGENT_LOCATION", ""),
-		PerplexityAPIKey:  utils.GetEnv("AI_AGENT_PERPLEXITY_API_KEY", ""),
+		MainAgentProject:         utils.GetEnv("AI_AGENT_MAIN_AGENT_PROJECT", gcpConfig.ProjectId),
+		MainAgentLocation:        utils.GetEnv("AI_AGENT_MAIN_AGENT_LOCATION", ""),
+		PerplexityAPIKey:         utils.GetEnv("AI_AGENT_PERPLEXITY_API_KEY", ""),
+		ModelsConfigOverridePath: utils.GetEnv("AI_AGENT_MODELS_CONFIG_OVERRIDE_FILE", ""),
 	}
 
 	infra.SetupSentry(workerConfig.sentryDsn, workerConfig.env, apiVersion)
@@ -371,6 +371,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		usecases.WithIpEnrichmentDatabase(ipEnrichmentDatabase),
 		usecases.WithScreeningOffloadingEnabled(utils.GetEnv("SCREENING_OFFLOADING_ENABLED", true)),
 		usecases.WithAIPromptsFS(aiPromptsFS),
+		usecases.WithAIAgentModelConfig(aiAgentModelConfig),
 	)
 	adminUc := jobs.GenerateUsecaseWithCredForMarbleAdmin(ctx, uc)
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"log/slog"
 	"maps"
 	"net/http"
@@ -22,7 +21,6 @@ import (
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/usecases"
-	"github.com/checkmarble/marble-backend/usecases/ai_agent"
 	"github.com/checkmarble/marble-backend/usecases/continuous_screening"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/worker_jobs"
@@ -341,15 +339,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 	}
 
 	aiPromptsServingDir := utils.GetEnv("AI_PROMPTS_SERVING_DIR", "")
-	var aiPromptsFS fs.FS
-	if license.LicenseValidationCode == models.VALID {
-		aiPromptsFS = infra.InitAiPromptsFS(ctx, aiPromptsServingDir, apiVersion, licenseConfig.LicenseKey)
-		if err := ai_agent.ValidatePromptsFS(aiPromptsFS); err != nil {
-			utils.LoggerFromContext(ctx).WarnContext(ctx, "ai prompts filesystem failed validation, ai features are unavailable",
-				"error", err.Error())
-			aiPromptsFS = nil
-		}
-	}
+	aiPromptsFS, aiAgentModelConfig := configAiResources(ctx, license, licenseConfig, aiAgentConfig, aiPromptsServingDir, apiVersion)
 
 	uc := usecases.NewUsecases(repositories,
 		usecases.WithAppName(appName),

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/iam v1.11.0
 	cloud.google.com/go/profiler v0.6.0
 	cloud.google.com/go/storage v1.63.0
+	dario.cat/mergo v1.0.2
 	firebase.google.com/go/v4 v4.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.8.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.33.0

--- a/go.mod
+++ b/go.mod
@@ -101,7 +101,6 @@ require (
 	cloud.google.com/go/longrunning v1.0.0 // indirect
 	cloud.google.com/go/monitoring v1.29.0 // indirect
 	cloud.google.com/go/trace v1.16.0 // indirect
-	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect

--- a/infra/config.go
+++ b/infra/config.go
@@ -194,7 +194,6 @@ type AIAgentConfiguration struct {
 	MainAgentProviderType AIAgentProviderType
 	MainAgentURL          string
 	MainAgentKey          string
-	MainAgentDefaultModel string
 
 	// For AI Studio
 	MainAgentBackend  genai.Backend
@@ -203,6 +202,10 @@ type AIAgentConfiguration struct {
 
 	// For Perplexity
 	PerplexityAPIKey string
+
+	// Path to an optional local JSON file overriding the light/heavy AI agent models, merged
+	// on top of the resolved ai_agent_models.json field by field. Empty means no override.
+	ModelsConfigOverridePath string
 }
 
 func AIAgentProviderTypeFromString(providerType string) AIAgentProviderType {

--- a/models/ai_agent_config.go
+++ b/models/ai_agent_config.go
@@ -2,63 +2,165 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
+	"io"
 	"io/fs"
+	"os"
+
+	"dario.cat/mergo"
+	"github.com/cockroachdb/errors"
 )
 
-// AiAgentModelConfig represents the configuration for AI agent models
-type AiAgentModelConfig struct {
-	// Default model to use when no specific model is configured for a prompt
-	DefaultModel string `json:"default_model"`
+type AiModelTier string
 
-	// Model configurations for specific prompts
-	PromptModels map[string]string `json:"prompt_models"`
+const (
+	AiModelTierLight AiModelTier = "light"
+	AiModelTierHeavy AiModelTier = "heavy"
+)
+
+type AiFeature string
+
+const (
+	AiFeatureCaseReview             AiFeature = "case_review"
+	AiFeatureRuleDescription        AiFeature = "rule_description"
+	AiFeatureRuleBuilder            AiFeature = "rule_builder"
+	AiFeatureScreeningHitSuggestion AiFeature = "screening_hit_suggestion"
+)
+
+// FeatureModelOverride overrides the light and/or heavy model for a single feature. Both
+// fields are optional: an empty one falls back to the config's global default for that tier.
+type FeatureModelOverride struct {
+	LightModel string `json:"light_model,omitempty"`
+	HeavyModel string `json:"heavy_model,omitempty"`
 }
 
-// LoadAiAgentModelConfig loads the AI agent model configuration from AiAgentModelConfigFileName
-// at the root of promptsFS. The default model is provided by the caller depends on the provider
-// it uses. If promptsFS is nil (no prompts filesystem available), the default configuration is
-// returned.
-func LoadAiAgentModelConfig(promptsFS fs.FS, defaultModel string) (*AiAgentModelConfig, error) {
-	if promptsFS == nil {
-		// Return default configuration if no prompts filesystem is available
-		return &AiAgentModelConfig{
-			DefaultModel: defaultModel,
-			PromptModels: make(map[string]string),
-		}, nil
-	}
+// AiAgentModelConfig represents the configuration for AI agent models: a global light/heavy
+// default, and an optional per-feature override of either tier. Each known feature is its own
+// named, optional field (rather than a map) so the schema is self-documenting and there's no
+// namespace-collision risk with client-supplied keys.
+type AiAgentModelConfig struct {
+	DefaultLightModel string `json:"default_light_model,omitempty"`
+	DefaultHeavyModel string `json:"default_heavy_model,omitempty"`
 
-	file, err := promptsFS.Open(AiAgentModelConfigFileName)
-	if err != nil {
-		return nil, fmt.Errorf("could not open AI agent config file %s: %w", AiAgentModelConfigFileName, err)
-	}
-	defer file.Close()
+	CaseReview             *FeatureModelOverride `json:"case_review,omitempty"`
+	RuleDescription        *FeatureModelOverride `json:"rule_description,omitempty"`
+	RuleBuilder            *FeatureModelOverride `json:"rule_builder,omitempty"`
+	ScreeningHitSuggestion *FeatureModelOverride `json:"screening_hit_suggestion,omitempty"`
+}
 
+func (c *AiAgentModelConfig) featureOverride(feature AiFeature) *FeatureModelOverride {
+	switch feature {
+	case AiFeatureCaseReview:
+		return c.CaseReview
+	case AiFeatureRuleDescription:
+		return c.RuleDescription
+	case AiFeatureRuleBuilder:
+		return c.RuleBuilder
+	case AiFeatureScreeningHitSuggestion:
+		return c.ScreeningHitSuggestion
+	default:
+		return nil
+	}
+}
+
+// Validate checks that c has enough information to resolve a model for every feature: both
+// global defaults must be set, since any feature/tier without its own override falls back to
+// them. Without this, GetModel could silently return "" for an unconfigured feature/tier.
+func (c *AiAgentModelConfig) Validate() error {
+	if c.DefaultLightModel == "" || c.DefaultHeavyModel == "" {
+		return errors.New("ai agent model configuration is missing default_light_model and/or default_heavy_model")
+	}
+	return nil
+}
+
+// GetModel returns the model to use for feature at tier: the feature's override for that tier
+// if set, else the config's global default for that tier.
+func (c *AiAgentModelConfig) GetModel(feature AiFeature, tier AiModelTier) string {
+	if override := c.featureOverride(feature); override != nil {
+		switch tier {
+		case AiModelTierLight:
+			if override.LightModel != "" {
+				return override.LightModel
+			}
+		case AiModelTierHeavy:
+			if override.HeavyModel != "" {
+				return override.HeavyModel
+			}
+		}
+	}
+	if tier == AiModelTierHeavy {
+		return c.DefaultHeavyModel
+	}
+	return c.DefaultLightModel
+}
+
+func decodeAiAgentModelConfig(r io.Reader) (*AiAgentModelConfig, error) {
 	var config AiAgentModelConfig
-	if err := json.NewDecoder(file).Decode(&config); err != nil {
-		return nil, fmt.Errorf("could not decode AI agent config file %s: %w", AiAgentModelConfigFileName, err)
+	if err := json.NewDecoder(r).Decode(&config); err != nil {
+		return nil, err
 	}
-
-	// Set default model if not specified
-	if config.DefaultModel == "" {
-		config.DefaultModel = defaultModel
-	}
-
-	// Initialize maps if they're nil
-	if config.PromptModels == nil {
-		config.PromptModels = make(map[string]string)
-	}
-
 	return &config, nil
 }
 
-// GetModelForPrompt returns the appropriate model for a given prompt path
-func (c *AiAgentModelConfig) GetModelForPrompt(promptPath string) string {
-	// First, check for exact prompt path match
-	if model, exists := c.PromptModels[promptPath]; exists {
-		return model
+// loadAiAgentModelConfigFromFS reads and decodes AiAgentModelConfigFileName from promptsFS.
+func loadAiAgentModelConfigFromFS(promptsFS fs.FS) (*AiAgentModelConfig, error) {
+	file, err := promptsFS.Open(AiAgentModelConfigFileName)
+	if err != nil {
+		return nil, errors.Newf("could not open AI agent config file %s: %w", AiAgentModelConfigFileName, err)
+	}
+	defer file.Close()
+
+	config, err := decodeAiAgentModelConfig(file)
+	if err != nil {
+		return nil, errors.Newf("could not decode AI agent config file %s: %w", AiAgentModelConfigFileName, err)
+	}
+	return config, nil
+}
+
+// loadAiAgentModelConfigFile reads and decodes an override config file from the local disk (not
+// from promptsFS - the override is a deployment-local file, independent of wherever the base
+// prompts/config came from).
+func loadAiAgentModelConfigFile(path string) (*AiAgentModelConfig, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Newf("could not open AI agent config override file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	config, err := decodeAiAgentModelConfig(file)
+	if err != nil {
+		return nil, errors.Newf("could not decode AI agent config override file %s: %w", path, err)
+	}
+	return config, nil
+}
+
+// LoadAiAgentModelConfig loads the AI agent model configuration.
+// The base configuration comes from AiAgentModelConfigFileName at the root of promptsFS
+// overridePath, if non-empty, points to an optional local JSON file (AI_AGENT_MODELS_CONFIG_OVERRIDE_FILE)
+func LoadAiAgentModelConfig(promptsFS fs.FS, overridePath string) (*AiAgentModelConfig, error) {
+	var base *AiAgentModelConfig
+	if promptsFS == nil {
+		base = &AiAgentModelConfig{}
+	} else {
+		var err error
+		base, err = loadAiAgentModelConfigFromFS(promptsFS)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Finally, return the default model
-	return c.DefaultModel
+	if overridePath != "" {
+		override, err := loadAiAgentModelConfigFile(overridePath)
+		if err != nil {
+			return nil, errors.Newf("could not load AI agent config override file %s: %w", overridePath, err)
+		}
+		if err := mergo.Merge(base, override, mergo.WithOverride); err != nil {
+			return nil, errors.Newf("could not merge AI agent config override file %s: %w", overridePath, err)
+		}
+	}
+
+	if err := base.Validate(); err != nil {
+		return nil, err
+	}
+
+	return base, nil
 }

--- a/models/ai_agent_config_test.go
+++ b/models/ai_agent_config_test.go
@@ -1,0 +1,123 @@
+package models
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func writeAiAgentConfigOverrideFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+// Without any override, the config is similar to the base config we can have in marble prompts.
+func TestLoadAiAgentModelConfig_FromPromptsFS(t *testing.T) {
+	promptsFS := fstest.MapFS{
+		AiAgentModelConfigFileName: {Data: []byte(`{
+			"default_light_model": "gemini-2.5-flash",
+			"default_heavy_model": "gemini-2.5-pro",
+			"rule_builder": { "heavy_model": "claude-opus-4-6" }
+		}`)},
+	}
+
+	config, err := LoadAiAgentModelConfig(promptsFS, "")
+	require.NoError(t, err)
+
+	require.Equal(t, "gemini-2.5-flash", config.GetModel(AiFeatureCaseReview, AiModelTierLight))
+	require.Equal(t, "gemini-2.5-pro", config.GetModel(AiFeatureCaseReview, AiModelTierHeavy))
+	require.Equal(t, "gemini-2.5-flash", config.GetModel(AiFeatureRuleDescription, AiModelTierLight))
+	require.Equal(t, "gemini-2.5-flash", config.GetModel(AiFeatureRuleBuilder, AiModelTierLight))
+	require.Equal(t, "claude-opus-4-6", config.GetModel(AiFeatureRuleBuilder, AiModelTierHeavy))
+}
+
+func TestLoadAiAgentModelConfig_OverridePartialGlobalDefaults(t *testing.T) {
+	promptsFS := fstest.MapFS{
+		AiAgentModelConfigFileName: {Data: []byte(`{
+			"default_light_model": "gemini-2.5-flash",
+			"default_heavy_model": "gemini-2.5-pro"
+		}`)},
+	}
+	overridePath := writeAiAgentConfigOverrideFile(t, t.TempDir(), "override.json", `{
+		"default_light_model": "custom-light-model"
+	}`)
+
+	config, err := LoadAiAgentModelConfig(promptsFS, overridePath)
+	require.NoError(t, err)
+
+	require.Equal(t, "custom-light-model", config.GetModel(AiFeatureCaseReview, AiModelTierLight))
+	require.Equal(t, "gemini-2.5-pro", config.GetModel(AiFeatureCaseReview, AiModelTierHeavy))
+}
+
+func TestLoadAiAgentModelConfig_OverridePartialFeatureField(t *testing.T) {
+	promptsFS := fstest.MapFS{
+		AiAgentModelConfigFileName: {Data: []byte(`{
+			"default_light_model": "gemini-2.5-flash",
+			"default_heavy_model": "gemini-2.5-pro",
+			"rule_builder": { "heavy_model": "claude-opus-4-6" }
+		}`)},
+	}
+	overridePath := writeAiAgentConfigOverrideFile(t, t.TempDir(), "override.json", `{
+		"rule_builder": { "light_model": "custom-light-model" }
+	}`)
+
+	config, err := LoadAiAgentModelConfig(promptsFS, overridePath)
+	require.NoError(t, err)
+
+	require.Equal(t, "custom-light-model", config.GetModel(AiFeatureRuleBuilder, AiModelTierLight))
+	require.Equal(t, "claude-opus-4-6", config.GetModel(AiFeatureRuleBuilder, AiModelTierHeavy))
+	require.Equal(t, "gemini-2.5-flash", config.GetModel(AiFeatureCaseReview, AiModelTierLight))
+	require.Equal(t, "gemini-2.5-pro", config.GetModel(AiFeatureCaseReview, AiModelTierHeavy))
+}
+
+func TestLoadAiAgentModelConfig_NoPromptsFS_ReturnsError(t *testing.T) {
+	_, err := LoadAiAgentModelConfig(nil, "")
+	require.Error(t, err)
+}
+
+func TestLoadAiAgentModelConfig_MissingDefaults_ReturnsError(t *testing.T) {
+	promptsFS := fstest.MapFS{
+		AiAgentModelConfigFileName: {Data: []byte(`{
+			"rule_builder": { "heavy_model": "claude-opus-4-6" }
+		}`)},
+	}
+
+	_, err := LoadAiAgentModelConfig(promptsFS, "")
+	require.Error(t, err)
+}
+
+func TestLoadAiAgentModelConfig_NoPromptsFSWithOverride_ProvidingBothDefaults(t *testing.T) {
+	overridePath := writeAiAgentConfigOverrideFile(t, t.TempDir(), "override.json", `{
+		"default_light_model": "gemini-2.5-flash",
+		"default_heavy_model": "claude-opus-4-6"
+	}`)
+
+	config, err := LoadAiAgentModelConfig(nil, overridePath)
+	require.NoError(t, err)
+
+	require.Equal(t, "gemini-2.5-flash", config.GetModel(AiFeatureCaseReview, AiModelTierLight))
+	require.Equal(t, "claude-opus-4-6", config.GetModel(AiFeatureCaseReview, AiModelTierHeavy))
+}
+
+func TestLoadAiAgentModelConfig_OverrideFeatureNotInBase(t *testing.T) {
+	promptsFS := fstest.MapFS{
+		AiAgentModelConfigFileName: {Data: []byte(`{
+			"default_light_model": "gemini-2.5-flash",
+			"default_heavy_model": "gemini-2.5-pro"
+		}`)},
+	}
+	overridePath := writeAiAgentConfigOverrideFile(t, t.TempDir(), "override.json", `{
+		"screening_hit_suggestion": { "light_model": "custom-light-model" }
+	}`)
+
+	config, err := LoadAiAgentModelConfig(promptsFS, overridePath)
+	require.NoError(t, err)
+
+	require.Equal(t, "custom-light-model", config.GetModel(AiFeatureScreeningHitSuggestion, AiModelTierLight))
+	require.Equal(t, "gemini-2.5-pro", config.GetModel(AiFeatureScreeningHitSuggestion, AiModelTierHeavy))
+}

--- a/usecases/ai_agent/ai_agent_usecase.go
+++ b/usecases/ai_agent/ai_agent_usecase.go
@@ -193,6 +193,7 @@ type AiAgentUsecase struct {
 	config                             infra.AIAgentConfiguration
 	caseManagerBucketUrl               string
 	promptsFS                          fs.FS
+	aiAgentModelConfig                 *models.AiAgentModelConfig
 
 	caseReviewAdapter *llmberjack.Llmberjack
 	enrichmentAdapter *llmberjack.Llmberjack
@@ -224,6 +225,7 @@ func NewAiAgentUsecase(
 	config infra.AIAgentConfiguration,
 	caseManagerBucketUrl string,
 	promptsFS fs.FS,
+	aiAgentModelConfig *models.AiAgentModelConfig,
 ) AiAgentUsecase {
 	return AiAgentUsecase{
 		enforceSecurityCase:                enforceSecurityCase,
@@ -250,6 +252,7 @@ func NewAiAgentUsecase(
 		config:                             config,
 		caseManagerBucketUrl:               caseManagerBucketUrl,
 		promptsFS:                          promptsFS,
+		aiAgentModelConfig:                 aiAgentModelConfig,
 	}
 }
 
@@ -519,18 +522,19 @@ func providerForModel(model string) string {
 }
 
 // Call preparePrompt and complete the model with the model configuration
-func (uc *AiAgentUsecase) preparePromptWithModel(promptPath string, data map[string]any) (provider string, model string, prompt string, err error) {
-	// Load model configuration on each call
-	// Give the possibility to change the prompt without reloading the application
-	modelConfig, err := models.LoadAiAgentModelConfig(uc.promptsFS, uc.config.MainAgentDefaultModel)
-	if err != nil {
-		return "", "", "", errors.Wrap(err, "could not load AI agent model configuration")
+func (uc *AiAgentUsecase) preparePromptWithModel(spec promptSpec, data map[string]any) (provider string, model string, prompt string, err error) {
+	if uc.aiAgentModelConfig == nil {
+		return "", "", "", errors.Errorf("cannot resolve model for feature %s: ai agent model configuration is not available", spec.Feature)
 	}
 
-	model = modelConfig.GetModelForPrompt(promptPath)
+	model = uc.aiAgentModelConfig.GetModel(spec.Feature, spec.Tier)
+	if model == "" {
+		return "", "", "", errors.Errorf(
+			"cannot resolve model for feature %s at tier %s: no model configured", spec.Feature, spec.Tier)
+	}
 	provider = providerForModel(model)
 
-	prompt, err = uc.preparePrompt(promptPath, data)
+	prompt, err = uc.preparePrompt(spec.Path, data)
 	if err != nil {
 		return "", "", "", errors.Wrap(err, "could not prepare prompt")
 	}

--- a/usecases/ai_agent/ai_case_review.go
+++ b/usecases/ai_agent/ai_case_review.go
@@ -33,17 +33,54 @@ const (
 
 var ReviewLevelEnum = []string{"probable_false_positive", "investigate", "escalate"}
 
+// Prompts not resolved via the model configuration (no model tier attached).
 const (
-	PROMPT_CASE_REVIEW_PATH                          = models.AiAgentCaseReviewPromptPath
-	PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS_PATH = models.AiAgentCaseReviewDataModelObjectFieldReadOptionsPromptPath
-	PROMPT_DATA_MODEL_SUMMARY_PATH                   = models.AiAgentCaseReviewDataModelSummaryPromptPath
-	PROMPT_RULE_DEFINITIONS_PATH                     = models.AiAgentCaseReviewRuleDefinitionsPromptPath
-	PROMPT_RULE_THRESHOLD_VALUES_PATH                = models.AiAgentCaseReviewRuleThresholdValuesPromptPath
-	PROMPT_SANITY_CHECK_PATH                         = models.AiAgentCaseReviewSanityCheckPromptPath
-	INSTRUCTION_CUSTOM_REPORT_PATH                   = models.AiAgentCaseReviewCustomReportInstructionPath
-	INSTRUCTION_LANGUAGE_PATH                        = models.AiAgentCaseReviewLanguageInstructionPath
-	INSTRUCTION_STRUCTURE_PATH                       = models.AiAgentCaseReviewStructureInstructionPath
-	SYSTEM_PROMPT_PATH                               = models.AiAgentSystemPromptPath
+	INSTRUCTION_CUSTOM_REPORT_PATH = models.AiAgentCaseReviewCustomReportInstructionPath
+	SYSTEM_PROMPT_PATH             = models.AiAgentSystemPromptPath
+)
+
+// Case review prompts, each tagged with the feature and model tier it needs.
+var (
+	PROMPT_CASE_REVIEW = promptSpec{
+		Path:    models.AiAgentCaseReviewPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierHeavy,
+	}
+	PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS = promptSpec{
+		Path:    models.AiAgentCaseReviewDataModelObjectFieldReadOptionsPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
+	PROMPT_DATA_MODEL_SUMMARY = promptSpec{
+		Path:    models.AiAgentCaseReviewDataModelSummaryPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
+	PROMPT_RULE_DEFINITIONS = promptSpec{
+		Path:    models.AiAgentCaseReviewRuleDefinitionsPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
+	PROMPT_RULE_THRESHOLD_VALUES = promptSpec{
+		Path:    models.AiAgentCaseReviewRuleThresholdValuesPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
+	PROMPT_SANITY_CHECK = promptSpec{
+		Path:    models.AiAgentCaseReviewSanityCheckPromptPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierHeavy,
+	}
+	INSTRUCTION_LANGUAGE = promptSpec{
+		Path:    models.AiAgentCaseReviewLanguageInstructionPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
+	INSTRUCTION_STRUCTURE = promptSpec{
+		Path:    models.AiAgentCaseReviewStructureInstructionPath,
+		Feature: models.AiFeatureCaseReview,
+		Tier:    models.AiModelTierLight,
+	}
 )
 
 type sanityCheckOutput struct {
@@ -306,7 +343,7 @@ func (uc *AiAgentUsecase) resolveLanguageInstruction(ctx context.Context,
 	}
 
 	_, model, customLanguagePrompt, err := uc.preparePromptWithModel(
-		INSTRUCTION_LANGUAGE_PATH,
+		INSTRUCTION_LANGUAGE,
 		map[string]any{
 			"language": language,
 		},
@@ -334,7 +371,7 @@ func (uc *AiAgentUsecase) getOrganizationInstructionsForPrompt(ctx context.Conte
 	}
 	if caseReviewSetting.Structure != nil {
 		_, model, customStructurePrompt, err := uc.preparePromptWithModel(
-			INSTRUCTION_STRUCTURE_PATH,
+			INSTRUCTION_STRUCTURE,
 			map[string]any{
 				"structure": *caseReviewSetting.Structure,
 			},
@@ -458,7 +495,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 	if caseReviewContext.DataModelSummary == nil {
 		// Data model summary, create thread because the response will be used in next steps
 		providerDataModelSummary, modelDataModelSummary, promptDataModelSummary, err := uc.preparePromptWithModel(
-			PROMPT_DATA_MODEL_SUMMARY_PATH, map[string]any{
+			PROMPT_DATA_MODEL_SUMMARY, map[string]any{
 				"data_model": caseData.dataModelDto,
 			})
 		if err != nil {
@@ -528,7 +565,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 					}
 
 					providerFieldReadOptions, modelDataModelObjectFieldReadOptions, promptDataModelObjectFieldReadOptions, err := uc.preparePromptWithModel(
-						PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS_PATH,
+						PROMPT_DATA_MODEL_OBJECT_FIELD_READ_OPTIONS,
 						map[string]any{
 							"data_model_table_names": tableNamesWithLargRowNbs,
 						},
@@ -598,7 +635,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			ruleDefinitionsData["activity_description"] = *aiSetting.CaseReviewSetting.OrgDescription
 		}
 		providerRulesDefinitions, modelRulesDefinitions, promptRulesDefinitions, err := uc.preparePromptWithModel(
-			PROMPT_RULE_DEFINITIONS_PATH,
+			PROMPT_RULE_DEFINITIONS,
 			ruleDefinitionsData,
 		)
 		if err != nil {
@@ -626,7 +663,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 	// Rule thresholds
 	if caseReviewContext.RuleThresholds == nil {
 		providerRuleThresholds, modelRuleThresholds, promptRuleThresholds, err := uc.preparePromptWithModel(
-			PROMPT_RULE_THRESHOLD_VALUES_PATH,
+			PROMPT_RULE_THRESHOLD_VALUES,
 			map[string]any{
 				"decisions": caseData.decisions,
 			},
@@ -739,7 +776,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			caseReviewData["additional_case_review_instruction"] = *aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
 		}
 		providerCaseReview, modelCaseReview, promptCaseReview, err := uc.preparePromptWithModel(
-			PROMPT_CASE_REVIEW_PATH,
+			PROMPT_CASE_REVIEW,
 			caseReviewData,
 		)
 		if err != nil {
@@ -808,7 +845,7 @@ func (uc *AiAgentUsecase) CreateCaseReviewSync(
 			sanityCheckData["additional_case_review_instruction"] = *aiSetting.CaseReviewSetting.AdditionalCaseReviewInstruction
 		}
 		providerSanityCheck, modelSanityCheck, promptSanityCheck, err := uc.preparePromptWithModel(
-			PROMPT_SANITY_CHECK_PATH,
+			PROMPT_SANITY_CHECK,
 			sanityCheckData,
 		)
 		if err != nil {

--- a/usecases/ai_agent/ai_rule_assist.go
+++ b/usecases/ai_agent/ai_rule_assist.go
@@ -15,10 +15,25 @@ import (
 	"github.com/google/uuid"
 )
 
-const (
-	RULE_DESCRIPTION_PROMPT_PATH      = models.AiAgentRuleDescriptionPromptPath
-	RULE_GENERATION_PROMPT_STEP1_PATH = models.AiAgentRuleGenerationStep1PromptPath
-	RULE_GENERATION_PROMPT_STEP2_PATH = models.AiAgentRuleGenerationStep2PromptPath
+// Rule assist prompts, each tagged with the feature and model tier it needs. Describing an
+// existing rule and building one from natural language are distinct features, so they can be
+// tuned independently.
+var (
+	RULE_DESCRIPTION_PROMPT = promptSpec{
+		Path:    models.AiAgentRuleDescriptionPromptPath,
+		Feature: models.AiFeatureRuleDescription,
+		Tier:    models.AiModelTierLight,
+	}
+	RULE_GENERATION_PROMPT_STEP1 = promptSpec{
+		Path:    models.AiAgentRuleGenerationStep1PromptPath,
+		Feature: models.AiFeatureRuleBuilder,
+		Tier:    models.AiModelTierHeavy,
+	}
+	RULE_GENERATION_PROMPT_STEP2 = promptSpec{
+		Path:    models.AiAgentRuleGenerationStep2PromptPath,
+		Feature: models.AiFeatureRuleBuilder,
+		Tier:    models.AiModelTierHeavy,
+	}
 )
 
 // GenerateRule generates a rule AST from a natural language instruction
@@ -92,7 +107,7 @@ func (uc *AiAgentUsecase) GenerateRule(
 	}
 
 	provider, model, ruleGenerationPrompt, err := uc.preparePromptWithModel(
-		RULE_GENERATION_PROMPT_STEP1_PATH, map[string]any{
+		RULE_GENERATION_PROMPT_STEP1, map[string]any{
 			"data_model":         dataModelDto,
 			"custom_list":        customListsDto,
 			"instruction":        instruction,
@@ -124,7 +139,7 @@ func (uc *AiAgentUsecase) GenerateRule(
 	logger.DebugContext(ctx, fmt.Sprintf("LLM response as string:\n%s\n", ruleAsString))
 
 	provider, model, ruleGenerationPrompt, err = uc.preparePromptWithModel(
-		RULE_GENERATION_PROMPT_STEP2_PATH, map[string]any{
+		RULE_GENERATION_PROMPT_STEP2, map[string]any{
 			"data_model":         dataModelDto,
 			"custom_list":        customListsDto,
 			"instruction":        instruction,
@@ -261,7 +276,7 @@ func (uc *AiAgentUsecase) AiASTDescription(
 
 	// Execute the LLM prompt and return the result
 	provider, model, ruleDescription, err := uc.preparePromptWithModel(
-		RULE_DESCRIPTION_PROMPT_PATH, map[string]any{
+		RULE_DESCRIPTION_PROMPT, map[string]any{
 			"data_model":  dataModelDto,
 			"custom_list": customListsDto,
 			"rule":        ruleAST,

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -17,10 +17,15 @@ import (
 )
 
 const (
-	PROMPT_SCREENING_HIT_EVALUATE_PATH   = models.AiAgentScreeningHitEvaluatePromptPath
 	SCREENING_HIT_SYSTEM_PROMPT_PATH     = models.AiAgentScreeningHitSystemPromptPath
 	SCREENING_HIT_SUGGESTION_BLOB_PREFIX = "ai_screening_reviews"
 )
+
+var PROMPT_SCREENING_HIT_EVALUATE = promptSpec{
+	Path:    models.AiAgentScreeningHitEvaluatePromptPath,
+	Feature: models.AiFeatureScreeningHitSuggestion,
+	Tier:    models.AiModelTierLight,
+}
 
 func screeningHitSuggestionBlobPath(screeningId, matchId string) string {
 	return fmt.Sprintf("%s/%s/%s.json", SCREENING_HIT_SUGGESTION_BLOB_PREFIX, screeningId, matchId)
@@ -197,7 +202,7 @@ func (uc *AiAgentUsecase) analyseScreeningMatch(
 	matchPromptData["MatchPayload"] = string(agent_dto.SanitizeScreeningPayloadForLLM(enrichedMatch.Payload))
 	matchPromptData["MatchScore"] = fmt.Sprintf("%.2f", enrichedMatch.GetScoreFromPayload())
 
-	_, model, userMessage, err := uc.preparePromptWithModel(PROMPT_SCREENING_HIT_EVALUATE_PATH, matchPromptData)
+	_, model, userMessage, err := uc.preparePromptWithModel(PROMPT_SCREENING_HIT_EVALUATE, matchPromptData)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not prepare prompt")
 	}

--- a/usecases/ai_agent/prompt_spec.go
+++ b/usecases/ai_agent/prompt_spec.go
@@ -1,0 +1,11 @@
+package ai_agent
+
+import "github.com/checkmarble/marble-backend/models"
+
+// promptSpec bundles a prompt's file path with the feature and model tier it needs, so each
+// prompt declares once, at its definition site, which model configuration governs it.
+type promptSpec struct {
+	Path    string
+	Feature models.AiFeature
+	Tier    models.AiModelTier
+}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -56,6 +56,7 @@ type Usecases struct {
 	screeningOffloadingEnabled   bool
 	aiPromptsServingDir          string
 	aiPromptsFS                  fs.FS
+	aiAgentModelConfig           *models.AiAgentModelConfig
 
 	coordsEnricher *rgeo.Rgeo
 	ipEnricher     *maxminddb.Reader
@@ -232,6 +233,12 @@ func WithAIPromptsFS(aiPromptsFS fs.FS) Option {
 	}
 }
 
+func WithAIAgentModelConfig(config *models.AiAgentModelConfig) Option {
+	return func(o *options) {
+		o.aiAgentModelConfig = config
+	}
+}
+
 type options struct {
 	appName                      string
 	apiVersion                   string
@@ -259,6 +266,7 @@ type options struct {
 	ipEnricher                   *maxminddb.Reader
 	aiPromptsServingDir          string
 	aiPromptsFS                  fs.FS
+	aiAgentModelConfig           *models.AiAgentModelConfig
 }
 
 func newUsecasesWithOptions(repositories repositories.Repositories, o *options) Usecases {
@@ -298,6 +306,7 @@ func newUsecasesWithOptions(repositories repositories.Repositories, o *options) 
 		screeningOffloadingEnabled:   o.screeningOffloadingEnabled,
 		aiPromptsServingDir:          o.aiPromptsServingDir,
 		aiPromptsFS:                  o.aiPromptsFS,
+		aiAgentModelConfig:           o.aiAgentModelConfig,
 
 		coordsEnricher: coordsEnricher,
 		ipEnricher:     o.ipEnricher,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -829,6 +829,7 @@ func (usecases *UsecasesWithCreds) NewAiAgentUsecase() ai_agent.AiAgentUsecase {
 		usecases.aiAgentConfig,
 		usecases.caseManagerBucketUrl, // TODO: I think we could avoid passing the caseManagerBucketURL here only for the creation of the model
 		usecases.aiPromptsFS,
+		usecases.aiAgentModelConfig,
 	)
 }
 


### PR DESCRIPTION
## Summary

Simplifies how AI agent models are configured, and lets self-hosted clients override which model is used per feature — without needing to touch or understand every individual prompt file.

I wrote a documentation about the AI configuration: https://docs.checkmarble.com/docs/ai-configuration

## Before

`prompts/ai_agent_models.json` mapped every individual **prompt file path** (12+ entries) to a literal model name:

```json
{
  "default_model": "gemini-2.5-flash",
  "prompt_models": {
    "case_review/case_review.md": "gemini-2.5-pro",
    "rule/rule_generation_step1.md": "claude-opus-4-6"
  }
}
```

This didn't scale for clients plugging in their own provider/models: they'd have to pick a model for every prompt path individually, with no guidance on which ones actually need a stronger model, and a renamed/added prompt file silently fell back to `default_model` with no warning.

## After

The config now has two knobs: a `light` and a `heavy` model tier, set globally and optionally overridden per **feature** (not per prompt file):

```json
{
  "default_light_model": "gemini-2.5-flash",
  "default_heavy_model": "gemini-2.5-pro",
  "rule_builder": {
    "heavy_model": "claude-opus-4-6"
  }
}
```

- **Only two tiers**: `light` and `heavy`. Each usecase already knows whether a given prompt is a cheap/fast step or a step that needs a stronger model — it declares that once via a `promptSpec{Path, Feature, Tier}` value at the prompt's definition site (e.g. `usecases/ai_agent/ai_rule_assist.go`), instead of a model name being pinned centrally per file path.
- **Features, not paths**: `case_review`, `rule_description`, `rule_builder`, `screening_hit_suggestion`. Each is an optional, named field in the config (not a map), so the schema is self-documenting and there's no key-collision risk.
- **Resolution**: `AiAgentModelConfig.GetModel(feature, tier)` returns the feature's override for that tier if set, else the global default for that tier.

## Overriding the configuration

A new env var, `AI_AGENT_MODELS_CONFIG_OVERRIDE_FILE`, points to an optional local JSON file merged on top of the base `ai_agent_models.json` (itself resolved from the prompts filesystem — local dir or downloaded bundle). The merge is field-by-field via `mergo`: every field in the override file is optional and falls back to the base's value when empty/absent, down to individual tiers within a feature — so a client can override just `rule_builder.heavy_model` without restating anything else.

## Other notable changes

- **Resolved once at startup, not per request**: the merged config used to be reloaded and re-merged (opening/parsing JSON) on every single prompt preparation call. It's now loaded once in `cmd/server.go`/`cmd/worker.go` (via the new `configAiRessource` helper, shared by both) and injected into `AiAgentUsecase`, alongside `aiPromptsFS`.
- **Validation**: the resolved config must have both `default_light_model` and `default_heavy_model` set, otherwise it's treated as unusable (`nil`) rather than silently resolving to an empty model string. `AiAgentUsecase.preparePromptWithModel` guards against both a `nil` config and an empty resolved model, returning a clear error instead of calling the LLM with no model or panicking.
- **Removed** `AI_AGENT_MAIN_AGENT_DEFAULT_MODEL` / `MainAgentDefaultModel` — dead code, since prompts (and now the model config) can't be read at all when there's no prompts filesystem, so the fallback was never reachable.
- `rule_assist` split into two independent features/tiers: `rule_description` (describing an existing rule, light) and `rule_builder` (building a rule from natural language, heavy).

## Test plan

- `go build ./...`, `go vet ./...`
- `go test ./models/... ./usecases/...`
- Added `models/ai_agent_config_test.go` covering: missing base file, missing defaults (rejected), partial override of global defaults, partial override of a single feature/tier, override introducing a feature not in the base, and override supplying defaults when there's no prompts filesystem at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable light/heavy AI models per feature with tiered resolution.
  * Added optional local JSON override file to customize model selections on top of the base prompts configuration.
  * Updated server/worker startup to use the override-driven model configuration.
* **Bug Fixes**
  * Improved validation and fail-safe startup behavior when model config or overrides are missing/invalid.
  * Enforced required light/heavy defaults and clear errors for unconfigured feature/tier combinations.
* **Tests**
  * Added coverage for base loading, partial overrides, missing settings, and overrides for features not present in base config.
* **Documentation**
  * Updated the example environment configuration to replace the removed default model setting with the new override file option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->