### PR TITLE
changes to blocking migrations for RDS & fixes on similarity filter q…

### DIFF
--- a/mocks/case_repository.go
+++ b/mocks/case_repository.go
@@ -14,10 +14,10 @@ type CaseRepository struct {
 	mock.Mock
 }
 
-func (r *CaseRepository) ListOrganizationCases(ctx context.Context, exec repositories.Executor,
+func (r *CaseRepository) ListOrganizationCases(ctx context.Context, tx repositories.Transaction,
 	filters models.CaseFilters, pagination models.PaginationAndSorting,
 ) ([]models.Case, error) {
-	args := r.Called(ctx, exec, filters, pagination)
+	args := r.Called(ctx, tx, filters, pagination)
 	return args.Get(0).([]models.Case), args.Error(1)
 }
 

--- a/mocks/inboxes_repository.go
+++ b/mocks/inboxes_repository.go
@@ -45,10 +45,10 @@ func (r *InboxRepository) SoftDeleteInbox(ctx context.Context, exec repositories
 	return args.Error(0)
 }
 
-func (r *InboxRepository) ListOrganizationCases(ctx context.Context, exec repositories.Executor,
+func (r *InboxRepository) ListOrganizationCases(ctx context.Context, tx repositories.Transaction,
 	filters models.CaseFilters, pagination models.PaginationAndSorting,
 ) ([]models.Case, error) {
-	args := r.Called(ctx, exec, filters, pagination)
+	args := r.Called(ctx, tx, filters, pagination)
 	return args.Get(0).([]models.Case), args.Error(1)
 }
 

--- a/repositories/case_repository.go
+++ b/repositories/case_repository.go
@@ -3,6 +3,7 @@ package repositories
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,13 +17,16 @@ import (
 	"github.com/checkmarble/marble-backend/repositories/dbmodels"
 )
 
+// ListOrganizationCases lists cases for an organization.
+// It expects a transaction as input, because (in the case a name filter is used) we need to SET LOCAL for the similarity threshold.
+// If this ever becomes inconvenient, we could use the GetPinnedExecutor method to get a stable session instead.
 func (repo *MarbleDbRepository) ListOrganizationCases(
 	ctx context.Context,
-	exec Executor,
+	tx Transaction,
 	filters models.CaseFilters,
 	pagination models.PaginationAndSorting,
 ) ([]models.Case, error) {
-	if err := validateMarbleDbExecutor(exec); err != nil {
+	if err := validateMarbleDbExecutor(tx); err != nil {
 		return nil, err
 	}
 
@@ -70,11 +74,17 @@ func (repo *MarbleDbRepository) ListOrganizationCases(
 		query = query.Where(squirrel.Eq{"c.inbox_id": filters.InboxIds})
 	}
 	if filters.Name != "" {
-		// Straight from the Postgres doc,
-		// "Same as word_similarity, but forces extent boundaries to match word boundaries. Since we don't have cross-word trigrams,
-		// this function actually returns greatest similarity between first string and any continuous extent of words of the second string."
-		// Hence, the (presumably shorter) string received as input should be used as the first argument.
-		query = query.Where("word_similarity(?, c.name) > ?", filters.Name, repo.similarityThreshold)
+		_, err := tx.Exec(
+			ctx,
+			`SELECT set_config('pg_trgm.word_similarity_threshold', $1, true)`,
+			strconv.FormatFloat(repo.similarityThreshold, 'f', -1, 64),
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to configure similarity threshold")
+		}
+		// word_similarity finds the greatest similarity between the search term and any continuous extent of the case name.
+		// It is asymmetric, so the shorter search term must be the first argument.
+		query = query.Where("? <% c.name", filters.Name)
 	}
 	if !filters.IncludeSnoozed {
 		query = query.Where(squirrel.Or{
@@ -104,7 +114,7 @@ func (repo *MarbleDbRepository) ListOrganizationCases(
 	var offsetCase models.Case
 	if pagination.OffsetId != "" {
 		var err error
-		offsetCase, err = repo.GetCaseById(ctx, exec, pagination.OffsetId)
+		offsetCase, err = repo.GetCaseById(ctx, tx, pagination.OffsetId)
 		if errors.Is(err, pgx.ErrNoRows) {
 			return []models.Case{}, errors.Wrap(models.NotFoundError,
 				"No row found matching the provided offset case Id")
@@ -119,7 +129,7 @@ func (repo *MarbleDbRepository) ListOrganizationCases(
 	}
 
 	// Then, fetch the cases
-	return SqlToListOfRow(ctx, exec, query, func(row pgx.CollectableRow) (models.Case, error) {
+	return SqlToListOfRow(ctx, tx, query, func(row pgx.CollectableRow) (models.Case, error) {
 		db, err := pgx.RowToStructByPos[dbmodels.DBCaseWithContributorsAndTags](row)
 		if err != nil {
 			return models.Case{}, err
@@ -279,7 +289,8 @@ func (repo *MarbleDbRepository) GetCaseReferents(ctx context.Context, exec Execu
 		Column(fmt.Sprintf("case when c.assigned_to is null then null else row(%s) end as assignee",
 			strings.Join(columnsNames("u", dbmodels.UserFields), ","))).
 		Column(fmt.Sprintf("row(%s) as inbox", strings.Join(
-			columnsNames("i", dbmodels.SelectInboxColumn), ","))).
+			columnsNames("i", dbmodels.SelectInboxColumn), ",",
+		))).
 		From(dbmodels.TABLE_CASES + " c").
 		LeftJoin(dbmodels.TABLE_USERS + " u on u.id = c.assigned_to").
 		InnerJoin(dbmodels.TABLE_INBOXES + " i on i.id = c.inbox_id").
@@ -449,7 +460,8 @@ func (repo *MarbleDbRepository) ListCaseTagsByCaseId(ctx context.Context, exec E
 		return nil, err
 	}
 
-	return SqlToListOfModels(ctx, exec,
+	return SqlToListOfModels(
+		ctx, exec,
 		NewQueryBuilder().
 			Select(dbmodels.SelectCaseTagColumn...).
 			From(dbmodels.TABLE_CASE_TAGS).
@@ -464,7 +476,8 @@ func (repo *MarbleDbRepository) ListCaseTagsByTagId(ctx context.Context, exec Ex
 		return nil, err
 	}
 
-	return SqlToListOfModels(ctx, exec,
+	return SqlToListOfModels(
+		ctx, exec,
 		NewQueryBuilder().
 			Select(dbmodels.SelectCaseTagColumn...).
 			From(dbmodels.TABLE_CASE_TAGS).

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -968,6 +968,9 @@ func (repo *IngestedDataReadRepositoryImpl) GatherFieldStatistics(ctx context.Co
 	return fieldStats, nil
 }
 
+// Filters on "field_name" %> 'search term', which is equivalent to word_similarity('search term', "field_name") > threshold
+// which means "look for rows where the search termis 'included' in the field".
+// The <->> operator in the ordering orders by (ascending) distance using the same metric as in the filter.
 func (repo *IngestedDataReadRepositoryImpl) SearchObjects(
 	ctx context.Context,
 	exec Executor,
@@ -992,6 +995,8 @@ func (repo *IngestedDataReadRepositoryImpl) SearchObjects(
 			squirrel.Or{
 				squirrel.Eq{"object_id": terms},
 				squirrel.Expr(fmt.Sprintf("%s %%> ?", field), terms),
+				// AKA "field" %> 'name input'
+				// which is equivalent to 'name input' <% "field"
 			},
 		}).
 		OrderByClause(squirrel.Expr(fmt.Sprintf("object_id = ? desc, %s <->> ? asc", field), terms, terms)).

--- a/repositories/ingested_data_read_repository.go
+++ b/repositories/ingested_data_read_repository.go
@@ -211,7 +211,8 @@ func addJoinsOnIntermediateTables(
 		link, ok := currentTable.LinksToSingle[linkName]
 		if !ok {
 			return squirrel.SelectBuilder{}, fmt.Errorf(
-				"no link with name %s on table %s: %w", linkName, currentTable.Name, models.NotFoundError)
+				"no link with name %s on table %s: %w", linkName, currentTable.Name, models.NotFoundError,
+			)
 		}
 		nextTable, ok := readParams.DataModel.Tables[link.ParentTableName]
 		if !ok {
@@ -230,7 +231,8 @@ func addJoinsOnIntermediateTables(
 			aliasCurrentTable,
 			link.ChildFieldName,
 			aliastNextTable,
-			link.ParentFieldName)
+			link.ParentFieldName,
+		)
 		query = query.
 			Join(joinClause).
 			Where(rowIsValid(aliastNextTable))
@@ -698,7 +700,8 @@ func addConditionForOperator(query squirrel.SelectBuilder, fieldName string, fie
 			squirrel.NotEq{fieldName: nil},
 		}
 		if fieldType == models.String {
-			andCondition = append(andCondition,
+			andCondition = append(
+				andCondition,
 				squirrel.NotEq{fieldName: ""},
 			)
 		}
@@ -716,7 +719,8 @@ func addConditionForOperator(query squirrel.SelectBuilder, fieldName string, fie
 		switch fuzzyFilterOptions.Algorithm {
 		case "bag_of_words_similarity_db":
 			// Basic word_similarity is not symmetric. Make it symmetric, checking if the shorter string is "mostly" included in the longer one.
-			condition := fmt.Sprintf(`
+			condition := fmt.Sprintf(
+				`
 			CASE
 				WHEN length(%s) < length(?) THEN word_similarity(%s, ?)
 				ELSE word_similarity(?, %s)
@@ -732,7 +736,8 @@ func addConditionForOperator(query squirrel.SelectBuilder, fieldName string, fie
 			// - string length below which the trigram similarity is boosted by an arbitrary value: 11
 			// - amount by which the trigram similarity is boosted: 0.05 times a factor, that is maximal when strings are the shortest (6 chars => 0.25 score bump)
 			//   and maximal when strings are just below the boost threshold (10 chars => 0.05 score bump)
-			condition := fmt.Sprintf(`
+			condition := fmt.Sprintf(
+				`
 			CASE
 				WHEN GREATEST(LENGTH(%s), LENGTH(?)) < 6 THEN 1.0 - (levenshtein(%s, ?)::float / GREATEST(LENGTH(%s), LENGTH(?)))
 				WHEN GREATEST(LENGTH(%s), LENGTH(?)) < 11 THEN LEAST(1.0, SIMILARITY(%s, ?) + 0.05 * (11 - LEAST(1, LENGTH(%s), LENGTH(?))))
@@ -989,7 +994,7 @@ func (repo *IngestedDataReadRepositoryImpl) SearchObjects(
 				squirrel.Expr(fmt.Sprintf("%s %%> ?", field), terms),
 			},
 		}).
-		OrderByClause(squirrel.Expr(fmt.Sprintf("object_id = ? desc, %s <<-> ? asc", field), terms, terms)).
+		OrderByClause(squirrel.Expr(fmt.Sprintf("object_id = ? desc, %s <->> ? asc", field), terms, terms)).
 		Limit(pageSize).
 		Offset(offset)
 

--- a/repositories/migrations/20241231000000_baseline_compacted.sql
+++ b/repositories/migrations/20241231000000_baseline_compacted.sql
@@ -20,12 +20,6 @@ $$;
 
 DO $$
 BEGIN
-   EXECUTE 'ALTER DATABASE ' || current_database() || ' SET search_path TO marble, public';
-END
-$$;
-
-DO $$
-BEGIN
    EXECUTE format('ALTER ROLE %I SET search_path = marble, public;', current_user);
 END
 $$;
@@ -87,7 +81,7 @@ $$;
 --
 CREATE TABLE
     marble.api_keys (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         prefix character varying NOT NULL,
         deleted_at timestamp with time zone,
@@ -103,7 +97,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.case_contributors (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         case_id uuid NOT NULL,
         user_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL
@@ -114,7 +108,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.case_events (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         case_id uuid NOT NULL,
         user_id uuid,
         event_type character varying NOT NULL,
@@ -131,7 +125,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.case_files (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         case_id uuid NOT NULL,
         bucket_name character varying(255) NOT NULL,
@@ -144,7 +138,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.case_tags (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         case_id uuid NOT NULL,
         tag_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
@@ -156,7 +150,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.cases (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         name text NOT NULL,
         status character varying DEFAULT 'open'::character varying NOT NULL,
@@ -169,7 +163,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.custom_list_values (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         custom_list_id uuid NOT NULL,
         value character varying NOT NULL,
         created_at timestamp with time zone DEFAULT now(),
@@ -181,7 +175,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.custom_lists (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         organization_id uuid NOT NULL,
         name character varying NOT NULL,
         description character varying NOT NULL,
@@ -207,7 +201,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.data_model_fields (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         table_id uuid NOT NULL,
         name text NOT NULL,
         type marble.data_model_types NOT NULL,
@@ -221,7 +215,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.data_model_links (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         organization_id uuid NOT NULL,
         name text NOT NULL,
         parent_table_id uuid NOT NULL,
@@ -235,7 +229,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.data_model_pivots (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         base_table_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         field_id uuid,
@@ -248,7 +242,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.data_model_tables (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         organization_id uuid NOT NULL,
         name text NOT NULL,
         description text
@@ -259,7 +253,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.decision_rules (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         decision_id uuid NOT NULL,
         score_modifier integer NOT NULL,
@@ -277,7 +271,7 @@ WITH
 --
 CREATE TABLE
     marble.decisions (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         outcome marble.decision_outcome NOT NULL,
@@ -301,7 +295,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.decisions_to_create (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         scheduled_execution_id uuid,
         object_id character varying(100) NOT NULL,
         status character varying(20) DEFAULT 'pending'::character varying NOT NULL,
@@ -329,7 +323,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.inbox_users (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL,
         inbox_id uuid NOT NULL,
@@ -342,7 +336,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.inboxes (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         name character varying(255) NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -355,7 +349,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.licenses (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         key character varying NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         suspended_at timestamp with time zone,
@@ -377,7 +371,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.organizations (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         name character varying NOT NULL,
         deleted_at timestamp with time zone,
         transfer_check_scenario_id uuid,
@@ -390,7 +384,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.organizations_schema (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid,
         schema_name character varying(255) NOT NULL
     );
@@ -400,7 +394,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.partners (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         name character varying(255) NOT NULL,
         bic character varying DEFAULT ''::character varying NOT NULL
@@ -411,7 +405,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.phantom_decisions (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         outcome marble.decision_outcome NOT NULL,
@@ -427,7 +421,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.rule_snoozes (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         created_by_user uuid NOT NULL,
         snooze_group_id uuid NOT NULL,
@@ -443,7 +437,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scenario_iteration_rules (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         scenario_iteration_id uuid NOT NULL,
         display_order smallint NOT NULL,
@@ -463,7 +457,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scenario_iterations (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         scenario_id uuid NOT NULL,
         version smallint,
@@ -482,7 +476,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scenario_publications (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         rank SERIAL NOT NULL,
         org_id uuid NOT NULL,
         scenario_id uuid NOT NULL,
@@ -496,7 +490,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scenario_test_run (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         scenario_iteration_id uuid NOT NULL,
         live_scenario_iteration_id uuid NOT NULL,
         created_at timestamp with time zone DEFAULT now(),
@@ -509,7 +503,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scenarios (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         name character varying NOT NULL,
         description character varying NOT NULL,
@@ -527,7 +521,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.scheduled_executions (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         organization_id uuid NOT NULL,
         scenario_id uuid NOT NULL,
         scenario_iteration_id uuid NOT NULL,
@@ -545,7 +539,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.snooze_groups (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         organization_id uuid NOT NULL
     );
@@ -555,7 +549,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.tags (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         name character varying(255) NOT NULL,
         color character varying(255) NOT NULL,
         created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
@@ -569,7 +563,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.transfer_alerts (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         transfer_id uuid NOT NULL,
         organization_id uuid NOT NULL,
         sender_partner_id uuid NOT NULL,
@@ -587,7 +581,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.transfer_mappings (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         organization_id uuid NOT NULL,
         client_transfer_id character varying(60) NOT NULL,
@@ -599,7 +593,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.upload_logs (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         org_id uuid NOT NULL,
         user_id uuid NOT NULL,
         file_name character varying NOT NULL,
@@ -616,7 +610,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.users (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         email character varying NOT NULL,
         role integer NOT NULL,
         organization_id uuid,
@@ -631,7 +625,7 @@ CREATE TABLE
 --
 CREATE TABLE
     marble.webhook_events (
-        id uuid DEFAULT marble.uuid_generate_v4 () NOT NULL,
+        id uuid DEFAULT uuid_generate_v4 () NOT NULL,
         created_at timestamp with time zone DEFAULT now() NOT NULL,
         updated_at timestamp with time zone DEFAULT now() NOT NULL,
         retry_count integer DEFAULT 0 NOT NULL,

--- a/repositories/migrations/20250117095221_fuzzy_match_on_case_name.sql
+++ b/repositories/migrations/20250117095221_fuzzy_match_on_case_name.sql
@@ -3,16 +3,6 @@
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
--- +goose StatementBegin
-
-DO $$
-BEGIN
-   EXECUTE format('ALTER ROLE %I SET pg_trgm.similarity_threshold = 0.1', current_user);
-END
-$$;
-
--- +goose StatementEnd
-
 CREATE INDEX CONCURRENTLY trgm_cases_on_name ON cases USING GIN (name gin_trgm_ops);
 
 CREATE INDEX CONCURRENTLY case_org_id_idx_2 ON cases (org_id, created_at DESC) INCLUDE (inbox_id, status, name);

--- a/usecases/case_usecase.go
+++ b/usecases/case_usecase.go
@@ -27,7 +27,7 @@ import (
 )
 
 type CaseUseCaseRepository interface {
-	ListOrganizationCases(ctx context.Context, exec repositories.Executor, filters models.CaseFilters,
+	ListOrganizationCases(ctx context.Context, tx repositories.Transaction, filters models.CaseFilters,
 		pagination models.PaginationAndSorting) ([]models.Case, error)
 	GetCaseById(ctx context.Context, exec repositories.Executor, caseId string) (models.Case, error)
 	GetCaseByIdForUpdate(ctx context.Context, exec repositories.Executor, caseId string) (models.CaseMetadata, error)

--- a/usecases/inboxes_usecase.go
+++ b/usecases/inboxes_usecase.go
@@ -22,7 +22,7 @@ type InboxRepository interface {
 	UpdateInbox(ctx context.Context, exec repositories.Executor, inboxId uuid.UUID, input models.UpdateInboxInput) error
 	SoftDeleteInbox(ctx context.Context, exec repositories.Executor, inboxId uuid.UUID) error
 
-	ListOrganizationCases(ctx context.Context, exec repositories.Executor, filters models.CaseFilters,
+	ListOrganizationCases(ctx context.Context, tx repositories.Transaction, filters models.CaseFilters,
 		pagination models.PaginationAndSorting) ([]models.Case, error)
 }
 


### PR DESCRIPTION
## Content
1. Remove "ALTER DATABASE" migration step that was both redundant and problematic for non-admin roles
2. Remove the assumption that the uuid extension is in the marble schema, it only need be in the search path (often in public schema)
3. Remove problematic `ALTER ROLE %I SET pg_trgm.similarity_threshold = 0.1` (does not work on RDS)
4. Replace it with a local set where we filter by name, change the executor expect by "list cases" repo to a transaction accordingly
5. Remove uses of word_similarity() to use the operator instead, as it is indexable (otherwise we have a useless index)
6. [bug fix?] *pointed out by AI, but seems legit*: In the method to search users (ingested data) by name, the filter and the ordering were not using the same score (because word_similarity is not symmetric). `"field" <<-> 'value'` is equivalent to `1-word_similarity("field",'value')` while the filter uses (through the operator) `word_similarity('value',"field")`, which is presumably the intent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved case-name filtering for more accurate fuzzy matches.
  - Updated object search ordering to better align with word-similarity results.
  - Improved database configuration to provide more reliable search and record creation behavior.

- **Refactor**
  - Updated case and inbox data access flows to use consistent transaction handling, improving reliability during database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->