### PR TITLE
Omit empty strings from being elligible pivot values.

### DIFF
--- a/usecases/evaluate_scenario/evaluate_scenario.go
+++ b/usecases/evaluate_scenario/evaluate_scenario.go
@@ -224,7 +224,8 @@ func (e ScenarioEvaluator) processScenarioIteration(
 				errPv,
 				"error getting pivot value in EvalScenario")
 		}
-		if value != nil {
+		// We skip this pivot if it was not defined or is an empty-equivalent string.
+		if value != nil && strings.TrimSpace(*value) != "" {
 			eligible = append(eligible, eligiblePivot{
 				pivot:      &params.Pivots[i],
 				value:      *value,


### PR DESCRIPTION
When making a decision, providing an empty string for a column used in a Belongs to relationship makes it elligible to become the decision's pivot value, which obviously in 99.999…% of the cases is not what is expected.

It is especially egregious when using CSV to create batch decisions, since no columns can be omitted, and null cannot be expressed.

Now, values that are empty or made entirely of whitespace will be excluded from becoming pivot values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pivot values containing only whitespace are now treated as undefined and excluded from eligible pivot selection.
  * Non-empty pivot values continue to be selected as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->