### PR TITLE
Revert "chore: bump github.com/twpayne/go-geos from 0.20.4 to 0.21.0"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/tidwall/gjson v1.19.0
 	github.com/twpayne/go-geom v1.6.1
-	github.com/twpayne/go-geos v0.21.0
+	github.com/twpayne/go-geos v0.20.4
 	github.com/twpayne/pgx-geos v1.0.1
 	github.com/vearne/gin-timeout v0.2.3
 	go.opentelemetry.io/contrib/detectors/gcp v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -648,8 +648,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/twpayne/go-geom v1.6.1 h1:iLE+Opv0Ihm/ABIcvQFGIiFBXd76oBIar9drAwHFhR4=
 github.com/twpayne/go-geom v1.6.1/go.mod h1:Kr+Nly6BswFsKM5sd31YaoWS5PeDDH2NftJTK7Gd028=
-github.com/twpayne/go-geos v0.21.0 h1:Oul17oxet6M4GpX06UKDJJfQ7s/bQ+Ii6yUv90l82PM=
-github.com/twpayne/go-geos v0.21.0/go.mod h1:p+e9NFLU4+uwudHz1A5sVLIgKs2I0wMOr7XBpjKdnCQ=
+github.com/twpayne/go-geos v0.20.4 h1:lnjMpeCgX3HDZtLixz22PKNJBekka4rIkYgvTmEDEQ4=
+github.com/twpayne/go-geos v0.20.4/go.mod h1:pclaO38DG71FzG6f8RJd/DOQ9njaZLrMYerBtMChQZ4=
 github.com/twpayne/pgx-geos v1.0.1 h1:RTJ269z1BMZpejm/eJ7F5vpjoRBhlUU4aoqj2G6wDrA=
 github.com/twpayne/pgx-geos v1.0.1/go.mod h1:j/IsZpQFB69eGy34LIY8I5UyeD468jTM8E0dYSQF3FI=
 github.com/ugorji/go/codec v1.3.1 h1:waO7eEiFDwidsBN6agj1vJQ4AG7lh2yqXyOXqhgQuyY=


### PR DESCRIPTION
Reverts checkmarble/marble-backend#1890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal mapping dependency to an earlier compatible version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->