### PR TITLE
Allow per-config weights in all screening features.

### DIFF
--- a/infra/screening.go
+++ b/infra/screening.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -54,8 +55,9 @@ type NameRecognitionProvider struct {
 }
 
 type MotivaFeatures struct {
-	BodyParams  bool
-	ScopedIndex bool
+	BodyParams    bool
+	ScopedIndex   bool
+	CustomWeights bool
 }
 
 func InitializeScreening(ctx context.Context, client *http.Client, host, authMethod, creds string) Screening {
@@ -230,14 +232,19 @@ func (os *Screening) MotivaFeatures(ctx context.Context) MotivaFeatures {
 			feats := MotivaFeatures{}
 
 			if resp.StatusCode == http.StatusOK {
+
 				var v motivaVersionInfo
 
 				if err := json.NewDecoder(resp.Body).Decode(&v); err == nil {
+					// Let's ignore prereleases for feature gating
+					version, _, _ := strings.Cut(v.Motiva, "-")
+
 					// Features introduced in motiva v0.7.0
 					//  - transmit unbounded query parameters in request body
 					//  - use scoped index
-					feats.BodyParams = semver.Compare(v.Motiva, "v0.7.0") >= 0
-					feats.ScopedIndex = semver.Compare(v.Motiva, "v0.7.0") >= 0
+					feats.BodyParams = semver.Compare(version, "v0.7.0") >= 0
+					feats.ScopedIndex = semver.Compare(version, "v0.7.0") >= 0
+					feats.CustomWeights = semver.Compare(version, "v0.10.0") >= 0
 				}
 			}
 

--- a/models/continuous_screening_config.go
+++ b/models/continuous_screening_config.go
@@ -26,6 +26,7 @@ type ContinuousScreeningConfig struct {
 	MatchThreshold int
 
 	MatchLimit int
+	Weights    map[string]float64
 	Enabled    bool
 
 	CreatedAt time.Time
@@ -63,6 +64,7 @@ type CreateContinuousScreeningConfig struct {
 	MatchLimit     int
 	ObjectTypes    []string
 	MappingConfigs []ContinuousScreeningMappingConfig
+	Weights        map[string]float64
 }
 
 type UpdateContinuousScreeningConfig struct {

--- a/models/scenario_iterations.go
+++ b/models/scenario_iterations.go
@@ -99,6 +99,7 @@ type ScreeningConfig struct {
 	CounterpartyIdExpression *ast.Node
 	Preprocessing            ScreeningConfigPreprocessing
 	ConfigVersion            string
+	Weights                  map[string]float64
 }
 
 type ScreeningConfigFilters struct {
@@ -371,6 +372,7 @@ type UpdateScreeningConfigInput struct {
 	ForcedOutcome            *Outcome
 	Preprocessing            *ScreeningConfigPreprocessing
 	ConfigVersion            string
+	Weights                  map[string]float64
 }
 
 type RulesAndScreenings struct {

--- a/repositories/continuous_screening_repository.go
+++ b/repositories/continuous_screening_repository.go
@@ -163,6 +163,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningConfig(ctx context.Cont
 			"match_threshold",
 			"match_limit",
 			"object_types",
+			"weights",
 		).
 		Values(
 			pure_utils.NewId(),
@@ -178,6 +179,7 @@ func (repo *MarbleDbRepository) CreateContinuousScreeningConfig(ctx context.Cont
 			input.MatchThreshold,
 			input.MatchLimit,
 			input.ObjectTypes,
+			input.Weights,
 		)
 
 	return SqlToModel(ctx, exec, sql, dbmodels.AdaptContinuousScreeningConfig)

--- a/repositories/dbmodels/db_continuous_screening_config.go
+++ b/repositories/dbmodels/db_continuous_screening_config.go
@@ -25,6 +25,7 @@ type DBContinuousScreeningConfig struct {
 	MatchThreshold int                           `db:"match_threshold"`
 	MatchLimit     int                           `db:"match_limit"`
 	Enabled        bool                          `db:"enabled"`
+	Weights        map[string]float64            `db:"weights"`
 	CreatedAt      time.Time                     `db:"created_at"`
 	UpdatedAt      time.Time                     `db:"updated_at"`
 }
@@ -47,6 +48,7 @@ func AdaptContinuousScreeningConfig(db DBContinuousScreeningConfig) (models.Cont
 		MatchThreshold: db.MatchThreshold,
 		MatchLimit:     db.MatchLimit,
 		Enabled:        db.Enabled,
+		Weights:        db.Weights,
 		CreatedAt:      db.CreatedAt,
 		UpdatedAt:      db.UpdatedAt,
 	}, nil

--- a/repositories/dbmodels/db_screening_config.go
+++ b/repositories/dbmodels/db_screening_config.go
@@ -32,6 +32,7 @@ type DBScreeningConfigs struct {
 	UpdatedAt           time.Time                           `db:"updated_at"`
 	Preprocessing       models.ScreeningConfigPreprocessing `db:"preprocessing"`
 	ConfigVersion       string                              `db:"config_version"`
+	Weights             map[string]float64                  `db:"weights"`
 }
 
 var ScreeningConfigColumnList = utils.ColumnList[DBScreeningConfigs]()
@@ -52,6 +53,7 @@ func AdaptScreeningConfig(db DBScreeningConfigs) (models.ScreeningConfig, error)
 		ForcedOutcome:       models.OutcomeFrom(db.ForcedOutcome),
 		Preprocessing:       db.Preprocessing,
 		ConfigVersion:       db.ConfigVersion,
+		Weights:             db.Weights,
 	}
 
 	if db.TriggerRule != nil {

--- a/repositories/migrations/20260727104900_screening_custom_weights.sql
+++ b/repositories/migrations/20260727104900_screening_custom_weights.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+
+alter table screening_configs
+    add column weights jsonb;
+
+alter table continuous_screening_configs
+    add column weights jsonb;
+
+-- +goose Down
+
+alter table screening_configs
+    drop column weights;
+
+alter table continuous_screening_configs
+    drop column weights;

--- a/repositories/screening/provider_lexisnexis.go
+++ b/repositories/screening/provider_lexisnexis.go
@@ -41,6 +41,10 @@ func (p ScreeningLexisNexisProvider) SearchRequest(ctx context.Context,
 		}
 	}
 
+	if p.Config.MotivaFeatures(ctx).CustomWeights && query.Config.Weights != nil {
+		q.Weights = query.Config.Weights
+	}
+
 	for _, subquery := range query.Queries {
 		filters := query.Config.Filters.Resolve()
 

--- a/repositories/screening/provider_opensanctions.go
+++ b/repositories/screening/provider_opensanctions.go
@@ -45,6 +45,10 @@ func (p ScreeningOpenSanctionsProvider) SearchRequest(ctx context.Context,
 		}
 	}
 
+	if p.Config.MotivaFeatures(ctx).CustomWeights && query.Config.Weights != nil {
+		q.Weights = query.Config.Weights
+	}
+
 	for _, subquery := range query.Queries {
 		rq := openSanctionsRequestQuery{
 			Schema:     subquery.Type,

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -64,6 +64,7 @@ type OpenSanctionsRepository struct {
 type openSanctionsRequest struct {
 	Queries map[string]openSanctionsRequestQuery `json:"queries"`
 	Params  *motivaRequestParams                 `json:"params,omitempty"`
+	Weights map[string]float64                   `json:"weights,omitempty"`
 }
 
 type motivaRequestParams struct {

--- a/repositories/screening_config_repository.go
+++ b/repositories/screening_config_repository.go
@@ -176,7 +176,8 @@ func (repo *MarbleDbRepository) CreateScreeningConfig(ctx context.Context, exec 
 			"query",
 			"counterparty_id_expression",
 			"preprocessing",
-			"config_version").
+			"config_version",
+			"weights").
 		Values(
 			squirrel.Expr("coalesce(?, gen_random_uuid())", cfg.StableId),
 			scenarioIterationId,
@@ -194,6 +195,7 @@ func (repo *MarbleDbRepository) CreateScreeningConfig(ctx context.Context, exec 
 			counterpartyIdExpr,
 			utils.Or(cfg.Preprocessing, models.ScreeningConfigPreprocessing{}),
 			configVersion,
+			cfg.Weights,
 		).
 		Suffix(fmt.Sprintf("RETURNING %s", strings.Join(dbmodels.ScreeningConfigColumnList, ",")))
 

--- a/usecases/continuous_screening/monitored_object.go
+++ b/usecases/continuous_screening/monitored_object.go
@@ -300,6 +300,7 @@ func prepareOpenSanctionsQuery(
 		Config: models.ScreeningConfig{
 			Datasets: config.Datasets,
 			Filters:  config.Filters,
+			Weights:  config.Weights,
 		},
 		Queries: []models.OpenSanctionsCheckQuery{
 			{

--- a/usecases/continuous_screening/org_config.go
+++ b/usecases/continuous_screening/org_config.go
@@ -411,6 +411,7 @@ func createUpdatedConfig(config models.ContinuousScreeningConfig,
 		MatchLimit:     pure_utils.PtrValueOrDefault(updateInput.MatchLimit, config.MatchLimit),
 		ObjectTypes:    pure_utils.PtrSliceValueOrDefault(updateInput.ObjectTypes, config.ObjectTypes),
 		InboxId:        pure_utils.PtrValueOrDefault(updateInput.InboxId, config.InboxId),
+		Weights:        config.Weights,
 	}
 }
 

--- a/usecases/continuous_screening/worker_apply_delta_file.go
+++ b/usecases/continuous_screening/worker_apply_delta_file.go
@@ -561,6 +561,9 @@ func (w *ApplyDeltaFileWorker) buildOpenSanctionQuery(
 			MatchThreshold: updateJob.Config.MatchThreshold,
 			MatchLimit:     updateJob.Config.MatchLimit,
 		},
+		Config: models.ScreeningConfig{
+			Weights: updateJob.Config.Weights,
+		},
 		Queries: []models.OpenSanctionsCheckQuery{
 			{
 				Type:    record.Entity.Schema,

--- a/usecases/scenario_iterations_usecase.go
+++ b/usecases/scenario_iterations_usecase.go
@@ -375,6 +375,7 @@ func (usecase *ScenarioIterationUsecase) CreateDraftFromScenarioIteration(
 						ForcedOutcome:            &scc.ForcedOutcome,
 						Preprocessing:            &scc.Preprocessing,
 						ConfigVersion:            scc.ConfigVersion,
+						Weights:                  scc.Weights,
 					}
 				})
 


### PR DESCRIPTION
**Note:** this a a hidden feature for now, it can only be configured directly in the database.

Allows to set custom screening weights per screening configuration in both transaction monitoring and continuous monitoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable per-key weight values for screening configurations.
  - Persisted weights in screening setup, and retained them across updates and scenario draft creation.
  - Sent weights in supported screening requests when custom weighting is enabled.
- **Bug Fixes**
  - Improved Motiva custom-weight detection by correctly handling prerelease/suffixed version strings so feature gating works reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->