### PR TITLE
Backfill pivot_object_id from client object data if empty.

### DIFF
--- a/api/handle_client360.go
+++ b/api/handle_client360.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
@@ -94,6 +95,11 @@ func handleEntityRelatedCases(uc usecases.Usecases) func(c *gin.Context) {
 		caseUsecase := uc.NewCaseUseCase()
 
 		objectType, objectId := c.Param("object_type"), c.Param("object_id")
+
+		if strings.TrimSpace(objectId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "object_id cannot be empty"))
+			return
+		}
 
 		cases, err := caseUsecase.GetEntityRelatedCases(ctx, objectType, objectId)
 		if presentError(ctx, c, err) {

--- a/api/handle_client_data.go
+++ b/api/handle_client_data.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
@@ -22,6 +23,11 @@ func handleGetIngestedObject(uc usecases.Usecases) func(c *gin.Context) {
 
 		objectType := c.Param("object_type")
 		objectId := c.Param("object_id")
+
+		if strings.TrimSpace(objectId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "object_id cannot be empty"))
+			return
+		}
 
 		usecase := usecasesWithCreds(ctx, uc).NewIngestedDataReaderUsecase()
 		objects, err := usecase.GetIngestedObject(ctx, organizationID, nil, objectType, objectId, "object_id")

--- a/api/handle_entity_annotations.go
+++ b/api/handle_entity_annotations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/dto"
 	"github.com/checkmarble/marble-backend/models"
@@ -19,6 +20,11 @@ func handleListEntityAnnotations(uc usecases.Usecases) gin.HandlerFunc {
 
 		objectType := c.Param("object_type")
 		objectId := c.Param("object_id")
+
+		if strings.TrimSpace(objectId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "object_id cannot be empty"))
+			return
+		}
 
 		uc := usecasesWithCreds(ctx, uc)
 		annotationsUsecase := uc.NewEntityAnnotationUsecase()
@@ -177,6 +183,11 @@ func handleCreateEntityAnnotation(uc usecases.Usecases) gin.HandlerFunc {
 		objectType := c.Param("object_type")
 		objectId := c.Param("object_id")
 
+		if strings.TrimSpace(objectId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "object_id cannot be empty"))
+			return
+		}
+
 		var payload dto.PostEntityAnnotationDto
 
 		if err := c.ShouldBindBodyWithJSON(&payload); err != nil {
@@ -237,6 +248,11 @@ func handleCreateEntityFileAnnotation(uc usecases.Usecases) gin.HandlerFunc {
 
 		objectType := c.Param("object_type")
 		objectId := c.Param("object_id")
+
+		if strings.TrimSpace(objectId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "object_id cannot be empty"))
+			return
+		}
 
 		var payload dto.PostEntityFileAnnotationDto
 

--- a/api/handle_scoring.go
+++ b/api/handle_scoring.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/dto"
@@ -69,7 +70,14 @@ func handleScoringComputeScore(uc usecases.Usecases) gin.HandlerFunc {
 			return
 		}
 
-		_, eval, err := scoringUsecase.ComputeScore(ctx, orgId, c.Param("recordType"), c.Param("recordId"))
+		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "recordId cannot be empty"))
+			return
+		}
+
+		_, eval, err := scoringUsecase.ComputeScore(ctx, orgId, c.Param("recordType"), recordId)
 		if presentError(ctx, c, err) {
 			return
 		}
@@ -312,12 +320,19 @@ func handleScoringScoreHistory(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
+		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "recordId cannot be empty"))
+			return
+		}
+
 		uc := usecasesWithCreds(ctx, uc)
 		scoringUsecase := uc.NewScoringScoresUsecase()
 
 		record := models.ScoringRecordRef{
 			RecordType: c.Param("recordType"),
-			RecordId:   c.Param("recordId"),
+			RecordId:   recordId,
 		}
 
 		scores, err := scoringUsecase.GetScoreHistory(ctx, record)
@@ -333,6 +348,13 @@ func handleScoringGetActiveScore(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
+		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "recordId cannot be empty"))
+			return
+		}
+
 		uc := usecasesWithCreds(ctx, uc)
 		scoringUsecase := uc.NewScoringScoresUsecase()
 
