### PR TITLE
fix: process large csv file

### DIFF
--- a/integration_test/batch_ingestion_and_execution_test.go
+++ b/integration_test/batch_ingestion_and_execution_test.go
@@ -81,10 +81,13 @@ a8ca9ad7-1581-44f8-89d0-1f00500f2d02,2024-08-11T22:47:00Z,7b7ffdbc-cf98-48cb-a46
 	}
 	fmt.Printf("Created upload log %s in pending state", log.Id)
 
-	err = ingestionUsecase.IngestDataFromCsvByUploadLogId(ctx, log.Id, models.IngestionOptions{})
+	// The context carries no deadline here, so the ingestion runs to completion instead of
+	// checkpointing and asking to be resumed.
+	outcome, err := ingestionUsecase.IngestDataFromCsvByUploadLogId(ctx, log.Id, models.IngestionOptions{})
 	if err != nil {
 		assert.FailNow(t, "Failed to ingest data from csv file", err)
 	}
+	assert.Equal(t, models.CsvIngestionCompleted, outcome, "ingestion should have completed in one pass")
 
 	logs, err := ingestionUsecase.ListUploadLogs(ctx, organizationId, "transactions")
 	if err != nil {

--- a/mocks/upload_log_repository.go
+++ b/mocks/upload_log_repository.go
@@ -24,7 +24,14 @@ func (r *UploadLogRepository) UpdateUploadLogStatus(ctx context.Context, exec re
 	return true, args.Error(0)
 }
 
-func (r *UploadLogRepository) UploadLogById(ctx context.Context, exec repositories.Executor, id string) (models.UploadLog, error) {
+func (r *UploadLogRepository) SaveUploadLogCheckpoint(ctx context.Context, exec repositories.Executor,
+	id uuid.UUID, byteOffset int64, rowsIngested int,
+) error {
+	args := r.Called(ctx, exec, id, byteOffset, rowsIngested)
+	return args.Error(0)
+}
+
+func (r *UploadLogRepository) UploadLogById(ctx context.Context, exec repositories.Executor, id uuid.UUID) (models.UploadLog, error) {
 	args := r.Called(ctx, exec, id)
 	return args.Get(0).(models.UploadLog), args.Error(1)
 }

--- a/mocks/upload_log_repository.go
+++ b/mocks/upload_log_repository.go
@@ -36,6 +36,18 @@ func (r *UploadLogRepository) UploadLogById(ctx context.Context, exec repositori
 	return args.Get(0).(models.UploadLog), args.Error(1)
 }
 
+func (r *UploadLogRepository) ListUploadLogs(
+	ctx context.Context,
+	exec repositories.Executor,
+	organizationId uuid.UUID,
+	tableName string,
+	filters models.UploadLogFilters,
+	pagination models.PaginationAndSorting,
+) ([]models.UploadLog, error) {
+	args := r.Called(ctx, exec, organizationId, tableName, filters, pagination)
+	return args.Get(0).([]models.UploadLog), args.Error(1)
+}
+
 func (r *UploadLogRepository) AllUploadLogsByTable(
 	ctx context.Context,
 	exec repositories.Executor,

--- a/models/upload_log.go
+++ b/models/upload_log.go
@@ -21,9 +21,26 @@ type UploadLog struct {
 	FinishedAt     *time.Time
 	LinesProcessed int
 	RowsIngested   int
-	InputError     *string
-	Error          *string
+	// ByteOffset is the offset of the first CSV row not yet ingested. Zero means the file has not
+	// been read yet; ingestion resumes from here when a previous attempt ran out of time.
+	ByteOffset int64
+	InputError *string
+	Error      *string
 }
+
+// CsvIngestionOutcome tells the CsvIngestionWorker whether an upload log is done with or whether it
+// ran out of time and should be resumed from its checkpoint on a later attempt. It exists so the
+// ingestion usecase does not have to return river.JobSnooze itself.
+type CsvIngestionOutcome int
+
+const (
+	// CsvIngestionCompleted means there is nothing left to do for this upload log, either because
+	// it finished, failed, or was already in a terminal state.
+	CsvIngestionCompleted CsvIngestionOutcome = iota
+	// CsvIngestionIncomplete means the file was checkpointed part-way through and the job should be
+	// snoozed so a later attempt picks up from the saved offset.
+	CsvIngestionIncomplete
+)
 
 type UploadStatus string
 

--- a/pure_utils/clean_bom.go
+++ b/pure_utils/clean_bom.go
@@ -12,14 +12,23 @@ const (
 )
 
 func NewReaderWithoutBom(r io.Reader) io.Reader {
+	reader, _ := TrimBom(r)
+	return reader
+}
+
+// TrimBom behaves like NewReaderWithoutBom and additionally reports how many bytes it discarded
+// (0 or 3). Callers that track absolute byte offsets into the file need that count: the returned
+// reader starts after the BOM, so offsets measured on it are short by exactly this many bytes.
+func TrimBom(r io.Reader) (io.Reader, int64) {
 	buf := bufio.NewReader(r)
 	b, err := buf.Peek(3)
 	if err != nil {
 		// not enough bytes
-		return buf
+		return buf, 0
 	}
 	if b[0] == bom0 && b[1] == bom1 && b[2] == bom2 {
 		_, _ = buf.Discard(3)
+		return buf, 3
 	}
-	return buf
+	return buf, 0
 }

--- a/repositories/dbmodels/db_upload_logs.go
+++ b/repositories/dbmodels/db_upload_logs.go
@@ -19,6 +19,7 @@ type DBUploadLog struct {
 	FinishedAt      *time.Time `db:"finished_at"`
 	LinesProcessed  int        `db:"lines_processed"`
 	NumRowsIngested int        `db:"num_rows_ingested"`
+	ByteOffset      int64      `db:"byte_offset"`
 	InputError      *string    `db:"input_error"`
 	Error           *string    `db:"error"`
 }
@@ -39,6 +40,7 @@ func AdaptUploadLog(db DBUploadLog) (models.UploadLog, error) {
 		FinishedAt:     db.FinishedAt,
 		LinesProcessed: db.LinesProcessed,
 		RowsIngested:   db.NumRowsIngested,
+		ByteOffset:     db.ByteOffset,
 		InputError:     db.InputError,
 		Error:          db.Error,
 	}, nil

--- a/repositories/migrations/20260803120000_add_byte_offset_to_upload_logs.sql
+++ b/repositories/migrations/20260803120000_add_byte_offset_to_upload_logs.sql
@@ -1,9 +1,5 @@
 -- +goose Up
 
--- Byte offset of the first CSV row that has not been ingested yet, so a csv_ingestion job that
--- ran out of time can resume where it stopped instead of restarting the whole file.
--- bigint (int64) and not integer: the async upload path allows files up to 10 GiB, well past the
--- 2 GiB ceiling of int32.
 alter table upload_logs
     add column byte_offset bigint not null default 0;
 

--- a/repositories/migrations/20260803120000_add_byte_offset_to_upload_logs.sql
+++ b/repositories/migrations/20260803120000_add_byte_offset_to_upload_logs.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Byte offset of the first CSV row that has not been ingested yet, so a csv_ingestion job that
+-- ran out of time can resume where it stopped instead of restarting the whole file.
+-- bigint (int64) and not integer: the async upload path allows files up to 10 GiB, well past the
+-- 2 GiB ceiling of int32.
+alter table upload_logs
+    add column byte_offset bigint not null default 0;
+
+-- +goose Down
+
+alter table upload_logs
+    drop column byte_offset;

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -128,7 +128,12 @@ func (repo *UploadLogRepositoryImpl) SaveUploadLogCheckpoint(
 			Set("byte_offset", byteOffset).
 			Set("num_rows_ingested", rowsIngested).
 			Where(squirrel.Eq{"id": id}).
-			Where(squirrel.Eq{"status": models.UploadProcessing}),
+			Where(squirrel.Eq{"status": models.UploadProcessing}).
+			// Never let the offset move backwards. River normally runs a single attempt of a job at a
+			// time, but that has edges — its rescuer requeues at the Timeout boundary while the previous
+			// attempt is still unwinding, and the single-job CLI path can be pointed at a running upload
+			// log — and a stale attempt rewinding the checkpoint would re-ingest everything past it.
+			Where(squirrel.LtOrEq{"byte_offset": byteOffset}),
 	)
 }
 

--- a/repositories/upload_log_repository.go
+++ b/repositories/upload_log_repository.go
@@ -14,6 +14,7 @@ import (
 type UploadLogRepository interface {
 	CreateUploadLog(ctx context.Context, exec Executor, log models.UploadLog) error
 	UpdateUploadLogStatus(ctx context.Context, exec Executor, input models.UpdateUploadLogStatusInput) (executed bool, err error)
+	SaveUploadLogCheckpoint(ctx context.Context, exec Executor, id uuid.UUID, byteOffset int64, rowsIngested int) error
 	UploadLogById(ctx context.Context, exec Executor, id uuid.UUID) (models.UploadLog, error)
 	AllUploadLogsByTable(ctx context.Context, exec Executor, organizationId uuid.UUID,
 		tableName string) ([]models.UploadLog, error)
@@ -105,6 +106,30 @@ func (repo *UploadLogRepositoryImpl) UpdateUploadLogStatus(
 	}
 
 	return tag.RowsAffected() > 0, nil
+}
+
+// SaveUploadLogCheckpoint records how far into the CSV the ingestion got, so a later attempt can
+// resume from there rather than restarting the file.
+func (repo *UploadLogRepositoryImpl) SaveUploadLogCheckpoint(
+	ctx context.Context,
+	exec Executor,
+	id uuid.UUID,
+	byteOffset int64,
+	rowsIngested int,
+) error {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return err
+	}
+
+	return ExecBuilder(
+		ctx,
+		exec,
+		NewQueryBuilder().Update(dbmodels.TABLE_UPLOAD_LOGS).
+			Set("byte_offset", byteOffset).
+			Set("num_rows_ingested", rowsIngested).
+			Where(squirrel.Eq{"id": id}).
+			Where(squirrel.Eq{"status": models.UploadProcessing}),
+	)
 }
 
 func (repo *UploadLogRepositoryImpl) UploadLogById(ctx context.Context, exec Executor, id uuid.UUID) (models.UploadLog, error) {

--- a/usecases/ingestion_csv_resume_test.go
+++ b/usecases/ingestion_csv_resume_test.go
@@ -204,15 +204,19 @@ func TestIngestionDeadline(t *testing.T) {
 			"the ingestion must give up before river cancels the job, not after")
 	})
 
-	t.Run("already past the margin", func(t *testing.T) {
-		ctx, cancel := context.WithDeadline(context.Background(),
-			time.Now().Add(CSV_INGESTION_TIMEOUT_MARGIN/2))
+	t.Run("clamps the margin when the timeout is shorter than it", func(t *testing.T) {
+		riverDeadline := time.Now().Add(CSV_INGESTION_TIMEOUT_MARGIN / 2)
+		ctx, cancel := context.WithDeadline(context.Background(), riverDeadline)
 		defer cancel()
 
 		deadline, ok := ingestionDeadline(ctx)
 		require.True(t, ok)
-		assert.True(t, time.Now().After(deadline),
-			"an attempt starting with less headroom than the margin should checkpoint after its first batch")
+		assert.True(t, deadline.After(time.Now()),
+			"a short timeout must still leave time to ingest, otherwise every attempt snoozes after one batch")
+		assert.True(t, deadline.Before(riverDeadline),
+			"the ingestion must give up before river cancels the job, not after")
+		assert.WithinDuration(t, time.Now().Add(CSV_INGESTION_TIMEOUT_MARGIN/4), deadline, time.Second,
+			"the clamped margin is half the remaining time, leaving the other half to ingest")
 	})
 }
 

--- a/usecases/ingestion_csv_resume_test.go
+++ b/usecases/ingestion_csv_resume_test.go
@@ -1,0 +1,241 @@
+package usecases
+
+import (
+	"context"
+	"encoding/csv"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/checkmarble/marble-backend/mocks"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testResumeBucket = "gs://test-ingestion"
+	testResumeKey    = "uploads/org/transactions/upload"
+)
+
+// nopSeekCloser adapts a strings.Reader to the io.ReadSeekCloser that models.Blob carries.
+type nopSeekCloser struct {
+	*strings.Reader
+}
+
+func (nopSeekCloser) Close() error { return nil }
+
+// makeHeaderReadUsecase returns a usecase whose blob repository serves `content` for the unranged
+// GetBlob that readCsvHeader performs.
+func makeHeaderReadUsecase(content string) (*IngestionUseCase, *mocks.MockBlobRepository) {
+	blobRepository := new(mocks.MockBlobRepository)
+	blobRepository.On("GetBlob", mock.Anything, testResumeBucket, testResumeKey, mock.Anything).
+		Return(models.Blob{
+			FileName:   testResumeKey,
+			ReadCloser: nopSeekCloser{strings.NewReader(content)},
+		}, nil)
+
+	return &IngestionUseCase{
+		blobRepository:     blobRepository,
+		ingestionBucketUrl: testResumeBucket,
+	}, blobRepository
+}
+
+func TestReadCsvHeader(t *testing.T) {
+	const bom = "\ufeff"
+
+	tests := []struct {
+		name       string
+		headerLine string
+	}{
+		{
+			name:       "plain LF",
+			headerLine: "object_id,updated_at,value\n",
+		},
+		{
+			name:       "CRLF",
+			headerLine: "object_id,updated_at,value\r\n",
+		},
+		{
+			// Written by Excel and other Windows tools. The BOM must be trimmed off the first header
+			// name, but must still be counted in the offset, otherwise a resume lands mid-field.
+			name:       "UTF-8 BOM",
+			headerLine: bom + "object_id,updated_at,value\n",
+		},
+		{
+			name:       "quoted header name",
+			headerLine: "object_id,\"updated_at\",value\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			content := tc.headerLine + "abc,2024-01-01T00:00:00Z,1\n"
+			uc, blobRepository := makeHeaderReadUsecase(content)
+
+			header, dataStart, err := uc.readCsvHeader(context.Background(), testResumeKey)
+			require.NoError(t, err)
+
+			assert.Equal(t, []string{"object_id", "updated_at", "value"}, header,
+				"the BOM must not leak into the first header name")
+			assert.Equal(t, int64(len(tc.headerLine)), dataStart,
+				"dataStart must be the absolute offset of the first data row, BOM included")
+
+			// The offset is only useful if it actually lands on the first data row.
+			assert.Equal(t, "abc,2024-01-01T00:00:00Z,1\n", content[dataStart:])
+
+			blobRepository.AssertExpectations(t)
+		})
+	}
+}
+
+func TestReadCsvHeaderEmptyFile(t *testing.T) {
+	uc, _ := makeHeaderReadUsecase("")
+
+	_, _, err := uc.readCsvHeader(context.Background(), testResumeKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error reading first row of CSV")
+}
+
+// TestCsvResumeFromCheckpointOffset covers the core invariant of resumable ingestion: the offset the
+// loop persists, startOffset + csv.Reader.InputOffset(), is a record boundary, so reopening the file
+// there yields every remaining row exactly once, with no gap and no duplicate.
+func TestCsvResumeFromCheckpointOffset(t *testing.T) {
+	tests := []struct {
+		name string
+		rows []string
+	}{
+		{
+			name: "plain rows",
+			rows: []string{
+				"a,2024-01-01T00:00:00Z,1\n",
+				"b,2024-01-02T00:00:00Z,2\n",
+				"c,2024-01-03T00:00:00Z,3\n",
+				"d,2024-01-04T00:00:00Z,4\n",
+			},
+		},
+		{
+			// A quoted field may contain the record separator. The checkpoint has to account for the
+			// whole record, not stop at the first newline it sees.
+			name: "quoted field containing a newline",
+			rows: []string{
+				"a,2024-01-01T00:00:00Z,1\n",
+				"b,\"2024-01-02T00:00:00Z\",\"multi\nline\"\n",
+				"c,2024-01-03T00:00:00Z,3\n",
+				"d,2024-01-04T00:00:00Z,4\n",
+			},
+		},
+		{
+			name: "no trailing newline on the last row",
+			rows: []string{
+				"a,2024-01-01T00:00:00Z,1\n",
+				"b,2024-01-02T00:00:00Z,2\n",
+				"c,2024-01-03T00:00:00Z,3",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			const headerLine = "\ufeffobject_id,updated_at,value\n"
+			content := headerLine + strings.Join(tc.rows, "")
+
+			uc, _ := makeHeaderReadUsecase(content)
+			header, dataStart, err := uc.readCsvHeader(context.Background(), testResumeKey)
+			require.NoError(t, err)
+
+			// First pass: read two records, then checkpoint exactly the way ingestObjectsFromCSV does.
+			startOffset := dataStart
+			reader := newDataReader(content, startOffset, header)
+
+			firstPass := readAll(t, reader, 2)
+			checkpoint := startOffset + reader.InputOffset()
+
+			// Second pass: resume from the checkpoint and drain the rest.
+			resumed := newDataReader(content, checkpoint, header)
+			secondPass := readAll(t, resumed, -1)
+
+			// Reading the whole file in one pass is the reference: splitting it across a checkpoint
+			// must produce exactly the same records in the same order.
+			whole := readAll(t, newDataReader(content, dataStart, header), -1)
+
+			assert.Equal(t, len(tc.rows), len(whole), "reference pass should read every row")
+			assert.Equal(t, whole, append(firstPass, secondPass...),
+				"resuming at the checkpoint must not skip or duplicate any row")
+		})
+	}
+}
+
+// TestCsvCheckpointAtEndOfFile documents why processUploadLog compares the checkpoint against the
+// blob size: after the last record, the persisted offset equals the file length, and a range read
+// starting there has nothing left to return.
+func TestCsvCheckpointAtEndOfFile(t *testing.T) {
+	const headerLine = "object_id,updated_at,value\n"
+	content := headerLine + "a,2024-01-01T00:00:00Z,1\n"
+
+	uc, _ := makeHeaderReadUsecase(content)
+	header, dataStart, err := uc.readCsvHeader(context.Background(), testResumeKey)
+	require.NoError(t, err)
+
+	reader := newDataReader(content, dataStart, header)
+	readAll(t, reader, -1)
+
+	assert.Equal(t, int64(len(content)), dataStart+reader.InputOffset(),
+		"the final checkpoint sits at EOF, which is why resuming there must be short-circuited")
+}
+
+func TestIngestionDeadline(t *testing.T) {
+	t.Run("no deadline on the context", func(t *testing.T) {
+		_, ok := ingestionDeadline(context.Background())
+		assert.False(t, ok, "without a deadline the ingestion must run to completion rather than snooze")
+	})
+
+	t.Run("reserves the margin before river cancels", func(t *testing.T) {
+		riverDeadline := time.Now().Add(time.Hour)
+		ctx, cancel := context.WithDeadline(context.Background(), riverDeadline)
+		defer cancel()
+
+		deadline, ok := ingestionDeadline(ctx)
+		require.True(t, ok)
+		assert.Equal(t, riverDeadline.Add(-CSV_INGESTION_TIMEOUT_MARGIN), deadline)
+		assert.True(t, deadline.Before(riverDeadline),
+			"the ingestion must give up before river cancels the job, not after")
+	})
+
+	t.Run("already past the margin", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(),
+			time.Now().Add(CSV_INGESTION_TIMEOUT_MARGIN/2))
+		defer cancel()
+
+		deadline, ok := ingestionDeadline(ctx)
+		require.True(t, ok)
+		assert.True(t, time.Now().After(deadline),
+			"an attempt starting with less headroom than the margin should checkpoint after its first batch")
+	})
+}
+
+// newDataReader mimics how ingestObjectsFromCSV consumes the file: a ranged read starting at an
+// explicit offset, with no header row and no BOM handling.
+func newDataReader(content string, offset int64, header []string) *csv.Reader {
+	reader := csv.NewReader(strings.NewReader(content[offset:]))
+	reader.FieldsPerRecord = len(header)
+	return reader
+}
+
+// readAll reads up to `limit` records, or every remaining record when limit is negative.
+func readAll(t *testing.T, reader *csv.Reader, limit int) [][]string {
+	t.Helper()
+
+	records := make([][]string, 0)
+	for limit < 0 || len(records) < limit {
+		record, err := reader.Read()
+		if err == io.EOF { //nolint:errorlint
+			break
+		}
+		require.NoError(t, err)
+		records = append(records, record)
+	}
+	return records
+}

