### PR TITLE
Increase metrics job timeout to 3 minutes.

### DIFF
--- a/usecases/worker_jobs/metrics_collection_job.go
+++ b/usecases/worker_jobs/metrics_collection_job.go
@@ -71,7 +71,7 @@ func NewMetricCollectionWorker(
 }
 
 func (w MetricCollectionWorker) Timeout(job *river.Job[models.MetricsCollectionArgs]) time.Duration {
-	return time.Minute
+	return 3 * time.Minute
 }
 
 // Work executes the metrics collection job by collecting both global and organization-specific metrics


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the metrics collection job timeout from 1 minute to 3 minutes, allowing more time for collection to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->