@@ -344,7 +366,7 @@ func handleScoringGetActiveScore(uc usecases.Usecases) gin.HandlerFunc {
 		record := models.ScoringRecordRef{
 			OrgId:      orgId,
 			RecordType: c.Param("recordType"),
-			RecordId:   c.Param("recordId"),
+			RecordId:   recordId,
 		}
 
 		opts := models.RefreshScoreOptions{
@@ -372,6 +394,13 @@ func handleOverrideRecordScore(uc usecases.Usecases) gin.HandlerFunc {
 
 		var payload scoring.OverrideScoreRequest
 
+		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			presentError(ctx, c, errors.Wrap(models.BadParameterError, "recordId cannot be empty"))
+			return
+		}
+
 		if err := c.ShouldBindBodyWithJSON(&payload); err != nil {
 			presentError(ctx, c, errors.Wrap(models.BadParameterError, err.Error()))
 			return
@@ -382,7 +411,7 @@ func handleOverrideRecordScore(uc usecases.Usecases) gin.HandlerFunc {
 
 		req := models.InsertScoreRequest{
 			RecordType: c.Param("recordType"),
-			RecordId:   c.Param("recordId"),
+			RecordId:   recordId,
 			RiskLevel:  payload.RiskLevel,
 			Source:     models.ScoreSourceOverride,
 			StaleAt:    payload.StaleAt,

--- a/pubapi/v1/v1beta/record.go
+++ b/pubapi/v1/v1beta/record.go
@@ -2,6 +2,7 @@ package v1beta
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/checkmarble/marble-backend/models"
 	"github.com/checkmarble/marble-backend/pubapi"
@@ -27,6 +28,11 @@ func HandleGetRecordAnnotations(uc usecases.Usecases) gin.HandlerFunc {
 
 		recordType := c.Param("recordType")
 		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			types.NewErrorResponse().WithError(errors.WithDetail(models.BadParameterError, "recordId cannot be empty")).Serve(c)
+			return
+		}
 
 		uc := pubapi.UsecasesWithCreds(ctx, uc).NewEntityAnnotationUsecase()
 		annotations, err := uc.List(
@@ -64,6 +70,11 @@ func HandleAttachRecordAnnotation(uc usecases.Usecases) gin.HandlerFunc {
 
 		recordType := c.Param("recordType")
 		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			types.NewErrorResponse().WithError(errors.WithDetail(models.BadParameterError, "recordId cannot be empty")).Serve(c)
+			return
+		}
 
 		var payload params.AttachRecordAnnotationParams
 		if err := c.ShouldBindBodyWithJSON(&payload); err != nil {
@@ -130,6 +141,11 @@ func HandleCreateEntityFileAnnotation(uc usecases.Usecases) gin.HandlerFunc {
 
 		recordType := c.Param("recordType")
 		recordId := c.Param("recordId")
+
+		if strings.TrimSpace(recordId) == "" {
+			types.NewErrorResponse().WithError(errors.WithDetail(models.BadParameterError, "recordId cannot be empty")).Serve(c)
+			return
+		}
 
 		var payload params.AttachRecordFileAnnotationParams
 

--- a/pubapi/v1/v1beta/scoring.go
+++ b/pubapi/v1/v1beta/scoring.go
@@ -2,8 +2,8 @@ package v1beta
 
 import (
 	"context"
-	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/checkmarble/marble-backend/models"
@@ -12,6 +12,7 @@ import (
 	"github.com/checkmarble/marble-backend/pubapi/v1/dto"
 	"github.com/checkmarble/marble-backend/usecases"
 	"github.com/checkmarble/marble-backend/utils"
+	"github.com/cockroachdb/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 )
@@ -19,6 +20,13 @@ import (
 func HandleGetObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
+
+		objectId := c.Param("objectId")
+
+		if strings.TrimSpace(objectId) == "" {
+			types.NewErrorResponse().WithError(errors.WithDetail(models.BadParameterError, "objectId cannot be empty")).Serve(c)
+			return
+		}
 
 		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if err != nil {
@@ -32,7 +40,7 @@ func HandleGetObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
 		record := models.ScoringRecordRef{
 			OrgId:      orgId,
 			RecordType: c.Param("objectType"),
-			RecordId:   c.Param("objectId"),
+			RecordId:   objectId,
 		}
 
 		opts := models.RefreshScoreOptions{
@@ -65,6 +73,13 @@ func HandleOverrideObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
 
+		objectId := c.Param("objectId")
+
+		if strings.TrimSpace(objectId) == "" {
+			types.NewErrorResponse().WithError(errors.WithDetail(models.BadParameterError, "objectId cannot be empty")).Serve(c)
+			return
+		}
+
 		orgId, err := utils.OrganizationIdFromRequest(c.Request)
 		if err != nil {
 			types.NewErrorResponse().WithError(err).Serve(c)
@@ -84,7 +99,7 @@ func HandleOverrideObjectRiskLevel(uc usecases.Usecases) gin.HandlerFunc {
 		req := models.InsertScoreRequest{
 			OrgId:      orgId,
 			RecordType: c.Param("objectType"),
-			RecordId:   c.Param("objectId"),
+			RecordId:   objectId,
 			RiskLevel:  p.RiskLevel,
 			Source:     models.ScoreSourceOverride,
 		}

--- a/usecases/ingested_data_reader_usecase.go
+++ b/usecases/ingested_data_reader_usecase.go
@@ -233,7 +233,6 @@ func (usecase IngestedDataReaderUsecase) ReadPivotObjectsFromValues(
 		if pivotDetail.pivotField == "object_id" {
 			pivotObject.PivotObjectId = value.PivotValue
 		}
-
 		// Best effort: a pivot object that cannot be enriched (e.g. its pivot definition
 		// references data model elements that no longer exist) is still returned with the
 		// bare pivot value, and must not fail the whole batch.
@@ -250,7 +249,9 @@ func (usecase IngestedDataReaderUsecase) ReadPivotObjectsFromValues(
 
 	pivotObjectsAsSlice := make([]models.PivotObject, 0, len(pivotObjectsMap))
 	for _, pivotObject := range pivotObjectsMap {
-		pivotObjectsAsSlice = append(pivotObjectsAsSlice, pivotObject)
+		if pivotObject.PivotType != models.PivotTypeObject || pivotObject.PivotObjectId != "" {
+			pivotObjectsAsSlice = append(pivotObjectsAsSlice, pivotObject)
+		}
 	}
 	return pivotObjectsAsSlice, nil
 }
@@ -264,21 +265,6 @@ func (usecase IngestedDataReaderUsecase) enrichPivotObjectWithData(
 	if pivotObject.PivotType == models.PivotTypeField {
 		return pivotObject, nil
 	}
-
-	// Annotations don't depend on the existence of the pivot object in IngestedData, so we can get them first
-	// to enrich the pivot object data
-	annotations, err := usecase.repository.GetEntityAnnotations(
-		ctx,
-		usecase.executorFactory.NewExecutor(),
-		models.EntityAnnotationRequest{
-			OrgId:      organizationId,
-			ObjectType: pivotObject.PivotObjectName,
-			ObjectId:   pivotObject.PivotObjectId,
-		})
-	if err != nil {
-		return models.PivotObject{}, err
-	}
-	pivotObject.PivotObjectData.Annotations = models.GroupAnnotationsByType(annotations)
 
 	objectDataSlice, err := usecase.GetIngestedObject(
 		ctx,
@@ -299,8 +285,30 @@ func (usecase IngestedDataReaderUsecase) enrichPivotObjectWithData(
 	objectData := objectDataSlice[0]
 
 	pivotObject.PivotObjectData.Data = objectData.Data
+
 	pivotObject.PivotObjectData.Metadata = objectData.Metadata
 	pivotObject.IsIngested = true
+
+	if pivotObject.PivotObjectId == "" {
+		if objectId, ok := objectData.Data["object_id"].(string); ok {
+			pivotObject.PivotObjectId = objectId
+		}
+	}
+
+	// Annotations don't depend on the existence of the pivot object in IngestedData, so we can get them first
+	// to enrich the pivot object data
+	annotations, err := usecase.repository.GetEntityAnnotations(
+		ctx,
+		usecase.executorFactory.NewExecutor(),
+		models.EntityAnnotationRequest{
+			OrgId:      organizationId,
+			ObjectType: pivotObject.PivotObjectName,
+			ObjectId:   pivotObject.PivotObjectId,
+		})
+	if err != nil {
+		return models.PivotObject{}, err
+	}
+	pivotObject.PivotObjectData.Annotations = models.GroupAnnotationsByType(annotations)
 
 	// Enriches the pivot object with one level of related objects (fiend objects that are linked to the pivot object, without further recursion)
 	pivotObject.PivotObjectData, err = usecase.enrichClientDataObjectWithRelatedObjectsData(


### PR DESCRIPTION
In some legacy cases, where a link was pointing to a field different from
object_id, the endpoint to retrieve a case's pivot objects would send an empty
pivot_object_id.

This had consequences in the case manager where the frontend would use that empty
string to perform subsequent actions (such as attaching documents to the object).
Those document were all attached to an empty string, and several, unrelated objects
could end up sharing those annotations.

This backfills the object ID derived from the pivot value from the actual object's
data, which always contains an object_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to reject blank or whitespace-only object and record identifiers with clear bad-parameter errors.
  * Prevented invalid requests from proceeding to data retrieval, annotation, and scoring operations.
  * Improved risk-level lookup validation for empty object identifiers.
  * Ensured pivot objects are returned only when they have valid identifiers.
  * Filled missing pivot object identifiers from available ingested data when possible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->