--- a/usecases/ingestion_csv_resume_test.go
+++ b/usecases/ingestion_csv_resume_test.go
@@ -68,6 +68,13 @@ func TestReadCsvHeader(t *testing.T) {
 			name:       "quoted header name",
 			headerLine: "object_id,\"updated_at\",value\n",
 		},
+		{
+			// The combination that trimming the BOM off the *parsed* header name cannot handle:
+			// csv.Reader sees the BOM as the start of an unquoted first field and rejects the quote
+			// that follows it, failing the whole file. The BOM has to go before parsing.
+			name:       "UTF-8 BOM with quoted header names",
+			headerLine: bom + "\"object_id\",\"updated_at\",\"value\"\n",
+		},
 	}
 
 	for _, tc := range tests {

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -38,9 +38,11 @@ const (
 	CSV_INGESTION_ITERATION_TIMEOUT = 10 * time.Second
 
 	// CSV_INGESTION_TIMEOUT_MARGIN is the headroom reserved before river's own Timeout, so there is
-	// time to save the checkpoint and snooze before river cancels the job. It must exceed the
-	// worst-case duration of one batch: CSV_INGESTION_ITERATION_TIMEOUT times retryIngestion's
-	// attempts, plus one checkpoint write.
+	// time to save the checkpoint and snooze before river cancels the job. The deadline is only
+	// checked once a batch has committed, so the margin must cover one more full iteration: reading
+	// csvIngestionBatchSize rows off the blob reader (bounded by nothing but river's cancellation),
+	// one ingestion batch (bounded by CSV_INGESTION_ITERATION_TIMEOUT, which retryIngestion's two
+	// attempts share as a single deadline), and one checkpoint write.
 	CSV_INGESTION_TIMEOUT_MARGIN = 2 * time.Minute
 	CSV_INGESTION_SNOOZE_DELAY   = 5 * time.Second
 )
@@ -726,7 +728,11 @@ func ingestionDeadline(ctx context.Context) (time.Time, bool) {
 	if !ok {
 		return time.Time{}, false
 	}
-	return deadline.Add(-CSV_INGESTION_TIMEOUT_MARGIN), true
+	// CSV_INGESTION_TIMEOUT is configurable while the margin is not, so guard against a timeout short
+	// enough that the full margin would land before the attempt even starts: that would make every
+	// attempt snooze after a single batch and hit csvIngestionMaxSnoozes instead of ingesting.
+	margin := min(CSV_INGESTION_TIMEOUT_MARGIN, time.Until(deadline)/2)
+	return deadline.Add(-margin), true
 }
 
 type ingestionResult struct {

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -623,27 +623,46 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 		}
 	}
 
