### PR TITLE
Fix timestamp not being accepted in screening birth date field.

### DIFF
--- a/usecases/ast_eval/evaluate/eval_string_concat.go
+++ b/usecases/ast_eval/evaluate/eval_string_concat.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/checkmarble/marble-backend/models/ast"
 	"github.com/cockroachdb/errors"
@@ -28,18 +29,20 @@ func (f StringConcat) Evaluate(ctx context.Context, arguments ast.Arguments) (an
 	}
 
 	for idx, arg := range arguments.Args {
-		switch arg.(type) {
+		switch v := arg.(type) {
 		case nil:
 			continue
 		case string, int, float64:
+			fmt.Fprintf(&sb, "%v", arg)
+
+			if withSeparator && idx < len(arguments.Args)-1 {
+				sb.WriteString(separator)
+			}
+		case time.Time:
+			// If time.Time, get rid of the StringConcat wrapper that will not be used for screenings.
+			return v, nil
 		default:
 			return nil, []error{errors.New("argument is not supported for StringConcat")}
-		}
-
-		fmt.Fprintf(&sb, "%v", arg)
-
-		if withSeparator && idx < len(arguments.Args)-1 {
-			sb.WriteString(separator)
 		}
 	}
 

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -144,7 +144,8 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 						Error: errors.Wrap(models.BadParameterError,
 							"screening trigger formula does not return a boolean"),
 						Code: models.FormulaMustReturnBoolean,
-					})
+					},
+				)
 			}
 		}
 
@@ -180,7 +181,8 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 							Error: errors.Wrapf(models.BadParameterError,
 								"screening field filter '%s' does not return a string or a timestamp", field),
 							Code: models.FormulaMustReturnString,
-						})
+						},
+					)
 				}
 
 				scResult.QueryFields[field] = queryNameValidation
@@ -207,7 +209,8 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 						Error: errors.Wrap(models.BadParameterError,
 							"screening counterparty ID expression does not return a string"),
 						Code: models.FormulaMustReturnString,
-					})
+					},
+				)
 			}
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved string concatenation handling for string, integer, and decimal values, including optional separators.
  - Empty values are skipped during concatenation.
  - Time values are returned immediately when encountered.
  - Unsupported value types now produce a clear error instead of being formatted unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->