### PR TITLE
Allow creating initial org and user when instance is empty.

### DIFF
--- a/api/handle_onboarding.go
+++ b/api/handle_onboarding.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/usecases"
+	"github.com/gin-gonic/gin"
+)
+
+func handleCreateInitialOrganization(uc usecases.Usecases, cfg Configuration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		var payload dto.CreateInitialOrg
+
+		if err := c.ShouldBindBodyWithJSON(&payload); presentError(ctx, c, err) {
+			return
+		}
+
+		onboardingUsecase := uc.NewOnboardingUsecase(cfg.TokenProvider)
+
+		if err := onboardingUsecase.CreateInitialOrganization(ctx, payload); presentError(ctx, c, err) {
+			return
+		}
+
+		c.Status(http.StatusCreated)
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -72,6 +72,8 @@ func addRoutes(r *gin.Engine, conf Configuration, uc usecases.Usecases, auth uti
 		r.GET("/ai-prompts/download", tom, handleAiPromptsDownload(uc))
 	}
 
+	r.POST("/admin/onboard", tom, handleCreateInitialOrganization(uc, conf))
+
 	// Public API initialization
 	{
 		cfg := pubapi.Config{

--- a/dto/onboarding_dto.go
+++ b/dto/onboarding_dto.go
@@ -1,0 +1,9 @@
+package dto
+
+type CreateInitialOrg struct {
+	Organization string `json:"organization" binding:"required,min=1"`
+	Email        string `json:"email" binding:"required,email"`
+	Password     string `json:"password" binding:"omitempty,min=8"`
+	Firstname    string `json:"firstname" binding:"required,min=1"`
+	Lastname     string `json:"lastname" binding:"required,min=1"`
+}

--- a/integration_test/init_test.go
+++ b/integration_test/init_test.go
@@ -161,7 +161,8 @@ func TestMain(m *testing.M) {
 	_ = mredis.Start()
 	redisClient, _ := repositories.NewRedisClient(infra.RedisConfig{Address: mredis.Addr()})
 
-	repos := repositories.NewRepositories(dbPool,
+	repos := repositories.NewRepositories(
+		dbPool,
 		infra.GcpConfig{},
 		repositories.WithRiverClient(riverClient),
 		repositories.WithRedisClient(redisClient),
@@ -170,12 +171,13 @@ func TestMain(m *testing.M) {
 	firebaseAdminClient := &mocks.FirebaseAdminClient{}
 	firebaseAdminClient.On("CreateUser", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	testUsecases = usecases.NewUsecases(repos,
+	testUsecases = usecases.NewUsecases(
+		repos,
 		usecases.WithAppName("marble-test"),
 		usecases.WithLicense(models.NewFullLicense()),
-		usecases.WithIngestionBucketUrl("file://./tempFiles?create_dir=true"),
-		usecases.WithCaseManagerBucketUrl("file://./tempFiles?create_dir=true"),
-		usecases.WithOffloadingBucketUrl("file://./tempFiles?create_dir=true"),
+		usecases.WithIngestionBucketUrl("file:///tmp/tempFiles?create_dir=true"),
+		usecases.WithCaseManagerBucketUrl("file:///tmp/tempFiles?create_dir=true"),
+		usecases.WithOffloadingBucketUrl("file:///tmp/tempFiles?create_dir=true"),
 		usecases.WithFirebaseAdmin(auth.TokenProviderFirebase, firebaseAdminClient),
 	)
 

--- a/mocks/firebase_token_verifier.go
+++ b/mocks/firebase_token_verifier.go
@@ -38,6 +38,12 @@ func (m *FirebaseAdminClient) CreateUser(ctx context.Context, email, name string
 	return args.Error(0)
 }
 
+func (m *FirebaseAdminClient) CreateFirstUser(ctx context.Context, email, password, name string) error {
+	args := m.Called(ctx, email, password, name)
+
+	return args.Error(0)
+}
+
 func (m *FirebaseAdminClient) ListMfaEnrollment(ctx context.Context, emails []string) (map[string]bool, error) {
 	args := m.Called(ctx, emails)
 

--- a/repositories/idp/firebase_admin.go
+++ b/repositories/idp/firebase_admin.go
@@ -17,6 +17,7 @@ import (
 
 type Adminer interface {
 	CreateUser(ctx context.Context, email, name string) error
+	CreateFirstUser(ctx context.Context, email, password, name string) error
 	ListMfaEnrollment(ctx context.Context, emails []string) (map[string]bool, error)
 }
 
@@ -38,6 +39,42 @@ func (c AdminClient) CreateUser(ctx context.Context, email, name string) error {
 	req := new(auth.UserToCreate).
 		Email(email).
 		EmailVerified(false).
+		DisplayName(name)
+
+	user, err := c.client.CreateUser(ctx, req)
+	if err != nil {
+		if auth.IsEmailAlreadyExists(err) {
+			utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user already exists for user %s, skipping creating it", email),
+				"email", email)
+
+			return nil
+		}
+
+		utils.LoggerFromContext(ctx).WarnContext(ctx, fmt.Sprintf("could not create firebase user %s, your administrator will need to create it manually", email),
+			"error", err.Error(),
+			"email", email)
+
+		return err
+	}
+
+	utils.LoggerFromContext(ctx).InfoContext(ctx, fmt.Sprintf("firebase user created for user %s", user.Email),
+		"uid", user.UID,
+		"email", user.Email)
+
+	if err := c.SendPasswordResetEmail(ctx, user); err != nil {
+		utils.LoggerFromContext(ctx).WarnContext(ctx, fmt.Sprintf("could not send the password reset email to user %s: %s", user.Email, err.Error()),
+			"uid", user.UID,
+			"email", user.Email)
+	}
+
+	return nil
+}
+
+func (c AdminClient) CreateFirstUser(ctx context.Context, email, password, name string) error {
+	req := new(auth.UserToCreate).
+		Email(email).
+		Password(password).
+		EmailVerified(true).
 		DisplayName(name)
 
 	user, err := c.client.CreateUser(ctx, req)

--- a/usecases/onboarding_usecase.go
+++ b/usecases/onboarding_usecase.go
@@ -1,0 +1,117 @@
+package usecases
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/pure_utils"
+	"github.com/checkmarble/marble-backend/repositories"
+	"github.com/checkmarble/marble-backend/repositories/idp"
+	"github.com/checkmarble/marble-backend/usecases/auth"
+	"github.com/checkmarble/marble-backend/usecases/executor_factory"
+	"github.com/cockroachdb/errors"
+)
+
+const initialOnboardingLockKey = "marble_initial_onboarding"
+
+type OnboardingUsecase struct {
+	executorFactory    executor_factory.ExecutorFactory
+	transactionFactory executor_factory.TransactionFactory
+	orgRepository      repositories.OrganizationRepository
+	userRepository     repositories.UserRepository
+	tokenProvider      auth.TokenProvider
+	firebase           idp.Adminer
+}
+
+func NewOnboardingUsecase(
+	executorFactory executor_factory.ExecutorFactory,
+	transactionFactory executor_factory.TransactionFactory,
+	orgRepository repositories.OrganizationRepository,
+	userRepository repositories.UserRepository,
+	tokenProvider auth.TokenProvider,
+	firebase idp.Adminer,
+) OnboardingUsecase {
+	return OnboardingUsecase{
+		executorFactory:    executorFactory,
+		transactionFactory: transactionFactory,
+		orgRepository:      orgRepository,
+		userRepository:     userRepository,
+		tokenProvider:      tokenProvider,
+		firebase:           firebase,
+	}
+}
+
+func (uc OnboardingUsecase) CreateInitialOrganization(ctx context.Context, req dto.CreateInitialOrg) error {
+	usesFirebase := uc.tokenProvider == auth.TokenProviderFirebase
+
+	if usesFirebase {
+		if req.Password == "" {
+			return errors.Wrap(models.BadParameterError,
+				"a password is required when configured to use Firebase authentication")
+		}
+		if uc.firebase == nil {
+			return errors.New("configured to use Firebase authentication, but no Firebase admin client is available")
+		}
+	}
+
+	hasAnOrganization, err := uc.orgRepository.HasOrganizations(ctx, uc.executorFactory.NewExecutor())
+	if err != nil {
+		return err
+	}
+	if hasAnOrganization {
+		return errors.Wrap(models.ConflictError, "an organization already exists on this instance")
+	}
+
+	email := strings.TrimSpace(strings.ToLower(req.Email))
+
+	if usesFirebase {
+		if err := uc.firebase.CreateFirstUser(ctx, email, req.Password,
+			fmt.Sprintf("%s %s", req.Firstname, req.Lastname)); err != nil {
+			return errors.Wrap(err, "could not create Firebase user")
+		}
+	}
+
+	return uc.transactionFactory.Transaction(ctx, func(tx repositories.Transaction) error {
+		if err := repositories.GetAdvisoryLockTx(ctx, tx, initialOnboardingLockKey); err != nil {
+			return errors.Wrap(err, "error getting advisory lock on initial onboarding")
+		}
+
+		hasAnOrganization, err := uc.orgRepository.HasOrganizations(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if hasAnOrganization {
+			return errors.Wrap(models.ConflictError, "an organization already exists on this instance")
+		}
+
+		orgId := pure_utils.NewId()
+
+		if err := uc.orgRepository.CreateOrganization(ctx, tx, orgId,
+			models.CreateOrganizationInput{Name: req.Organization}); err != nil {
+			if repositories.IsUniqueViolationError(err) {
+				return errors.Wrap(models.ConflictError, "organization with the same name already exists")
+			}
+			return err
+		}
+
+		userCreate := models.CreateUser{
+			OrganizationId: orgId,
+			Email:          email,
+			FirstName:      req.Firstname,
+			LastName:       req.Lastname,
+			Role:           models.ADMIN,
+		}
+
+		if _, err := uc.userRepository.CreateUser(ctx, tx, userCreate); err != nil {
+			if repositories.IsUniqueViolationError(err) {
+				return errors.Wrap(models.ConflictError, "user with the same email already exists")
+			}
+			return err
+		}
+
+		return nil
+	})
+}

--- a/usecases/onboarding_usecase_test.go
+++ b/usecases/onboarding_usecase_test.go
@@ -1,0 +1,260 @@
+package usecases
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/jackc/pgerrcode"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/checkmarble/marble-backend/dto"
+	"github.com/checkmarble/marble-backend/mocks"
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/usecases/auth"
+)
+
+type onboardingTestDeps struct {
+	exec               *mocks.Executor
+	transaction        *mocks.Transaction
+	transactionFactory *mocks.TransactionFactory
+	executorFactory    *mocks.ExecutorFactory
+	orgRepository      *mocks.OrganizationRepository
+	userRepository     *mocks.UserRepository
+	firebase           *mocks.FirebaseAdminClient
+}
+
+func onboardingUsecaseForTest(tokenProvider auth.TokenProvider) (OnboardingUsecase, onboardingTestDeps) {
+	deps := onboardingTestDeps{
+		exec:            new(mocks.Executor),
+		transaction:     new(mocks.Transaction),
+		executorFactory: new(mocks.ExecutorFactory),
+		orgRepository:   new(mocks.OrganizationRepository),
+		userRepository:  new(mocks.UserRepository),
+		firebase:        new(mocks.FirebaseAdminClient),
+	}
+	deps.transactionFactory = &mocks.TransactionFactory{TxMock: deps.transaction}
+
+	uc := NewOnboardingUsecase(
+		deps.executorFactory,
+		deps.transactionFactory,
+		deps.orgRepository,
+		deps.userRepository,
+		tokenProvider,
+		deps.firebase,
+	)
+
+	return uc, deps
+}
+
+// expectAdvisoryLock stubs the pg_advisory_xact_lock call issued by GetAdvisoryLockTx.
+func (deps onboardingTestDeps) expectAdvisoryLock() {
+	deps.transaction.On("Exec", mock.Anything, "SELECT pg_advisory_xact_lock($1)", mock.Anything).
+		Return(pgconn.NewCommandTag("SELECT 1"), nil)
+}
+
+func validOnboardingPayload() dto.CreateInitialOrg {
+	return dto.CreateInitialOrg{
+		Organization: "Acme",
+		Email:        "admin@acme.com",
+		Firstname:    "Ada",
+		Lastname:     "Lovelace",
+	}
+}
+
+func TestCreateInitialOrganization(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates the organization and its admin user when the instance is empty", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.exec).Return(false, nil)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.transaction).Return(false, nil)
+		deps.orgRepository.On("CreateOrganization", ctx, deps.transaction, mock.Anything,
+			models.CreateOrganizationInput{Name: "Acme"}).Return(nil)
+		deps.userRepository.On("CreateUser", ctx, deps.transaction, mock.MatchedBy(
+			func(u models.CreateUser) bool {
+				return u.Email == "admin@acme.com" && u.Role == models.ADMIN
+			},
+		)).Return("some-user-id", nil)
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		require.NoError(t, uc.CreateInitialOrganization(ctx, validOnboardingPayload()))
+
+		deps.orgRepository.AssertExpectations(t)
+		deps.userRepository.AssertExpectations(t)
+	})
+
+	t.Run("normalizes the email before persisting it", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", mock.Anything, mock.Anything).Return(false, nil)
+		deps.orgRepository.On("CreateOrganization", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(nil)
+		deps.userRepository.On("CreateUser", ctx, deps.transaction, mock.MatchedBy(
+			func(u models.CreateUser) bool { return u.Email == "admin@acme.com" },
+		)).
+			Return("some-user-id", nil)
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		payload := validOnboardingPayload()
+		payload.Email = "  Admin@Acme.COM "
+
+		require.NoError(t, uc.CreateInitialOrganization(ctx, payload))
+
+		deps.userRepository.AssertExpectations(t)
+	})
+
+	t.Run("rejects onboarding when an organization already exists", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.exec).Return(true, nil)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, models.ConflictError)
+		deps.orgRepository.AssertNotCalled(t, "CreateOrganization")
+		deps.userRepository.AssertNotCalled(t, "CreateUser")
+	})
+
+	// The authoritative check: the pre-check saw an empty instance, but a concurrent request won
+	// the race and committed before this one acquired the advisory lock.
+	t.Run("rejects onboarding when a concurrent request created the organization", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.exec).Return(false, nil)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.transaction).Return(true, nil)
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, models.ConflictError)
+		deps.orgRepository.AssertNotCalled(t, "CreateOrganization")
+		deps.userRepository.AssertNotCalled(t, "CreateUser")
+	})
+
+	// Regression test: the instance used to be considered empty when the tables did not exist.
+	t.Run("maps a duplicate organization name to a conflict", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", mock.Anything, mock.Anything).Return(false, nil)
+		deps.orgRepository.On("CreateOrganization", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(&pgconn.PgError{Code: pgerrcode.UniqueViolation})
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, models.ConflictError)
+		deps.userRepository.AssertNotCalled(t, "CreateUser")
+	})
+
+	t.Run("maps a duplicate user email to a conflict", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", mock.Anything, mock.Anything).Return(false, nil)
+		deps.orgRepository.On("CreateOrganization", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(nil)
+		deps.userRepository.On("CreateUser", mock.Anything, mock.Anything, mock.Anything).
+			Return("", &pgconn.PgError{Code: pgerrcode.UniqueViolation})
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, models.ConflictError)
+	})
+
+	t.Run("requires a password when configured to use Firebase", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderFirebase)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, models.BadParameterError)
+		deps.executorFactory.AssertNotCalled(t, "NewExecutor")
+		deps.orgRepository.AssertNotCalled(t, "CreateOrganization")
+		deps.userRepository.AssertNotCalled(t, "CreateUser")
+	})
+
+	// The identity provider account is created before the transaction opens, so that no network
+	// call is made while holding a pooled connection and the advisory lock.
+	t.Run("creates the Firebase user before opening the transaction", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderFirebase)
+		firebaseCalled := false
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", mock.Anything, mock.Anything).Return(false, nil)
+		deps.firebase.On("CreateFirstUser", ctx, "admin@acme.com", "hunter2hunter2", "Ada Lovelace").
+			Return(nil).Run(func(mock.Arguments) { firebaseCalled = true })
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).
+			Return(nil).
+			Run(func(mock.Arguments) {
+				assert.True(t, firebaseCalled, "Firebase user must be created before the transaction opens")
+			})
+		deps.orgRepository.On("CreateOrganization", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(nil)
+		deps.userRepository.On("CreateUser", mock.Anything, mock.Anything, mock.Anything).
+			Return("some-user-id", nil)
+
+		payload := validOnboardingPayload()
+		payload.Password = "hunter2hunter2"
+
+		require.NoError(t, uc.CreateInitialOrganization(ctx, payload))
+
+		deps.firebase.AssertExpectations(t)
+	})
+
+	t.Run("does not create the organization when the Firebase user cannot be created", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderFirebase)
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.exec).Return(false, nil)
+		deps.firebase.On("CreateFirstUser", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(errors.New("firebase is down"))
+
+		payload := validOnboardingPayload()
+		payload.Password = "hunter2hunter2"
+
+		err := uc.CreateInitialOrganization(ctx, payload)
+
+		require.Error(t, err)
+		deps.transactionFactory.AssertNotCalled(t, "Transaction")
+		deps.orgRepository.AssertNotCalled(t, "CreateOrganization")
+	})
+
+	t.Run("does not touch the identity provider on an already onboarded instance", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderFirebase)
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", ctx, deps.exec).Return(true, nil)
+
+		payload := validOnboardingPayload()
+		payload.Password = "hunter2hunter2"
+
+		err := uc.CreateInitialOrganization(ctx, payload)
+
+		assert.ErrorIs(t, err, models.ConflictError)
+		deps.firebase.AssertNotCalled(t, "CreateFirstUser")
+		deps.transactionFactory.AssertNotCalled(t, "Transaction")
+	})
+
+	t.Run("propagates repository errors that are not conflicts", func(t *testing.T) {
+		uc, deps := onboardingUsecaseForTest(auth.TokenProviderOidc)
+		expected := errors.New("boom")
+		deps.expectAdvisoryLock()
+		deps.executorFactory.On("NewExecutor").Return(deps.exec)
+		deps.orgRepository.On("HasOrganizations", mock.Anything, mock.Anything).Return(false, nil)
+		deps.orgRepository.On("CreateOrganization", mock.Anything, mock.Anything, mock.Anything,
+			mock.Anything).Return(expected)
+		deps.transactionFactory.On("Transaction", ctx, mock.Anything).Return(nil)
+
+		err := uc.CreateInitialOrganization(ctx, validOnboardingPayload())
+
+		assert.ErrorIs(t, err, expected)
+		assert.NotErrorIs(t, err, models.ConflictError)
+	})
+}

