### PR TITLE
feat: implement numeric switch functionality with case evaluation

### DIFF
--- a/dto/dto_ast_node_test.go
+++ b/dto/dto_ast_node_test.go
@@ -57,3 +57,34 @@ func TestAstToJson(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, serialized)
 }
+
+func TestNumericSwitchDtoRoundTrip(t *testing.T) {
+	input := NodeDto{
+		Name: "Switch",
+		Children: []NodeDto{
+			{
+				Name: "Case",
+				Children: []NodeDto{
+					{Constant: true},
+					{Constant: 42.0},
+				},
+			},
+		},
+		NamedChildren: map[string]NodeDto{
+			"fallback": {Constant: 10.0},
+		},
+	}
+
+	node, err := AdaptASTNode(input)
+	assert.NoError(t, err)
+	assert.Equal(t, ast.FUNC_SWITCH, node.Function)
+	assert.Equal(t, ast.FUNC_CASE, node.Children[0].Function)
+
+	output, err := AdaptNodeDto(node)
+	assert.NoError(t, err)
+	assert.Equal(t, "Switch", output.Name)
+	assert.Equal(t, "Case", output.Children[0].Name)
+	assert.Equal(t, true, output.Children[0].Children[0].Constant)
+	assert.Equal(t, 42.0, output.Children[0].Children[1].Constant)
+	assert.Equal(t, 10.0, output.NamedChildren["fallback"].Constant)
+}

