### PR TITLE
fix redis delete prefix when redis is not configured

### DIFF
--- a/repositories/redis_executor.go
+++ b/repositories/redis_executor.go
@@ -150,6 +150,10 @@ func (exec *RedisExecutor) IsInSet(ctx context.Context, key, value string) (bool
 }
 
 func (exec *RedisExecutor) DeletePrefix(ctx context.Context, prefix string) error {
+	if exec == nil {
+		return nil
+	}
+
 	var cursor uint64
 
 	for {


### PR DESCRIPTION
This method didn't check if redis is configured