### PR TITLE
SLA cases analytics return only stats cases in SLA-enabled inboxes

### DIFF
--- a/repositories/case_analytics_repository.go
+++ b/repositories/case_analytics_repository.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/checkmarble/marble-backend/models/analytics"
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
+	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -337,7 +338,7 @@ func buildCaseSlaStatusByDateQuery(filters analytics.CaseAnalyticsFilter) (squir
 
 	closedAtSQL, closedAtArgs, err := closedAtSubq.ToSql()
 	if err != nil {
-		return squirrel.SelectBuilder{}, err
+		return squirrel.SelectBuilder{}, errors.Wrap(err, "build closed-at subquery")
 	}
 
 	// dueAt calculates the SLA deadline: case created_at + inbox SLA duration (in days).

--- a/repositories/case_analytics_repository.go
+++ b/repositories/case_analytics_repository.go
@@ -321,11 +321,10 @@ func (repo MarbleDbRepository) CaseStatusByDate(
 	})
 }
 
-func (repo MarbleDbRepository) CaseSlaStatusByDate(
-	ctx context.Context,
-	exec Executor,
-	filters analytics.CaseAnalyticsFilter,
-) ([]analytics.CaseSlaStatusByDate, error) {
+// buildCaseSlaStatusByDateQuery builds the SQL query for SLA status analytics.
+// This is a separate function to allow testing the query structure without a database.
+// Only includes inboxes with SLA configured (i.sla IS NOT NULL).
+func buildCaseSlaStatusByDateQuery(filters analytics.CaseAnalyticsFilter) (squirrel.SelectBuilder, error) {
 	// Same "closed_at" derivation as CasesDurationByTimeStats.
 	closedAtSubq := squirrel.
 		Select("ce.case_id", "max(ce.created_at) as closed_at").
@@ -338,26 +337,25 @@ func (repo MarbleDbRepository) CaseSlaStatusByDate(
 
 	closedAtSQL, closedAtArgs, err := closedAtSubq.ToSql()
 	if err != nil {
-		return nil, err
+		return squirrel.SelectBuilder{}, err
 	}
 
-	// due_at is null (no deadline, never breached) when the inbox has no SLA configured.
+	// dueAt calculates the SLA deadline: case created_at + inbox SLA duration (in days).
+	// All cases come from inboxes with sla IS NOT NULL, so this is always defined.
 	dueAt := "c.created_at + (i.sla || ' days')::interval"
 
 	query := NewQueryBuilder().
 		Select(
 			fmt.Sprintf("(c.created_at + interval '%d s')::date as date", filters.TzOffsetSeconds),
 			fmt.Sprintf(`count(*) filter (
-				where c.status = 'closed' and (i.sla is null or ce_agg.closed_at <= %s)
+				where c.status = 'closed' and ce_agg.closed_at <= %s
 			) as completed_within_sla`, dueAt),
 			fmt.Sprintf(`count(*) filter (
-				where i.sla is not null and (
-					(c.status = 'closed' and ce_agg.closed_at > %s) or
+				where (c.status = 'closed' and ce_agg.closed_at > %s) or
 					(c.status != 'closed' and now() > %s)
-				)
 			) as sla_breached`, dueAt, dueAt),
 			fmt.Sprintf(`count(*) filter (
-				where c.status != 'closed' and (i.sla is null or now() <= %s)
+				where c.status != 'closed' and now() <= %s
 			) as still_open_within_sla`, dueAt),
 		).
 		From(dbmodels.TABLE_CASES+" c").
@@ -367,6 +365,7 @@ func (repo MarbleDbRepository) CaseSlaStatusByDate(
 			"c.org_id":   filters.OrgId,
 			"c.inbox_id": filters.InboxIds,
 		}).
+		Where(squirrel.NotEq{"i.sla": nil}).
 		Where(squirrel.And{
 			squirrel.GtOrEq{"c.created_at": filters.Start},
 			squirrel.Lt{"c.created_at": filters.End},
@@ -376,6 +375,19 @@ func (repo MarbleDbRepository) CaseSlaStatusByDate(
 
 	if filters.AssignedUserId != nil {
 		query = query.Where(squirrel.Eq{"c.assigned_to": *filters.AssignedUserId})
+	}
+
+	return query, nil
+}
+
+func (repo MarbleDbRepository) CaseSlaStatusByDate(
+	ctx context.Context,
+	exec Executor,
+	filters analytics.CaseAnalyticsFilter,
+) ([]analytics.CaseSlaStatusByDate, error) {
+	query, err := buildCaseSlaStatusByDateQuery(filters)
+	if err != nil {
+		return nil, err
 	}
 
 	return SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (analytics.CaseSlaStatusByDate, error) {

--- a/repositories/case_analytics_repository_test.go
+++ b/repositories/case_analytics_repository_test.go
@@ -1,0 +1,86 @@
+package repositories
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/checkmarble/marble-backend/models/analytics"
+)
+
+func TestBuildCaseSlaStatusByDateQuery_ExcludesNullSLA(t *testing.T) {
+	// Arrange: create a filter with test values
+	orgId := uuid.New()
+	inboxId := uuid.New()
+	now := time.Now()
+
+	filters := analytics.CaseAnalyticsFilter{
+		OrgId:           orgId,
+		InboxIds:        []uuid.UUID{inboxId},
+		TzOffsetSeconds: 0,
+		Start:           now.Add(-24 * time.Hour),
+		End:             now,
+	}
+
+	// Act: build the query
+	query, err := buildCaseSlaStatusByDateQuery(filters)
+	require.NoError(t, err)
+
+	// Convert to SQL to inspect the query structure
+	sql, args, err := query.ToSql()
+	require.NoError(t, err)
+
+	// Assert: verify the query includes the critical WHERE clause for non-null SLA
+	require.Contains(t, sql, "i.sla IS NOT NULL", "Query must filter for inboxes with SLA configured (i.sla IS NOT NULL)")
+
+	// Assert: verify old "or i.sla is null" clauses are removed
+	require.NotContains(t, sql, "i.sla is null or", "Old 'i.sla is null or' clauses should be removed")
+	require.NotContains(t, sql, "or i.sla is null", "Old 'or i.sla is null' clauses should be removed")
+
+	// Assert: verify org_id and inbox_id filters are still present
+	require.Contains(t, sql, "c.org_id", "Query must filter by organization ID")
+	require.Contains(t, sql, "c.inbox_id", "Query must filter by inbox IDs")
+
+	// Assert: verify date range filters are still present
+	require.Contains(t, sql, "c.created_at", "Query must filter by creation date range")
+
+	// Assert: verify the expected aggregate functions are present
+	require.Contains(t, sql, "completed_within_sla", "Query must return completed_within_sla column")
+	require.Contains(t, sql, "sla_breached", "Query must return sla_breached column")
+	require.Contains(t, sql, "still_open_within_sla", "Query must return still_open_within_sla column")
+
+	// Verify args contain expected values (at minimum 2 UUIDs for org and inbox, 2 timestamps, and event type/status)
+	require.GreaterOrEqual(t, len(args), 5, "Query args must include at least org ID, inbox ID, date range, and event type")
+}
+
+func TestBuildCaseSlaStatusByDateQuery_WithAssignedUserId(t *testing.T) {
+	// Arrange: create a filter with an assigned user ID
+	orgId := uuid.New()
+	inboxId := uuid.New()
+	assignedUserId := "test-user-123"
+	now := time.Now()
+
+	filters := analytics.CaseAnalyticsFilter{
+		OrgId:          orgId,
+		InboxIds:       []uuid.UUID{inboxId},
+		AssignedUserId: &assignedUserId,
+		Start:          now.Add(-24 * time.Hour),
+		End:            now,
+	}
+
+	// Act: build the query
+	query, err := buildCaseSlaStatusByDateQuery(filters)
+	require.NoError(t, err)
+
+	// Convert to SQL to inspect the query structure
+	sql, args, err := query.ToSql()
+	require.NoError(t, err)
+
+	// Assert: verify assigned_to filter is present
+	require.Contains(t, sql, "c.assigned_to", "Query must filter by assigned user when provided")
+
+	// Verify we have more args than the base case (should include the assigned user ID)
+	require.GreaterOrEqual(t, len(args), 6, "Query args must include assigned user ID in addition to base filters")
+}


### PR DESCRIPTION
## Fix: exclude inboxes without SLA from SLA analytics stats

The `case_sla_status_by_date` analytics endpoint was mixing stats from
inboxes with and without SLA configured, which was confusing for users.
Cases from no-SLA inboxes were silently counted as "completed within SLA" /
"still open within SLA", inflating those buckets.

Now the query filters on `i.sla IS NOT NULL`, so only inboxes with SLA
configured contribute to the stats.

### Changes

- `repositories/case_analytics_repository.go`: extracted query building into
  `buildCaseSlaStatusByDateQuery`, added `WHERE i.sla IS NOT NULL`, simplified
  the 3 aggregate filters (removed now-redundant `i.sla is null` fallbacks)
- `repositories/case_analytics_repository_test.go`: new unit tests covering
  the generated SQL (no DB required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SLA status reporting now excludes inboxes without a configured SLA, improving the accuracy of case analytics.
  * Organization, inbox, date-range, aggregation, and assigned-user filters continue to work as expected.

* **Tests**
  * Added coverage for SLA filtering and query criteria to help ensure reliable analytics results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->