### PR TITLE
Case SLAs

### DIFF
--- a/api/handle_inboxes.go
+++ b/api/handle_inboxes.go
@@ -337,7 +337,7 @@ func handleDeleteInboxUser(uc usecases.Usecases) func(c *gin.Context) {
 	}
 }
 
-func handleBulkUpdateInboxSla(uc usecases.Usecases) func(c *gin.Context) {
+func handleBulkUpdateInbox(uc usecases.Usecases) func(c *gin.Context) {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
@@ -345,14 +345,14 @@ func handleBulkUpdateInboxSla(uc usecases.Usecases) func(c *gin.Context) {
 			return
 		}
 
-		var input dto.BulkUpdateInboxSlaInput
+		var input dto.BulkUpdateInboxInput
 		if err := c.ShouldBind(&input); err != nil {
 			c.Status(http.StatusBadRequest)
 			return
 		}
 
 		usecase := usecasesWithCreds(ctx, uc).NewInboxUsecase()
-		inboxes, err := usecase.BulkUpdateInboxSla(ctx, organizationId, dto.AdaptBulkUpdateInboxSlaInput(input))
+		inboxes, err := usecase.BulkUpdateInbox(ctx, organizationId, dto.AdaptBulkUpdateInboxInput(input))
 		if presentError(ctx, c, err) {
 			return
 		}

--- a/api/handle_inboxes.go
+++ b/api/handle_inboxes.go
@@ -336,3 +336,27 @@ func handleDeleteInboxUser(uc usecases.Usecases) func(c *gin.Context) {
 		c.Status(http.StatusOK)
 	}
 }
+
+func handleBulkUpdateInboxSla(uc usecases.Usecases) func(c *gin.Context) {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+		organizationId, err := utils.OrganizationIdFromRequest(c.Request)
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		var input dto.BulkUpdateInboxSlaInput
+		if err := c.ShouldBind(&input); err != nil {
+			c.Status(http.StatusBadRequest)
+			return
+		}
+
+		usecase := usecasesWithCreds(ctx, uc).NewInboxUsecase()
+		inboxes, err := usecase.BulkUpdateInboxSla(ctx, organizationId, dto.AdaptBulkUpdateInboxSlaInput(input))
+		if presentError(ctx, c, err) {
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{"inboxes": pure_utils.Map(inboxes, dto.AdaptInboxDto)})
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -329,6 +329,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.GET("/inboxes", tom, handleListInboxes(uc))
 	router.GET("/inboxes/metadata", tom, handleListInboxesMetadata(uc))
 	router.POST("/inboxes", tom, handlePostInbox(uc))
+	router.PATCH("/inboxes", tom, handleBulkUpdateInboxSla(uc))
 	router.GET("/inbox_users", tom, handleListAllInboxUsers(uc))
 	router.GET("/inbox_users/:inbox_user_id", tom, handleGetInboxUserById(uc))
 	router.PATCH("/inbox_users/:inbox_user_id", tom, handlePatchInboxUser(uc))

--- a/api/routes.go
+++ b/api/routes.go
@@ -329,7 +329,7 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 	router.GET("/inboxes", tom, handleListInboxes(uc))
 	router.GET("/inboxes/metadata", tom, handleListInboxesMetadata(uc))
 	router.POST("/inboxes", tom, handlePostInbox(uc))
-	router.PATCH("/inboxes", tom, handleBulkUpdateInboxSla(uc))
+	router.PATCH("/inboxes", tom, handleBulkUpdateInbox(uc))
 	router.GET("/inbox_users", tom, handleListAllInboxUsers(uc))
 	router.GET("/inbox_users/:inbox_user_id", tom, handleGetInboxUserById(uc))
 	router.PATCH("/inbox_users/:inbox_user_id", tom, handlePatchInboxUser(uc))

--- a/dto/case_dto.go
+++ b/dto/case_dto.go
@@ -27,6 +27,7 @@ type APICase struct {
 	Boost          string               `json:"boost,omitempty"`
 	Type           string               `json:"type"`
 	ReviewLevel    *string              `json:"review_level"`
+	DueAt          *time.Time           `json:"due_at,omitempty"`
 }
 
 type APICaseWithDetails struct {
@@ -51,6 +52,7 @@ func AdaptCaseDto(c models.Case) APICase {
 		Boost:          c.Boost.String(),
 		Type:           c.Type.String(),
 		ReviewLevel:    c.ReviewLevel,
+		DueAt:          c.DueAt,
 	}
 
 	if c.SnoozedUntil != nil && c.SnoozedUntil.After(time.Now()) {

--- a/dto/inbox_dto.go
+++ b/dto/inbox_dto.go
@@ -85,7 +85,7 @@ type UpdateInboxInput struct {
 	CaseReviewManual        *bool                      `json:"case_review_manual"`
 	CaseReviewOnCaseCreated *bool                      `json:"case_review_on_case_created"`
 	CaseReviewOnEscalate    *bool                      `json:"case_review_on_escalate"`
-	Sla                     pure_utils.Null[int]      `json:"sla" binding:"omitempty,min=1"`
+	Sla                     pure_utils.Null[int]       `json:"sla" binding:"omitempty,min=1"`
 }
 
 func AdaptUpdateInboxInput(i UpdateInboxInput) models.UpdateInboxInput {

--- a/dto/inbox_dto.go
+++ b/dto/inbox_dto.go
@@ -85,6 +85,7 @@ type UpdateInboxInput struct {
 	CaseReviewManual        *bool                      `json:"case_review_manual"`
 	CaseReviewOnCaseCreated *bool                      `json:"case_review_on_case_created"`
 	CaseReviewOnEscalate    *bool                      `json:"case_review_on_escalate"`
+	Sla                     pure_utils.Null[int]      `json:"sla" binding:"omitempty,min=1"`
 }
 
 func AdaptUpdateInboxInput(i UpdateInboxInput) models.UpdateInboxInput {
@@ -95,22 +96,22 @@ func AdaptUpdateInboxInput(i UpdateInboxInput) models.UpdateInboxInput {
 		CaseReviewManual:        i.CaseReviewManual,
 		CaseReviewOnCaseCreated: i.CaseReviewOnCaseCreated,
 		CaseReviewOnEscalate:    i.CaseReviewOnEscalate,
-		Sla:                     pure_utils.Null[int]{},
+		Sla:                     i.Sla,
 	}
 }
 
-type UpdateInboxSlaItem struct {
+type UpdateInboxItem struct {
 	Id  uuid.UUID `json:"id" binding:"required"`
 	Sla *int      `json:"sla" binding:"omitempty,min=1"`
 }
 
-type BulkUpdateInboxSlaInput struct {
-	Inboxes []UpdateInboxSlaItem `json:"inboxes" binding:"required"`
+type BulkUpdateInboxInput struct {
+	Inboxes []UpdateInboxItem `json:"inboxes" binding:"required"`
 }
 
-func AdaptBulkUpdateInboxSlaInput(i BulkUpdateInboxSlaInput) []models.UpdateInboxSlaItem {
-	return pure_utils.Map(i.Inboxes, func(item UpdateInboxSlaItem) models.UpdateInboxSlaItem {
-		return models.UpdateInboxSlaItem{
+func AdaptBulkUpdateInboxInput(i BulkUpdateInboxInput) []models.UpdateInboxItem {
+	return pure_utils.Map(i.Inboxes, func(item UpdateInboxItem) models.UpdateInboxItem {
+		return models.UpdateInboxItem{
 			Id:  item.Id,
 			Sla: item.Sla,
 		}

--- a/dto/inbox_dto.go
+++ b/dto/inbox_dto.go
@@ -17,6 +17,7 @@ type InboxDto struct {
 	EscalationInboxId *uuid.UUID     `json:"escalation_inbox_id"`
 	AutoAssignEnabled bool           `json:"auto_assign_enabled"`
 	Users             []InboxUserDto `json:"users"`
+	Sla               *int           `json:"sla"`
 
 	CaseReviewManual        bool `json:"case_review_manual"`
 	CaseReviewOnCaseCreated bool `json:"case_review_on_case_created"`
@@ -35,6 +36,7 @@ func AdaptInboxDto(i models.Inbox) InboxDto {
 		EscalationInboxId:       i.EscalationInboxId,
 		AutoAssignEnabled:       i.AutoAssignEnabled,
 		Users:                   pure_utils.Map(i.InboxUsers, AdaptInboxUserDto),
+		Sla:                     i.Sla,
 		CaseReviewManual:        i.CaseReviewManual,
 		CaseReviewOnCaseCreated: i.CaseReviewOnCaseCreated,
 		CaseReviewOnEscalate:    i.CaseReviewOnEscalate,
@@ -93,5 +95,24 @@ func AdaptUpdateInboxInput(i UpdateInboxInput) models.UpdateInboxInput {
 		CaseReviewManual:        i.CaseReviewManual,
 		CaseReviewOnCaseCreated: i.CaseReviewOnCaseCreated,
 		CaseReviewOnEscalate:    i.CaseReviewOnEscalate,
+		Sla:                     pure_utils.Null[int]{},
 	}
+}
+
+type UpdateInboxSlaItem struct {
+	Id  uuid.UUID `json:"id" binding:"required"`
+	Sla *int      `json:"sla" binding:"omitempty,min=1"`
+}
+
+type BulkUpdateInboxSlaInput struct {
+	Inboxes []UpdateInboxSlaItem `json:"inboxes" binding:"required"`
+}
+
+func AdaptBulkUpdateInboxSlaInput(i BulkUpdateInboxSlaInput) []models.UpdateInboxSlaItem {
+	return pure_utils.Map(i.Inboxes, func(item UpdateInboxSlaItem) models.UpdateInboxSlaItem {
+		return models.UpdateInboxSlaItem{
+			Id:  item.Id,
+			Sla: item.Sla,
+		}
+	})
 }

--- a/models/case.go
+++ b/models/case.go
@@ -58,6 +58,7 @@ type Case struct {
 	Boost                *BoostReason
 	Type                 CaseType
 	ReviewLevel          *string
+	DueAt                *time.Time
 }
 
 type CaseReferents struct {
@@ -309,4 +310,14 @@ func CaseMassUpdateActionFromString(s string) CaseMassUpdateAction {
 	default:
 		return CaseMassUpdateUnknown
 	}
+}
+
+// ComputeSlaDueAt computes the SLA due date as created_at + sla days.
+// Returns nil if sla is nil or zero.
+func ComputeSlaDueAt(createdAt time.Time, sla *int) *time.Time {
+	if sla == nil || *sla == 0 {
+		return nil
+	}
+	dueAt := createdAt.AddDate(0, 0, *sla)
+	return &dueAt
 }

--- a/models/inbox.go
+++ b/models/inbox.go
@@ -25,6 +25,7 @@ type Inbox struct {
 	UpdatedAt         time.Time
 	InboxUsers        []InboxUser
 	CasesCount        *int
+	Sla               *int
 
 	// Fields for case review (automatic or manual) settings. May be moved to a separate implementation if or when
 	// we have more advanced automations implemented on cases.
@@ -60,4 +61,10 @@ type UpdateInboxInput struct {
 	CaseReviewManual        *bool                      `json:"case_review_manual"`
 	CaseReviewOnCaseCreated *bool                      `json:"case_review_on_case_created"`
 	CaseReviewOnEscalate    *bool                      `json:"case_review_on_escalate"`
+	Sla                     pure_utils.Null[int]       `json:"sla"`
+}
+
+type UpdateInboxSlaItem struct {
+	Id  uuid.UUID
+	Sla *int
 }

--- a/models/inbox.go
+++ b/models/inbox.go
@@ -64,7 +64,7 @@ type UpdateInboxInput struct {
 	Sla                     pure_utils.Null[int]       `json:"sla"`
 }
 
-type UpdateInboxSlaItem struct {
+type UpdateInboxItem struct {
 	Id  uuid.UUID
 	Sla *int
 }

--- a/repositories/dbmodels/db_inbox.go
+++ b/repositories/dbmodels/db_inbox.go
@@ -19,6 +19,7 @@ type DBInbox struct {
 	Status            string     `db:"status"`
 	EscalationInboxId *uuid.UUID `db:"escalation_inbox_id"`
 	AutoAssignEnabled bool       `db:"auto_assign_enabled"`
+	Sla               *int       `db:"sla"`
 
 	// Fields for case review (automatic or manual) settings. May be moved to a separate implementation if or when
 	// we have more advanced automations implemented on cases.
@@ -41,6 +42,7 @@ func AdaptInbox(db DBInbox) (models.Inbox, error) {
 		Status:                  models.InboxStatus(db.Status),
 		EscalationInboxId:       db.EscalationInboxId,
 		AutoAssignEnabled:       db.AutoAssignEnabled,
+		Sla:                     db.Sla,
 		CaseReviewManual:        db.CaseReviewManual,
 		CaseReviewOnCaseCreated: db.CaseReviewOnCaseCreated,
 		CaseReviewOnEscalate:    db.CaseReviewOnEscalate,

--- a/repositories/inboxes_repository.go
+++ b/repositories/inboxes_repository.go
@@ -159,6 +159,14 @@ func (repo *MarbleDbRepository) UpdateInbox(
 		sql = sql.Set("case_review_on_escalate", *input.CaseReviewOnEscalate)
 		hasUpdates = true
 	}
+	if input.Sla.Set {
+		if input.Sla.Valid {
+			sql = sql.Set("sla", input.Sla.Value())
+		} else {
+			sql = sql.Set("sla", nil)
+		}
+		hasUpdates = true
+	}
 
 	if !hasUpdates {
 		return nil

--- a/repositories/migrations/20260803134500_add_inbox_sla.sql
+++ b/repositories/migrations/20260803134500_add_inbox_sla.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+alter table inboxes
+    add column sla integer,
+    add constraint inboxes_sla_check check (sla is null or sla >= 1);
+
+-- +goose Down
+alter table inboxes
+    drop constraint inboxes_sla_check,
+    drop column sla;

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -232,6 +232,15 @@ func (usecase *CaseUseCase) ListCases(
 				return models.CaseListPage{}, nil
 			}
 
+			slaMap, err := usecase.getInboxSlaMap(ctx, tx, organizationId)
+			if err != nil {
+				return models.CaseListPage{}, err
+			}
+
+			for i := range cases {
+				cases[i].DueAt = models.ComputeSlaDueAt(cases[i].CreatedAt, slaMap[cases[i].InboxId])
+			}
+
 			hasNextPage := len(cases) > pagination.Limit
 			if hasNextPage {
 				cases = cases[:len(cases)-1]
@@ -334,6 +343,18 @@ func (usecase *CaseUseCase) getAvailableInboxIds(ctx context.Context, exec repos
 	return availableInboxIds, nil
 }
 
+func (usecase *CaseUseCase) getInboxSlaMap(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (map[uuid.UUID]*int, error) {
+	inboxes, err := usecase.inboxReader.ListInboxes(ctx, exec, orgId, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list inboxes for SLA map")
+	}
+	m := make(map[uuid.UUID]*int, len(inboxes))
+	for _, ib := range inboxes {
+		m[ib.Id] = ib.Sla
+	}
+	return m, nil
+}
+
 func (usecase *CaseUseCase) GetCase(ctx context.Context, caseId string) (models.Case, error) {
 	exec := usecase.executorFactory.NewExecutor()
 	c, err := usecase.getCaseWithDetails(ctx, exec, caseId)
@@ -372,6 +393,17 @@ func (usecase *CaseUseCase) GetEntityRelatedCases(ctx context.Context, objectTyp
 		if err := usecase.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), availableInboxIds); err == nil {
 			allowedCases = append(allowedCases, c)
 		}
+	}
+
+	// Fetch SLA map for computing due dates
+	slaMap, err := usecase.getInboxSlaMap(ctx, exec, orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute due dates for all cases
+	for i := range allowedCases {
+		allowedCases[i].DueAt = models.ComputeSlaDueAt(allowedCases[i].CreatedAt, slaMap[allowedCases[i].InboxId])
 	}
 
 	return allowedCases, nil
@@ -1456,6 +1488,12 @@ func (usecase *CaseUseCase) getCaseWithDetails(ctx context.Context, exec reposit
 	}
 	c.Events = events
 
+	inbox, err := usecase.inboxReader.GetInboxById(ctx, exec, c.InboxId)
+	if err != nil {
+		return models.Case{}, errors.Wrap(err, "could not fetch inbox for SLA calculation")
+	}
+	c.DueAt = models.ComputeSlaDueAt(c.CreatedAt, inbox.Sla)
+
 	return c, nil
 }
 
@@ -2079,6 +2117,15 @@ func (usecase *CaseUseCase) GetRelatedCasesByPivotValue(ctx context.Context, org
 		}
 	}
 
+	slaMap, err := usecase.getInboxSlaMap(ctx, exec, orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range allowedCases {
+		allowedCases[i].DueAt = models.ComputeSlaDueAt(allowedCases[i].CreatedAt, slaMap[allowedCases[i].InboxId])
+	}
+
 	return allowedCases, nil
 }
 
@@ -2124,6 +2171,15 @@ func (usecase *CaseUseCase) GetRelatedContinuousScreeningCasesByObjectAttr(
 		if err := usecase.enforceSecurity.ReadOrUpdateCase(c.GetMetadata(), availableInboxIds); err == nil {
 			allowedCases = append(allowedCases, c)
 		}
+	}
+
+	slaMap, err := usecase.getInboxSlaMap(ctx, exec, orgId)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range allowedCases {
+		allowedCases[i].DueAt = models.ComputeSlaDueAt(allowedCases[i].CreatedAt, slaMap[allowedCases[i].InboxId])
 	}
 
 	return allowedCases, nil

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -132,13 +132,13 @@ func (usecase *InboxUsecase) CreateInboxWithExecutor(
 	return inbox, nil
 }
 
-func (usecase *InboxUsecase) updateSingleInboxWithValidation(
+func (usecase *InboxUsecase) updateSingleInbox(
 	ctx context.Context,
-	tx repositories.Transaction,
+	exec repositories.Executor,
 	inboxId uuid.UUID,
 	input models.UpdateInboxInput,
 ) (models.Inbox, error) {
-	inbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
+	inbox, err := usecase.inboxRepository.GetInboxById(ctx, exec, inboxId)
 	if err != nil {
 		return models.Inbox{}, err
 	}
@@ -153,7 +153,7 @@ func (usecase *InboxUsecase) updateSingleInboxWithValidation(
 	}
 
 	if input.EscalationInboxId.Set && input.EscalationInboxId.Valid {
-		escalationInbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, input.EscalationInboxId.Value())
+		escalationInbox, err := usecase.inboxRepository.GetInboxById(ctx, exec, input.EscalationInboxId.Value())
 		if err != nil {
 			return models.Inbox{}, err
 		}
@@ -162,20 +162,15 @@ func (usecase *InboxUsecase) updateSingleInboxWithValidation(
 		}
 	}
 
-	if err := usecase.inboxRepository.UpdateInbox(ctx, tx, inboxId, input); err != nil {
+	if err := usecase.inboxRepository.UpdateInbox(ctx, exec, inboxId, input); err != nil {
 		return models.Inbox{}, err
 	}
 
-	return usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
+	return usecase.inboxRepository.GetInboxById(ctx, exec, inboxId)
 }
 
 func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId uuid.UUID, input models.UpdateInboxInput) (models.Inbox, error) {
-	inbox, err := executor_factory.TransactionReturnValue(
-		ctx,
-		usecase.transactionFactory,
-		func(tx repositories.Transaction) (models.Inbox, error) {
-			return usecase.updateSingleInboxWithValidation(ctx, tx, inboxId, input)
-		})
+	inbox, err := usecase.updateSingleInbox(ctx, usecase.executorFactory.NewExecutor(), inboxId, input)
 	if err != nil {
 		return models.Inbox{}, err
 	}
@@ -237,7 +232,7 @@ func (usecase *InboxUsecase) BulkUpdateInbox(ctx context.Context, orgId uuid.UUI
 				input := models.UpdateInboxInput{
 					Sla: pure_utils.NullFromPtr(item.Sla),
 				}
-				updatedInbox, err := usecase.updateSingleInboxWithValidation(ctx, tx, item.Id, input)
+				updatedInbox, err := usecase.updateSingleInbox(ctx, tx, item.Id, input)
 				if err != nil {
 					return nil, err
 				}

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -132,40 +132,49 @@ func (usecase *InboxUsecase) CreateInboxWithExecutor(
 	return inbox, nil
 }
 
+func (usecase *InboxUsecase) updateSingleInboxWithValidation(
+	ctx context.Context,
+	tx repositories.Transaction,
+	inboxId uuid.UUID,
+	input models.UpdateInboxInput,
+) (models.Inbox, error) {
+	inbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
+	if err != nil {
+		return models.Inbox{}, err
+	}
+
+	if inbox.Status != models.InboxStatusActive {
+		return models.Inbox{}, errors.Wrap(models.ForbiddenError,
+			"This inbox is archived and cannot be updated")
+	}
+
+	if err := usecase.enforceSecurity.UpdateInbox(inbox); err != nil {
+		return models.Inbox{}, err
+	}
+
+	if input.EscalationInboxId.Set && input.EscalationInboxId.Valid {
+		escalationInbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, input.EscalationInboxId.Value())
+		if err != nil {
+			return models.Inbox{}, err
+		}
+		if err := usecase.enforceSecurity.ReadInbox(escalationInbox); err != nil {
+			return models.Inbox{}, err
+		}
+	}
+
+	if err := usecase.inboxRepository.UpdateInbox(ctx, tx, inboxId, input); err != nil {
+		return models.Inbox{}, err
+	}
+
+	return usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
+}
+
 func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId uuid.UUID, input models.UpdateInboxInput) (models.Inbox, error) {
 	inbox, err := executor_factory.TransactionReturnValue(
 		ctx,
 		usecase.transactionFactory,
 		func(tx repositories.Transaction) (models.Inbox, error) {
-			inbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
-			if err != nil {
-				return models.Inbox{}, err
-			}
-
-			if inbox.Status != models.InboxStatusActive {
-				return models.Inbox{}, errors.Wrap(models.ForbiddenError,
-					"This inbox is archived and cannot be updated")
-			}
-
-			if err := usecase.enforceSecurity.UpdateInbox(inbox); err != nil {
-				return models.Inbox{}, err
-			}
-
-			if input.EscalationInboxId.Set && input.EscalationInboxId.Valid {
-				escalationInbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, input.EscalationInboxId.Value())
-				if err != nil {
-					return models.Inbox{}, err
-				}
-				if err := usecase.enforceSecurity.ReadInbox(escalationInbox); err != nil {
-					return models.Inbox{}, err
-				}
-			}
-
-			if err := usecase.inboxRepository.UpdateInbox(ctx, tx, inboxId, input); err != nil {
-				return models.Inbox{}, err
-			}
-
-			return usecase.inboxRepository.GetInboxById(ctx, tx, inboxId)
+			return usecase.updateSingleInboxWithValidation(ctx, tx, inboxId, input)
 		})
 	if err != nil {
 		return models.Inbox{}, err
@@ -218,31 +227,17 @@ func (usecase *InboxUsecase) DeleteInbox(ctx context.Context, inboxId uuid.UUID)
 	return nil
 }
 
-func (usecase *InboxUsecase) BulkUpdateInboxSla(ctx context.Context, orgId uuid.UUID, items []models.UpdateInboxSlaItem) ([]models.Inbox, error) {
+func (usecase *InboxUsecase) BulkUpdateInbox(ctx context.Context, orgId uuid.UUID, items []models.UpdateInboxItem) ([]models.Inbox, error) {
 	inboxes, err := executor_factory.TransactionReturnValue(
 		ctx,
 		usecase.transactionFactory,
 		func(tx repositories.Transaction) ([]models.Inbox, error) {
 			updated := make([]models.Inbox, 0, len(items))
 			for _, item := range items {
-				if item.Sla != nil && *item.Sla < 1 {
-					return nil, errors.Wrap(models.BadParameterError, "sla must be null or >= 1")
+				input := models.UpdateInboxInput{
+					Sla: pure_utils.NullFromPtr(item.Sla),
 				}
-				inbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, item.Id)
-				if err != nil {
-					return nil, err
-				}
-				if inbox.Status != models.InboxStatusActive {
-					return nil, errors.Wrap(models.ForbiddenError, "This inbox is archived and cannot be updated")
-				}
-				if err := usecase.enforceSecurity.UpdateInbox(inbox); err != nil {
-					return nil, err
-				}
-				if err := usecase.inboxRepository.UpdateInbox(ctx, tx, item.Id,
-					models.UpdateInboxInput{Sla: pure_utils.NullFromPtr(item.Sla)}); err != nil {
-					return nil, err
-				}
-				updatedInbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, item.Id)
+				updatedInbox, err := usecase.updateSingleInboxWithValidation(ctx, tx, item.Id, input)
 				if err != nil {
 					return nil, err
 				}

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -170,7 +170,12 @@ func (usecase *InboxUsecase) updateSingleInbox(
 }
 
 func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId uuid.UUID, input models.UpdateInboxInput) (models.Inbox, error) {
-	inbox, err := usecase.updateSingleInbox(ctx, usecase.executorFactory.NewExecutor(), inboxId, input)
+	inbox, err := executor_factory.TransactionReturnValue(
+		ctx,
+		usecase.transactionFactory,
+		func(tx repositories.Transaction) (models.Inbox, error) {
+			return usecase.updateSingleInbox(ctx, tx, inboxId, input)
+		})
 	if err != nil {
 		return models.Inbox{}, err
 	}

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -135,12 +135,17 @@ func (usecase *InboxUsecase) CreateInboxWithExecutor(
 func (usecase *InboxUsecase) updateSingleInbox(
 	ctx context.Context,
 	exec repositories.Executor,
+	orgId uuid.UUID,
 	inboxId uuid.UUID,
 	input models.UpdateInboxInput,
 ) (models.Inbox, error) {
 	inbox, err := usecase.inboxRepository.GetInboxById(ctx, exec, inboxId)
 	if err != nil {
 		return models.Inbox{}, err
+	}
+
+	if inbox.OrganizationId != orgId {
+		return models.Inbox{}, models.NotFoundError
 	}
 
 	if inbox.Status != models.InboxStatusActive {
@@ -157,6 +162,11 @@ func (usecase *InboxUsecase) updateSingleInbox(
 		if err != nil {
 			return models.Inbox{}, err
 		}
+
+		if escalationInbox.OrganizationId != orgId {
+			return models.Inbox{}, models.NotFoundError
+		}
+
 		if err := usecase.enforceSecurity.ReadInbox(escalationInbox); err != nil {
 			return models.Inbox{}, err
 		}
@@ -174,7 +184,7 @@ func (usecase *InboxUsecase) UpdateInbox(ctx context.Context, inboxId uuid.UUID,
 		ctx,
 		usecase.transactionFactory,
 		func(tx repositories.Transaction) (models.Inbox, error) {
-			return usecase.updateSingleInbox(ctx, tx, inboxId, input)
+			return usecase.updateSingleInbox(ctx, tx, usecase.credentials.OrganizationId, inboxId, input)
 		})
 	if err != nil {
 		return models.Inbox{}, err
@@ -237,7 +247,7 @@ func (usecase *InboxUsecase) BulkUpdateInbox(ctx context.Context, orgId uuid.UUI
 				input := models.UpdateInboxInput{
 					Sla: pure_utils.NullFromPtr(item.Sla),
 				}
-				updatedInbox, err := usecase.updateSingleInbox(ctx, tx, item.Id, input)
+				updatedInbox, err := usecase.updateSingleInbox(ctx, tx, orgId, item.Id, input)
 				if err != nil {
 					return nil, err
 				}

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -218,6 +218,50 @@ func (usecase *InboxUsecase) DeleteInbox(ctx context.Context, inboxId uuid.UUID)
 	return nil
 }
 
+func (usecase *InboxUsecase) BulkUpdateInboxSla(ctx context.Context, orgId uuid.UUID, items []models.UpdateInboxSlaItem) ([]models.Inbox, error) {
+	inboxes, err := executor_factory.TransactionReturnValue(
+		ctx,
+		usecase.transactionFactory,
+		func(tx repositories.Transaction) ([]models.Inbox, error) {
+			updated := make([]models.Inbox, 0, len(items))
+			for _, item := range items {
+				if item.Sla != nil && *item.Sla < 1 {
+					return nil, errors.Wrap(models.BadParameterError, "sla must be null or >= 1")
+				}
+				inbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, item.Id)
+				if err != nil {
+					return nil, err
+				}
+				if inbox.Status != models.InboxStatusActive {
+					return nil, errors.Wrap(models.ForbiddenError, "This inbox is archived and cannot be updated")
+				}
+				if err := usecase.enforceSecurity.UpdateInbox(inbox); err != nil {
+					return nil, err
+				}
+				if err := usecase.inboxRepository.UpdateInbox(ctx, tx, item.Id,
+					models.UpdateInboxInput{Sla: pure_utils.NullFromPtr(item.Sla)}); err != nil {
+					return nil, err
+				}
+				updatedInbox, err := usecase.inboxRepository.GetInboxById(ctx, tx, item.Id)
+				if err != nil {
+					return nil, err
+				}
+				updated = append(updated, updatedInbox)
+			}
+			return updated, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, inbox := range inboxes {
+		tracking.TrackEvent(ctx, models.AnalyticsInboxUpdated, map[string]interface{}{
+			"inbox_id": inbox.Id,
+		})
+	}
+	return inboxes, nil
+}
+
 func (usecase *InboxUsecase) GetInboxUserById(ctx context.Context, inboxUserId uuid.UUID) (models.InboxUser, error) {
 	return usecase.inboxUsers.GetInboxUserById(ctx, inboxUserId)
 }


### PR DESCRIPTION
This PR introduces Service Level Agreement (SLA) functionality to inboxes, allowing teams to configure response time expectations for cases.

## Features

- SLA Configuration: Inbox admins can now set an SLA duration (in days, >= 1) via a new bulk update endpoint PATCH /inboxes. The SLA value is nullable to allow disabling SLAs.
- Case Due Dates: Every case response now includes a computed due_at field, calculated as created_at + inbox.sla_days using calendar days arithmetic.
- Efficient Data Loading: Single-case fetches compute due_at with one additional inbox lookup; list endpoints batch-load all inbox SLAs in a single query to avoid N+1 problems.
- Atomic Bulk Updates: The bulk SLA update endpoint guarantees atomicity—all inboxes are updated successfully or none are updated.

## Technical Details

- Database: Added nullable sla integer column to inboxes table with CHECK constraint (sla IS NULL OR sla >= 1).
- Validation: SLA values are validated at both the DTO layer (binding tags) and usecase layer (manual checks).
- API: Internal API only (public API unchanged); due_at is omitted from responses when the case's inbox has no SLA configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure and update SLA targets for one or multiple inboxes.
  * Clear or update SLA settings with validation.
  * Cases now display calculated due dates based on inbox SLA settings.
* **Bug Fixes**
  * Improved inbox update validation and access checks.
  * Case due dates now reflect related inbox SLA settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->