+	// failAttempt ends the attempt on an error. A cancelled job context means this attempt was cut
+	// short from the outside — a graceful worker shutdown, or river cancelling the job at its
+	// Timeout — and says nothing about the file, so the log must stay in `processing` for the next
+	// attempt to resume from its checkpoint. Marking it `failure` there would be a terminal status
+	// that makes the checkpoint unreachable, defeating the point of saving one.
+	failAttempt := func(numRowsIngested int, inputErr error, ingestErr error) (models.CsvIngestionOutcome, error) {
+		err := errors.Join(inputErr, ingestErr)
+		if ctx.Err() != nil {
+			logger.WarnContext(ctx, "csv ingestion attempt was cancelled, leaving the upload log resumable",
+				"upload_log_id", uploadLog.Id, "byte_offset", uploadLog.ByteOffset, "error", err.Error())
+			return models.CsvIngestionCompleted, err
+		}
+
+		// Failures raised before the ingestion loop is reached report zero rows; don't let that
+		// erase what previous attempts already ingested.
+		setToFailed(max(numRowsIngested, uploadLog.RowsIngested), inputErr, ingestErr)
+		return models.CsvIngestionCompleted, err
+	}
+
 	// The header is read from its own reader at the start of the file, so that the data reader can
 	// always be opened at an explicit offset and never has to deal with the header row nor with a
 	// leading BOM, whether this is a first attempt or a resume.
 	header, dataStart, err := usecase.readCsvHeader(ctx, uploadLog.FileName)
 	if err != nil {
-		setToFailed(uploadLog.RowsIngested, nil, err)
-		return models.CsvIngestionCompleted, err
+		return failAttempt(uploadLog.RowsIngested, nil, err)
 	}
 
 	startOffset := max(uploadLog.ByteOffset, dataStart)
 
 	attrs, err := usecase.blobRepository.GetBlobAttributes(ctx, usecase.ingestionBucketUrl, uploadLog.FileName)
 	if err != nil {
-		setToFailed(uploadLog.RowsIngested, nil, err)
-		return models.CsvIngestionCompleted, err
+		return failAttempt(uploadLog.RowsIngested, nil, err)
 	}
 
 	// A previous attempt may have checkpointed exactly at EOF and died before marking the log
