### PR TITLE
Add relevant decision to case.decisions_updated webhook event.

### DIFF
--- a/models/webhook.go
+++ b/models/webhook.go
@@ -213,8 +213,10 @@ func NewWebhookEventCaseContinuousScreeningMatchReviewed(
 	)
 }
 
-func NewWebhookEventCaseDecisionsUpdated(c Case) WebhookEventContent {
-	return newWebhookContent(WebhookEventType_CaseDecisionsUpdated, WebhookEventData{Case: &c})
+func NewWebhookEventCaseDecisionsUpdated(c Case, decision Decision) WebhookEventContent {
+	d := &DecisionWithRuleExecutions{Decision: decision}
+
+	return newWebhookContent(WebhookEventType_CaseDecisionsUpdated, WebhookEventData{Case: &c, Decision: d})
 }
 
 func NewWebhookEventCaseTagsUpdated(c Case) WebhookEventContent {

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -191,7 +191,8 @@ func (usecase *CaseUseCase) ListCases(
 				for _, inboxId := range filters.InboxIds {
 					if !slices.Contains(availableInboxIds, inboxId) {
 						return models.CaseListPage{}, errors.Wrap(
-							models.ForbiddenError, fmt.Sprintf("inbox %s is not accessible", inboxId))
+							models.ForbiddenError, fmt.Sprintf("inbox %s is not accessible", inboxId),
+						)
 					}
 				}
 			}
@@ -614,7 +615,8 @@ func (usecase *CaseUseCase) UpdateCase(
 		availableInboxIds, err := usecase.getAvailableInboxIds(
 			ctx,
 			tx,
-			c.OrganizationId)
+			c.OrganizationId,
+		)
 		if err != nil {
 			return models.Case{}, err
 		}
@@ -1059,12 +1061,18 @@ func (usecase *CaseUseCase) AddDecisionsToCase(ctx context.Context, userId, case
 			return models.Case{}, err
 		}
 
-		err = usecase.webhookEventsUsecase.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
-			OrganizationId: updatedCase.OrganizationId,
-			EventContent:   models.NewWebhookEventCaseDecisionsUpdated(updatedCase),
-		})
-		if err != nil {
-			return models.Case{}, err
+		for _, decision := range updatedCase.Decisions {
+			if !slices.Contains(decisionIds, decision.DecisionId.String()) {
+				continue
+			}
+
+			err = usecase.webhookEventsUsecase.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
+				OrganizationId: updatedCase.OrganizationId,
+				EventContent:   models.NewWebhookEventCaseDecisionsUpdated(updatedCase, decision),
+			})
+			if err != nil {
+				return models.Case{}, err
+			}
 		}
 
 		return updatedCase, nil
@@ -1154,7 +1162,8 @@ func (usecase *CaseUseCase) UpdateCaseTags(
 		availableInboxIds, err := usecase.getAvailableInboxIds(
 			ctx,
 			usecase.executorFactory.NewExecutor(),
-			c.OrganizationId)
+			c.OrganizationId,
+		)
 		if err != nil {
 			return models.Case{}, err
 		}
@@ -1262,7 +1271,8 @@ func (usecase *CaseUseCase) AddCaseTags(ctx context.Context, caseId string, tagI
 		}
 
 		availableInboxIds, err := usecase.getAvailableInboxIds(
-			ctx, usecase.executorFactory.NewExecutor(), caseMeta.OrganizationId)
+			ctx, usecase.executorFactory.NewExecutor(), caseMeta.OrganizationId,
+		)
 		if err != nil {
 			return models.Case{}, err
 		}
@@ -1347,7 +1357,8 @@ func (usecase *CaseUseCase) RemoveCaseTag(ctx context.Context, caseId string, ta
 		}
 
 		availableInboxIds, err := usecase.getAvailableInboxIds(
-			ctx, usecase.executorFactory.NewExecutor(), caseMeta.OrganizationId)
+			ctx, usecase.executorFactory.NewExecutor(), caseMeta.OrganizationId,
+		)
 		if err != nil {
 			return err
 		}
@@ -2456,7 +2467,8 @@ func (usecase *CaseUseCase) MassUpdate(ctx context.Context, req dto.CaseMassUpda
 		// If we are trying to mass-assign, we need to check, for each case, that the target user can manage the case.
 		if req.Action == models.CaseMassUpdateAssign.String() {
 			if err := security.EnforceSecurityCaseForUser(newAssignee).ReadOrUpdateCase(
-				c.GetMetadata(), availableInboxIds); err != nil {
+				c.GetMetadata(), availableInboxIds,
+			); err != nil {
 				return errors.Wrap(err, "target user lacks case permissions for assignment")
 			}
 		}

--- a/usecases/decision_workflows/actions_case.go
+++ b/usecases/decision_workflows/actions_case.go
@@ -157,7 +157,7 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 
 		err = d.webhookEventCreator.CreateWebhookEvent(ctx, tx, models.WebhookEventCreate{
 			OrganizationId: matchedCase.OrganizationId,
-			EventContent:   models.NewWebhookEventCaseDecisionsUpdated(c),
+			EventContent:   models.NewWebhookEventCaseDecisionsUpdated(c, decision.Decision),
 		})
 		if err != nil {
 			return models.WorkflowExecution{}, err
@@ -168,7 +168,8 @@ func (d DecisionsWorkflows) AutomaticDecisionToCase(
 		}, nil
 	default:
 		return models.WorkflowExecution{}, errors.New(
-			fmt.Sprintf("unknown workflow type: %s", action.Action))
+			fmt.Sprintf("unknown workflow type: %s", action.Action),
+		)
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Webhook notifications for decisions added to cases now include the decision details and associated rule executions.
  - Separate webhook events are emitted for each newly added decision, rather than one event for the entire case update.

- **Refactor**
  - Improved consistency in webhook event payloads for case decision updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->