### PR TITLE
change checkpoint save in DB

### DIFF
--- a/usecases/ingestion_usecase.go
+++ b/usecases/ingestion_usecase.go
@@ -974,27 +974,15 @@ func (usecase *IngestionUseCase) ingestObjectsFromCSV(
 		// file deferring would pile up tens of thousands of pending calls until the function returns.
 		iterationCancel()
 
-		// Offset of the first row not ingested yet, saved once the batch has committed. A crash in
-		// that window re-ingests this batch on the next attempt rather than skipping it, which is the
-		// safe direction: upload_logs and the client objects live in different databases, so the two
-		// writes cannot share a transaction.
-		checkpoint := startOffset + r.InputOffset()
-		if err := usecase.uploadLogRepository.SaveUploadLogCheckpoint(ctx, exec, uploadLog.Id,
-			checkpoint, previouslyIngested+total); err != nil {
-			return ingestionResult{
-				numRowsIngested: previouslyIngested + total,
-				err:             errors.Wrap(err, "error saving upload log checkpoint"),
-			}
-		}
-
-		logger.DebugContext(ctx, "csv ingestion progress",
-			"upload_log_id", uploadLog.Id,
-			"rows_ingested", previouslyIngested+total,
-			"byte_offset", checkpoint,
-			"file_size", fileSize,
-		)
-
 		if keepParsingFile && hasDeadline && time.Now().After(deadline) {
+			checkpoint := startOffset + r.InputOffset()
+			if err := usecase.uploadLogRepository.SaveUploadLogCheckpoint(ctx, exec, uploadLog.Id,
+				checkpoint, previouslyIngested+total); err != nil {
+				return ingestionResult{
+					numRowsIngested: previouslyIngested + total,
+					err:             errors.Wrap(err, "error saving upload log checkpoint"),
+				}
+			}
 			logger.InfoContext(ctx, "csv ingestion: approaching job timeout, checkpointed and stopping for now",
 				"upload_log_id", uploadLog.Id, "byte_offset", checkpoint,
 				"rows_ingested", previouslyIngested+total)


### PR DESCRIPTION
Before deploying in production, I tested the ingestion on staging and noticed a significant slowdown.

I’d like to point out that in both production and staging environments, we process batches of 100 items instead of 1000 (as specified in the environment variable for production).

Instead of saving the checkpoint in the database after each ingestion batch, we only save it if we need to resume work for the next iteration. 
In case of an error, we won’t resume the job and mark it as failed. Consequently, this upload will be ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - CSV ingestion now saves checkpoint progress when the ingestion deadline is reached instead of after every batch.
  - Incomplete ingestion results continue to report the latest available checkpoint.

- **Bug Fixes**
  - Improved deadline-based ingestion handling to ensure checkpoint progress is returned correctly when processing cannot finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->