-	// successful. Requesting a range that starts at the file size is rejected by the storage
-	// backends, so short-circuit straight to the success path: there is nothing left to read.
-	out := ingestionResult{numRowsIngested: uploadLog.RowsIngested}
+	// successful, and a header-only file has no data range at all. Requesting a range that starts at
+	// the file size is rejected by the storage backends, so feed an empty reader rather than skipping
+	// readFileIngestObjects: its validation (required fields, table exists, CanIngest) must still run,
+	// it simply has no rows left to read.
+	var dataReader io.Reader = strings.NewReader("")
 	if startOffset < attrs.Size {
 		file, err := usecase.blobRepository.GetBlob(ctx, usecase.ingestionBucketUrl, uploadLog.FileName,
 			repositories.WithBeginOffset(startOffset))
@@ -651,24 +670,21 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 			defer file.ReadCloser.Close()
 		}
 		if err != nil {
-			setToFailed(uploadLog.RowsIngested, nil, err)
-			return models.CsvIngestionCompleted, err
+			return failAttempt(uploadLog.RowsIngested, nil, err)
 		}
+		dataReader = file.ReadCloser
+	}
 
-		out = usecase.readFileIngestObjects(ctx, exec, uploadLog, header, startOffset,
-			file.ReadCloser, ingestionOptions)
-		if out.inputErr != nil || out.err != nil {
-			// Failures raised before the ingestion loop is reached report zero rows; don't let that
-			// erase what previous attempts already ingested.
-			setToFailed(max(out.numRowsIngested, uploadLog.RowsIngested), out.inputErr, out.err)
-			return models.CsvIngestionCompleted, errors.Join(out.inputErr, out.err)
-		}
+	out := usecase.readFileIngestObjects(ctx, exec, uploadLog, header, startOffset, attrs.Size,
+		dataReader, ingestionOptions)
+	if out.inputErr != nil || out.err != nil {
+		return failAttempt(out.numRowsIngested, out.inputErr, out.err)
+	}
 
-		// Out of time: the loop already saved the checkpoint, so leave the log in `processing` for a
-		// later attempt to resume from it.
-		if out.incomplete {
-			return models.CsvIngestionIncomplete, nil
-		}
+	// Out of time: the loop already saved the checkpoint, so leave the log in `processing` for a
+	// later attempt to resume from it.
+	if out.incomplete {
+		return models.CsvIngestionIncomplete, nil
 	}
 
 	currentTime := time.Now()
@@ -688,10 +704,13 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 // readCsvHeader reads the header row from the start of the file and returns it along with the
 // absolute byte offset at which the first data row begins.
 //
-// The reader is deliberately not wrapped in pure_utils.NewReaderWithoutBom: that wrapper discards the
-// BOM before csv.Reader sees it, which would make InputOffset() relative to the post-BOM stream and
-// leave every offset we persist 3 bytes short. Instead the BOM is trimmed off the one thing it
-// actually breaks, the first header name.
+// Excel and other Windows tools prefix UTF-8 CSVs with a BOM. It has to be discarded before parsing
+// rather than trimmed off the parsed header name, because csv.Reader treats it as part of the first
+// field: on a quoted header it turns `\ufeff"object_id"` into an unquoted field containing a bare quote
+// and fails the whole file. Only presigned uploads can carry one, since the synchronous path strips
+// it on upload. Discarding it hides those bytes from csv.Reader, so bomLen is added back to keep the
+// returned offset absolute \u2014 without it every persisted offset would be 3 bytes short and a resume
+// would restart mid-field.
 func (usecase *IngestionUseCase) readCsvHeader(ctx context.Context, fileName string) ([]string, int64, error) {
 	blob, err := usecase.blobRepository.GetBlob(ctx, usecase.ingestionBucketUrl, fileName)
 	if blob.ReadCloser != nil {
@@ -703,18 +722,14 @@ func (usecase *IngestionUseCase) readCsvHeader(ctx context.Context, fileName str
 		return nil, 0, err
 	}
 
-	csvReader := csv.NewReader(blob.ReadCloser)
+	reader, bomLen := pure_utils.TrimBom(blob.ReadCloser)
+	csvReader := csv.NewReader(reader)
 	header, err := csvReader.Read()
 	if err != nil {
 		return nil, 0, fmt.Errorf("error reading first row of CSV: %w", err)
 	}
 
-	// Excel and other Windows tools prefix UTF-8 CSVs with a BOM, which lands on the first header
-	// name and would fail the required-field check. Only files uploaded straight to blob storage
-	// through a presigned link can still carry one; the synchronous path strips it on upload.
-	header[0] = strings.TrimPrefix(header[0], "\ufeff")
-
-	return header, csvReader.InputOffset(), nil
+	return header, bomLen + csvReader.InputOffset(), nil
 }
 
 // ingestionDeadline returns the point in time past which the ingestion should checkpoint and give up
@@ -748,7 +763,7 @@ type ingestionResult struct {
 // an error occurred.
 func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
 	exec repositories.Executor, uploadLog models.UploadLog, header []string,
-	startOffset int64, fileReader io.Reader, ingestionOptions models.IngestionOptions,
+	startOffset, fileSize int64, fileReader io.Reader, ingestionOptions models.IngestionOptions,
 ) ingestionResult {
 	logger := utils.LoggerFromContext(ctx)
 	fileName := uploadLog.FileName
@@ -806,7 +821,7 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
 		}
 	}
 
