### PR TITLE
Adapt license key generator to produce a dashless UUIDv4.

### DIFF
--- a/usecases/license_usecase.go
+++ b/usecases/license_usecase.go
@@ -2,9 +2,7 @@ package usecases
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
-	"fmt"
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -92,12 +90,7 @@ func (usecase *ProtectedLicenseUseCase) CreateLicense(ctx context.Context, input
 }
 
 func generateLicense() string {
-	key := make([]byte, 32)
-	_, err := rand.Read(key)
-	if err != nil {
-		panic(fmt.Errorf("generateLicense: %w", err))
-	}
-	return hex.EncodeToString(key)
+	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
 func (usecase *ProtectedLicenseUseCase) UpdateLicense(ctx context.Context, input models.UpdateLicenseInput) (models.License, error) {


### PR DESCRIPTION
This method was unused until now, but some tools expect the license key to be 36-byte long max.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * License keys are now generated in a standardized UUID-based format.
  * Hyphens are removed from generated license keys for a compact value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->