### PR TITLE
Fix race condition in public API tests.

### DIFF
--- a/pubapi/tests/fixtures/decisions.yml
+++ b/pubapi/tests/fixtures/decisions.yml
@@ -16,7 +16,7 @@
     object_id: 11111111-1111-1111-1111-111111111111
     lorem: ipsum
   pivot_value: 11111111-1111-1111-1111-111111111111
-  created_at: RAW=now()
+  created_at: RAW=now() - interval '1 minute'
 
 # Decision without a screening
 

--- a/pubapi/tests/setup_test.go
+++ b/pubapi/tests/setup_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/gavv/httpexpect/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/go-testfixtures/testfixtures/v3"
+	moby "github.com/moby/moby/client"
 	"github.com/pressly/goose/v3"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/stretchr/testify/assert"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -64,13 +66,26 @@ func setupPostgres(t *testing.T, ctx context.Context) *postgres.PostgresContaine
 
 	goose.SetLogger(goose.NopLogger())
 
+	provider, err := testcontainers.NewDockerProvider()
+	assert.NoError(t, err)
+	info, err := provider.Client().Info(ctx, moby.InfoOptions{})
+	assert.NoError(t, err)
+
+	image := "postgis/postgis:18-3.6-alpine"
+	platform := "linux/x86_64"
+
+	if info.Info.Architecture == "aarch64" {
+		image = "imresamu/postgis:18-3.6-alpine3.23"
+		platform = "linux/arm64"
+	}
+
 	pg, err := postgres.Run(
 		ctx,
-		"postgis/postgis:18-3.6-alpine",
+		image,
 		postgres.WithDatabase("marble_test"),
 		postgres.WithUsername("postgres"),
 		postgres.WithPassword("marble"),
-		testcontainers.WithImagePlatform("linux/amd64"),
+		testcontainers.WithImagePlatform(platform),
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).


### PR DESCRIPTION
On macOS, Docker running on a virtual machine runs in the possibility to have both clock skewed by a few seconds. Some public API tests relies on the fact that a decision that was just made is visible through the API.

When `now()` was used in the database, a decision could be created in the future, making is invisible to `created_at <= now()`.

Also, use a native ARM64 PostgreSQL image when on ARM64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test data to use a decision timestamp one minute in the past.
  - Improved test environment compatibility across ARM64 and x86_64 systems by selecting the appropriate PostGIS container image automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->