-	return usecase.ingestObjectsFromCSV(ctx, organizationId, uploadLog, header, startOffset,
+	return usecase.ingestObjectsFromCSV(ctx, organizationId, uploadLog, header, startOffset, fileSize,
 		fileReader, table, ingestionOptions)
 }
 
@@ -816,6 +831,7 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 	uploadLog models.UploadLog,
 	header []string,
 	startOffset int64,
+	fileSize int64,
 	fileReader io.Reader,
 	table models.Table,
 	ingestionOptions models.IngestionOptions,
@@ -885,15 +901,27 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 
 	deadline, hasDeadline := ingestionDeadline(ctx)
 
+	// describeRow labels a row for user-facing error messages. The counter is relative to this pass,
+	// not an absolute CSV line number: after a resume the absolute number is unknowable, because
+	// num_rows_ingested counts objects inserted (IngestObjects dedupes by object_id and skips
+	// payloads older than the stored version) rather than rows read. The byte offset is reported
+	// either way so the offending row stays locatable.
+	resumed := uploadLog.ByteOffset > 0
+	describeRow := func(idx int, offset int64) string {
+		if resumed {
+			return fmt.Sprintf("row %d of the resumed pass (byte offset %d)", idx, offset)
+		}
+		return fmt.Sprintf("line %d (byte offset %d)", idx, offset)
+	}
+
 	keepParsingFile := true
-	objectIdx := previouslyIngested
+	objectIdx := 0
 	for keepParsingFile {
 		iterationCtx, iterationCancel := context.WithTimeout(ctx, CSV_INGESTION_ITERATION_TIMEOUT)
 
 		windowEnd := objectIdx + csvIngestionBatchSize
 		clientObjects := make([]models.ClientObject, 0, csvIngestionBatchSize)
 		for ; objectIdx < windowEnd; objectIdx++ {
-			logger.DebugContext(iterationCtx, fmt.Sprintf("Start reading line %v", objectIdx))
 			record, err := r.Read()
 			if err == io.EOF { //nolint:errorlint
 				keepParsingFile = false
@@ -902,8 +930,8 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 				iterationCancel()
 				return ingestionResult{
 					numRowsIngested: previouslyIngested + total,
-					err: fmt.Errorf("error reading line %d of CSV (byte offset %d): %w",
-						objectIdx, startOffset+r.InputOffset(), err),
+					err: fmt.Errorf("error reading %s of CSV: %w",
+						describeRow(objectIdx, startOffset+r.InputOffset()), err),
 				}
 			}
 
@@ -913,14 +941,19 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 				return ingestionResult{
 					numRowsIngested: previouslyIngested + total,
 					inputErr: errors.WithDetailf(err,
-						"error parsing field value in CSV at line %d (byte offset %d): %v",
-						objectIdx, startOffset+r.InputOffset(), err),
+						"error parsing field value in CSV at %s: %v",
+						describeRow(objectIdx, startOffset+r.InputOffset()), err),
 				}
 			}
-			logger.DebugContext(iterationCtx, fmt.Sprintf("Object to ingest %d: %+v", objectIdx, object))
-
 			clientObject := models.ClientObject{TableName: table.Name, Data: object}
 			clientObjects = append(clientObjects, clientObject)
+		}
+
+		// A file whose rows divide exactly into batches hits EOF on an otherwise empty iteration, and a
+		// file with no data rows at all starts on one. Nothing to ingest and nothing new to checkpoint.
+		if len(clientObjects) == 0 {
+			iterationCancel()
+			break
 		}
 
 		var ingestionResults models.IngestionResults
@@ -953,6 +986,13 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 				err:             errors.Wrap(err, "error saving upload log checkpoint"),
 			}
 		}
