### PR TITLE
Accept partner as a valid target for belongs to relationships.

### DIFF
--- a/models/data_model_table_semantic.go
+++ b/models/data_model_table_semantic.go
@@ -42,7 +42,7 @@ func SemanticTypeFrom(s string) SemanticType {
 
 // Need for validation, some semantic type require a BelongsTo link to a Party
 func (s SemanticType) IsParty() bool {
-	return s == SemanticTypePerson || s == SemanticTypeCompany
+	return s == SemanticTypePerson || s == SemanticTypeCompany || s == SemanticTypePartner
 }
 
 func (s SemanticType) RequiresBelongsToLink() bool {


### PR DESCRIPTION
A generic person table is sent by the frontend as a `partner` semantic type, which was not allowed to become the target of a belongs to relationship, which is not expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Partner records are now correctly recognized as party types, alongside people and companies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->