### PR TITLE
feat: add case_sla_status_by_date case analytics

### DIFF
--- a/api/handle_case_analytics.go
+++ b/api/handle_case_analytics.go
@@ -54,6 +54,8 @@ func handleCaseAnalyticsQuery(uc usecases.Usecases) func(c *gin.Context) {
 			results, err = uc.SarDelayDistribution(ctx, filters)
 		case "case_status_by_date":
 			results, err = uc.CaseStatusByDate(ctx, filters)
+		case "case_sla_status_by_date":
+			results, err = uc.CaseSlaStatusByDate(ctx, filters)
 		case "case_status_by_inbox":
 			results, err = uc.CaseStatusByInbox(ctx, filters)
 		default:

--- a/models/analytics/results.go
+++ b/models/analytics/results.go
@@ -68,6 +68,13 @@ type CaseStatusByDate struct {
 	Snoozed       int       `json:"snoozed"`
 }
 
+type CaseSlaStatusByDate struct {
+	Date               time.Time `json:"date"`
+	CompletedWithinSla int       `json:"completed_within_sla"`
+	SlaBreached        int       `json:"sla_breached"`
+	StillOpenWithinSla int       `json:"still_open_within_sla"`
+}
+
 type CaseStatusByInbox struct {
 	Inbox         string `json:"inbox"`
 	Pending       int    `json:"pending"`
@@ -120,8 +127,9 @@ type Dated interface {
 	GetDate() time.Time
 }
 
-func (r CasesCreated) GetDate() time.Time          { return r.Date }
+func (r CasesCreated) GetDate() time.Time           { return r.Date }
 func (r CasesFalsePositiveRate) GetDate() time.Time { return r.Date }
 func (r CasesDuration) GetDate() time.Time          { return r.Date }
 func (r SarDelay) GetDate() time.Time               { return r.Date }
 func (r CaseStatusByDate) GetDate() time.Time       { return r.Date }
+func (r CaseSlaStatusByDate) GetDate() time.Time    { return r.Date }

--- a/repositories/case_analytics_repository.go
+++ b/repositories/case_analytics_repository.go
@@ -321,6 +321,70 @@ func (repo MarbleDbRepository) CaseStatusByDate(
 	})
 }
 