+
+		logger.DebugContext(ctx, "csv ingestion progress",
+			"upload_log_id", uploadLog.Id,
+			"rows_ingested", previouslyIngested+total,
+			"byte_offset", checkpoint,
+			"file_size", fileSize,
+		)
 
 		if keepParsingFile && hasDeadline && time.Now().After(deadline) {
 			logger.InfoContext(ctx, "csv ingestion: approaching job timeout, checkpointed and stopping for now",
@@ -1293,8 +1333,9 @@ func (w *CsvIngestionWorker) Timeout(job *river.Job[models.CsvIngestionArgs]) ti
 func (w *CsvIngestionWorker) Work(ctx context.Context, job *river.Job[models.CsvIngestionArgs]) error {
 	// Reading river's `snoozes` metadata counter and not job.Attempt: JobSnooze deliberately
 	// decrements Attempt so that resuming never consumes a retry, which also means an oversized file
-	// could otherwise be resumed forever.
-	if gjson.GetBytes(job.Metadata, "snoozes").Int() > int64(csvIngestionMaxSnoozes) {
+	// could otherwise be resumed forever. The counter is the number of resumes already granted, so
+	// `>=` stops on the attempt that would be the (max+1)-th rather than one past it.
+	if gjson.GetBytes(job.Metadata, "snoozes").Int() >= int64(csvIngestionMaxSnoozes) {
 		utils.LoggerFromContext(ctx).ErrorContext(ctx, "csv ingestion exceeded its maximum number of resumes",
 			"upload_log_id", job.Args.UploadLogId, "max_snoozes", csvIngestionMaxSnoozes)
 

--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/riverqueue/river"
+	"github.com/tidwall/gjson"
 	"github.com/twpayne/go-geom"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -35,9 +36,21 @@ const (
 	DefaultApiBatchIngestionSize = 100
 
 	CSV_INGESTION_ITERATION_TIMEOUT = 10 * time.Second
+
+	// CSV_INGESTION_TIMEOUT_MARGIN is the headroom reserved before river's own Timeout, so there is
+	// time to save the checkpoint and snooze before river cancels the job. It must exceed the
+	// worst-case duration of one batch: CSV_INGESTION_ITERATION_TIMEOUT times retryIngestion's
+	// attempts, plus one checkpoint write.
+	CSV_INGESTION_TIMEOUT_MARGIN = 2 * time.Minute
+	CSV_INGESTION_SNOOZE_DELAY   = 5 * time.Second
 )
 
 var csvIngestionBatchSize = utils.GetEnv("CSV_INGESTION_BATCH_SIZE", 1000)
+
+// csvIngestionMaxSnoozes bounds how many times a single upload may be resumed before we give up on
+// it. It is coupled to CSV_INGESTION_TIMEOUT (default 1h), so the default is roughly a 24h ceiling:
+// change one and revisit the other.
+var csvIngestionMaxSnoozes = utils.GetEnv("CSV_INGESTION_MAX_SNOOZES", 24)
 
 type continuousScreeningRepository interface {
 	GetOrganizationById(ctx context.Context, exec repositories.Executor, organizationId uuid.UUID) (models.Organization, error)
@@ -511,36 +524,72 @@ func (usecase *IngestionUseCase) ValidateAndUploadIngestionCsv(ctx context.Conte
 
 // IngestDataFromCsvByUploadLogId processes a single upload log by its ID.
 // This is the main entry point for the CSV ingestion worker.
+//
+// Large files may not fit in a single job attempt: the returned outcome tells the caller whether the
+// upload finished or whether it was checkpointed part-way and should be resumed later.
 func (usecase *IngestionUseCase) IngestDataFromCsvByUploadLogId(ctx context.Context,
 	uploadLogId uuid.UUID, ingestionOptions models.IngestionOptions,
-) error {
+) (models.CsvIngestionOutcome, error) {
 	logger := utils.LoggerFromContext(ctx)
 	logger.InfoContext(ctx, fmt.Sprintf("Start ingesting data from upload log %s", uploadLogId))
 
 	exec := usecase.executorFactory.NewExecutor()
 	uploadLog, err := usecase.uploadLogRepository.UploadLogById(ctx, exec, uploadLogId)
 	if err != nil {
-		return err
+		return models.CsvIngestionCompleted, err
 	}
 
 	return usecase.processUploadLog(ctx, uploadLog, ingestionOptions)
 }
 
-func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog models.UploadLog, ingestionOptions models.IngestionOptions) error {
+// FailUploadLog marks an upload log as failed from outside the ingestion loop, used when the worker
+// gives up on resuming it. byte_offset and num_rows_ingested are deliberately left untouched, so the
+// failure can be diagnosed from where the ingestion stopped.
+func (usecase *IngestionUseCase) FailUploadLog(ctx context.Context, uploadLogId uuid.UUID, reason string) error {
+	exec := usecase.executorFactory.NewExecutor()
+	finishedAt := time.Now()
+
+	_, err := usecase.uploadLogRepository.UpdateUploadLogStatus(ctx, exec, models.UpdateUploadLogStatusInput{
+		Id:                           uploadLogId,
+		CurrentUploadStatusCondition: models.UploadProcessing,
+		UploadStatus:                 models.UploadFailure,
+		FinishedAt:                   &finishedAt,
+		Error:                        &reason,
+	})
+	return err
+}
+
+func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog models.UploadLog,
+	ingestionOptions models.IngestionOptions,
+) (models.CsvIngestionOutcome, error) {
 	exec := usecase.executorFactory.NewExecutor()
 	logger := utils.LoggerFromContext(ctx)
 	logger.InfoContext(ctx, fmt.Sprintf("Start processing UploadLog %s", uploadLog.Id))
 
-	done, err := usecase.uploadLogRepository.UpdateUploadLogStatus(ctx, exec, models.UpdateUploadLogStatusInput{
-		Id:                           uploadLog.Id,
-		CurrentUploadStatusCondition: models.UploadPending,
-		UploadStatus:                 models.UploadProcessing,
-	})
-	if err != nil {
-		return err
-	} else if !done {
-		logger.InfoContext(ctx, fmt.Sprintf("UploadLog %s is no longed in pending status", uploadLog.Id))
-		return nil
+	switch uploadLog.UploadStatus {
+	case models.UploadPending:
+		done, err := usecase.uploadLogRepository.UpdateUploadLogStatus(ctx, exec, models.UpdateUploadLogStatusInput{
+			Id:                           uploadLog.Id,
+			CurrentUploadStatusCondition: models.UploadPending,
+			UploadStatus:                 models.UploadProcessing,
+		})
+		if err != nil {
+			return models.CsvIngestionCompleted, err
+		} else if !done {
+			logger.InfoContext(ctx, fmt.Sprintf("UploadLog %s is no longed in pending status", uploadLog.Id))
+			return models.CsvIngestionCompleted, nil
+		}
+	case models.UploadProcessing:
+		// Resuming: either a previous attempt snoozed itself on approaching its timeout, or it was
+		// killed mid-file and river requeued it. Either way the status is already correct and
+		// uploadLog.ByteOffset says where to pick up. River runs at most one attempt of a given job
+		// at a time, so this cannot race with another worker on the same upload log.
+		logger.InfoContext(ctx, fmt.Sprintf("Resuming UploadLog %s", uploadLog.Id),
+			"byte_offset", uploadLog.ByteOffset, "rows_ingested", uploadLog.RowsIngested)
+	default:
+		logger.InfoContext(ctx, fmt.Sprintf("UploadLog %s is in terminal status %s, nothing to do",
+			uploadLog.Id, uploadLog.UploadStatus))
+		return models.CsvIngestionCompleted, nil
 	}
 
 	setToFailed := func(numRowsIngested int, inputErr error, ingestErr error) {
@@ -572,19 +621,52 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 		}
 	}
 
-	file, err := usecase.blobRepository.GetBlob(ctx, usecase.ingestionBucketUrl, uploadLog.FileName)
-	if file.ReadCloser != nil {
-		defer file.ReadCloser.Close()
-	}
+	// The header is read from its own reader at the start of the file, so that the data reader can
+	// always be opened at an explicit offset and never has to deal with the header row nor with a
+	// leading BOM, whether this is a first attempt or a resume.
+	header, dataStart, err := usecase.readCsvHeader(ctx, uploadLog.FileName)
 	if err != nil {
-		setToFailed(0, nil, err)
-		return err
+		setToFailed(uploadLog.RowsIngested, nil, err)
+		return models.CsvIngestionCompleted, err
 	}
 
-	out := usecase.readFileIngestObjects(ctx, exec, file.FileName, file.ReadCloser, ingestionOptions)
-	if out.inputErr != nil || out.err != nil {
-		setToFailed(out.numRowsIngested, out.inputErr, out.err)
-		return errors.Join(out.inputErr, out.err)
+	startOffset := max(uploadLog.ByteOffset, dataStart)
+
+	attrs, err := usecase.blobRepository.GetBlobAttributes(ctx, usecase.ingestionBucketUrl, uploadLog.FileName)
+	if err != nil {
+		setToFailed(uploadLog.RowsIngested, nil, err)
+		return models.CsvIngestionCompleted, err
+	}
+
+	// A previous attempt may have checkpointed exactly at EOF and died before marking the log
+	// successful. Requesting a range that starts at the file size is rejected by the storage
+	// backends, so short-circuit straight to the success path: there is nothing left to read.
+	out := ingestionResult{numRowsIngested: uploadLog.RowsIngested}
+	if startOffset < attrs.Size {
+		file, err := usecase.blobRepository.GetBlob(ctx, usecase.ingestionBucketUrl, uploadLog.FileName,
+			repositories.WithBeginOffset(startOffset))
+		if file.ReadCloser != nil {
+			defer file.ReadCloser.Close()
+		}
+		if err != nil {
+			setToFailed(uploadLog.RowsIngested, nil, err)
+			return models.CsvIngestionCompleted, err
+		}
+
+		out = usecase.readFileIngestObjects(ctx, exec, uploadLog, header, startOffset,
+			file.ReadCloser, ingestionOptions)
+		if out.inputErr != nil || out.err != nil {
+			// Failures raised before the ingestion loop is reached report zero rows; don't let that
+			// erase what previous attempts already ingested.
+			setToFailed(max(out.numRowsIngested, uploadLog.RowsIngested), out.inputErr, out.err)
+			return models.CsvIngestionCompleted, errors.Join(out.inputErr, out.err)
+		}
+
+		// Out of time: the loop already saved the checkpoint, so leave the log in `processing` for a
+		// later attempt to resume from it.
+		if out.incomplete {
+			return models.CsvIngestionIncomplete, nil
+		}
 	}
 
 	currentTime := time.Now()
@@ -596,24 +678,74 @@ func (usecase *IngestionUseCase) processUploadLog(ctx context.Context, uploadLog
 		NumRowsIngested:              &out.numRowsIngested,
 	}
 	if _, err = usecase.uploadLogRepository.UpdateUploadLogStatus(ctx, exec, input); err != nil {
-		return err
+		return models.CsvIngestionCompleted, err
 	}
-	return nil
+	return models.CsvIngestionCompleted, nil
+}
+
+// readCsvHeader reads the header row from the start of the file and returns it along with the
+// absolute byte offset at which the first data row begins.
+//
+// The reader is deliberately not wrapped in pure_utils.NewReaderWithoutBom: that wrapper discards the
+// BOM before csv.Reader sees it, which would make InputOffset() relative to the post-BOM stream and
+// leave every offset we persist 3 bytes short. Instead the BOM is trimmed off the one thing it
+// actually breaks, the first header name.
+func (usecase *IngestionUseCase) readCsvHeader(ctx context.Context, fileName string) ([]string, int64, error) {
+	blob, err := usecase.blobRepository.GetBlob(ctx, usecase.ingestionBucketUrl, fileName)
+	if blob.ReadCloser != nil {
+		// Closed as soon as the header is read: the range reader streams lazily, so only the first
+		// buffered chunk of the file is ever transferred, not the whole thing.
+		defer blob.ReadCloser.Close()
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+
+	csvReader := csv.NewReader(blob.ReadCloser)
+	header, err := csvReader.Read()
+	if err != nil {
+		return nil, 0, fmt.Errorf("error reading first row of CSV: %w", err)
+	}
+
+	// Excel and other Windows tools prefix UTF-8 CSVs with a BOM, which lands on the first header
+	// name and would fail the required-field check. Only files uploaded straight to blob storage
+	// through a presigned link can still carry one; the synchronous path strips it on upload.
+	header[0] = strings.TrimPrefix(header[0], "\ufeff")
+
+	return header, csvReader.InputOffset(), nil
+}
+
+// ingestionDeadline returns the point in time past which the ingestion should checkpoint and give up
+// its attempt, keeping CSV_INGESTION_TIMEOUT_MARGIN of headroom before river cancels the job.
+//
+// It is derived from the context rather than recomputed from CsvIngestionWorker.Timeout so that the
+// margin is measured against river's actual cancellation point. Callers without a deadline (the
+// integration tests and the cmd/worker.go single-job path) run to completion and never snooze.
+func ingestionDeadline(ctx context.Context) (time.Time, bool) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return time.Time{}, false
+	}
+	return deadline.Add(-CSV_INGESTION_TIMEOUT_MARGIN), true
 }
 
 type ingestionResult struct {
 	numRowsIngested int
-	inputErr        error
-	err             error
+	// incomplete reports that the file was checkpointed part-way through because the attempt was
+	// running out of time, and that ingestion should be resumed from the saved offset.
+	incomplete bool
+	inputErr   error
+	err        error
 }
 
 // This method uses a return value wrapping an error, because we still want to use the number of rows ingested even if
 // an error occurred.
 func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
-	exec repositories.Executor, fileName string, fileReader io.Reader,
-	ingestionOptions models.IngestionOptions,
+	exec repositories.Executor, uploadLog models.UploadLog, header []string,
+	startOffset int64, fileReader io.Reader, ingestionOptions models.IngestionOptions,
 ) ingestionResult {
 	logger := utils.LoggerFromContext(ctx)
+	fileName := uploadLog.FileName
 	logger.InfoContext(ctx, fmt.Sprintf("Ingesting data from CSV %s", fileName))
 
 	var (
@@ -668,12 +800,16 @@ func (usecase *IngestionUseCase) readFileIngestObjects(ctx context.Context,
 		}
 	}
 
-	return usecase.ingestObjectsFromCSV(ctx, organizationId, fileReader, table, ingestionOptions)
+	return usecase.ingestObjectsFromCSV(ctx, organizationId, uploadLog, header, startOffset,
+		fileReader, table, ingestionOptions)
 }
 
 func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 	ctx context.Context,
 	organizationId uuid.UUID,
+	uploadLog models.UploadLog,
+	header []string,
+	startOffset int64,
 	fileReader io.Reader,
 	table models.Table,
 	ingestionOptions models.IngestionOptions,
@@ -701,19 +837,19 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 	}
 	defer printDuration()
 
-	r := csv.NewReader(pure_utils.NewReaderWithoutBom(fileReader))
-
-	firstRow, err := r.Read()
-	if err != nil {
-		return ingestionResult{
-			err: fmt.Errorf("error reading first row of CSV: %w", err),
-		}
-	}
+	// fileReader is positioned on a data row, not on the header: the header was read separately by
+	// readCsvHeader so that this reader can start at an arbitrary offset when resuming. No BOM
+	// handling either, since a BOM can only ever sit at byte 0 of the file.
+	r := csv.NewReader(fileReader)
+	// Normally established by the first row csv.Reader reads, which here is a data row rather than
+	// the header. Setting it explicitly keeps the column-count check identical on a first attempt
+	// and on a resume.
+	r.FieldsPerRecord = len(header)
 
 	// first, check presence of all required fields in the csv
 	for name, field := range table.Fields {
 		if !field.Nullable {
-			if !slices.Contains(firstRow, name) {
+			if !slices.Contains(header, name) {
 				return ingestionResult{
 					inputErr: errors.WithDetailf(models.BadParameterError, "missing required field %s in CSV", name),
 				}
@@ -737,11 +873,16 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 		}
 	}
 
+	// Rows ingested by previous attempts. Kept apart from `total` so printDuration still reports the
+	// throughput of this attempt alone, while the persisted counter accumulates across attempts.
+	previouslyIngested := uploadLog.RowsIngested
+
+	deadline, hasDeadline := ingestionDeadline(ctx)
+
 	keepParsingFile := true
-	objectIdx := 0
+	objectIdx := previouslyIngested
 	for keepParsingFile {
 		iterationCtx, iterationCancel := context.WithTimeout(ctx, CSV_INGESTION_ITERATION_TIMEOUT)
-		defer iterationCancel()
 
 		windowEnd := objectIdx + csvIngestionBatchSize
 		clientObjects := make([]models.ClientObject, 0, csvIngestionBatchSize)
@@ -752,17 +893,22 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 				keepParsingFile = false
 				break
 			} else if err != nil {
+				iterationCancel()
 				return ingestionResult{
-					numRowsIngested: total,
-					err:             fmt.Errorf("error reading line %d of CSV: %w", objectIdx, err),
+					numRowsIngested: previouslyIngested + total,
+					err: fmt.Errorf("error reading line %d of CSV (byte offset %d): %w",
+						objectIdx, startOffset+r.InputOffset(), err),
 				}
 			}
 
-			object, err := parseStringValuesToMap(firstRow, record, table, usecase.payloadEnricher)
+			object, err := parseStringValuesToMap(header, record, table, usecase.payloadEnricher)
 			if err != nil {
+				iterationCancel()
 				return ingestionResult{
-					numRowsIngested: total,
-					inputErr:        errors.WithDetailf(err, "error parsing field value in CSV at line %d: %v", objectIdx, err),
+					numRowsIngested: previouslyIngested + total,
+					inputErr: errors.WithDetailf(err,
+						"error parsing field value in CSV at line %d (byte offset %d): %v",
+						objectIdx, startOffset+r.InputOffset(), err),
 				}
 			}
 			logger.DebugContext(iterationCtx, fmt.Sprintf("Object to ingest %d: %+v", objectIdx, object))
@@ -777,17 +923,44 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 				organizationId, clientObjects, table, ingestionOptions)
 			return err
 		}); err != nil {
+			iterationCancel()
 			return ingestionResult{
-				numRowsIngested: total,
+				numRowsIngested: previouslyIngested + total,
 				err:             err,
 			}
 		}
 		nbInsertedObjects := len(ingestionResults)
 		total += nbInsertedObjects
+		// Cancelled here rather than deferred: this loop body runs once per batch, so on a multi-GB
+		// file deferring would pile up tens of thousands of pending calls until the function returns.
+		iterationCancel()
+
+		// Offset of the first row not ingested yet, saved once the batch has committed. A crash in
+		// that window re-ingests this batch on the next attempt rather than skipping it, which is the
+		// safe direction: upload_logs and the client objects live in different databases, so the two
+		// writes cannot share a transaction.
+		checkpoint := startOffset + r.InputOffset()
+		if err := usecase.uploadLogRepository.SaveUploadLogCheckpoint(ctx, exec, uploadLog.Id,
+			checkpoint, previouslyIngested+total); err != nil {
+			return ingestionResult{
+				numRowsIngested: previouslyIngested + total,
+				err:             errors.Wrap(err, "error saving upload log checkpoint"),
+			}
+		}
+
+		if keepParsingFile && hasDeadline && time.Now().After(deadline) {
+			logger.InfoContext(ctx, "csv ingestion: approaching job timeout, checkpointed and stopping for now",
+				"upload_log_id", uploadLog.Id, "byte_offset", checkpoint,
+				"rows_ingested", previouslyIngested+total)
+			return ingestionResult{
+				numRowsIngested: previouslyIngested + total,
+				incomplete:      true,
+			}
+		}
 	}
 
 	return ingestionResult{
-		numRowsIngested: total,
+		numRowsIngested: previouslyIngested + total,
 	}
 }
 
@@ -1112,5 +1285,28 @@ func (w *CsvIngestionWorker) Timeout(job *river.Job[models.CsvIngestionArgs]) ti
 }
 
 func (w *CsvIngestionWorker) Work(ctx context.Context, job *river.Job[models.CsvIngestionArgs]) error {
-	return w.ingestionUsecase.IngestDataFromCsvByUploadLogId(ctx, job.Args.UploadLogId, job.Args.IngestionOptions)
+	// Reading river's `snoozes` metadata counter and not job.Attempt: JobSnooze deliberately
+	// decrements Attempt so that resuming never consumes a retry, which also means an oversized file
+	// could otherwise be resumed forever.
+	if gjson.GetBytes(job.Metadata, "snoozes").Int() > int64(csvIngestionMaxSnoozes) {
+		utils.LoggerFromContext(ctx).ErrorContext(ctx, "csv ingestion exceeded its maximum number of resumes",
+			"upload_log_id", job.Args.UploadLogId, "max_snoozes", csvIngestionMaxSnoozes)
+
+		if err := w.ingestionUsecase.FailUploadLog(ctx, job.Args.UploadLogId,
+			fmt.Sprintf("ingestion did not complete after %d resumes", csvIngestionMaxSnoozes)); err != nil {
+			return err
+		}
+		return river.JobCancel(errors.New("csv ingestion exceeded its maximum number of resumes"))
+	}
+
+	outcome, err := w.ingestionUsecase.IngestDataFromCsvByUploadLogId(ctx, job.Args.UploadLogId,
+		job.Args.IngestionOptions)
+	if err != nil {
+		return err
+	}
+
+	if outcome == models.CsvIngestionIncomplete {
+		return river.JobSnooze(CSV_INGESTION_SNOOZE_DELAY)
+	}
+	return nil
 }


