### PR TITLE
change CS intervals

### DIFF
--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -84,8 +84,8 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		otelSamplingRates:            utils.GetEnv("TRACING_SAMPLING_RATES", ""),
 		enablePrometheus:             utils.GetEnv("ENABLE_PROMETHEUS", false),
 		enableTracing:                utils.GetEnv("ENABLE_TRACING", false),
-		ScanDatasetUpdatesInterval:   utils.GetEnvDuration("SCAN_DATASET_UPDATES_INTERVAL", 24*time.Hour),
-		CreateFullDatasetInterval:    utils.GetEnvDuration("CREATE_FULL_DATASET_INTERVAL", 24*time.Hour),
+		ScanDatasetUpdatesInterval:   utils.GetEnvDuration("SCAN_DATASET_UPDATES_INTERVAL", 4*time.Hour),
+		CreateFullDatasetInterval:    utils.GetEnvDuration("CREATE_FULL_DATASET_INTERVAL", 4*time.Hour),
 		continuousScreeningBucketUrl: utils.GetEnv("CONTINUOUS_SCREENING_BUCKET_URL", ""),
 	}
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -85,7 +85,7 @@ func RunTaskQueue(apiVersion string, only, onlyArgs string) error {
 		enablePrometheus:             utils.GetEnv("ENABLE_PROMETHEUS", false),
 		enableTracing:                utils.GetEnv("ENABLE_TRACING", false),
 		ScanDatasetUpdatesInterval:   utils.GetEnvDuration("SCAN_DATASET_UPDATES_INTERVAL", 4*time.Hour),
-		CreateFullDatasetInterval:    utils.GetEnvDuration("CREATE_FULL_DATASET_INTERVAL", 4*time.Hour),
+		CreateFullDatasetInterval:    utils.GetEnvDuration("CREATE_FULL_DATASET_INTERVAL", 8*time.Hour),
 		continuousScreeningBucketUrl: utils.GetEnv("CONTINUOUS_SCREENING_BUCKET_URL", ""),
 	}
 


### PR DESCRIPTION
Reduce the default interval of our CS worker job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Reduced the default dataset update scan interval from 24 hours to 4 hours.
  * Reduced the default full dataset generation interval from 24 hours to 8 hours.
  * Existing environment settings remain available for customizing both intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->