### PR TITLE
avoid token overflow with lexis nexis data on screening review

### DIFF
--- a/dto/agent_dto/decisions.go
+++ b/dto/agent_dto/decisions.go
@@ -75,7 +75,7 @@ func AdaptScreeningMatch(match models.ScreeningMatch) ScreeningMatch {
 	return ScreeningMatch{
 		IsMatch: match.IsMatch,
 		Status:  match.Status.String(),
-		Payload: match.Payload,
+		Payload: SanitizeScreeningPayloadForLLM(match.Payload),
 	}
 }
 

--- a/dto/agent_dto/screening_payload.go
+++ b/dto/agent_dto/screening_payload.go
@@ -1,0 +1,128 @@
+package agent_dto
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Maximum nesting depth of entities kept in full. The matched entity is depth 0;
+// its directly attached records (Sanction, Identification, Address, or a
+// relationship edge such as Family/Associate) are depth 1 and keep their own
+// scalar fields; anything nested deeper — typically the profile of a related
+// party reached through a relationship edge — is collapsed to base identifying
+// info (id, caption, schema, name).
+const screeningMaxEntityDepth = 1
+
+// baseEntityFields are the identifying fields kept for a collapsed nested entity.
+var baseEntityFields = []string{"id", "caption", "schema"}
+
+// SanitizeScreeningPayloadForLLM trims a FollowTheMoney screening entity payload
+// before it is handed to the AI agent for review.
+//
+// Richer providers (e.g. LexisNexis) return entities carrying long lists of
+// referent IDs, many link URLs, and deeply nested relationship graphs. Feeding
+// those verbatim into the review prompt inflates the context past the model's
+// token limit without adding analytical signal. This function:
+//   - drops "referents" (the aggregated list of source-record IDs) at every level,
+//   - strips link/URL values from properties (e.g. sourceUrl, programUrl), and
+//   - collapses relatives — the profiles of parties reached through relationship
+//     edges — to their base identifying info, while keeping the matched entity's
+//     own records (sanctions, identifications, ...) intact.
+//
+// The stored payload is never modified; sanitization applies only to the copy
+// sent to the LLM. If the payload is not a JSON object, it is returned unchanged.
+func SanitizeScreeningPayloadForLLM(payload []byte) json.RawMessage {
+	if len(payload) == 0 {
+		return payload
+	}
+
+	var entity map[string]any
+	if err := json.Unmarshal(payload, &entity); err != nil {
+		return payload
+	}
+
+	sanitizeEntity(entity, 0)
+
+	out, err := json.Marshal(entity)
+	if err != nil {
+		return payload
+	}
+	return out
+}
+
+// sanitizeEntity rewrites an FTM entity in place: it removes "referents" and then
+// walks "properties", stripping link values and recursing into nested entities.
+func sanitizeEntity(entity map[string]any, depth int) {
+	delete(entity, "referents")
+
+	props, ok := entity["properties"].(map[string]any)
+	if !ok {
+		return
+	}
+
+	for name, raw := range props {
+		values, ok := raw.([]any)
+		if !ok {
+			delete(props, name)
+			continue
+		}
+
+		filtered := make([]any, 0, len(values))
+		for _, v := range values {
+			switch val := v.(type) {
+			case string:
+				if isLinkValue(val) {
+					continue // strip links: many tokens, no analytical signal
+				}
+				filtered = append(filtered, val)
+			case map[string]any:
+				filtered = append(filtered, reduceNestedEntity(val, depth+1))
+			default:
+				filtered = append(filtered, val)
+			}
+		}
+
+		if len(filtered) == 0 {
+			delete(props, name)
+			continue
+		}
+		props[name] = filtered
+	}
+}
+
+// reduceNestedEntity keeps a nested entity in full (minus referents/links) while
+// it is within screeningMaxEntityDepth, and collapses it to base identifying info
+// plus its name once past that depth — the point at which we are looking at a
+// related party's own profile rather than a record of the matched entity.
+func reduceNestedEntity(entity map[string]any, depth int) map[string]any {
+	if depth > screeningMaxEntityDepth {
+		reduced := baseEntity(entity)
+		if props, ok := entity["properties"].(map[string]any); ok {
+			if name, ok := props["name"]; ok {
+				reduced["properties"] = map[string]any{"name": name}
+			}
+		}
+		return reduced
+	}
+
+	reduced := baseEntity(entity)
+	if props, ok := entity["properties"].(map[string]any); ok {
+		reduced["properties"] = props
+		sanitizeEntity(reduced, depth)
+	}
+	return reduced
+}
+
+func baseEntity(entity map[string]any) map[string]any {
+	reduced := make(map[string]any, len(baseEntityFields)+1)
+	for _, key := range baseEntityFields {
+		if v, ok := entity[key]; ok {
+			reduced[key] = v
+		}
+	}
+	return reduced
+}
+
+func isLinkValue(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}