+func (repo MarbleDbRepository) CaseSlaStatusByDate(
+	ctx context.Context,
+	exec Executor,
+	filters analytics.CaseAnalyticsFilter,
+) ([]analytics.CaseSlaStatusByDate, error) {
+	// Same "closed_at" derivation as CasesDurationByTimeStats.
+	closedAtSubq := squirrel.
+		Select("ce.case_id", "max(ce.created_at) as closed_at").
+		From(dbmodels.TABLE_CASE_EVENTS + " ce").
+		Where(squirrel.Eq{
+			"ce.event_type": "status_updated",
+			"ce.new_value":  "closed",
+		}).
+		GroupBy("ce.case_id")
+
+	closedAtSQL, closedAtArgs, err := closedAtSubq.ToSql()
+	if err != nil {
+		return nil, err
+	}
+
+	// due_at is null (no deadline, never breached) when the inbox has no SLA configured.
+	dueAt := "c.created_at + (i.sla || ' days')::interval"
+
+	query := NewQueryBuilder().
+		Select(
+			fmt.Sprintf("(c.created_at + interval '%d s')::date as date", filters.TzOffsetSeconds),
+			fmt.Sprintf(`count(*) filter (
+				where c.status = 'closed' and (i.sla is null or ce_agg.closed_at <= %s)
+			) as completed_within_sla`, dueAt),
+			fmt.Sprintf(`count(*) filter (
+				where i.sla is not null and (
+					(c.status = 'closed' and ce_agg.closed_at > %s) or
+					(c.status != 'closed' and now() > %s)
+				)
+			) as sla_breached`, dueAt, dueAt),
+			fmt.Sprintf(`count(*) filter (
+				where c.status != 'closed' and (i.sla is null or now() <= %s)
+			) as still_open_within_sla`, dueAt),
+		).
+		From(dbmodels.TABLE_CASES+" c").
+		Join(dbmodels.TABLE_INBOXES+" i on i.id = c.inbox_id").
+		LeftJoin(fmt.Sprintf("(%s) ce_agg on ce_agg.case_id = c.id", closedAtSQL), closedAtArgs...).
+		Where(squirrel.Eq{
+			"c.org_id":   filters.OrgId,
+			"c.inbox_id": filters.InboxIds,
+		}).
+		Where(squirrel.And{
+			squirrel.GtOrEq{"c.created_at": filters.Start},
+			squirrel.Lt{"c.created_at": filters.End},
+		}).
+		GroupBy("date").
+		OrderBy("date")
+
+	if filters.AssignedUserId != nil {
+		query = query.Where(squirrel.Eq{"c.assigned_to": *filters.AssignedUserId})
+	}
+
+	return SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (analytics.CaseSlaStatusByDate, error) {
+		var res analytics.CaseSlaStatusByDate
+		err := row.Scan(&res.Date, &res.CompletedWithinSla, &res.SlaBreached, &res.StillOpenWithinSla)
+		return res, err
+	})
+}
+
 func (repo MarbleDbRepository) CaseStatusByInbox(
 	ctx context.Context,
 	exec Executor,

--- a/usecases/case_analytics_cache.go
+++ b/usecases/case_analytics_cache.go
@@ -7,12 +7,36 @@ import (
 	"time"
 
 	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/models/analytics"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
 )
 
 const caseAnalyticsCacheTTL = 1 * time.Hour
+
+func validateAssignedUserId(
+	ctx context.Context,
+	uc CaseAnalyticsUsecase,
+	exec repositories.Executor,
+	filters dto.CaseAnalyticsFilters,
+) error {
+	if filters.AssignedUserId == nil {
+		return nil
+	}
+
+	user, err := uc.repository.UserById(ctx, exec, *filters.AssignedUserId)
+	switch {
+	case errors.Is(err, models.NotFoundError):
+		return models.ForbiddenError
+	case err != nil:
+		return err
+	case user.OrganizationId != filters.OrgId:
+		return models.ForbiddenError
+	}
+	return nil
+}
 
 // cachedTimeSeriesQuery handles the full cache flow for time-series analytics queries.
 // It loads cached data from Redis, queries the DB only for missing date ranges,
@@ -31,6 +55,11 @@ func cachedTimeSeriesQuery[T analytics.Dated](
 	}
 
 	exec := uc.executorFactory.NewExecutor()
+
+	if err := validateAssignedUserId(ctx, uc, exec, filters); err != nil {
+		return nil, err
+	}
+
 	cache := exec.Cache(ctx)
 	cacheKey, cacheEnabled := buildCaseAnalyticsCacheKey(ctx, cache, queryName, filters, false)
 
@@ -150,6 +179,11 @@ func cachedScalarQuery[T any](
 	}
 
 	exec := uc.executorFactory.NewExecutor()
+
+	if err := validateAssignedUserId(ctx, uc, exec, filters); err != nil {
+		return zero, err
+	}
+
 	cache := exec.Cache(ctx)
 	cacheKey, cacheEnabled := buildCaseAnalyticsCacheKey(ctx, cache, queryName, filters, true)
 

--- a/usecases/case_analytics_usecase.go
+++ b/usecases/case_analytics_usecase.go
@@ -56,6 +56,11 @@ type CaseAnalyticsRepository interface {
 		exec repositories.Executor,
 		filters analytics.CaseAnalyticsFilter,
 	) ([]analytics.CaseStatusByDate, error)
+	CaseSlaStatusByDate(
+		ctx context.Context,
+		exec repositories.Executor,
+		filters analytics.CaseAnalyticsFilter,
+	) ([]analytics.CaseSlaStatusByDate, error)
 	CaseStatusByInbox(
 		ctx context.Context,
 		exec repositories.Executor,
@@ -159,6 +164,17 @@ func (uc CaseAnalyticsUsecase) CaseStatusByDate(
 		func(d time.Time) analytics.CaseStatusByDate {
 			return analytics.CaseStatusByDate{Date: d}
 		})
+}
+
+func (uc CaseAnalyticsUsecase) CaseSlaStatusByDate(
+	ctx context.Context,
+	filters dto.CaseAnalyticsFilters,
+) ([]analytics.CaseSlaStatusByDate, error) {
+	if !uc.license.Analytics {
+		return nil, nil
+	}
+	return cachedTimeSeriesQuery(ctx, uc, filters, "case_sla_status_by_date", uc.repository.CaseSlaStatusByDate,
+		func(d time.Time) analytics.CaseSlaStatusByDate { return analytics.CaseSlaStatusByDate{Date: d} })
 }
 
 func (uc CaseAnalyticsUsecase) CaseStatusByInbox(

--- a/usecases/case_analytics_usecase.go
+++ b/usecases/case_analytics_usecase.go
@@ -66,6 +66,7 @@ type CaseAnalyticsRepository interface {
 		exec repositories.Executor,
 		filters analytics.CaseAnalyticsFilter,
 	) ([]analytics.CaseStatusByInbox, error)
+	UserById(ctx context.Context, exec repositories.Executor, userId string) (models.User, error)
 }
 
 type CaseAnalyticsUsecase struct {


### PR DESCRIPTION
## Add SLA status time-series to case analytics

Adds a new case analytics query, `case_sla_status_by_date`, exposed via the
existing `POST /analytics/cases/:query` endpoint.

For each day in the requested range (bucketed by case creation date, in the
caller's timezone), it returns the count of cases in three buckets relative
to their inbox's configured SLA (`inboxes.sla`, in calendar days):

- `completed_within_sla`: closed before the SLA due date
- `sla_breached`: closed after the due date, or still open past the due date
- `still_open_within_sla`: still open and not yet past the due date

Cases whose inbox has no SLA configured never breach (fall into
`completed_within_sla`/`still_open_within_sla` depending on status).

Respects the existing filters (date range, timezone, inbox, assigned user)
and reuses the existing Redis time-series cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added daily case SLA analytics.
  * Reports cases completed within SLA, SLA-breached cases, and cases still open within SLA.
  * Supports filtering by date range, inbox, organization, and assignee.
  * Available through the case analytics query interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->