### PR TITLE
fix: import feature which duplicate navigation option

### DIFF
--- a/usecases/org_import_usecase.go
+++ b/usecases/org_import_usecase.go
@@ -1,10 +1,13 @@
 package usecases
 
 import (
+	"cmp"
 	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 
 	"github.com/checkmarble/marble-backend/dto"
@@ -536,22 +539,21 @@ func (uc *OrgImportUsecase) createDataModel(ctx context.Context, tx repositories
 		}
 	}
 
-	// Step G: Create navigation options
-	for navTableId, navOptionsList := range dataModel.NavigationOptions {
-		for _, navOption := range navOptionsList {
-			err := uc.dataModelUsecase.CreateNavigationOption(ctx, models.CreateNavigationOptionInput{
-				Blocking:        true,
-				SourceTableId:   ids[navTableId],
-				SourceFieldId:   ids[navOption.SourceFieldId],
-				TargetTableId:   ids[navOption.TargetTableId],
-				FilterFieldId:   ids[navOption.FilterFieldId],
-				OrderingFieldId: ids[navOption.OrderingFieldId],
-			})
-			if err != nil {
-				// Navigation options are checked for duplication, we want to ignore that
-				if !errors.Is(err, models.ConflictError) {
-					return err
-				}
+	// Step G: Create the navigation options that are not already covered by an index
+	// scheduled in step C (see navOptionsToCreate).
+	for _, navOption := range navOptionsToCreate(dataModel.Tables, includedLinks, dataModel.NavigationOptions) {
+		err := uc.dataModelUsecase.CreateNavigationOption(ctx, models.CreateNavigationOptionInput{
+			Blocking:        true,
+			SourceTableId:   ids[navOption.sourceTableId],
+			SourceFieldId:   ids[navOption.option.SourceFieldId],
+			TargetTableId:   ids[navOption.option.TargetTableId],
+			FilterFieldId:   ids[navOption.option.FilterFieldId],
+			OrderingFieldId: ids[navOption.option.OrderingFieldId],
+		})
+		if err != nil {
+			// Navigation options are checked for duplication, we want to ignore that
+			if !errors.Is(err, models.ConflictError) {
+				return err
 			}
 		}
 	}
@@ -723,6 +725,65 @@ func buildCreateTableLinkInputs(
 		})
 	}
 	return result
+}
+
+type navOptionToCreate struct {
+	sourceTableId string
+	option        dto.CreateNavigationOptionInput
+}
+
+// navIndexSignature identifies the physical index backing a navigation option: an index
+// on the target table over (filter field, ordering field). Several navigation options can
+// share the same index, since the source table plays no part in it.
+func navIndexSignature(targetTableId, filterFieldId, orderingFieldId string) string {
+	return strings.Join([]string{targetTableId, filterFieldId, orderingFieldId}, "|")
+}
+
+// navOptionsToCreate returns the navigation options the import has to create explicitly,
+// in a deterministic order, leaving out those whose index is already accounted for.
+//
+// Creating a link creates its navigation index, so every link passed to
+// CreateDataModelTable in step C already schedules an index on (child field, ordering
+// field) of the child table. That creation goes through the task queue and therefore only
+// happens once the import transaction commits, which makes it invisible to the duplicate
+// detection of CreateNavigationOption: recreating those navigation options here would
+// create each index a second time, under a different name.
+func navOptionsToCreate(
+	tables []dto.Table,
+	includedLinks []dto.LinkToSingle,
+	navOptions map[string][]dto.CreateNavigationOptionInput,
+) []navOptionToCreate {
+	tableById := make(map[string]dto.Table, len(tables))
+	for _, table := range tables {
+		tableById[table.ID] = table
+	}
+
+	covered := make(map[string]struct{}, len(includedLinks))
+	for _, link := range includedLinks {
+		childTable, ok := tableById[link.ChildTableId]
+		if !ok {
+			continue
+		}
+		orderingField, ok := childTable.Fields[cmp.Or(childTable.PrimaryOrderingField, "updated_at")]
+		if !ok {
+			continue
+		}
+		covered[navIndexSignature(link.ChildTableId, link.ChildFieldId, orderingField.ID)] = struct{}{}
+	}
+
+	toCreate := make([]navOptionToCreate, 0, len(navOptions))
+	for _, sourceTableId := range slices.Sorted(maps.Keys(navOptions)) {
+		for _, option := range navOptions[sourceTableId] {
+			sig := navIndexSignature(option.TargetTableId, option.FilterFieldId, option.OrderingFieldId)
+			if _, ok := covered[sig]; ok {
+				continue
+			}
+			covered[sig] = struct{}{}
+			toCreate = append(toCreate, navOptionToCreate{sourceTableId: sourceTableId, option: option})
+		}
+	}
+
+	return toCreate
 }
 
 // pivotSignature creates a string key to identify a pivot by its structure.


### PR DESCRIPTION
MAR-2170

## Problem

Importing an org data model created **two physical navigation indexes for the same `(target table, filter field, ordering field)` triplet** on client tables.

The import builds the data model in ordered steps inside one transaction:

- **Step C** creates the tables *with* their links via `CreateDataModelTable`. Every link created there also computes a navigation index on the child table over `(child field, ordering field)` — where the ordering field is `cmp.Or(childTable.PrimaryOrderingField, "updated_at")` — and enqueues its creation with `EnqueueCreateIndexTask` (`usecases/data_model_usecase.go:409`, `usecases/data_model_usecase.go:1454-1462`).
- **Step G** then replayed *every* navigation option from the import spec through `CreateNavigationOption`.

`CreateNavigationOption` does guard against duplicates, but it does so by listing the navigation indexes that actually exist in the client DB (`usecases/data_model_usecase.go:1806-1830`). The indexes scheduled in step C only get created once the import transaction commits and the queued task runs, so at step G they are neither `valid` nor `pending` — invisible to that check. The `ConflictError` the loop was swallowing therefore never fired for them, and step G created the index a second time. Because index names carry a random suffix (`models/concrete_index.go:94-118`), the duplicate does not collide on name: both `nav_<table>_<cols>_<id1>` and `nav_<table>_<cols>_<id2>` end up on the client table.

## Fix

Introduce `navOptionsToCreate`, which decides up front which navigation options step G still has to create:

1. Compute the index signature `(target table, filter field, ordering field)` already covered by each link passed to step C, resolving the ordering field the same way link creation does (`PrimaryOrderingField`, falling back to `updated_at`).
2. Skip any spec navigation option whose signature is already covered. The source table is deliberately not part of the signature: several navigation options can share one physical index, since the index lives on the target table only.
3. Deduplicate the remaining options against each other via the same signature set, so two spec entries pointing at the same index only trigger one creation.
4. Iterate source tables in sorted order, so the import performs the same creations in the same order on every run.

The `ConflictError` tolerance in the loop is kept as a safety net for options that genuinely already exist.

## Result

- No more duplicate navigation indexes on freshly imported client tables — one index per distinct `(target table, filter field, ordering field)`.
- Deterministic import behaviour, independent of Go map iteration order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate navigation options when equivalent navigation is already provided by existing links.
  * Made navigation option creation deterministic and consistently ordered for more reliable imports.
  * Improved navigation option handling for source references during the import process, reducing mismatches and redundant entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