### PR DESCRIPTION
## Problem

A CSV upload is handled by a single `csv_ingestion` job with a 1-hour timeout. Large files —
the presigned-link path allows up to 10 GB — don't finish in time: river cancels the job, and
the next attempt returns immediately because the upload log is no longer `pending`. The upload
stays stuck in `processing` and the whole file has to be re-uploaded.

## Approach

Make the job resumable, the same way `apply_delta_file` does in continuous screening: persist a
byte offset after each batch, and when the attempt is about to run out of time, save the
checkpoint and snooze instead of dying.

## What changed

- **Migration** — `upload_logs.byte_offset bigint`: offset of the first row not yet ingested.
  `bigint` and not `integer`, since files go up to 10 GB.
- **Checkpoint** — `SaveUploadLogCheckpoint` writes `byte_offset` + `num_rows_ingested` in a
  single UPDATE, once per batch of `CSV_INGESTION_BATCH_SIZE` rows.
- **Resume** — `processUploadLog` now accepts a log already in `processing` and reopens the blob
  at its stored offset through `WithBeginOffset`.
- **Snooze** — the loop compares against a deadline derived from `ctx.Deadline()` minus a
  2-minute margin. Past it, it checkpoints and returns `Incomplete`, which the worker turns into
  `river.JobSnooze`. `CsvIngestionOutcome` exists so the usecase doesn't return river sentinels.
