### PR TITLE
properly set role in postgres DSN for duckdb

### DIFF
--- a/usecases/executor_factory/analytics_executor_factory.go
+++ b/usecases/executor_factory/analytics_executor_factory.go
@@ -52,13 +52,7 @@ func (f AnalyticsExecutorFactory) GetExecutor(ctx context.Context) (repositories
 		// compared to the native httpfs cache. We will come back to this in the future to give an option for deployments of
 		// Marble that have a persistent disk. It should then be setup at connection dial and configured here.
 		ddb, err = duckdb.NewConnector("", func(execer driver.ExecerContext) error {
-			if f.config.PgConfig.ImpersonateRole != "" {
-				_, err := execer.ExecContext(ctx, "set role "+pgx.Identifier([]string{f.config.PgConfig.ImpersonateRole}).Sanitize(), nil)
-				if err != nil {
-					return err
-				}
-			}
-			_, err = execer.ExecContext(ctx, `set threads = $1;`, []driver.NamedValue{
+			_, err := execer.ExecContext(ctx, `set threads = $1;`, []driver.NamedValue{
 				{
 					// We use a number of threads higher than the number of CPUs to account for the fact that, on the volumes we have been testing,
 					// the response time is IO rather than CPU bound. An even higher value may even make sense.
@@ -267,8 +261,23 @@ func (f AnalyticsExecutorFactory) buildUpstreamAttachStatement(alias string) str
 	// transactions, so we need to set query options on the connections
 	// directly.
 	q := dsn.Query()
-	q.Set("options", `-cenable_seqscan=0`)
-	dsn.RawQuery = q.Encode()
+	options := `-cenable_seqscan=0`
+	if f.config.PgConfig.ImpersonateRole != "" {
+		role := strings.NewReplacer(
+			`\`, `\\`,
+			" ", "\\ ",
+			"\t", "\\\t",
+			"\n", "\\\n",
+			"\v", "\\\v",
+			"\f", "\\\f",
+			"\r", "\\\r",
+		).Replace(f.config.PgConfig.ImpersonateRole)
+		options += ` -c role=` + role
+	}
+	q.Set("options", options)
+	// PostgreSQL connection URIs require RFC percent-encoding and do not
+	// interpret '+' as a space like application/x-www-form-urlencoded does.
+	dsn.RawQuery = strings.ReplaceAll(q.Encode(), "+", "%20")
 
 	return fmt.Sprintf(
 		`attach or replace '%s' as %s (type postgres, read_only)`,

--- a/usecases/executor_factory/analytics_executor_factory_test.go
+++ b/usecases/executor_factory/analytics_executor_factory_test.go
@@ -5,9 +5,26 @@ import (
 	"time"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/checkmarble/marble-backend/infra"
 	"github.com/google/uuid"
 	"gotest.tools/v3/assert"
 )
+
+func TestBuildUpstreamAttachStatementWithImpersonateRole(t *testing.T) {
+	f := AnalyticsExecutorFactory{config: infra.AnalyticsConfig{
+		PgConfig: infra.PgConfig{
+			ConnectionString: "postgres://iam:secret@localhost/marble?sslmode=require",
+			ImpersonateRole:  `marble app\reader`,
+		},
+	}}
+
+	statement := f.buildUpstreamAttachStatement("pg")
+
+	assert.Equal(t,
+		"attach or replace 'postgres://iam:secret@localhost/marble?options=-cenable_seqscan%3D0%20-c%20role%3Dmarble%5C%20app%5C%5Creader&sslmode=require' as pg (type postgres, read_only)",
+		statement,
+	)
+}
 
 func TestDifferentSeparateYears(t *testing.T) {
 	f := AnalyticsExecutorFactory{}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL connection handling for configured impersonation roles.
  * Correctly preserves spaces, backslashes, and other special characters in role names when establishing connections.
  * Ensures read-only upstream connections receive the configured role consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->