### PR TITLE
Add new analytics event

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -403,15 +403,21 @@ func RunServer(config CompiledConfig, mode api.ServerMode) error {
 	// Seed the database
 	////////////////////////////////////////////////////////////
 	seedUsecase := uc.NewSeedUseCase()
+	// The seeding runs outside of the HTTP middleware stack, so the Segment client has to be
+	// injected in the context explicitly for the seeding analytics events to be sent.
+	seedCtx := ctx
+	if !apiConfig.DisableSegment {
+		seedCtx = utils.StoreSegmentClientInContext(ctx, deps.SegmentClient)
+	}
 	marbleAdminEmail := seedOrgConfig.CreateGlobalAdminEmail
 	if marbleAdminEmail != "" {
-		if err := seedUsecase.SeedMarbleAdmins(ctx, marbleAdminEmail); err != nil {
+		if err := seedUsecase.SeedMarbleAdmins(seedCtx, marbleAdminEmail); err != nil {
 			utils.LogAndReportSentryError(ctx, err)
 			return err
 		}
 	}
 	if seedOrgConfig.CreateOrgName != "" {
-		if err := seedUsecase.CreateOrgAndUser(ctx, models.InitOrgInput{
+		if err := seedUsecase.CreateOrgAndUser(seedCtx, models.InitOrgInput{
 			OrgName:    seedOrgConfig.CreateOrgName,
 			AdminEmail: seedOrgConfig.CreateOrgAdminEmail,
 		}); err != nil {

--- a/models/events.go
+++ b/models/events.go
@@ -19,7 +19,7 @@ const (
 	AnalyticsCaseCreated                AnalyticsEvent = "Created a Case"
 	AnalyticsCaseUpdated                AnalyticsEvent = "Updated a Case"
 	AnalyticsCaseStatusUpdated          AnalyticsEvent = "Updated Case Status"
-	AnalyticsFirstCaseStatusUpdated     AnalyticsEvent = "Updated first Case Status"
+	AnalyticsFirstCaseClosed            AnalyticsEvent = "Closed a first Case"
 	AnalyticsCaseCommentCreated         AnalyticsEvent = "Created a Case Comment"
 	AnalyticsCaseTagsUpdated            AnalyticsEvent = "Updated Case Tags on Case"
 	AnalyticsCaseFileCreated            AnalyticsEvent = "Created a Case File"

--- a/models/events.go
+++ b/models/events.go
@@ -19,6 +19,7 @@ const (
 	AnalyticsCaseCreated                AnalyticsEvent = "Created a Case"
 	AnalyticsCaseUpdated                AnalyticsEvent = "Updated a Case"
 	AnalyticsCaseStatusUpdated          AnalyticsEvent = "Updated Case Status"
+	AnalyticsFirstCaseStatusUpdated     AnalyticsEvent = "Updated first Case Status"
 	AnalyticsCaseCommentCreated         AnalyticsEvent = "Created a Case Comment"
 	AnalyticsCaseTagsUpdated            AnalyticsEvent = "Updated Case Tags on Case"
 	AnalyticsCaseFileCreated            AnalyticsEvent = "Created a Case File"
@@ -26,6 +27,7 @@ const (
 	AnalyticsTagCreated                 AnalyticsEvent = "Created a Tag"
 	AnalyticsTagUpdated                 AnalyticsEvent = "Updated a Tag"
 	AnalyticsTagDeleted                 AnalyticsEvent = "Deleted a Tag"
+	AnalyticsFirstUserSetup             AnalyticsEvent = "Set up a first User"
 	AnalyticsUserCreated                AnalyticsEvent = "Created a User"
 	AnalyticsUserUpdated                AnalyticsEvent = "Updated a User"
 	AnalyticsUserDeleted                AnalyticsEvent = "Deleted a User"
@@ -37,4 +39,5 @@ const (
 	AnalyticsInboxUserDeleted           AnalyticsEvent = "Deleted an Inbox User"
 	AnalyticsApiKeyCreated              AnalyticsEvent = "Created an Api Key"
 	AnalyticsApiKeyDeleted              AnalyticsEvent = "Deleted an Api Key"
+	AnalyticsFirstTableCreated          AnalyticsEvent = "Created a first Table"
 )

--- a/models/events.go
+++ b/models/events.go
@@ -27,7 +27,7 @@ const (
 	AnalyticsTagCreated                 AnalyticsEvent = "Created a Tag"
 	AnalyticsTagUpdated                 AnalyticsEvent = "Updated a Tag"
 	AnalyticsTagDeleted                 AnalyticsEvent = "Deleted a Tag"
-	AnalyticsFirstUserSetup             AnalyticsEvent = "Set up a first User"
+	AnalyticsUserSetup                  AnalyticsEvent = "Set up a User"
 	AnalyticsUserCreated                AnalyticsEvent = "Created a User"
 	AnalyticsUserUpdated                AnalyticsEvent = "Updated a User"
 	AnalyticsUserDeleted                AnalyticsEvent = "Deleted a User"
@@ -39,5 +39,5 @@ const (
 	AnalyticsInboxUserDeleted           AnalyticsEvent = "Deleted an Inbox User"
 	AnalyticsApiKeyCreated              AnalyticsEvent = "Created an Api Key"
 	AnalyticsApiKeyDeleted              AnalyticsEvent = "Deleted an Api Key"
-	AnalyticsFirstTableCreated          AnalyticsEvent = "Created a first Table"
+	AnalyticsTableCreated               AnalyticsEvent = "Created a Table"
 )

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -779,9 +779,7 @@ func (repo *MarbleDbRepository) ObjectHasConfirmedRisks(ctx context.Context, exe
 	return hasConfirmedRisks, nil
 }
 
-// Returns whether the organization has at least one case whose status is not the default one
-// ("pending"), meaning a case status was already updated at least once in this organization.
-func (repo *MarbleDbRepository) OrgHasCaseWithUpdatedStatus(ctx context.Context, exec Executor,
+func (repo *MarbleDbRepository) OrgHasClosedCase(ctx context.Context, exec Executor,
 	orgId uuid.UUID,
 ) (bool, error) {
 	if err := validateMarbleDbExecutor(exec); err != nil {
@@ -794,7 +792,7 @@ func (repo *MarbleDbRepository) OrgHasCaseWithUpdatedStatus(ctx context.Context,
 		Suffix(")").
 		From(dbmodels.TABLE_CASES).
 		Where(squirrel.Eq{"org_id": orgId}).
-		Where(squirrel.NotEq{"status": models.CasePending})
+		Where(squirrel.Eq{"status": models.CaseClosed})
 
 	sql, args, err := query.ToSql()
 	if err != nil {

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -779,6 +779,37 @@ func (repo *MarbleDbRepository) ObjectHasConfirmedRisks(ctx context.Context, exe
 	return hasConfirmedRisks, nil
 }
 
+// Returns whether the organization has at least one case whose status is not the default one
+// ("pending"), meaning a case status was already updated at least once in this organization.
+func (repo *MarbleDbRepository) OrgHasCaseWithUpdatedStatus(ctx context.Context, exec Executor,
+	orgId uuid.UUID,
+) (bool, error) {
+	if err := validateMarbleDbExecutor(exec); err != nil {
+		return false, err
+	}
+
+	query := NewQueryBuilder().
+		Select("1").
+		Prefix("select exists(").
+		Suffix(")").
+		From(dbmodels.TABLE_CASES).
+		Where(squirrel.Eq{"org_id": orgId}).
+		Where(squirrel.NotEq{"status": models.CasePending})
+
+	sql, args, err := query.ToSql()
+	if err != nil {
+		return false, err
+	}
+
+	var exists bool
+
+	if err := exec.QueryRow(ctx, sql, args...).Scan(&exists); err != nil {
+		return false, err
+	}
+
+	return exists, nil
+}
+
 // Count the number of cases for each organization in the given time range, return a map of orgId to count
 // From date is inclusive, to date is exclusive
 func (repo *MarbleDbRepository) CountCasesByOrg(ctx context.Context, exec Executor,

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -36,7 +36,7 @@ type CaseUseCaseRepository interface {
 		createCaseAttributes models.CreateCaseAttributes, newCaseId string) error
 	UpdateCase(ctx context.Context, exec repositories.Executor,
 		updateCaseAttributes models.UpdateCaseAttributes) error
-	OrgHasCaseWithUpdatedStatus(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (bool, error)
+	OrgHasClosedCase(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (bool, error)
 	SnoozeCase(ctx context.Context, exec repositories.Executor, snoozeRequest models.CaseSnoozeRequest) error
 	UnsnoozeCase(ctx context.Context, exec repositories.Executor,
 		caseId string) error
@@ -599,7 +599,7 @@ func (usecase *CaseUseCase) UpdateCase(
 	updateCaseAttributes models.UpdateCaseAttributes,
 ) (models.Case, error) {
 	updateDone := false
-	isFirstStatusUpdate := false
+	isFirstCaseClosed := false
 
 	updatedCase, err := executor_factory.TransactionReturnValue(ctx, usecase.transactionFactory, func(
 		tx repositories.Transaction,
@@ -643,16 +643,14 @@ func (usecase *CaseUseCase) UpdateCase(
 				fmt.Sprintf("invalid case status transition from %s to %s", c.Status, updateCaseAttributes.Status))
 		}
 
-		// Detect the first case status update of the organization: no case has moved out of the
-		// default "pending" status yet. Must be checked before the update below is applied.
-		// If this case is already out of "pending", it is itself the proof that the organization
-		// updated a status before, so the query can be skipped.
-		if updateCaseAttributes.Status != "" && c.Status == models.CasePending {
-			alreadyUpdated, err := usecase.repository.OrgHasCaseWithUpdatedStatus(ctx, tx, c.OrganizationId)
+		// Detect the first case ever closed in the organization. Must be checked before the
+		// update below is applied, otherwise this very case would count as a closed one.
+		if updateCaseAttributes.Status == models.CaseClosed && c.Status != models.CaseClosed {
+			orgHadClosedCase, err := usecase.repository.OrgHasClosedCase(ctx, tx, c.OrganizationId)
 			if err != nil {
 				return models.Case{}, err
 			}
-			isFirstStatusUpdate = !alreadyUpdated
+			isFirstCaseClosed = !orgHadClosedCase
 		}
 
 		if updateCaseAttributes.Outcome != "" {
@@ -728,7 +726,7 @@ func (usecase *CaseUseCase) UpdateCase(
 	}
 
 	if updateDone {
-		trackCaseUpdatedEvents(ctx, updatedCase.Id, updateCaseAttributes, isFirstStatusUpdate)
+		trackCaseUpdatedEvents(ctx, updatedCase.Id, updateCaseAttributes, isFirstCaseClosed)
 	}
 
 	return updatedCase, nil
@@ -1667,23 +1665,27 @@ func trackCaseUpdatedEvents(
 	ctx context.Context,
 	caseId string,
 	updateCaseAttributes models.UpdateCaseAttributes,
-	isFirstStatusUpdate bool,
+	isFirstCaseClosed bool,
 ) {
 	if updateCaseAttributes.Status != "" {
 		tracking.TrackEvent(ctx, models.AnalyticsCaseStatusUpdated, map[string]interface{}{
 			"case_id": caseId,
 		})
-		if isFirstStatusUpdate {
-			tracking.TrackEvent(ctx, models.AnalyticsFirstCaseStatusUpdated, map[string]interface{}{
-				"case_id": caseId,
-			})
-		}
+	}
+	if isFirstCaseClosed {
+		trackFirstCaseClosed(ctx, caseId)
 	}
 	if updateCaseAttributes.Name != "" {
 		tracking.TrackEvent(ctx, models.AnalyticsCaseUpdated, map[string]interface{}{
 			"case_id": caseId,
 		})
 	}
+}
+
+func trackFirstCaseClosed(ctx context.Context, caseId string) {
+	tracking.TrackEvent(ctx, models.AnalyticsFirstCaseClosed, map[string]interface{}{
+		"case_id": caseId,
+	})
 }
 
 func (usecase *CaseUseCase) CreateCaseFiles(ctx context.Context, input models.CreateCaseFilesInput) (models.Case, []models.CaseFile, error) {
@@ -2437,7 +2439,10 @@ func (usecase *CaseUseCase) MassUpdate(ctx context.Context, req dto.CaseMassUpda
 	sourceCases := make(map[string]models.Case, len(req.CaseIds))
 	events := make(map[string]models.CreateCaseEventAttributes, len(req.CaseIds))
 
-	var newAssignee models.User
+	var (
+		newAssignee       models.User
+		firstClosedCaseId string
+	)
 
 	cases, err := usecase.repository.GetMassCasesByIds(ctx, exec, req.CaseIds)
 	if err != nil {
@@ -2495,12 +2500,22 @@ func (usecase *CaseUseCase) MassUpdate(ctx context.Context, req dto.CaseMassUpda
 		}
 	}
 
-	return usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+	err = usecase.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
 		switch models.CaseMassUpdateActionFromString(req.Action) {
 		case models.CaseMassUpdateClose:
+			// Checked before the status change, otherwise the cases closed here would count.
+			orgHadClosedCase, err := usecase.repository.OrgHasClosedCase(ctx, tx, orgId)
+			if err != nil {
+				return errors.Wrap(err, "could not check for previously closed cases")
+			}
+
 			updatedIds, err := usecase.repository.CaseMassChangeStatus(ctx, tx, req.CaseIds, models.CaseClosed)
 			if err != nil {
 				return errors.Wrap(err, "could not update case status in mass update")
+			}
+
+			if !orgHadClosedCase && len(updatedIds) > 0 {
+				firstClosedCaseId = updatedIds[0].String()
 			}
 
 			for _, updatedId := range updatedIds {
@@ -2582,4 +2597,13 @@ func (usecase *CaseUseCase) MassUpdate(ctx context.Context, req dto.CaseMassUpda
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	if firstClosedCaseId != "" {
+		trackFirstCaseClosed(ctx, firstClosedCaseId)
+	}
+
+	return nil
 }

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -36,6 +36,7 @@ type CaseUseCaseRepository interface {
 		createCaseAttributes models.CreateCaseAttributes, newCaseId string) error
 	UpdateCase(ctx context.Context, exec repositories.Executor,
 		updateCaseAttributes models.UpdateCaseAttributes) error
+	OrgHasCaseWithUpdatedStatus(ctx context.Context, exec repositories.Executor, orgId uuid.UUID) (bool, error)
 	SnoozeCase(ctx context.Context, exec repositories.Executor, snoozeRequest models.CaseSnoozeRequest) error
 	UnsnoozeCase(ctx context.Context, exec repositories.Executor,
 		caseId string) error
@@ -598,6 +599,7 @@ func (usecase *CaseUseCase) UpdateCase(
 	updateCaseAttributes models.UpdateCaseAttributes,
 ) (models.Case, error) {
 	updateDone := false
+	isFirstStatusUpdate := false
 
 	updatedCase, err := executor_factory.TransactionReturnValue(ctx, usecase.transactionFactory, func(
 		tx repositories.Transaction,
@@ -639,6 +641,18 @@ func (usecase *CaseUseCase) UpdateCase(
 		if updateCaseAttributes.Status != "" && !c.Status.CanTransition(updateCaseAttributes.Status) {
 			return c, errors.Wrap(models.BadParameterError,
 				fmt.Sprintf("invalid case status transition from %s to %s", c.Status, updateCaseAttributes.Status))
+		}
+
+		// Detect the first case status update of the organization: no case has moved out of the
+		// default "pending" status yet. Must be checked before the update below is applied.
+		// If this case is already out of "pending", it is itself the proof that the organization
+		// updated a status before, so the query can be skipped.
+		if updateCaseAttributes.Status != "" && c.Status == models.CasePending {
+			alreadyUpdated, err := usecase.repository.OrgHasCaseWithUpdatedStatus(ctx, tx, c.OrganizationId)
+			if err != nil {
+				return models.Case{}, err
+			}
+			isFirstStatusUpdate = !alreadyUpdated
 		}
 
 		if updateCaseAttributes.Outcome != "" {
@@ -714,7 +728,7 @@ func (usecase *CaseUseCase) UpdateCase(
 	}
 
 	if updateDone {
-		trackCaseUpdatedEvents(ctx, updatedCase.Id, updateCaseAttributes)
+		trackCaseUpdatedEvents(ctx, updatedCase.Id, updateCaseAttributes, isFirstStatusUpdate)
 	}
 
 	return updatedCase, nil
@@ -1649,11 +1663,21 @@ func (usecase *CaseUseCase) createCaseContributorIfNotExist(ctx context.Context,
 	return usecase.repository.CreateCaseContributor(ctx, exec, caseId, userId)
 }
 
-func trackCaseUpdatedEvents(ctx context.Context, caseId string, updateCaseAttributes models.UpdateCaseAttributes) {
+func trackCaseUpdatedEvents(
+	ctx context.Context,
+	caseId string,
+	updateCaseAttributes models.UpdateCaseAttributes,
+	isFirstStatusUpdate bool,
+) {
 	if updateCaseAttributes.Status != "" {
 		tracking.TrackEvent(ctx, models.AnalyticsCaseStatusUpdated, map[string]interface{}{
 			"case_id": caseId,
 		})
+		if isFirstStatusUpdate {
+			tracking.TrackEvent(ctx, models.AnalyticsFirstCaseStatusUpdated, map[string]interface{}{
+				"case_id": caseId,
+			})
+		}
 	}
 	if updateCaseAttributes.Name != "" {
 		tracking.TrackEvent(ctx, models.AnalyticsCaseUpdated, map[string]interface{}{

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/indexes"
 	"github.com/checkmarble/marble-backend/usecases/security"
+	"github.com/checkmarble/marble-backend/usecases/tracking"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -304,6 +305,8 @@ func (usecase *usecase) CreateDataModelTable(
 	if err != nil {
 		return "", err
 	}
+	// The organization has no table yet, so the one we are about to create is its first one.
+	isFirstTable := len(oldDatamodel.Tables) == 0
 	// input.Links miss the ParentFieldID since we automatically use the `object_id` field of the parent table. Need to retrieve the ID before creating the links
 	tablesById := oldDatamodel.AllTablesAsMap()
 	for i := range input.Links {
@@ -453,6 +456,12 @@ func (usecase *usecase) CreateDataModelTable(
 	})
 	if err != nil {
 		return "", err
+	}
+
+	if isFirstTable {
+		tracking.TrackEvent(ctx, models.AnalyticsFirstTableCreated, map[string]interface{}{
+			"table_id": tableId,
+		})
 	}
 
 	return tableId, nil

--- a/usecases/data_model_usecase.go
+++ b/usecases/data_model_usecase.go
@@ -305,8 +305,6 @@ func (usecase *usecase) CreateDataModelTable(
 	if err != nil {
 		return "", err
 	}
-	// The organization has no table yet, so the one we are about to create is its first one.
-	isFirstTable := len(oldDatamodel.Tables) == 0
 	// input.Links miss the ParentFieldID since we automatically use the `object_id` field of the parent table. Need to retrieve the ID before creating the links
 	tablesById := oldDatamodel.AllTablesAsMap()
 	for i := range input.Links {
@@ -458,11 +456,9 @@ func (usecase *usecase) CreateDataModelTable(
 		return "", err
 	}
 
-	if isFirstTable {
-		tracking.TrackEvent(ctx, models.AnalyticsFirstTableCreated, map[string]interface{}{
-			"table_id": tableId,
-		})
-	}
+	tracking.TrackEvent(ctx, models.AnalyticsTableCreated, map[string]interface{}{
+		"table_id": tableId,
+	})
 
 	return tableId, nil
 }

--- a/usecases/seed_usecase.go
+++ b/usecases/seed_usecase.go
@@ -10,6 +10,7 @@ import (
 	"github.com/checkmarble/marble-backend/repositories/idp"
 	"github.com/checkmarble/marble-backend/usecases/executor_factory"
 	"github.com/checkmarble/marble-backend/usecases/organization"
+	"github.com/checkmarble/marble-backend/usecases/tracking"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/google/uuid"
 
@@ -109,18 +110,34 @@ func (usecase *SeedUseCase) CreateOrgAndUser(ctx context.Context, input models.I
 	}
 
 	if input.AdminEmail != "" {
-		_, err := usecase.userRepository.CreateUser(ctx, exec, models.CreateUser{
+		createdUserId, err := usecase.userRepository.CreateUser(ctx, exec, models.CreateUser{
 			Email:          input.AdminEmail,
 			OrganizationId: targetOrg.Id,
 			Role:           models.ADMIN,
 		})
-		if err != nil && !repositories.IsUniqueViolationError(err) {
+		userAlreadyExists := repositories.IsUniqueViolationError(err)
+		if err != nil && !userAlreadyExists {
 			return err
 		}
-		logger.InfoContext(
-			ctx,
-			fmt.Sprintf("Created admin user for organization %s with email %s (or already exists)", targetOrg.Id, input.AdminEmail),
-		)
+
+		if userAlreadyExists {
+			logger.InfoContext(
+				ctx,
+				fmt.Sprintf("Admin user with email %s already exists for organization %s", input.AdminEmail, targetOrg.Id),
+			)
+		} else {
+			logger.InfoContext(
+				ctx,
+				fmt.Sprintf("Created admin user for organization %s with email %s", targetOrg.Id, input.AdminEmail),
+			)
+			tracking.TrackEventWithUserId(ctx, models.AnalyticsFirstUserSetup, models.UserId(createdUserId),
+				map[string]any{
+					"user_id": createdUserId,
+					"email":   input.AdminEmail,
+					"org_id":  targetOrg.Id,
+				},
+			)
+		}
 
 		if err := usecase.createFirebaseUser(ctx, input.AdminEmail); err != nil {
 			return err

--- a/usecases/seed_usecase.go
+++ b/usecases/seed_usecase.go
@@ -130,7 +130,7 @@ func (usecase *SeedUseCase) CreateOrgAndUser(ctx context.Context, input models.I
 				ctx,
 				fmt.Sprintf("Created admin user for organization %s with email %s", targetOrg.Id, input.AdminEmail),
 			)
-			tracking.TrackEventWithUserId(ctx, models.AnalyticsFirstUserSetup, models.UserId(createdUserId),
+			tracking.TrackEventWithUserId(ctx, models.AnalyticsUserSetup, models.UserId(createdUserId),
 				map[string]any{
 					"user_id": createdUserId,
 					"email":   input.AdminEmail,

--- a/usecases/usecases_with_creds.go
+++ b/usecases/usecases_with_creds.go
@@ -463,11 +463,12 @@ func (usecases *UsecasesWithCreds) NewScheduledExecutionUsecase() ScheduledExecu
 
 func (usecases *UsecasesWithCreds) NewUserUseCase() UserUseCase {
 	return UserUseCase{
-		enforceUserSecurity: usecases.NewEnforceUserSecurity(),
-		executorFactory:     usecases.NewExecutorFactory(),
-		transactionFactory:  usecases.NewTransactionFactory(),
-		userRepository:      usecases.Repositories.MarbleDbRepository,
-		firebaseAdmin:       usecases.firebaseAdmin,
+		enforceUserSecurity:    usecases.NewEnforceUserSecurity(),
+		executorFactory:        usecases.NewExecutorFactory(),
+		transactionFactory:     usecases.NewTransactionFactory(),
+		userRepository:         usecases.Repositories.MarbleDbRepository,
+		organizationRepository: usecases.Repositories.MarbleDbRepository,
+		firebaseAdmin:          usecases.firebaseAdmin,
 	}
 }
 

--- a/usecases/user_usecase.go
+++ b/usecases/user_usecase.go
@@ -20,17 +20,24 @@ import (
 )
 
 type UserUseCase struct {
-	enforceUserSecurity security.EnforceSecurityUser
-	executorFactory     executor_factory.ExecutorFactory
-	transactionFactory  executor_factory.TransactionFactory
-	userRepository      repositories.UserRepository
-	firebaseAdmin       idp.Adminer
+	enforceUserSecurity    security.EnforceSecurityUser
+	executorFactory        executor_factory.ExecutorFactory
+	transactionFactory     executor_factory.TransactionFactory
+	userRepository         repositories.UserRepository
+	organizationRepository repositories.OrganizationRepository
+	firebaseAdmin          idp.Adminer
 }
 
 func (usecase *UserUseCase) AddUser(ctx context.Context, createUser models.CreateUser) (models.User, error) {
 	if err := usecase.enforceUserSecurity.CreateUser(createUser); err != nil {
 		return models.User{}, err
 	}
+
+	org, err := usecase.organizationRepository.GetOrganizationById(ctx, usecase.executorFactory.NewExecutor(), createUser.OrganizationId)
+	if err != nil {
+		return models.User{}, errors.Wrap(err, "GetOrganizationById error")
+	}
+
 	createdUser, err := executor_factory.TransactionReturnValue(
 		ctx,
 		usecase.transactionFactory,
@@ -61,8 +68,19 @@ func (usecase *UserUseCase) AddUser(ctx context.Context, createUser models.Creat
 	if err != nil {
 		return models.User{}, err
 	}
+	tracking.Identify(ctx, createdUser.UserId, map[string]interface{}{
+		"email":           createdUser.Email,
+		"organization_id": createdUser.OrganizationId,
+		"first_name":      createdUser.FirstName,
+		"last_name":       createdUser.LastName,
+	})
+	tracking.Group(ctx, createdUser.UserId, createdUser.OrganizationId, map[string]any{
+		"name": org.Name,
+	})
 	tracking.TrackEvent(ctx, models.AnalyticsUserCreated, map[string]interface{}{
-		"user_id": createdUser.UserId,
+		"user_id":         createdUser.UserId,
+		"email":           createdUser.Email,
+		"organization_id": createdUser.OrganizationId,
 	})
 
 	return createdUser, nil
@@ -93,8 +111,16 @@ func (usecase *UserUseCase) UpdateUser(ctx context.Context, updateUser models.Up
 	if err != nil {
 		return models.User{}, err
 	}
+	tracking.Identify(ctx, updatedUser.UserId, map[string]interface{}{
+		"email":           updatedUser.Email,
+		"organization_id": updatedUser.OrganizationId,
+		"first_name":      updatedUser.FirstName,
+		"last_name":       updatedUser.LastName,
+	})
 	tracking.TrackEvent(ctx, models.AnalyticsUserUpdated, map[string]interface{}{
-		"user_id": updatedUser.UserId,
+		"user_id":         updatedUser.UserId,
+		"email":           updatedUser.Email,
+		"organization_id": updatedUser.OrganizationId,
 	})
 
 	return updatedUser, nil


### PR DESCRIPTION
For analytic needs, we add 3 new events to determine if the user: 
- `AnalyticsFirstUserSetup` -> First installation
- `AnalyticsFirstTableCreated` -> Create the first table, first marble utilization and configuration 
- `AnalyticsFirstCaseClosed` -> Aha moment, the user close a case for the first time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for first case closure, user setup, table creation, and user profile changes.
  * User activity events now include relevant email and organization details.
  * Seeding can now emit analytics events when tracking is enabled.

* **Bug Fixes**
  * Improved handling of duplicate users during organization setup.
  * User creation and update tracking now records the correct identity and organization context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->