### PR TITLE
Move override param into JSON body.

### DIFF
--- a/pubapi/openapi/v1beta.yml
+++ b/pubapi/openapi/v1beta.yml
@@ -1423,11 +1423,17 @@ paths:
           required: true
           schema:
             type: string
-        - name: risk_level
-          in: query
-          required: true
-          schema:
-            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [risk_level]
+              properties:
+                risk_level:
+                  type: integer
+                  minimum: 1
       responses:
         "200":
           description: New risk level

--- a/pubapi/v1/dto/score.go
+++ b/pubapi/v1/dto/score.go
@@ -30,3 +30,7 @@ func AdaptRiskLevel(rl models.ScoringScore, overriddenBy *Ref) RiskLevel {
 		}(),
 	}
 }
+
+type RiskLevelOverride struct {
+	RiskLevel int `json:"risk_level"`
+}

--- a/pubapi/v1/params/scoring.go
+++ b/pubapi/v1/params/scoring.go
@@ -1,5 +1,0 @@
-package params
-
-type RiskLevelOverrideParams struct {
-	RiskLevel int `form:"risk_level"`
-}

--- a/pubapi/v1/v1beta/scoring.go
+++ b/pubapi/v1/v1beta/scoring.go
@@ -10,7 +10,6 @@ import (
 	"github.com/checkmarble/marble-backend/pubapi"
 	"github.com/checkmarble/marble-backend/pubapi/types"
 	"github.com/checkmarble/marble-backend/pubapi/v1/dto"
-	"github.com/checkmarble/marble-backend/pubapi/v1/params"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/gin-gonic/gin"
@@ -72,9 +71,9 @@ func HandleOverrideObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
 			return
 		}
 
-		var p params.RiskLevelOverrideParams
+		var p dto.RiskLevelOverride
 
-		if err := c.ShouldBindQuery(&p); err != nil {
+		if err := c.ShouldBindBodyWithJSON(&p); err != nil {
 			types.NewErrorResponse().WithError(err).Serve(c)
 			return
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Risk-level overrides can now be submitted via JSON request body instead of query parameters.
  * Override payloads accept a `risk_level` field, validated to be an integer with a minimum value of `1`.

* **Bug Fixes**
  * Improved risk-level override request handling by binding override data from the JSON body for more reliable submissions.

* **Documentation**
  * Updated the OpenAPI contract for `POST /risk-levels/{objectType}/{objectId}` to reflect the new JSON request-body schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->