### PR TITLE
Add decision details in case created webhook event.

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -176,11 +176,23 @@ func NewWebhookEventCaseUpdated(c Case) WebhookEventContent {
 }
 
 func NewWebhookEventCaseCreatedManually(c Case) WebhookEventContent {
-	return newWebhookContent(WebhookEventType_CaseCreatedManually, WebhookEventData{Case: &c})
+	var d *DecisionWithRuleExecutions
+
+	if len(c.Decisions) > 0 {
+		d = &DecisionWithRuleExecutions{Decision: c.Decisions[0]}
+	}
+
+	return newWebhookContent(WebhookEventType_CaseCreatedManually, WebhookEventData{Case: &c, Decision: d})
 }
 
 func NewWebhookEventCaseCreatedWorkflow(c Case) WebhookEventContent {
-	return newWebhookContent(WebhookEventType_CaseCreatedWorkflow, WebhookEventData{Case: &c})
+	var d *DecisionWithRuleExecutions
+
+	if len(c.Decisions) > 0 {
+		d = &DecisionWithRuleExecutions{Decision: c.Decisions[0]}
+	}
+
+	return newWebhookContent(WebhookEventType_CaseCreatedWorkflow, WebhookEventData{Case: &c, Decision: d})
 }
 
 func NewWebhookEventCaseCreatedFromContinuousScreening(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Webhook notifications for newly created cases now include the case’s first decision when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->