### PR TITLE
fix: version outdated check ignore future version to be released

### DIFF
--- a/utils/outdated.go
+++ b/utils/outdated.go
@@ -62,12 +62,12 @@ func checkOutdated(ctx context.Context, appVersion string) (info OutdatedInfo) {
 	withoutPrerelease, _ := currentSv.SetPrerelease("")
 	currentSv = &withoutPrerelease
 
-	releases, err := fetchReleases(ctx, GithubBackendReleaseUrl)
+	backendReleases, err := fetchReleases(ctx, GithubBackendReleaseUrl)
 	// In case we cannot retrieve releases or the list is empty, bail out.
 	if err != nil {
 		return
 	}
-	if len(releases) == 0 {
+	if len(backendReleases) == 0 {
 		return
 	}
 
@@ -76,7 +76,7 @@ func checkOutdated(ctx context.Context, appVersion string) (info OutdatedInfo) {
 		minorsSince    = 1
 	)
 
-	latest := releases[0]
+	latest := backendReleases[0]
 	latestSv, err := semver.NewVersion(latest.TagName)
 	if err != nil {
 		return
@@ -85,10 +85,14 @@ func checkOutdated(ctx context.Context, appVersion string) (info OutdatedInfo) {
 	// Keep the latest unique minor version found, so we can count them.
 	var seenMinor *semver.Version
 
-	info.ReleaseNotes = make([]string, 0, minorsSince)
-
-	for _, r := range releases {
-		if r.TagName == currentSv.Original() {
+	for _, r := range backendReleases {
+		rSv, err := semver.NewVersion(r.TagName)
+		if err != nil {
+			continue
+		}
+		withoutPrerelease, _ := rSv.SetPrerelease("")
+		rSv = &withoutPrerelease
+		if currentSv.Equal(rSv) {
 			currentRelease = &r
 			break
 		}
@@ -111,6 +115,7 @@ func checkOutdated(ctx context.Context, appVersion string) (info OutdatedInfo) {
 		release := releases[0]
 		info.LatestVersion = release.TagName
 		info.LatestUrl = release.HtmlUrl
+		info.ReleaseNotes = make([]string, 0, len(releases))
 
 		for _, release := range releases {
 			sv, err := semver.NewVersion(release.TagName)

--- a/utils/outdated_test.go
+++ b/utils/outdated_test.go
@@ -12,6 +12,18 @@ import (
 func TestOudatedVersion(t *testing.T) {
 	defer gock.Off()
 
+	backendReleases := []GithubRelease{
+		{"v0.11.0-rc.1", true, time.Now().Add(-7 * 24 * time.Hour), "https://v0.11.0-rc.1", "Release notes for v0.11.0"},
+		{"v0.10.0", false, time.Now().Add(-7 * 24 * time.Hour), "https://v0.10.0", "Release notes for v0.10.0"},
+		{"v0.9.2", false, time.Now().Add(-31 * 24 * time.Hour), "https://v0.9.2", "Release notes for v0.9.0"},
+		{"v0.9.1", false, time.Now().Add(-32 * 24 * time.Hour), "https://v0.9.1", "Release notes for v0.9.2"},
+		{"v0.9.0", false, time.Now().Add(-33 * 24 * time.Hour), "https://v0.9.0", "Release notes for v0.9.1"},
+		{"v0.6.0", false, time.Now().Add(-90 * 24 * time.Hour), "https://v0.6.0", "Release notes for v0.6.0"},
+		{"v0.5.0", false, time.Now().Add(-90 * 24 * time.Hour), "https://v0.5.0", "Release notes for v0.5.0"},
+		{"v0.4.0", false, time.Now().Add(-15 * 24 * time.Hour), "https://v0.4.0", "Release notes for v0.4.0"},
+		{"v0.1.0", false, time.Now().Add(-90 * 24 * time.Hour), "https://v0.1.0", "Release notes for v0.1.0"},
+	}
+
 	releases := []GithubRelease{
 		{"v0.10.0", false, time.Now().Add(-7 * 24 * time.Hour), "https://v0.10.0", "Release notes for v0.10.0"},
 		{"v0.9.2", false, time.Now().Add(-31 * 24 * time.Hour), "https://v0.9.2", "Release notes for v0.9.0"},
@@ -27,7 +39,7 @@ func TestOudatedVersion(t *testing.T) {
 		Get("/repos/checkmarble/marble-backend/releases").
 		MatchParam("per_page", "100").
 		Reply(http.StatusOK).
-		JSON(releases)
+		JSON(backendReleases)
 
 	gock.New("https://api.github.com").Persist().
 		Get("/repos/checkmarble/marble/releases").
@@ -39,14 +51,15 @@ func TestOudatedVersion(t *testing.T) {
 		version  string
 		expected bool
 	}{
-		{"dev", false},                 // Development version
-		{"v0.100.0", true},             // Unknown version
-		{"v0.10.0", false},             // Latest version
-		{"v0.10.0-10-abcd1234", false}, // Ahead of latest version
-		{"v0.6.0", false},              // Old version, within minor spread tolerance
-		{"v0.4.0", false},              // Old version, within grace period
-		{"v0.5.0", true},               // Outdated version
-		{"v0.1.0", true},               // Outdated version
+		{"dev", false},                       // Development version
+		{"v0.100.0", true},                   // Unknown version
+		{"v0.11.0-rc.1-20-gf03117ab", false}, // Future version but not yet released
+		{"v0.10.0", false},                   // Latest version
+		{"v0.10.0-10-abcd1234", false},       // Ahead of latest version
+		{"v0.6.0", false},                    // Old version, within minor spread tolerance
+		{"v0.4.0", false},                    // Old version, within grace period
+		{"v0.5.0", true},                     // Outdated version
+		{"v0.1.0", true},                     // Outdated version
 	}
 
 	for _, tt := range tts {


### PR DESCRIPTION
Since we use the RC version before releasing the marble open-source package, the `outdated` feature on our staging environment will always open the outdated modal to inform us that we are in an unusual configuration (it cannot locate our RC version because it is after the latest open source released version of marble).

To prevent this issue, I modified the comparison of the backend versions with the current one, excluding the pre-release string value. This change ensures that the current version is always discoverable and prevents the `Outdated` field from being updated.

The only restriction is that the `LatestVersion` and `LatestUrl` will point to the last marble open-source version, rather than the latest backend pre-released version, but the frontend should not use these value since we return `outdated = false` in the body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version update detection by using the backend release list as the source of truth for the latest available version.
  * Enhanced semantic version matching by normalizing prerelease tags and comparing versions semantically (not by raw tag text).
  * More reliably handles unusual tags and accurately flags future or unreleased versions.
  * Kept release-note generation behavior, while improving overall accuracy across a wider range of versions.
* **Tests**
  * Expanded coverage with additional historical and prerelease scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->