### PR TITLE
fix: missing config on webhooks

### DIFF
--- a/models/organization_feature_access.go
+++ b/models/organization_feature_access.go
@@ -58,7 +58,6 @@ type UpdateOrganizationFeatureAccessInput struct {
 }
 
 type FeaturesConfiguration struct {
-	Webhooks        bool
 	Sanctions       bool
 	NameRecognition bool
 	Analytics       bool
@@ -129,9 +128,6 @@ func (f DbStoredOrganizationFeatureAccess) MergeWithLicenseEntitlement(
 	// remove the feature accesses that are not allowed by the configuration
 	if o.Analytics.IsAllowed() && !c.Analytics {
 		o.Analytics = MissingConfiguration
-	}
-	if o.Webhooks.IsAllowed() && !c.Webhooks {
-		o.Webhooks = MissingConfiguration
 	}
 	if o.Sanctions.IsAllowed() && !c.Sanctions {
 		o.Sanctions = MissingConfiguration

--- a/models/organization_feature_access_test.go
+++ b/models/organization_feature_access_test.go
@@ -36,7 +36,6 @@ func TestMergeWithLicenseEntitlement(t *testing.T) {
 				CaseAutoAssign: true,
 			},
 			config: FeaturesConfiguration{
-				Webhooks:        true,
 				Sanctions:       true,
 				NameRecognition: true,
 				Analytics:       true,
@@ -76,7 +75,6 @@ func TestMergeWithLicenseEntitlement(t *testing.T) {
 				Sanctions:   false,
 			},
 			config: FeaturesConfiguration{
-				Webhooks:        true,
 				Sanctions:       true,
 				NameRecognition: true,
 				Analytics:       true,
@@ -117,7 +115,6 @@ func TestMergeWithLicenseEntitlement(t *testing.T) {
 				CaseAutoAssign: true,
 			},
 			config: FeaturesConfiguration{
-				Webhooks:        false,
 				Sanctions:       false,
 				NameRecognition: false,
 				Analytics:       false,

--- a/models/organization_feature_access_test.go
+++ b/models/organization_feature_access_test.go
@@ -127,7 +127,7 @@ func TestMergeWithLicenseEntitlement(t *testing.T) {
 				Sanctions:       MissingConfiguration,
 				NameRecognition: MissingConfiguration,
 				Analytics:       MissingConfiguration,
-				Webhooks:        MissingConfiguration,
+				Webhooks:        Allowed,
 				Workflows:       Allowed,
 				RuleSnoozes:     Allowed,
 				Roles:           Allowed,


### PR DESCRIPTION
Fix a small leftover from https://github.com/checkmarble/marble-backend/pull/1873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated feature access handling so webhook availability is determined consistently by license entitlements.
  * Prevented omitted webhook configuration from being treated as an explicit restriction.
  * Preserved existing access behavior for analytics, sanctions, name recognition, and continuous screening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->