--- a/models/ast/ast_function.go
+++ b/models/ast/ast_function.go
@@ -58,6 +58,7 @@ const (
 	FUNC_RECORD_RISK_LEVEL
 	FUNC_SCORE_COMPUTATION
 	FUNC_SWITCH
+	FUNC_CASE
 
 	FUNC_UNDEFINED Function = -1
 	FUNC_UNKNOWN   Function = -2
@@ -90,6 +91,11 @@ type ScoreComputationResult struct {
 	Branch   *int `json:"branch,omitempty"`
 	Fallback bool `json:"fallback"`
 	Default  bool `json:"default"`
+}
+
+type SwitchCaseResult struct {
+	Matched bool    `json:"matched"`
+	Value   float64 `json:"value"`
 }
 
 // If number of arguments -1 the function can take any number of arguments
@@ -321,8 +327,12 @@ var FuncAttributesMap = map[Function]FuncAttributes{
 	FUNC_SWITCH: {
 		DebugName:           "FUNC_SWITCH",
 		AstName:             "Switch",
-		NamedArguments:      []string{"field", "type"},
-		LazyChildEvaluation: shortCircuitIfScoringTriggered,
+		NamedArguments:      []string{"field", "type", "fallback"},
+		LazyChildEvaluation: shortCircuitIfSwitchTriggered,
+	},
+	FUNC_CASE: {
+		DebugName: "FUNC_CASE",
+		AstName:   "Case",
 	},
 }
 
@@ -374,11 +384,15 @@ func shortCircuitIfFalse(res NodeEvaluation) bool {
 	return true
 }
 
-func shortCircuitIfScoringTriggered(res NodeEvaluation) bool {
-	if s, ok := res.ReturnValue.(ScoreComputationResult); ok {
+func shortCircuitIfSwitchTriggered(res NodeEvaluation) bool {
+	switch s := res.ReturnValue.(type) {
+	case ScoreComputationResult:
 		return !s.Triggered
+	case SwitchCaseResult:
+		return !s.Matched
+	default:
+		return false
 	}
-	return false
 }
 
 func IsLogicalOperation(f Function) bool {

--- a/usecases/ast_eval/evaluate/evaluate_case.go
+++ b/usecases/ast_eval/evaluate/evaluate_case.go
@@ -1,0 +1,32 @@
+package evaluate
+
+import (
+	"context"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+)
+
+type Case struct{}
+
+func (Case) Evaluate(_ context.Context, arguments ast.Arguments) (any, []error) {
+	if err := verifyNumberOfArguments(arguments.Args, 2); err != nil {
+		return MakeEvaluateError(err)
+	}
+
+	var conditionErr error
+	matched := false
+	if arguments.Args[0] != nil {
+		matched, conditionErr = adaptArgumentToBool(arguments.Args[0])
+	}
+
+	value, valueErr := promoteArgumentToFloat64(arguments.Args[1])
+	errs := MakeAdaptedArgsErrors([]error{conditionErr, valueErr})
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return ast.SwitchCaseResult{
+		Matched: matched,
+		Value:   value,
+	}, nil
+}

--- a/usecases/ast_eval/evaluate/evaluate_case_test.go
+++ b/usecases/ast_eval/evaluate/evaluate_case_test.go
@@ -1,0 +1,72 @@
+package evaluate
+
+import (
+	"context"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCase(t *testing.T) {
+	t.Run("matches and normalizes an integer value", func(t *testing.T) {
+		result, errs := (Case{}).Evaluate(context.Background(), ast.Arguments{
+			Args: []any{true, 42},
+		})
+
+		require.Empty(t, errs)
+		assert.Equal(t, ast.SwitchCaseResult{Matched: true, Value: 42.0}, result)
+	})
+
+	t.Run("does not match false or nil predicates", func(t *testing.T) {
+		for _, predicate := range []any{false, nil} {
+			result, errs := (Case{}).Evaluate(context.Background(), ast.Arguments{
+				Args: []any{predicate, 4.2},
+			})
+
+			require.Empty(t, errs)
+			assert.Equal(t, ast.SwitchCaseResult{Matched: false, Value: 4.2}, result)
+		}
+	})
+
+	t.Run("requires exactly two children", func(t *testing.T) {
+		result, errs := (Case{}).Evaluate(context.Background(), ast.Arguments{
+			Args: []any{true},
+		})
+
+		assert.Nil(t, result)
+		require.Len(t, errs, 1)
+		assert.ErrorIs(t, errs[0], ast.ErrWrongNumberOfArgument)
+	})
+
+	t.Run("rejects a non-boolean predicate at argument zero", func(t *testing.T) {
+		result, errs := (Case{}).Evaluate(context.Background(), ast.Arguments{
+			Args: []any{"true", 42},
+		})
+
+		assert.Nil(t, result)
+		require.Len(t, errs, 1)
+		assert.ErrorIs(t, errs[0], ast.ErrArgumentMustBeBool)
+		assert.Equal(t, ast.NewArgumentError(0), extractArgumentError(t, errs[0]))
+	})
+
+	t.Run("rejects a non-numeric value at argument one", func(t *testing.T) {
+		result, errs := (Case{}).Evaluate(context.Background(), ast.Arguments{
+			Args: []any{true, "42"},
+		})
+
+		assert.Nil(t, result)
+		require.Len(t, errs, 1)
+		assert.ErrorIs(t, errs[0], ast.ErrArgumentMustBeIntOrFloat)
+		assert.Equal(t, ast.NewArgumentError(1), extractArgumentError(t, errs[0]))
+	})
+}
+
+func extractArgumentError(t *testing.T, err error) ast.ArgumentError {
+	t.Helper()
+
+	var argumentErr ast.ArgumentError
+	require.ErrorAs(t, err, &argumentErr)
+	return argumentErr
+}

--- a/usecases/ast_eval/evaluate/evaluate_switch.go
+++ b/usecases/ast_eval/evaluate/evaluate_switch.go
@@ -9,22 +9,26 @@ import (
 
 type Switch struct{}
 
-func (p Switch) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []error) {
-	var errs []error
-
+func (Switch) Evaluate(_ context.Context, arguments ast.Arguments) (any, []error) {
 	if len(arguments.Args) == 0 {
-		errs = append(errs, errors.Wrap(ast.ErrWrongNumberOfArgument, "Switch should have at least one branch"))
+		return MakeEvaluateError(errors.Wrap(ast.ErrWrongNumberOfArgument, "Switch should have at least one branch"))
 	}
 
-	if len(errs) > 0 {
-		return nil, errs
+	switch arguments.Args[0].(type) {
+	case ast.ScoreComputationResult:
+		return evaluateScoringSwitch(arguments)
+	case ast.SwitchCaseResult:
+		return evaluateNumericSwitch(arguments)
+	default:
+		return MakeEvaluateError(errors.Wrap(
+			ast.ErrArgumentInvalidType,
+			"Switch branches must return either ScoreComputationResult or SwitchCaseResult",
+		))
 	}
+}
 
-	nodes, err := adaptArgumentToListOfThings[ast.ScoreComputationResult](arguments.Args)
-	if err != nil {
-		errs = append(errs, err)
-	}
-
+func evaluateScoringSwitch(arguments ast.Arguments) (any, []error) {
+	nodes, errs := AdaptArguments(arguments.Args, adaptArgumentToThing[ast.ScoreComputationResult])
 	if len(errs) > 0 {
 		return nil, errs
 	}
@@ -49,4 +53,22 @@ func (p Switch) Evaluate(ctx context.Context, arguments ast.Arguments) (any, []e
 	}
 
 	return ast.ScoreComputationResult{Triggered: true, Default: true}, nil
+}
+
+func evaluateNumericSwitch(arguments ast.Arguments) (any, []error) {
+	cases, errs := AdaptArguments(arguments.Args, adaptArgumentToThing[ast.SwitchCaseResult])
+	fallback, fallbackErr := AdaptNamedArgument(arguments.NamedArgs, "fallback", promoteArgumentToFloat64)
+	errs = append(errs, fallbackErr)
+	errs = filterNilErrors(errs...)
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	for _, switchCase := range cases {
+		if switchCase.Matched {
+			return switchCase.Value, nil
+		}
+	}
+
+	return fallback, nil
 }

--- a/usecases/ast_eval/evaluate_ast_numeric_switch_test.go
+++ b/usecases/ast_eval/evaluate_ast_numeric_switch_test.go
@@ -1,0 +1,150 @@
+package ast_eval
+
+import (
+	"context"
+	"testing"
+
+	"github.com/checkmarble/marble-backend/models"
+	"github.com/checkmarble/marble-backend/models/ast"
+	"github.com/checkmarble/marble-backend/usecases/ast_eval/evaluate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNumericSwitchUsesFirstMatchingCase(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+	root := numericSwitchNode(
+		10,
+		numericCaseNode(ast.NewNodeConstant(false), 20),
+		numericCaseNode(ast.NewNodeConstant(true), 30),
+		ast.Node{
+			Function: ast.FUNC_CASE,
+			Children: []ast.Node{
+				{Function: ast.FUNC_UNDEFINED},
+				ast.NewNodeConstant(40),
+			},
+		},
+	)
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.True(t, ok)
+	assert.Equal(t, 30.0, evaluation.ReturnValue)
+	assert.Len(t, evaluation.Children, 2)
+}
+
+func TestNumericSwitchUsesRequiredFallback(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+
+	t.Run("returns fallback when no case matches", func(t *testing.T) {
+		root := numericSwitchNode(12, numericCaseNode(ast.NewNodeConstant(false), 20))
+
+		evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+		require.True(t, ok)
+		assert.Equal(t, 12.0, evaluation.ReturnValue)
+	})
+
+	t.Run("rejects a missing fallback", func(t *testing.T) {
+		root := ast.Node{Function: ast.FUNC_SWITCH}.
+			AddChild(numericCaseNode(ast.NewNodeConstant(false), 20))
+
+		evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+		require.False(t, ok)
+		require.Len(t, evaluation.Errors, 1)
+		assert.ErrorIs(t, evaluation.Errors[0], ast.ErrMissingNamedArgument)
+		var argumentErr ast.ArgumentError
+		require.ErrorAs(t, evaluation.Errors[0], &argumentErr)
+		assert.Equal(t, ast.NewNamedArgumentError("fallback"), argumentErr)
+	})
+
+	t.Run("rejects a non-numeric fallback", func(t *testing.T) {
+		root := numericSwitchNode("default", numericCaseNode(ast.NewNodeConstant(false), 20))
+
+		evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+		require.False(t, ok)
+		require.Len(t, evaluation.Errors, 1)
+		assert.ErrorIs(t, evaluation.Errors[0], ast.ErrArgumentMustBeIntOrFloat)
+	})
+}
+
+func TestNumericSwitchSupportsStringFieldPredicate(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+	environment.AddEvaluator(ast.FUNC_PAYLOAD, evaluate.NewPayload(ast.FUNC_PAYLOAD, models.ClientObject{
+		Data: map[string]any{"status": "PEP"},
+	}))
+	predicate := ast.Node{Function: ast.FUNC_EQUAL}.
+		AddChild(ast.Node{Function: ast.FUNC_PAYLOAD}.AddChild(ast.NewNodeConstant("status"))).
+		AddChild(ast.NewNodeConstant("PEP"))
+	root := numericSwitchNode(5, numericCaseNode(predicate, 25))
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.True(t, ok)
+	assert.Equal(t, 25.0, evaluation.ReturnValue)
+}
+
+func TestNumericSwitchSupportsTwoVariablePredicate(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+	environment.AddEvaluator(ast.FUNC_PAYLOAD, evaluate.NewPayload(ast.FUNC_PAYLOAD, models.ClientObject{
+		Data: map[string]any{"status": "PEP"},
+	}))
+	environment.AddEvaluator(ast.FUNC_RECORD_RISK_LEVEL, staticEvaluator{result: true})
+
+	stringPredicate := ast.Node{Function: ast.FUNC_EQUAL}.
+		AddChild(ast.Node{Function: ast.FUNC_PAYLOAD}.AddChild(ast.NewNodeConstant("status"))).
+		AddChild(ast.NewNodeConstant("PEP"))
+	riskLevelPredicate := ast.Node{Function: ast.FUNC_RECORD_RISK_LEVEL}.
+		AddChild(ast.NewNodeConstant([]float64{2}))
+	combinedPredicate := ast.Node{Function: ast.FUNC_AND}.
+		AddChild(stringPredicate).
+		AddChild(riskLevelPredicate)
+	root := numericSwitchNode(5, numericCaseNode(combinedPredicate, 35))
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.True(t, ok)
+	assert.Equal(t, 35.0, evaluation.ReturnValue)
+}
+
+func TestSwitchRejectsMixedBranchKindsDuringValidation(t *testing.T) {
+	environment := NewAstEvaluationEnvironment().WithoutOptimizations()
+	scoringCase := ast.Node{Function: ast.FUNC_SCORE_COMPUTATION}.
+		AddChild(ast.NewNodeConstant(true)).
+		AddNamedChild("modifier", ast.NewNodeConstant(10))
+	root := numericSwitchNode(
+		5,
+		numericCaseNode(ast.NewNodeConstant(false), 20),
+		scoringCase,
+	)
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.False(t, ok)
+	require.Len(t, evaluation.Errors, 1)
+	assert.ErrorIs(t, evaluation.Errors[0], ast.ErrArgumentInvalidType)
+	var argumentErr ast.ArgumentError
+	require.ErrorAs(t, evaluation.Errors[0], &argumentErr)
+	assert.Equal(t, ast.NewArgumentError(1), argumentErr)
+}
+
+type staticEvaluator struct {
+	result any
+}
+
+func (e staticEvaluator) Evaluate(context.Context, ast.Arguments) (any, []error) {
+	return e.result, nil
+}
+
+func numericCaseNode(predicate ast.Node, value any) ast.Node {
+	return ast.Node{Function: ast.FUNC_CASE}.
+		AddChild(predicate).
+		AddChild(ast.NewNodeConstant(value))
+}
+
+func numericSwitchNode(fallback any, cases ...ast.Node) ast.Node {
+	root := ast.Node{Function: ast.FUNC_SWITCH, Children: cases}
+	return root.AddNamedChild("fallback", ast.NewNodeConstant(fallback))
+}

--- a/usecases/ast_eval/evaluate_ast_scoring_test.go
+++ b/usecases/ast_eval/evaluate_ast_scoring_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestScoreComputation(t *testing.T) {
@@ -121,6 +122,10 @@ func TestSwitchScoring(t *testing.T) {
 
 	assert.Equal(t, 100, scoring.Modifier)
 	assert.Equal(t, 3, scoring.Floor)
+	require.NotNil(t, scoring.Branch)
+	assert.Equal(t, 1, *scoring.Branch)
+	assert.False(t, scoring.Fallback)
+	assert.False(t, scoring.Default)
 }
 
 func TestSwitchScoringDefaultCase(t *testing.T) {
@@ -178,6 +183,49 @@ func TestSwitchScoringDefaultCase(t *testing.T) {
 
 	assert.Equal(t, 42, scoring.Modifier)
 	assert.Equal(t, 9000, scoring.Floor)
+	require.NotNil(t, scoring.Branch)
+	assert.Equal(t, 2, *scoring.Branch)
+	assert.False(t, scoring.Fallback)
+	assert.False(t, scoring.Default)
+}
+
+func TestSwitchScoringFallbackMetadata(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+	root := ast.Node{Function: ast.FUNC_SWITCH}.
+		AddChild(ast.Node{Function: ast.FUNC_SCORE_COMPUTATION}.
+			AddChild(ast.NewNodeConstant(false)).
+			AddNamedChild("modifier", ast.NewNodeConstant(10))).
+		AddNamedChild("fallback", ast.Node{Function: ast.FUNC_SCORE_COMPUTATION}.
+			AddChild(ast.NewNodeConstant(true)).
+			AddNamedChild("modifier", ast.NewNodeConstant(25)))
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.True(t, ok)
+	scoring, ok := evaluation.ReturnValue.(ast.ScoreComputationResult)
+	require.True(t, ok)
+	assert.Equal(t, 25, scoring.Modifier)
+	assert.Nil(t, scoring.Branch)
+	assert.True(t, scoring.Fallback)
+	assert.False(t, scoring.Default)
+}
+
+func TestSwitchScoringDefaultMetadata(t *testing.T) {
+	environment := NewAstEvaluationEnvironment()
+	root := ast.Node{Function: ast.FUNC_SWITCH}.
+		AddChild(ast.Node{Function: ast.FUNC_SCORE_COMPUTATION}.
+			AddChild(ast.NewNodeConstant(false)).
+			AddNamedChild("modifier", ast.NewNodeConstant(10)))
+
+	evaluation, ok := EvaluateAst(context.Background(), nil, environment, root)
+
+	require.True(t, ok)
+	scoring, ok := evaluation.ReturnValue.(ast.ScoreComputationResult)
+	require.True(t, ok)
+	assert.True(t, scoring.Triggered)
+	assert.Nil(t, scoring.Branch)
+	assert.False(t, scoring.Fallback)
+	assert.True(t, scoring.Default)
 }
 
 func TestSwitchErrorOnNoCaseExecuted(t *testing.T) {

--- a/usecases/ast_eval/evaluate_environment.go
+++ b/usecases/ast_eval/evaluate_environment.go
@@ -101,6 +101,7 @@ func NewAstEvaluationEnvironment() AstEvaluationEnvironment {
 
 	environment.AddEvaluator(ast.FUNC_SCORE_COMPUTATION, evaluate.ScoreComputation{})
 	environment.AddEvaluator(ast.FUNC_SWITCH, evaluate.Switch{})
+	environment.AddEvaluator(ast.FUNC_CASE, evaluate.Case{})
 
 	return environment
 }

--- a/usecases/scenarios/scenario_validation_test.go
+++ b/usecases/scenarios/scenario_validation_test.go
@@ -299,3 +299,82 @@ func TestValidationShouldBypassCircuitBreaking(t *testing.T) {
 	})
 	assert.NotEmpty(t, ScenarioValidationToError(result))
 }
+
+func TestValidateScenarioAstNumericSwitch(t *testing.T) {
+	validator := ValidateScenarioAstImpl{
+		AstValidator: staticAstValidator{
+			environment: ast_eval.NewAstEvaluationEnvironment().WithoutOptimizations(),
+		},
+	}
+
+	t.Run("returns a float that can be used in a boolean comparison", func(t *testing.T) {
+		numericSwitch := ast.Node{Function: ast.FUNC_SWITCH}.
+			AddChild(ast.Node{Function: ast.FUNC_CASE}.
+				AddChild(ast.NewNodeConstant(true)).
+				AddChild(ast.NewNodeConstant(20))).
+			AddNamedChild("fallback", ast.NewNodeConstant(10))
+		switchValidation := validator.Validate(context.Background(), models.Scenario{}, &numericSwitch, "float")
+		assert.Empty(t, switchValidation.Errors)
+		assert.Equal(t, 20.0, switchValidation.Evaluation.ReturnValue)
+
+		formula := ast.Node{Function: ast.FUNC_GREATER}.
+			AddChild(ast.NewNodeConstant(30)).
+			AddChild(numericSwitch)
+
+		validation := validator.Validate(context.Background(), models.Scenario{}, &formula, "bool")
+
+		assert.Empty(t, validation.Errors)
+		assert.Empty(t, validation.Evaluation.FlattenErrors())
+		assert.Equal(t, true, validation.Evaluation.ReturnValue)
+		assert.Equal(t, 20.0, validation.Evaluation.Children[1].ReturnValue)
+	})
+
+	t.Run("targets a malformed case value", func(t *testing.T) {
+		numericSwitch := ast.Node{Function: ast.FUNC_SWITCH}.
+			AddChild(ast.Node{Function: ast.FUNC_CASE}.
+				AddChild(ast.NewNodeConstant(true)).
+				AddChild(ast.NewNodeConstant("not a number"))).
+			AddNamedChild("fallback", ast.NewNodeConstant(10))
+		formula := ast.Node{Function: ast.FUNC_GREATER}.
+			AddChild(ast.NewNodeConstant(30)).
+			AddChild(numericSwitch)
+
+		validation := validator.Validate(context.Background(), models.Scenario{}, &formula, "bool")
+
+		caseErrors := validation.Evaluation.Children[1].Children[0].Errors
+		assert.NotEmpty(t, caseErrors)
+		var argumentErr ast.ArgumentError
+		assert.ErrorAs(t, caseErrors[0], &argumentErr)
+		assert.Equal(t, ast.NewArgumentError(1), argumentErr)
+	})
+
+	t.Run("targets a malformed fallback", func(t *testing.T) {
+		numericSwitch := ast.Node{Function: ast.FUNC_SWITCH}.
+			AddChild(ast.Node{Function: ast.FUNC_CASE}.
+				AddChild(ast.NewNodeConstant(false)).
+				AddChild(ast.NewNodeConstant(20))).
+			AddNamedChild("fallback", ast.NewNodeConstant("not a number"))
+		formula := ast.Node{Function: ast.FUNC_GREATER}.
+			AddChild(ast.NewNodeConstant(30)).
+			AddChild(numericSwitch)
+
+		validation := validator.Validate(context.Background(), models.Scenario{}, &formula, "bool")
+
+		switchErrors := validation.Evaluation.Children[1].Errors
+		assert.NotEmpty(t, switchErrors)
+		var argumentErr ast.ArgumentError
+		assert.ErrorAs(t, switchErrors[0], &argumentErr)
+		assert.Equal(t, ast.NewNamedArgumentError("fallback"), argumentErr)
+	})
+}
+
+type staticAstValidator struct {
+	environment ast_eval.AstEvaluationEnvironment
+}
+
+func (v staticAstValidator) MakeDryRunEnvironment(
+	context.Context,
+	models.Scenario,
+) (ast_eval.AstEvaluationEnvironment, *models.ScenarioValidationError) {
+	return v.environment, nil
+}


### PR DESCRIPTION
## What was added

Rules can now express:

```go
Switch(
  Case(predicate, number),
  Case(predicate, number),
  ...,
  fallback: number
)
```

Evaluation is first-match: the first true case returns its number; if none match, the required fallback is returned. The result is always a `float64`, so it can sit in comparisons like Greater(payload.amount, Switch(...)).

## How it works

New Case AST node. `FUNC_CASE` takes exactly two children: a boolean-or-nil predicate, and a numeric value. False or nil means “unmatched” (so missing data falls through to fallback). Non-boolean predicates and non-numeric values are rejected with argument-indexed errors.

Switch now has two families. It looks at the first child:

- `ScoreComputationResult` → existing scoring switch (optional fallback, default metadata)
- `SwitchCaseResult` → new numeric switch (required numeric fallback)
- 
Mixing the two is rejected during full validation.

Short-circuiting. The old scoring-only circuit breaker now also stops after the first matching numeric case, so later cases are not evaluated at runtime. Validation still evaluates all children so malformed later branches are reported.

## What did not change

Scoring switches still validate and evaluate the same way, including Branch, Fallback, and Default metadata. Persistence is still the generic `AST DTO` (name, children, namedChildren), so there is no migration or OpenAPI change. Case is picked up automatically by the existing function-name map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric switch evaluation with ordered case matching and fallback values.
  * Added conditional case branches supporting boolean conditions and numeric results.
  * Numeric switches can be used in formulas and reference payload fields.
  * Added validation for missing or invalid case and fallback values.
  * Existing scoring switch behavior now reports selected branch and fallback metadata more consistently.

* **Tests**
  * Added coverage for numeric switch evaluation, validation, type conversion, and scoring branch selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->