### PR TITLE
Prevent N+1 queries per enum field when retrieving their values.

### DIFF
--- a/repositories/data_model_repository.go
+++ b/repositories/data_model_repository.go
@@ -130,12 +130,24 @@ func (repo MarbleDbRepository) GetDataModel(
 		Tables: make(map[string]models.Table),
 	}
 
+	var fieldEnumValues map[string][]any
+
+	if fetchEnumValues {
+		allFieldIds := pure_utils.Map(fields, func(f dbmodels.DbDataModelTableJoinField) string {
+			return f.FieldID
+		})
+
+		fieldEnumValues, err = repo.GetEnumValues(ctx, exec, allFieldIds)
+		if err != nil {
+			return models.DataModel{}, err
+		}
+	}
+
 	for _, field := range fields {
 		var values []any
 		if field.FieldIsEnum && fetchEnumValues {
-			values, err = repo.GetEnumValues(ctx, exec, field.FieldID)
-			if err != nil {
-				return models.DataModel{}, err
+			if enumValues, ok := fieldEnumValues[field.FieldID]; ok {
+				values = enumValues
 			}
 		}
 
@@ -324,7 +336,8 @@ func (repo MarbleDbRepository) CreateDataModelField(
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id`
 
-	_, err := exec.Exec(ctx,
+	_, err := exec.Exec(
+		ctx,
 		query,
 		fieldId,
 		field.TableId,
@@ -578,39 +591,53 @@ func (repo MarbleDbRepository) DeleteDataModel(ctx context.Context, exec Executo
 	)
 }
 
-func (repo MarbleDbRepository) GetEnumValues(ctx context.Context, exec Executor, fieldID string) ([]any, error) {
+func (repo MarbleDbRepository) GetEnumValues(ctx context.Context, exec Executor, fieldIDs []string) (map[string][]any, error) {
 	if err := validateMarbleDbExecutor(exec); err != nil {
 		return nil, err
 	}
 
-	query, args, err := NewQueryBuilder().
-		Select("text_value", "float_value").
-		From("data_model_enum_values").
-		Where(squirrel.Eq{"field_id": fieldID}).
-		Where("(text_value IS NOT NULL OR float_value IS NOT NULL)").
-		Limit(100).
-		ToSql()
+	sql := `
+		select v.field_id, v.text_value, v.float_value
+		from (select unnest($1::uuid[]) as field_id) as ids
+		cross join lateral (
+			select v.field_id, v.text_value, v.float_value
+			from data_model_enum_values v
+			where v.field_id = ids.field_id
+			limit 100
+		) v
+	`
+
+	rows, err := exec.Query(ctx, sql, fieldIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	rows, err := exec.Query(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
+	values := make(map[string][]any)
 
-	values, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (any, error) {
-		var valueString, valueFloat any
-		if err := rows.Scan(&valueString, &valueFloat); err != nil {
-			return "", err
+	var fieldId string
+	var valueString, valueFloat any
+
+	_, err = pgx.ForEachRow(rows, []any{&fieldId, &valueString, &valueFloat}, func() error {
+		if err := rows.Scan(&fieldId, &valueString, &valueFloat); err != nil {
+			return err
 		}
+
+		if _, ok := values[fieldId]; !ok {
+			values[fieldId] = make([]any, 0)
+		}
+
 		// presumably if there is a row, one of the values should be non-nil
 		if valueString != nil {
-			return valueString, nil
+			values[fieldId] = append(values[fieldId], valueString)
 		}
-		return valueFloat, err
+		if valueFloat != nil {
+			values[fieldId] = append(values[fieldId], valueFloat)
+		}
+
+		return nil
 	})
-	return values, nil
+
+	return values, err
 }
 
 func (repo MarbleDbRepository) GetDataModelField(ctx context.Context, exec Executor, fieldId string) (models.FieldMetadata, error) {

--- a/repositories/migrations/20260908115100_create_enum_index.sql
+++ b/repositories/migrations/20260908115100_create_enum_index.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose NO TRANSACTION
+
+create unique index concurrently if not exists enum_values_coalesced on
+  data_model_enum_values(field_id, coalesce(text_value, float_value::text))
+  include (text_value, float_value);
+
+-- +goose Down
+
+drop index concurrently if exists enum_values_coalesced;


### PR DESCRIPTION
When getting the data model, a separate SQL query is performed, for each field, to retrieve the enum values. This adds up quickly for organizations having dozens of enums.

Since they are performed serially, those organizations were seeing increased timeout errors when getting the data model.

This also adds an index on field_id, which is used to query that table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved data model loading by retrieving requested enum values in a single batch operation, reducing repeated database queries.
  * Added an index to improve lookup performance for enum values associated with fields.
* **Reliability**
  * Enum value retrieval now handles multiple fields consistently while preserving results grouped by field.
  * Limits the number of enum values returned per field to help maintain predictable response times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->