--- a/dto/agent_dto/screening_payload_test.go
+++ b/dto/agent_dto/screening_payload_test.go
@@ -1,0 +1,121 @@
+package agent_dto
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realistic (trimmed) OFAC person payload with an attribute record (Sanction),
+// a link, referents, and a relationship edge (Family) pointing to a relative.
+const sampleScreeningPayload = `{
+	"id": "NK-1",
+	"caption": "Ayesha QADHAFI",
+	"schema": "Person",
+	"score": 0.9,
+	"referents": ["ofac-12610", "gb-hmt-11635", "unsc-690757"],
+	"properties": {
+		"name": ["Ayesha QADHAFI"],
+		"topics": ["sanction"],
+		"sourceUrl": ["https://sanctionssearch.ofac.treas.gov/Details.aspx?id=12610"],
+		"sanctions": [{
+			"id": "ofac-sanction",
+			"caption": "LIBYA2",
+			"schema": "Sanction",
+			"referents": [],
+			"first_seen": "2023-04-20T10:27:20",
+			"properties": {
+				"program": ["LIBYA2"],
+				"reason": ["Executive Order 13566 (Libya)"],
+				"sourceUrl": ["https://www.treasury.gov/x"],
+				"programUrl": ["https://ofac.treasury.gov/y"]
+			}
+		}],
+		"familyPerson": [{
+			"id": "fam-1",
+			"caption": "Ayesha - Muammar",
+			"schema": "Family",
+			"properties": {
+				"relationship": ["daughter"],
+				"relative": [{
+					"id": "NK-2",
+					"caption": "Muammar QADHAFI",
+					"schema": "Person",
+					"referents": ["x", "y"],
+					"properties": {
+						"name": ["Muammar QADHAFI"],
+						"birthDate": ["1942"],
+						"sourceUrl": ["https://example.com/z"]
+					}
+				}]
+			}
+		}]
+	}
+}`
+
+func TestSanitizeScreeningPayloadForLLM(t *testing.T) {
+	out := parse(t, SanitizeScreeningPayloadForLLM([]byte(sampleScreeningPayload)))
+
+	t.Run("drops top-level referents and link properties, keeps base fields", func(t *testing.T) {
+		assert.NotContains(t, out, "referents")
+		assert.Equal(t, "NK-1", out["id"])
+		assert.EqualValues(t, 0.9, out["score"])
+
+		props := out["properties"].(map[string]any)
+		assert.Equal(t, []any{"Ayesha QADHAFI"}, props["name"])
+		assert.Equal(t, []any{"sanction"}, props["topics"])
+		assert.NotContains(t, props, "sourceUrl", "url-only property is dropped")
+	})
+
+	t.Run("keeps attribute records (Sanction) with their scalar detail, minus links and referents", func(t *testing.T) {
+		props := out["properties"].(map[string]any)
+		sanction := props["sanctions"].([]any)[0].(map[string]any)
+
+		assert.Equal(t, "Sanction", sanction["schema"])
+		assert.NotContains(t, sanction, "referents")
+		assert.NotContains(t, sanction, "first_seen", "noisy timestamps dropped from nested records")
+
+		sp := sanction["properties"].(map[string]any)
+		assert.Equal(t, []any{"LIBYA2"}, sp["program"])
+		assert.Equal(t, []any{"Executive Order 13566 (Libya)"}, sp["reason"])
+		assert.NotContains(t, sp, "sourceUrl")
+		assert.NotContains(t, sp, "programUrl")
+	})
+
+	t.Run("keeps the relationship edge but collapses the relative to base info + name", func(t *testing.T) {
+		props := out["properties"].(map[string]any)
+		fam := props["familyPerson"].([]any)[0].(map[string]any)
+
+		assert.Equal(t, "Family", fam["schema"])
+		famProps := fam["properties"].(map[string]any)
+		assert.Equal(t, []any{"daughter"}, famProps["relationship"], "relationship type is kept")
+
+		relative := famProps["relative"].([]any)[0].(map[string]any)
+		assert.Equal(t, "Muammar QADHAFI", relative["caption"])
+		assert.Equal(t, "NK-2", relative["id"])
+		assert.NotContains(t, relative, "referents")
+
+		relProps := relative["properties"].(map[string]any)
+		assert.Equal(t, []any{"Muammar QADHAFI"}, relProps["name"], "name is kept")
+		assert.NotContains(t, relProps, "birthDate", "relative's details are dropped")
+		assert.NotContains(t, relProps, "sourceUrl")
+	})
+
+	t.Run("non-object payload returned unchanged", func(t *testing.T) {
+		payload := []byte(`["not", "an", "object"]`)
+		assert.JSONEq(t, string(payload), string(SanitizeScreeningPayloadForLLM(payload)))
+	})
+
+	t.Run("empty payload", func(t *testing.T) {
+		assert.Empty(t, SanitizeScreeningPayloadForLLM(nil))
+	})
+}
+
+func parse(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}

--- a/usecases/ai_agent/ai_screening_suggestion.go
+++ b/usecases/ai_agent/ai_screening_suggestion.go
@@ -194,7 +194,7 @@ func (uc *AiAgentUsecase) analyseScreeningMatch(
 	// Add per-match data to the prompt data
 	matchPromptData := make(map[string]any, len(promptData)+2)
 	maps.Copy(matchPromptData, promptData)
-	matchPromptData["MatchPayload"] = string(enrichedMatch.Payload)
+	matchPromptData["MatchPayload"] = string(agent_dto.SanitizeScreeningPayloadForLLM(enrichedMatch.Payload))
 	matchPromptData["MatchScore"] = fmt.Sprintf("%.2f", enrichedMatch.GetScoreFromPayload())
 
 	_, model, userMessage, err := uc.preparePromptWithModel(PROMPT_SCREENING_HIT_EVALUATE_PATH, matchPromptData)


### PR DESCRIPTION
Tentative fix for context overflows using AI reviews on cases with screenings. The issue mostly happens with Lexis data (for reasons of data volume).