### PR TITLE
Expose graph exploration on feature access API

### DIFF
--- a/dto/organization_feature_access_dto.go
+++ b/dto/organization_feature_access_dto.go
@@ -21,6 +21,7 @@ type APIOrganizationFeatureAccess struct {
 	AiRuleBuilding      string `json:"ai_rule_building"`
 	UserScoring         string `json:"user_scoring"`
 	LexisNexis          string `json:"lexisnexis"` //nolint:tagliatelle
+	GraphExploration    string `json:"graph_exploration"`
 
 	// user-scoped
 	// Currently only used to control display of the AI assist button in the UI - DO NOT use for anything else as it will be removed
@@ -44,6 +45,7 @@ func AdaptOrganizationFeatureAccessDto(f models.OrganizationFeatureAccess) APIOr
 		AiAssist:            f.AiAssist.String(),
 		UserScoring:         f.UserScoring.String(),
 		LexisNexis:          f.LexisNexis.String(),
+		GraphExploration:    f.GraphExploration.String(),
 	}
 }
 
@@ -55,12 +57,13 @@ type UpdateOrganizationFeatureAccessBodyDto struct {
 	ContinuousScreening *string `json:"continuous_screening"`
 	AiRuleBuilding      *string `json:"ai_rule_building"`
 	LexisNexis          *string `json:"lexisnexis"` //nolint:tagliatelle
+	GraphExploration    *string `json:"graph_exploration"`
 }
 
 func AdaptUpdateOrganizationFeatureAccessInput(f UpdateOrganizationFeatureAccessBodyDto,
 	orgId uuid.UUID,
 ) models.UpdateOrganizationFeatureAccessInput {
-	var testRun, sanctions, caseAutoAssign, caseAiAssist, continuousScreening, aiRuleBuilding, lexisNexis *models.FeatureAccess
+	var testRun, sanctions, caseAutoAssign, caseAiAssist, continuousScreening, aiRuleBuilding, lexisNexis, graphExploration *models.FeatureAccess
 	if f.TestRun != nil {
 		testRun = utils.Ptr(models.FeatureAccessFrom(*f.TestRun))
 	}
@@ -82,6 +85,9 @@ func AdaptUpdateOrganizationFeatureAccessInput(f UpdateOrganizationFeatureAccess
 	if f.LexisNexis != nil {
 		lexisNexis = utils.Ptr(models.FeatureAccessFrom(*f.LexisNexis))
 	}
+	if f.GraphExploration != nil {
+		graphExploration = utils.Ptr(models.FeatureAccessFrom(*f.GraphExploration))
+	}
 	return models.UpdateOrganizationFeatureAccessInput{
 		OrganizationId:      orgId,
 		TestRun:             testRun,
@@ -91,5 +97,6 @@ func AdaptUpdateOrganizationFeatureAccessInput(f UpdateOrganizationFeatureAccess
 		ContinuousScreening: continuousScreening,
 		AiRuleBuilding:      aiRuleBuilding,
 		LexisNexis:          lexisNexis,
+		GraphExploration:    graphExploration,
 	}
 }

--- a/repositories/organization_repository.go
+++ b/repositories/organization_repository.go
@@ -261,6 +261,10 @@ func (repo *MarbleDbRepository) UpdateOrganizationFeatureAccess(
 		query = query.Set("lexisnexis", *updateFeatureAccess.LexisNexis)
 		nbUpdated++
 	}
+	if updateFeatureAccess.GraphExploration != nil {
+		query = query.Set("graph_exploration", *updateFeatureAccess.GraphExploration)
+		nbUpdated++
+	}
 
 	if nbUpdated == 0 {
 		return nil


### PR DESCRIPTION
## Summary
- Return `graph_exploration` on `GET /feature_access` so the frontend can hide graph UI from the org entitlement.
- Accept `graph_exploration` on the org feature-access PATCH and persist it, matching the existing update input.

The license field and usecase checks already exist on this branch. The GET payload was the missing piece.

## Test plan
- [ ] `GET /feature_access` includes `graph_exploration` (`allowed` / `restricted` / `test`)
- [ ] `PATCH /organizations/{id}/feature_access` with `{ "graph_exploration": "restricted" }` persists and shows up on the next GET
- [ ] Graph walk / relations still 403 when the org feature access is not allowed