### PR TITLE
feat: server only check validity of the license to serve prompt

### DIFF
--- a/usecases/prompt_serving_usecase.go
+++ b/usecases/prompt_serving_usecase.go
@@ -38,7 +38,7 @@ func NewPromptServingUsecase(licenseValidator promptsLicenseValidator, aiPrompts
 	}
 }
 
-// validateEntitlement checks that licenseKey is valid and entitled to the AI feature.
+// validateEntitlement checks that licenseKey is valid
 func (uc PromptServingUsecase) validateEntitlement(ctx context.Context, licenseKey string) error {
 	license, err := uc.licenseValidator.ValidateLicense(ctx, licenseKey, uuid.Nil)
 	if err != nil {
@@ -46,9 +46,6 @@ func (uc PromptServingUsecase) validateEntitlement(ctx context.Context, licenseK
 	}
 	if license.LicenseValidationCode != models.VALID {
 		return errors.Wrap(models.ForbiddenError, "invalid license")
-	}
-	if !license.CaseAiAssist {
-		return errors.Wrap(models.MissingLicenseEntitlementError, "license is not entitled to the ai feature")
 	}
 	return nil
 }

--- a/usecases/prompt_serving_usecase_test.go
+++ b/usecases/prompt_serving_usecase_test.go
@@ -33,7 +33,6 @@ func (s stubLicenseValidator) ValidateLicense(
 func validLicenseWithAi() models.LicenseValidation {
 	return models.LicenseValidation{
 		LicenseValidationCode: models.VALID,
-		LicenseEntitlements:   models.LicenseEntitlements{CaseAiAssist: true},
 	}
 }
 
@@ -132,12 +131,6 @@ func Test_PromptServingUsecase_DownloadPrompts_Authorization(t *testing.T) {
 			aiPromptsServingDir: dir,
 			validation:          stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.NOT_FOUND}},
 			wantErr:             models.ForbiddenError,
-		},
-		{
-			name:                "valid license without AI entitlement",
-			aiPromptsServingDir: dir,
-			validation:          stubLicenseValidator{validation: models.LicenseValidation{LicenseValidationCode: models.VALID}},
-			wantErr:             models.MissingLicenseEntitlementError,
 		},
 		{
 			name:                "no prompts directory configured on this server",


### PR DESCRIPTION
As discussed in internal, the server should only check if the client has a valid license. Some AI features are allowed and free to use for our "premium" client such as AI rule descriptions.

As a result, we don't have the mechanism to download only the prompts that users can use, depending on their license. This is because the license itself is not granular enough to allow only a subset of AI features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt serving now accepts any valid license without requiring a separate AI-feature entitlement.
  * Removed the prior authorization failure for valid licenses lacking AI entitlement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->