### PR TITLE
Gracefully handle partial errors in opensanctions responses

### DIFF
--- a/pubapi/tests/specs/v1/continuous_screenings.go
+++ b/pubapi/tests/specs/v1/continuous_screenings.go
@@ -109,6 +109,7 @@ func testContinuousScreeningAddAndDelete(t *testing.T, e *httpexpect.Expect) {
 		BodyString(`{
 			"responses": {
 				"query": {
+					"status": 200,
 					"total": { "value": 1 },
 					"results": [
 						{

--- a/pubapi/tests/specs/v1/screening.go
+++ b/pubapi/tests/specs/v1/screening.go
@@ -62,6 +62,7 @@ func screenings(t *testing.T, e *httpexpect.Expect) {
 		BodyString(`{
 				"responses": {
 					"out":{
+						"status": 200,
 						"total": { "value": 1 },
 						"results":[
 							{

--- a/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
+++ b/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
@@ -37,12 +37,6 @@
       "total": {
         "value": 0
       }
-    },
-    "query_vehicle": {
-      "results": [],
-      "total": {
-        "value": 0
-      }
     }
   },
   "limit": 1

--- a/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
+++ b/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
@@ -1,0 +1,43 @@
+{
+  "responses": {
+    "query_sanctions": {
+      "status": 200,
+      "results": [
+        {
+          "id": "ENTITY1",
+          "schema": "Person",
+          "properties": {
+            "name": ["Alice"]
+          },
+          "match": true,
+          "score": 0.95
+        }
+      ],
+      "total": {
+        "value": 1
+      }
+    },
+    "query_pep": {
+      "status": 400,
+      "results": [],
+      "total": {
+        "value": 0
+      }
+    },
+    "query_user": {
+      "status": 503,
+      "results": [],
+      "total": {
+        "value": 0
+      }
+    },
+    "query_company": {
+      "status": 202,
+      "results": [],
+      "total": {
+        "value": 0
+      }
+    }
+  },
+  "limit": 1
+}

--- a/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
+++ b/repositories/fixtures/opensanctions/response_multi_query_partial_error.json
@@ -37,6 +37,12 @@
       "total": {
         "value": 0
       }
+    },
+    "query_vehicle": {
+      "results": [],
+      "total": {
+        "value": 0
+      }
     }
   },
   "limit": 1

--- a/repositories/httpmodels/http_opensanctions_result.go
+++ b/repositories/httpmodels/http_opensanctions_result.go
@@ -12,6 +12,7 @@ import (
 
 type HTTPOpenSanctionsResult struct {
 	Responses map[string]struct {
+		Status int `json:"status"`
 		Total struct {
 			Value int `json:"value"`
 		} `json:"total"`

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -376,7 +376,7 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, providerName mod
 
 	var subqueryErrors []error
 	for queryId, resp := range matches.Responses {
-		if resp.Status < http.StatusOK || resp.Status >= 300 {
+		if resp.Status != 0 && (resp.Status < http.StatusOK || resp.Status >= 300) {
 			subqueryErrors = append(subqueryErrors, &HTTPError{
 				StatusCode: resp.Status,
 				Message:    fmt.Sprintf("subquery %s failed", queryId),

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -374,6 +374,20 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, providerName mod
 			"could not parse screening response")
 	}
 
+	var subqueryErrors []error
+	for queryId, resp := range matches.Responses {
+		if resp.Status < http.StatusOK || resp.Status >= 300 {
+			subqueryErrors = append(subqueryErrors, &HTTPError{
+				StatusCode: resp.Status,
+				Message:    fmt.Sprintf("subquery %s failed", queryId),
+			})
+		}
+	}
+
+	if len(subqueryErrors) > 0 {
+		return models.ScreeningRawSearchResponseWithMatches{}, errors.Join(subqueryErrors...)
+	}
+
 	screening, err := httpmodels.AdaptOpenSanctionsResult(rawQuery, matches)
 	if err != nil {
 		return screening, err

--- a/repositories/screening/screening_repository.go
+++ b/repositories/screening/screening_repository.go
@@ -376,7 +376,7 @@ func (repo OpenSanctionsRepository) Search(ctx context.Context, providerName mod
 
 	var subqueryErrors []error
 	for queryId, resp := range matches.Responses {
-		if resp.Status != 0 && (resp.Status < http.StatusOK || resp.Status >= 300) {
+		if resp.Status < http.StatusOK || resp.Status >= 300 {
 			subqueryErrors = append(subqueryErrors, &HTTPError{
 				StatusCode: resp.Status,
 				Message:    fmt.Sprintf("subquery %s failed", queryId),

--- a/repositories/screening/screening_repository_test.go
+++ b/repositories/screening/screening_repository_test.go
@@ -1,6 +1,7 @@
 package screening
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -464,4 +465,36 @@ func TestDatasetOutdatedDetector(t *testing.T) {
 		assert.NoError(t, dataset.CheckIsUpToDate(now))
 		assert.Equal(t, tt.expected, dataset.UpToDate)
 	}
+}
+
+func TestOpenSanctionsSearch_PartialSubqueryFailure(t *testing.T) {
+	defer gock.Off()
+
+	repo := getMockedOpenSanctionsRepository("", "", "")
+	body, _ := os.ReadFile("../fixtures/opensanctions/response_multi_query_partial_error.json")
+
+	gock.New(infra.OPEN_SANCTIONS_API_HOST).
+		Post("/match/default").
+		Reply(http.StatusOK).
+		Body(bytes.NewReader(body))
+
+	query := models.OpenSanctionsQuery{
+		Config: models.ScreeningConfig{},
+		Queries: []models.OpenSanctionsCheckQuery{
+			{
+				Type: "Person",
+				Filters: models.OpenSanctionsFilter{
+					"name": []string{"test"},
+				},
+			},
+		},
+		OrgConfig: models.OrganizationOpenSanctionsConfig{MatchThreshold: 70},
+	}
+
+	_, err := repo.Search(context.TODO(), models.ScreeningProviderOpenSanctions, query)
+
+	assert.NotNil(t, err)
+	errStr := err.Error()
+	assert.Contains(t, errStr, "subquery query_pep failed")
+	assert.Contains(t, errStr, "subquery query_user failed")
 }

--- a/repositories/screening/screening_repository_test.go
+++ b/repositories/screening/screening_repository_test.go
@@ -472,7 +472,10 @@ func TestOpenSanctionsSearch_PartialSubqueryFailure(t *testing.T) {
 	defer gock.Off()
 
 	repo := getMockedOpenSanctionsRepository("", "", "")
-	body, _ := os.ReadFile("../fixtures/opensanctions/response_multi_query_partial_error.json")
+	body, err := os.ReadFile("../fixtures/opensanctions/response_multi_query_partial_error.json")
+	if err != nil {
+		t.Fatalf("failed to read fixture file: %v", err)
+	}
 
 	gock.New(infra.OPEN_SANCTIONS_API_HOST).
 		Post("/match/default").
@@ -492,13 +495,13 @@ func TestOpenSanctionsSearch_PartialSubqueryFailure(t *testing.T) {
 		OrgConfig: models.OrganizationOpenSanctionsConfig{MatchThreshold: 70},
 	}
 
-	_, err := repo.Search(context.TODO(), models.ScreeningProviderOpenSanctions, query)
+	_, searchErr := repo.Search(context.TODO(), models.ScreeningProviderOpenSanctions, query)
 
-	assert.NotNil(t, err)
+	assert.NotNil(t, searchErr)
 
 	unwrappedErrs := []error{}
 	var joinErr interface{ Unwrap() []error }
-	if errors.As(err, &joinErr) {
+	if errors.As(searchErr, &joinErr) {
 		unwrappedErrs = joinErr.Unwrap()
 	}
 

--- a/repositories/screening/screening_repository_test.go
+++ b/repositories/screening/screening_repository_test.go
@@ -495,6 +495,6 @@ func TestOpenSanctionsSearch_PartialSubqueryFailure(t *testing.T) {
 
 	assert.NotNil(t, err)
 	errStr := err.Error()
-	assert.Contains(t, errStr, "subquery query_pep failed")
-	assert.Contains(t, errStr, "subquery query_user failed")
+	assert.Contains(t, errStr, "status 400: subquery query_pep failed")
+	assert.Contains(t, errStr, "status 503: subquery query_user failed")
 }

--- a/repositories/screening/screening_repository_test.go
+++ b/repositories/screening/screening_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -494,7 +495,30 @@ func TestOpenSanctionsSearch_PartialSubqueryFailure(t *testing.T) {
 	_, err := repo.Search(context.TODO(), models.ScreeningProviderOpenSanctions, query)
 
 	assert.NotNil(t, err)
-	errStr := err.Error()
-	assert.Contains(t, errStr, "status 400: subquery query_pep failed")
-	assert.Contains(t, errStr, "status 503: subquery query_user failed")
+
+	unwrappedErrs := []error{}
+	var joinErr interface{ Unwrap() []error }
+	if errors.As(err, &joinErr) {
+		unwrappedErrs = joinErr.Unwrap()
+	}
+
+	errorsByMessage := make(map[string]*HTTPError)
+	for _, e := range unwrappedErrs {
+		var httpErr *HTTPError
+		assert.True(t, errors.As(e, &httpErr), "expected HTTPError, got %T", e)
+		errorsByMessage[httpErr.Message] = httpErr
+		assert.True(t,
+			strings.Contains(httpErr.Message, "subquery") && strings.Contains(httpErr.Message, "failed"),
+			"expected message format 'subquery <name> failed', got: %s", httpErr.Message)
+	}
+
+	assert.Len(t, errorsByMessage, 2, "expected 2 distinct error messages")
+
+	assert.Contains(t, errorsByMessage, "subquery query_pep failed")
+	assert.Equal(t, http.StatusBadRequest, errorsByMessage["subquery query_pep failed"].StatusCode,
+		"expected query_pep to have status 400")
+
+	assert.Contains(t, errorsByMessage, "subquery query_user failed")
+	assert.Equal(t, http.StatusServiceUnavailable, errorsByMessage["subquery query_user failed"].StatusCode,
+		"expected query_user to have status 503")
 }


### PR DESCRIPTION
This change adds granular error handling for batch screening requests to Motiva.

When multiple subqueries are sent in a single request, each subquery response includes a status code.
If any subquery fails (non-2xx status), the entire request now fails with a joined error containing individual HTTPError entries for each failed subquery, preserving the original HTTP status code and a clear message for each failure.

This enables fail-fast behavior and better error tracking for debugging purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screening searches to report errors from all failed subqueries when results contain mixed success and failure statuses.
  * Successful subquery results remain available while detailed errors identify each failed query.
  * Added status handling for screening responses to improve error reporting and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->