--- a/usecases/usecases.go
+++ b/usecases/usecases.go
@@ -432,7 +432,8 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		Credentials: enforceSecurity.Credentials,
 	}
 
-	environment.AddEvaluator(ast.FUNC_CUSTOM_LIST_ACCESS,
+	environment.AddEvaluator(
+		ast.FUNC_CUSTOM_LIST_ACCESS,
 		evaluate.NewCustomListValuesAccess(
 			usecases.Repositories.CustomListRepository,
 			enforceSecurity,
@@ -441,7 +442,8 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		),
 	)
 
-	environment.AddEvaluator(ast.FUNC_DB_ACCESS,
+	environment.AddEvaluator(
+		ast.FUNC_DB_ACCESS,
 		evaluate.DatabaseAccess{
 			OrganizationId:             params.OrganizationId,
 			DataModel:                  params.DataModel,
@@ -472,9 +474,11 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		evaluate.NewTimestampExtract(
 			usecases.NewExecutorFactory(),
 			usecases.Repositories.MarbleDbRepository,
-			params.OrganizationId))
+			params.OrganizationId,
+		))
 
-	environment.AddEvaluator(ast.FUNC_MONITORING_LIST_CHECK,
+	environment.AddEvaluator(
+		ast.FUNC_MONITORING_LIST_CHECK,
 		evaluate.EntityAnnotationCheck{
 			AnnotationType:     models.EntityAnnotationRiskTag,
 			OrgId:              params.OrganizationId,
@@ -488,7 +492,8 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		},
 	)
 
-	environment.AddEvaluator(ast.FUNC_RECORD_HAS_TAGS,
+	environment.AddEvaluator(
+		ast.FUNC_RECORD_HAS_TAGS,
 		evaluate.EntityAnnotationCheck{
 			AnnotationType:     models.EntityAnnotationTag,
 			OrgId:              params.OrganizationId,
@@ -502,7 +507,8 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		},
 	)
 
-	environment.AddEvaluator(ast.FUNC_RECORD_HAS_PAST_ALERTS,
+	environment.AddEvaluator(
+		ast.FUNC_RECORD_HAS_PAST_ALERTS,
 		evaluate.PastAlerts{
 			ExecutorFactory: usecases.NewExecutorFactory(),
 			Repository:      usecases.Repositories.MarbleDbRepository,
@@ -512,7 +518,8 @@ func (usecases *Usecases) AstEvaluationEnvironmentFactory(params ast_eval.Evalua
 		},
 	)
 
-	environment.AddEvaluator(ast.FUNC_RECORD_RISK_LEVEL,
+	environment.AddEvaluator(
+		ast.FUNC_RECORD_RISK_LEVEL,
 		evaluate.NewRecordRiskLevelEvaluator(
 			params.OrganizationId,
 			usecases.NewExecutorFactory(),
@@ -677,5 +684,16 @@ func (usecases *Usecases) NewPayloadEnrichmentUsecase() payload_parser.PayloadEn
 	return payload_parser.NewPayloadEnrichmentUsecase(
 		usecases.coordsEnricher,
 		usecases.ipEnricher,
+	)
+}
+
+func (usecases *Usecases) NewOnboardingUsecase(tokenProvider auth.TokenProvider) OnboardingUsecase {
+	return NewOnboardingUsecase(
+		usecases.NewExecutorFactory(),
+		usecases.NewTransactionFactory(),
+		usecases.Repositories.MarbleDbRepository,
+		usecases.Repositories.MarbleDbRepository,
+		tokenProvider,
+		usecases.firebaseAdmin,
 	)
 }


### PR DESCRIPTION
For the effort of improving the first experience with Marble, this allows, when the instance is empty (no organization) to create, without having valid credentials, an initial organization and user.

Refers to https://github.com/checkmarble/marble-frontend/pull/1843.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /admin/onboard` to create the initial organization and administrator account.
  * Added validation for organization and administrator details, including email and password.
  * Prevents duplicate or premature setup attempts with clear conflict or validation errors.
  * Automatically provisions the first identity-provider account and sends a password reset email when applicable.
  * Returns a success response when initial setup is completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->