### PR TITLE
Support for StringConcat and List in screening config AST.

### DIFF
--- a/usecases/evaluate_scenario/evaluate_screening.go
+++ b/usecases/evaluate_scenario/evaluate_screening.go
@@ -56,7 +56,8 @@ func (e ScenarioEvaluator) evaluateScreening(
 		defer lock.Unlock()
 
 		utils.LoggerFromContext(ctx).Error(fmt.Sprintf(
-			"screening execution returned some fatal errors: %s", err),
+			"screening execution returned some fatal errors: %s", err,
+		),
 			"screening_config_id", scc.Id)
 
 		screeningErrors = append(screeningErrors, err)
@@ -132,7 +133,7 @@ func (e ScenarioEvaluator) evaluateScreening(
 						fieldAst, iteration.OrganizationId,
 						dataAccessor.ClientObject, dataAccessor.DataModel)
 					if err != nil {
-						addScreeningError(scc, errors.New("could not parse screening counterparty name AST expression"))
+						addScreeningError(scc, errors.New("could not parse field AST expression"))
 						return
 					}
 
@@ -149,6 +150,7 @@ func (e ScenarioEvaluator) evaluateScreening(
 						}
 
 						queriesBeforeProcessing[0].Filters[fieldName] = []string{input}
+
 					case time.Time:
 						if input.IsZero() {
 							numEmptyFields++
@@ -156,6 +158,35 @@ func (e ScenarioEvaluator) evaluateScreening(
 						}
 
 						queriesBeforeProcessing[0].Filters[fieldName] = []string{input.Format("2006-01-02")}
+
+					case []any:
+						values := make([]string, 0, len(input))
+
+						for _, input := range input {
+							switch input := input.(type) {
+							case string:
+								if input != "" {
+									values = append(values, input)
+								}
+
+							case time.Time:
+								if !input.IsZero() {
+									values = append(values, input.Format("2006-01-02"))
+								}
+							}
+						}
+
+						if len(values) == 0 {
+							numEmptyFields++
+							continue
+						}
+
+						switch fieldName {
+						case "name":
+							queriesBeforeProcessing[0].Filters[fieldName] = []string{values[0]}
+						default:
+							queriesBeforeProcessing[0].Filters[fieldName] = values
+						}
 
 					default:
 						addScreeningResult(idx, outcomeError(scc, ErrScreeningFieldsNotString, nil))

--- a/usecases/scenarios/scenario_validation.go
+++ b/usecases/scenarios/scenario_validation.go
@@ -174,6 +174,17 @@ func (self *ValidateScenarioIterationImpl) Validate(ctx context.Context,
 				if _, ok := queryNameValidation.RuleEvaluation.ReturnValue.(time.Time); ok {
 					returnTypeIsValid = true
 				}
+				if anyList, ok := queryNameValidation.RuleEvaluation.ReturnValue.([]any); ok && len(anyList) > 0 {
+					allValid := true
+					for idx := range anyList {
+						switch anyList[idx].(type) {
+						case string, time.Time:
+						default:
+							allValid = false
+						}
+					}
+					returnTypeIsValid = allValid
+				}
 
 				if !returnTypeIsValid {
 					queryNameValidation.Errors = append(

--- a/usecases/screening_config_usecase.go
+++ b/usecases/screening_config_usecase.go
@@ -51,9 +51,10 @@ func (uc ScreeningUsecase) CreateScreeningConfig(ctx context.Context, iterationI
 
 	if scCfg.Query != nil {
 		for field, v := range scCfg.Query {
-			if v.Function != ast.FUNC_STRING_CONCAT {
+			if v.Function != ast.FUNC_STRING_CONCAT && v.Function != ast.FUNC_LIST {
 				return models.ScreeningConfig{}, fmt.Errorf(
-					"query field '%s' is not a StringConcat", field)
+					"query field '%s' is not a StringConcat", field,
+				)
 			}
 		}
 	}
@@ -116,9 +117,10 @@ func (uc ScreeningUsecase) UpdateScreeningConfig(ctx context.Context,
 
 	if scCfg.Query != nil {
 		for field, v := range scCfg.Query {
-			if v.Function != ast.FUNC_STRING_CONCAT {
+			if v.Function != ast.FUNC_STRING_CONCAT && v.Function != ast.FUNC_LIST {
 				return models.ScreeningConfig{}, fmt.Errorf(
-					"query filter '%s' must be a StringConcat", field)
+					"query filter '%s' must be a StringConcat or a List of string-like objects", field,
+				)
 			}
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Screening evaluations now support fields that return multiple filter values.
  - Non-empty lists containing strings or dates are accepted when validating screening filters.
  - Screening configurations can use list-based query functions in addition to concatenated string functions.
  - Empty strings and zero dates are ignored when processing list-based values.
  - Name-based screening fields use the first available value from a list.

- **Bug Fixes**
  - Improved error messaging when a screening field expression cannot be evaluated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->