### PR TITLE
add the option to have a probe while migrations run (for job reaper)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,8 +119,9 @@ FIREBASE_API_KEY=dummy
 # If your Firebase project differs from the global Google Cloud project you use, you can set it here.
 # FIREBASE_PROJECT_ID=test-project
 
-# If running the worker process in an environment requiring all processes to respond on an HTTP port, uncomment this setting.
+# If running the worker or migration process in an environment requiring all processes to respond on an HTTP port, uncomment this setting.
 # For example, Cloud Run requires all services to process liveness checks to keep running.
+# The migration process only serves it while the migrations run, so it can also be used as a signal that the job is over.
 # CLOUD_RUN_PROBE_PORT=9000
 
 # Authenticate with OpenID Connect SSO

--- a/cmd/migrations.go
+++ b/cmd/migrations.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/checkmarble/marble-backend/infra"
 	"github.com/checkmarble/marble-backend/repositories"
 	"github.com/checkmarble/marble-backend/utils"
 	"github.com/cockroachdb/errors"
+	"github.com/gin-gonic/gin"
 )
 
 func RunMigrations(apiVersion string, migrateDownTo *int64) error {
@@ -39,6 +42,14 @@ func RunMigrations(apiVersion string, migrateDownTo *int64) error {
 
 	logger.InfoContext(ctx, "starting migrator", slog.String("version", apiVersion))
 
+	// Run a non-blocking basic http server to respond to Cloud Run http probes, to respect the Cloud Run
+	// contract. It is stopped as soon as the migrations are done, so that containers running alongside the
+	// migration job (such as the Cloud SQL auth proxy) can use it as a signal to shut down.
+	if probePort := utils.GetEnv("CLOUD_RUN_PROBE_PORT", ""); probePort != "" {
+		stopProbeServer := runMigrationProbeServer(ctx, probePort)
+		defer stopProbeServer()
+	}
+
 	migrater := repositories.NewMigrater(pgConfig)
 
 	if err := migrater.Run(ctx, migrateDownTo); err != nil {
@@ -47,4 +58,42 @@ func RunMigrations(apiVersion string, migrateDownTo *int64) error {
 	}
 
 	return nil
+}
+
+// Serves the liveness probe endpoints for the duration of the migrations, and returns a function
+// shutting the server down.
+func runMigrationProbeServer(ctx context.Context, port string) func() {
+	logger := utils.LoggerFromContext(ctx)
+
+	gin.SetMode(gin.ReleaseMode)
+
+	r := gin.New()
+
+	r.GET("/", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+	r.GET("/liveness", func(c *gin.Context) {
+		c.String(http.StatusOK, "OK")
+	})
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           r,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.ErrorContext(ctx, fmt.Sprintf("error running migration probe server: %v", err))
+		}
+	}()
+
+	return func() {
+		shutdownCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			logger.ErrorContext(ctx, fmt.Sprintf("error shutting down migration probe server: %v", err))
+		}
+	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Migration processes can now respond to Cloud Run health probes while running.
  * Added liveness and completion signaling for migration jobs.

* **Documentation**
  * Updated configuration guidance to describe probe behavior for migration and worker processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->