### PR TITLE
fix: prompt version selection, bad comparaison

### DIFF
--- a/pure_utils/prompt_version.go
+++ b/pure_utils/prompt_version.go
@@ -10,11 +10,22 @@ import (
 // used - never a newer one). Returns "" (not an error) if nothing qualifies, including when
 // availableDirNames is empty - callers decide how to treat that (e.g. map it to a not-found
 // error, or to "no local prompts available").
+//
+// requestedVersion's prerelease tag, if any (e.g. "1.7.0-rc.1"), is stripped before comparing:
+// prompts are only ever versioned at Major.Minor granularity, so a prerelease build is treated
+// as equivalent to its final release for this purpose - a 1.7.0-rc.1 build can resolve to
+// "v1.7" the same as a 1.7.0 build would, rather than being forced back to "v1.6" just because
+// semver orders prereleases below their release.
 func ResolveBestPromptVersion(availableDirNames []string, requestedVersion string) (string, error) {
 	reqV, err := semver.NewVersion(requestedVersion)
 	if err != nil {
 		return "", err
 	}
+	reqVWithoutPrerelease, err := reqV.SetPrerelease("")
+	if err != nil {
+		return "", err
+	}
+	reqV = &reqVWithoutPrerelease
 
 	var bestVersion *semver.Version
 	for _, name := range availableDirNames {

--- a/pure_utils/prompt_version_test.go
+++ b/pure_utils/prompt_version_test.go
@@ -48,4 +48,22 @@ func Test_ResolveBestPromptVersion(t *testing.T) {
 		_, err := ResolveBestPromptVersion([]string{"v1.0"}, "not-a-version")
 		require.Error(t, err)
 	})
+
+	t.Run("prerelease requested version is treated as its release for exact match", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.6", "v1.7"}, "1.7.0-rc.1")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.7", best)
+	})
+
+	t.Run("prerelease requested version falls back to nearest earlier when its release isn't published yet", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.6"}, "1.7.0-rc.1")
+		require.NoError(t, err)
+		assert.Equal(t, "v1.6", best)
+	})
+
+	t.Run("prerelease requested version below everything resolves to nothing", func(t *testing.T) {
+		best, err := ResolveBestPromptVersion([]string{"v1.8"}, "1.7.0-rc.1")
+		require.NoError(t, err)
+		assert.Equal(t, "", best)
+	})
 }


### PR DESCRIPTION
Since we deploy the `rc` version before the official release, all versions with a prerelease part or "suffix" are considered before those without.

For example, `v1.7.0` is considered before `v1.7.0-xxxxx`.

Therefore, in production, the prompt folder is not correctly fetched and used, resulting in the use of an outdated version that may be incompatible depending on the changes made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt version selection for prerelease requests by matching them with the corresponding stable release when available.
  * Added fallback handling for prerelease versions when only earlier releases exist.
  * Correctly returns no matching version when a prerelease is older than all available candidates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->