- **Cap** — after `CSV_INGESTION_MAX_SNOOZES` (24) resumes the upload is failed, with the offset
  and row count in the error message.

## Where to look carefully

1. **The header is read on its own, every attempt** (`readCsvHeader`). The data reader is then
   always opened at an explicit offset, so it never sees the header row or the BOM — that's what
   makes an arbitrary resume point possible.
2. **The BOM is discarded before `csv.Reader` sees it, and added back into the offset.** Trimming
   it off the parsed header name doesn't work: with a quoted header, `csv.Reader` reads the BOM as
   the start of an unquoted field and rejects the file. And since discarding it hides 3 bytes from
   the reader, `bomLen` has to be added back or every persisted offset is 3 bytes short and a
   resume lands mid-field.
3. **A cancelled context is not a failure.** `failAttempt` skips `setToFailed` when
   `ctx.Err() != nil` (worker shutdown, river timeout). `setToFailed` uses `context.WithoutCancel`,
   so without that guard it would happily write a terminal `failure` and make the checkpoint
   unreachable.

## Deliberate choices

- **The last batch is at-least-once.** `upload_logs` lives in the marble DB and client objects in
  the org DB, so the checkpoint can't share a transaction with the insert. It's ordered
  checkpoint-after-insert, so a crash in that window re-ingests up to one batch instead of
  skipping rows. Cost: duplicate object versions and re-enqueued screening/scoring for that batch.
- **No lease on the upload log.** River runs one attempt at a time; the checkpoint UPDATE also
  carries a `byte_offset <= new_offset` guard so a stale attempt can't rewind it.
- **After a resume, error line numbers are relative to the current pass.** `num_rows_ingested`
  counts inserted objects (deduped by `object_id`), not rows read, so the absolute line number
  isn't knowable. The byte offset is reported next to it.

## Fixed along the way

An upload whose worker was killed mid-file used to stay in `processing` forever, because the
retry early-returned on the status check. It now resumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSV ingestion can now resume from saved progress after interruptions or job time limits.
  - Progress is checkpointed after each completed batch, preserving processed rows and file position.
  - Improved handling for cancellations, deadlines, BOMs, quoted fields, and incomplete files.
  - Upload processing now reports whether ingestion completed or needs to continue later.
- **Bug Fixes**
  - Prevented progress checkpoints from moving backward.
  - Improved failure handling without losing previously saved progress.
- **Tests**
  - Added comprehensive coverage for CSV headers, resume behavior, end-of-file handling, and deadlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->